### PR TITLE
Mark unloadable images as failed.

### DIFF
--- a/Cesium3DTiles/src/RasterOverlayTile.cpp
+++ b/Cesium3DTiles/src/RasterOverlayTile.cpp
@@ -74,12 +74,15 @@ namespace Cesium3DTiles {
                 std::string warnings;
 
                 gsl::span<const uint8_t> data = pResponse->data();
-                tinygltf::LoadImageData(&this->_image, 0, &errors, &warnings, 0, 0, data.data(), static_cast<int>(data.size()), nullptr);
+                bool success = tinygltf::LoadImageData(&this->_image, 0, &errors, &warnings, 0, 0, data.data(), static_cast<int>(data.size()), nullptr);
 
-                // TODO: load failure?
-                this->_pRendererResources = this->_pTileProvider->getExternals().pPrepareRendererResources->prepareRasterInLoadThread(*this);
-
-                this->setState(LoadState::Loaded);
+                if (success) {
+                    this->_pRendererResources = this->_pTileProvider->getExternals().pPrepareRendererResources->prepareRasterInLoadThread(*this);
+                    this->setState(LoadState::Loaded);
+                } else {
+                    this->_pRendererResources = nullptr;
+                    this->setState(LoadState::Failed);
+                }
             });
         }
 


### PR DESCRIPTION
This fixes the strange "repeated texture" problem when zooming in very close to a CWT+Bing tileset. What was happening was:
* Bing Maps sometimes returns the text "Bad Image" rather than a zero-length image when requesting an image that is more detailed than is available. For example: https://t2.ssl.ak.dynamic.tiles.virtualearth.net/comp/ch/3112301330023222033020?mkt=en-US&it=A,G,L&src=t&og=1191&n=z
* We weren't probably handling image load errors, so "Bad Image" became a "successful" zero-size image.
* On the Unreal side, we can't create a zero-size UTexture, so we instead just returned nullptr and set the texture material parameter to nullptr.
* Setting a material texture parameter to nullptr in UE doesn't seem to reset it to its default value, but instead makes it use.. some random texture it gets from somewhere else?
