### PR TITLE
Fix generated texture coordinates near the anti-meridian.

### DIFF
--- a/CesiumGeometry/include/CesiumGeometry/Rectangle.h
+++ b/CesiumGeometry/include/CesiumGeometry/Rectangle.h
@@ -19,6 +19,16 @@ namespace CesiumGeometry {
         bool overlaps(const Rectangle& other) const;
         bool fullyContains(const Rectangle& other) const;
 
+        /**
+         * Computes the signed distance from a position to the edge of the rectangle.
+         * If the position is inside the rectangle, the distance is negative. If it is
+         * outside the rectangle, it is positive.
+         * 
+         * @param position The position.
+         * @return The signed distance.
+         */
+        double computeSignedDistance(const glm::dvec2& position) const;
+
         glm::dvec2 getLowerLeft() const { return glm::dvec2(this->minimumX, this->minimumY); }
         glm::dvec2 getLowerRight() const { return glm::dvec2(this->maximumX, this->minimumY); }
         glm::dvec2 getUpperLeft() const { return glm::dvec2(this->minimumX, this->maximumY); }

--- a/CesiumGeometry/src/Rectangle.cpp
+++ b/CesiumGeometry/src/Rectangle.cpp
@@ -1,4 +1,6 @@
 #include "CesiumGeometry/Rectangle.h"
+#include <glm/common.hpp>
+#include <glm/geometric.hpp>
 
 namespace CesiumGeometry {
 
@@ -33,6 +35,23 @@ namespace CesiumGeometry {
             other.minimumY >= this->minimumY &&
             other.maximumY <= this->maximumY
         );
+    }
+
+    double Rectangle::computeSignedDistance(const glm::dvec2& position) const {
+        glm::dvec2 bottomLeftDistance = glm::dvec2(minimumX, minimumY) - position;
+        glm::dvec2 topRightDistance = position - glm::dvec2(maximumX, maximumY);
+        glm::dvec2 maxDistance = glm::max(bottomLeftDistance, topRightDistance);
+
+        if (maxDistance.x <= 0.0 && maxDistance.y <= 0.0) {
+            // Inside, report closest edge.
+            return std::max(maxDistance.x, maxDistance.y);
+        } else if (maxDistance.x > 0.0 && maxDistance.y > 0.0) {
+            // Outside in both directions, closest point is a corner
+            return glm::length(maxDistance);
+        } else {
+            // Outside in one direction, report the distance in that direction.
+            return std::max(maxDistance.x, maxDistance.y);
+        }
     }
 
     double Rectangle::computeWidth() const {

--- a/CesiumGeometry/test/TestRectangle.cpp
+++ b/CesiumGeometry/test/TestRectangle.cpp
@@ -1,0 +1,109 @@
+#include "catch2/catch.hpp"
+#include "CesiumGeometry/Rectangle.h"
+#include "CesiumUtility/Math.h"
+
+TEST_CASE("Rectangle::computeSignedDistance") {
+    struct TestCase {
+        CesiumGeometry::Rectangle rectangle;
+        glm::dvec2 position;
+        double expectedResult;
+    };
+
+    CesiumGeometry::Rectangle positive(10.0, 20.0, 30.0, 40.0);
+    CesiumGeometry::Rectangle negative(-30.0, -40.0, -10.0, -20.0);
+
+    auto testCase = GENERATE_REF(
+        TestCase {
+            positive,
+            glm::dvec2(20.0, 30.0),
+            -10.0
+        },
+        TestCase {
+            negative,
+            glm::dvec2(-20.0, -30.0),
+            -10.0
+        },
+        TestCase {
+            positive,
+            glm::dvec2(-5.0, 30.0),
+            15.0
+        },
+        TestCase {
+            negative,
+            glm::dvec2(5.0, -30.0),
+            15.0
+        },
+        TestCase {
+            positive,
+            glm::dvec2(45.0, 30.0),
+            15.0
+        },
+        TestCase {
+            negative,
+            glm::dvec2(-45.0, -30.0),
+            15.0
+        },
+        TestCase {
+            positive,
+            glm::dvec2(20.0, 5.0),
+            15.0
+        },
+        TestCase {
+            negative,
+            glm::dvec2(-20.0, -5.0),
+            15.0
+        },
+        TestCase {
+            positive,
+            glm::dvec2(20.0, 55.0),
+            15.0
+        },
+        TestCase {
+            negative,
+            glm::dvec2(-20.0, -55.0),
+            15.0
+        },
+        TestCase {
+            positive,
+            glm::dvec2(5.0, 15.0),
+            std::sqrt(5.0 * 5.0 + 5.0 * 5.0)
+        },
+        TestCase {
+            negative,
+            glm::dvec2(-5.0, -15.0),
+            std::sqrt(5.0 * 5.0 + 5.0 * 5.0)
+        },
+        TestCase {
+            positive,
+            glm::dvec2(5.0, 45.0),
+            std::sqrt(5.0 * 5.0 + 5.0 * 5.0)
+        },
+        TestCase {
+            negative,
+            glm::dvec2(-5.0, -45.0),
+            std::sqrt(5.0 * 5.0 + 5.0 * 5.0)
+        },
+        TestCase {
+            positive,
+            glm::dvec2(35.0, 15.0),
+            std::sqrt(5.0 * 5.0 + 5.0 * 5.0)
+        },
+        TestCase {
+            negative,
+            glm::dvec2(-35.0, -15.0),
+            std::sqrt(5.0 * 5.0 + 5.0 * 5.0)
+        },
+        TestCase {
+            positive,
+            glm::dvec2(35.0, 45.0),
+            std::sqrt(5.0 * 5.0 + 5.0 * 5.0)
+        },
+        TestCase {
+            negative,
+            glm::dvec2(-35.0, -45.0),
+            std::sqrt(5.0 * 5.0 + 5.0 * 5.0)
+        }
+    );
+
+    CHECK(CesiumUtility::Math::equalsEpsilon(testCase.rectangle.computeSignedDistance(testCase.position), testCase.expectedResult, CesiumUtility::Math::EPSILON13));
+}


### PR DESCRIPTION
Overlay texture coordinates are computed from vertex positions. A position _on_ the anti-meridian can map to two very different texture coordinates, depending on whether you treat it as -180 or +180 degrees longitude. This PR makes the texture coordinate generation choose the correct one.