### PR TITLE
On MSVC, need algorithm for std::min and std::max

### DIFF
--- a/CesiumGeometry/src/Rectangle.cpp
+++ b/CesiumGeometry/src/Rectangle.cpp
@@ -1,6 +1,7 @@
 #include "CesiumGeometry/Rectangle.h"
 #include <glm/common.hpp>
 #include <glm/geometric.hpp>
+#include <algorithm>
 
 namespace CesiumGeometry {
 


### PR DESCRIPTION
The `std::min` and `std::max`  functions are declared in `<algorithm>`. Depending on what other `include`s might include, these functions may or may not be found by some compiler. MSVC does not seem to find them. 