### PR TITLE
Fix a crash while upsampling.

### DIFF
--- a/Cesium3DTiles/src/Tile.cpp
+++ b/Cesium3DTiles/src/Tile.cpp
@@ -202,6 +202,18 @@ namespace Cesium3DTiles {
             return false;
         }
 
+        // If a child tile is being upsampled from this one, we can't unload this one yet.
+        if (this->getState() == Tile::LoadState::Done && !this->getChildren().empty()) {
+            for (const Tile& child : this->getChildren()) {
+                if (
+                    child.getState() == Tile::LoadState::ContentLoading &&
+                    std::get_if<CesiumGeometry::QuadtreeChild>(&child.getTileID()) != nullptr
+                ) {
+                    return false;
+                }
+            }
+        }
+
         const TilesetExternals& externals = this->getTileset()->getExternals();
         if (externals.pPrepareRendererResources) {
             if (this->getState() == LoadState::ContentLoaded) {


### PR DESCRIPTION
This was a race condition that could manifest different ways. The fundamental problem was that we were allowing a parent tile to be unloaded while a child tile was being upsampled from it.
