### PR TITLE
Use BoundingBox for distance to degenerate BoundingRegion.

### DIFF
--- a/CesiumGeospatial/include/CesiumGeospatial/BoundingRegion.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/BoundingRegion.h
@@ -112,12 +112,14 @@ private:
         double _minimumHeight;
         double _maximumHeight;
         CesiumGeometry::OrientedBoundingBox _boundingBox;
+
         glm::dvec3 _southwestCornerCartesian;
         glm::dvec3 _northeastCornerCartesian;
         glm::dvec3 _westNormal;
         glm::dvec3 _eastNormal;
         glm::dvec3 _southNormal;
         glm::dvec3 _northNormal;
+        bool _planesAreInvalid;
     };
 
 }


### PR DESCRIPTION
Previously, a degenerate bounding region (i.e. west/east or south/north are equal) would cause the `BoundingRegion` to throw an exception. This can happen with bad data (i.e. a bug in Cesium OSM Buildings), or perhaps when a tile has just a single point. With this PR, we use the bounding box computed from the region to estimate distance when we can't compute the normals we need for bounding region distance.