### PR TITLE
Wait for raster loading before destroying tileset.

### DIFF
--- a/Cesium3DTiles/src/Tileset.cpp
+++ b/Cesium3DTiles/src/Tileset.cpp
@@ -110,6 +110,17 @@ namespace Cesium3DTiles {
             pCurrent->unloadContent();
             pCurrent = pNext;
         }
+
+        // Wait for all overlays to wrap up their loading, too.
+        uint32_t tilesLoading = 1;
+        while (tilesLoading > 0) {
+            this->_externals.pAssetAccessor->tick();
+
+            tilesLoading = 0;
+            for (auto& pOverlay : this->_overlays) {
+                tilesLoading += pOverlay->getTileProvider()->getNumberOfTilesLoading();
+            }
+        }
     }
 
     static bool operator<(const FogDensityAtHeight& fogDensity, double height) {


### PR DESCRIPTION
Fixes a possible crash when destroying a tileset while raster overlay tiles are in the process of loading.