### PR TITLE
Do not append empty queries to URLs

### DIFF
--- a/Cesium3DTiles/src/Uri.cpp
+++ b/Cesium3DTiles/src/Uri.cpp
@@ -56,13 +56,16 @@ std::string Uri::resolve(const std::string& base, const std::string& relative, b
 	if (useBaseQuery)
 	{
 		std::string query(baseUri.query.first, baseUri.query.afterLast);
-		if (resolvedUri.query.first)
+		if (query.length() > 0)
 		{
-			result += "&" + query;
-		}
-		else
-		{
-			result += "?" + query;
+			if (resolvedUri.query.first)
+			{
+				result += "&" + query;
+			}
+			else
+			{
+				result += "?" + query;
+			}
 		}
 	}
 


### PR DESCRIPTION
When the query string is empty, the `&` or `?` should not be appended to the URL.

(One might review whether the query string has to be appended manually in this form in the first place...)
