### PR TITLE
Disable certain warnings for draco

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -14,3 +14,35 @@ add_subdirectory(glm)
 
 set(BUILD_TESTS OFF CACHE BOOL "Build tinyxml2 tests" FORCE)
 add_subdirectory(tinyxml2)
+
+
+
+# Function to collect all targets of the current directory 
+# and all subdirectories (https://stackoverflow.com/a/62311397)
+function(get_all_targets var)
+    set(targets)
+    get_all_targets_recursive(targets ${CMAKE_CURRENT_SOURCE_DIR})
+    set(${var} ${targets} PARENT_SCOPE)
+endfunction()
+
+macro(get_all_targets_recursive targets dir)
+    get_property(subdirectories DIRECTORY ${dir} PROPERTY SUBDIRECTORIES)
+    foreach(subdir ${subdirectories})
+        get_all_targets_recursive(${targets} ${subdir})
+    endforeach()
+
+    get_property(current_targets DIRECTORY ${dir} PROPERTY BUILDSYSTEM_TARGETS)
+    list(APPEND ${targets} ${current_targets})
+endmacro()
+
+# Ingnore "warning C4661: '...': no suitable definition provided for explicit template instantiation request"
+# for all draco targets
+get_all_targets(all_targets)
+foreach(target ${all_targets}) 
+    if ("${target}" MATCHES "draco.*")
+        if (MSVC)
+            target_compile_options(${target} PUBLIC /wd4661)
+        endif()
+    endif()
+endforeach(target)
+


### PR DESCRIPTION
I know that my primary task is the documentation, but I hope it's OK to create such an unrelated PR.

I'm a fan of "High Warning Levels" and "Zero Warnings" (being aware of the difficulties that may come along with that). Right now, the draco libraries issued some warnings

    warning C4661: '...': no suitable definition provided for explicit template instantiation request

This is an attempt to switch this warning off for all draco targets. If this is **not** a sensible way of doing this (and I'm sure there are at least "better" ways), then this PR can be ignored, or at best serve as a reminder that one might look into how to avoid these warnings.

(There are many other warnings from the third-party library. I started tackling these, mainly via "pragma guards", similar to https://github.com/CesiumGS/cesium-native/blob/master/CesiumUtility/include/CesiumUtility/Json.h , but these appear to not show up during the build, but only as "Intellisense warnings" - I have to sort out how these "different types of warnings" can be aligned and sensibly be disabled for the third-party libraries...)
