### PR TITLE
Unload tiles prior to running the Tileset default constructor.

### DIFF
--- a/Cesium3DTiles/src/Tileset.cpp
+++ b/Cesium3DTiles/src/Tileset.cpp
@@ -101,6 +101,14 @@ namespace Cesium3DTiles {
         while (this->_loadsInProgress.load(std::memory_order::memory_order_acquire) > 0) {
             this->_externals.pAssetAccessor->tick();
         }
+
+        // Now that no tiles are in the loading state, unload all tiles
+        pCurrent = this->_loadedTiles.head();
+        while (pCurrent) {
+            Tile* pNext = this->_loadedTiles.next(pCurrent);
+            pCurrent->unloadContent();
+            pCurrent = pNext;
+        }
     }
 
     const ViewUpdateResult& Tileset::updateView(const Camera& camera) {


### PR DESCRIPTION
This avoids destruction order dependency between Tiles (which reference RasterOverlayTiles) and RasterOverlayTileProviders owned by the Tileset.

Prior to this change, we were use-after-free'ing RasterTileOverlayProviders, but didn't notice because it was so soon after free and the release CRT used by UE doesn't check the way the debug one does.