### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
 
 ## Prerequisites
 
-* Visual Studio 2019 or GCC v7.x+. Other compilers may work but haven't been tested.
-* CMake (add it to your path during install!)
+* Visual Studio 2019 with `Desktop Development with C++ workload` or GCC v7.x+. Other compilers may work but haven't been tested.
+* CMake 3.15 or higher (add it to your path during install!)
 
 ## Getting Started
 
 * Check out the repo with `git clone git@github.com:CesiumGS/cesium-native.git --recurse-submodules` so that you get the third party submodules.
 * Build the draco library with CMake:
-  * `pushd extern; mkdir build; cd build; mkdir draco; cd draco`
+  * `pushd extern; mkdir -p build; cd build; mkdir -p draco; cd draco`
   * `cmake ../../draco/`
   * `cmake --build . --config Release`
   * `popd`
 * Build the uriparser library with CMake:
-  * `pushd extern; mkdir build; cd build; mkdir uriparser; cd uriparser`
+  * `pushd extern; mkdir -p build; cd build; mkdir -p uriparser; cd uriparser`
   * `cmake ../../uriparser/ -DCMAKE_BUILD_TYPE=Release -D URIPARSER_BUILD_TESTS:BOOL=OFF -D URIPARSER_BUILD_DOCS:BOOL=OFF -D BUILD_SHARED_LIBS:BOOL=OFF -D URIPARSER_ENABLE_INSTALL:BOOL=OFF -D URIPARSER_BUILD_TOOLS:BOOL=OFF`
   * `cmake --build . --config Release`
   * `popd`


### PR DESCRIPTION
Just a couple small observations I noticed will setting up cesium-unreal the first time.

`mkdir -p` is to avoid an error when the folder already exists.

```
$ pushd extern; mkdir build; cd build; mkdir uriparser; cd uriparser
/c/Code/cesium-unreal/Plugins/Cesium/extern/cesium-native/extern /c/Code/cesium-unreal/Plugins/Cesium/extern/cesium-native /c/Code/cesium-unreal/Plugins/Cesium/extern/cesium-native
mkdir: cannot create directory ‘build’: File exists
```

Alternatively `mkdir build` can be removed from the `uriparser` instructions.

Note: I used `git bash` on windows so `mkdir -p` was available.

@kring feel free to tweak this in any way