### PR TITLE
Add n=z to Bing requests if it's not already there.

### DIFF
--- a/Cesium3DTiles/src/BingMapsRasterOverlay.cpp
+++ b/Cesium3DTiles/src/BingMapsRasterOverlay.cpp
@@ -217,6 +217,10 @@ namespace Cesium3DTiles {
                 return;
             }
 
+            if (urlTemplate.find("n=z") == std::string::npos) {
+                urlTemplate = Uri::addQuery(urlTemplate, "n", "z");
+            }
+
             // TODO: attribution
 
             std::string resolvedUrl = Uri::resolve(url, urlTemplate);


### PR DESCRIPTION
To avoid "no image" tiles in the non-labels Bing layer.