### PR TITLE
Select the tile(s) directly underneath the camera even if they're not in the view frustum

### DIFF
--- a/Cesium3DTiles/include/Cesium3DTiles/Tileset.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/Tileset.h
@@ -117,6 +117,15 @@ namespace Cesium3DTiles {
             { 628733.5874, 2.2e-6 },
             { 1000000.0, 0.0 }
         };
+
+        /**
+         * @brief Whether to render tiles directly under the camera, even if they're not in the view frustum.
+         * 
+         * This is useful for detecting the camera's collision with terrain and other models.
+         * NOTE: This option currently only works with tiles that use a `region` as their bounding volume.
+         * It is ignored for other bounding volume types.
+         */
+        bool renderTilesUnderCamera = true;
     };
 
     /**

--- a/Cesium3DTiles/src/Tileset.cpp
+++ b/Cesium3DTiles/src/Tileset.cpp
@@ -682,6 +682,24 @@ namespace Cesium3DTiles {
         const BoundingVolume& boundingVolume = tile.getBoundingVolume();
         bool isVisible = frameState.camera.isBoundingVolumeVisible(boundingVolume);
 
+        if (!isVisible && this->_options.renderTilesUnderCamera && frameState.camera.getPositionCartographic()) {
+            const CesiumGeospatial::BoundingRegion* pRegion = std::get_if<CesiumGeospatial::BoundingRegion>(&tile.getBoundingVolume());
+            const CesiumGeospatial::BoundingRegionWithLooseFittingHeights* pLooseRegion = std::get_if<CesiumGeospatial::BoundingRegionWithLooseFittingHeights>(&tile.getBoundingVolume());
+            
+            const CesiumGeospatial::GlobeRectangle* pRectangle = nullptr;
+            if (pRegion) {
+                pRectangle = &pRegion->getRectangle();
+            } else if (pLooseRegion) {
+                pRectangle = &pLooseRegion->getBoundingRegion().getRectangle();
+            }
+
+            if (pRectangle) {
+                if (pRectangle->contains(frameState.camera.getPositionCartographic().value())) {
+                    isVisible = true;
+                }
+            }
+        }
+
         double distance = 0.0;
 
         if (isVisible) {


### PR DESCRIPTION
This is useful for camera collisions with terrain.
