### PR TITLE
Make sure that unloadContent is only executed once.

### DIFF
--- a/Cesium3DTiles/include/Cesium3DTiles/IAssetAccessor.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/IAssetAccessor.h
@@ -38,7 +38,7 @@ namespace Cesium3DTiles {
          * If the asset accessor is not dependent on the main thread to
          * dispatch requests, this method does not need to do anything.
          */
-        virtual void tick() = 0;
+        virtual void tick() noexcept = 0;
     };
 
 }

--- a/Cesium3DTiles/include/Cesium3DTiles/IAssetRequest.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/IAssetRequest.h
@@ -38,7 +38,7 @@ namespace Cesium3DTiles {
          * @brief Cancels the request.
          * This method may only be called from the thread that created the request.
          */
-        virtual void cancel() = 0;
+        virtual void cancel() noexcept = 0;
     };
 
 }

--- a/Cesium3DTiles/include/Cesium3DTiles/IPrepareRendererResources.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/IPrepareRendererResources.h
@@ -68,7 +68,7 @@ namespace Cesium3DTiles {
          * @param pMainThreadResult The result returned by {@link prepareInMainThread}. 
          * If {@link prepareInMainThread} has not yet been called, this parameter will be `nullptr`.
          */
-        virtual void free(Tile& tile, void* pLoadThreadResult, void* pMainThreadResult) = 0;
+        virtual void free(Tile& tile, void* pLoadThreadResult, void* pMainThreadResult) noexcept = 0;
 
         /**
          * @brief Prepares a raster overlay tile. 

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlay.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlay.h
@@ -33,7 +33,7 @@ namespace Cesium3DTiles {
          * If {@link createTileProvider} has been called but the overlay is not yet ready to
          * provide tiles, a placeholder tile provider will be returned.
          */
-        RasterOverlayTileProvider* getTileProvider();
+        RasterOverlayTileProvider* getTileProvider() noexcept;
 
         /** @copydoc getTileProvider */
         const RasterOverlayTileProvider* getTileProvider() const;

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTile.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTile.h
@@ -112,7 +112,7 @@ namespace Cesium3DTiles {
         /**
          * @brief Returns the current {@link LoadState}.
          */
-        LoadState getState() const { return this->_state.load(std::memory_order::memory_order_acquire); }
+        LoadState getState() const noexcept { return this->_state.load(std::memory_order::memory_order_acquire); }
 
         /**
          * @brief Returns the image data for the tile.

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
@@ -126,7 +126,7 @@ namespace Cesium3DTiles {
         /**
          * @brief Returns the number of tiles that are currently loading.
          */
-        uint32_t getNumberOfTilesLoading() const;
+        uint32_t getNumberOfTilesLoading() const noexcept;
 
         /**
          * Computes the appropriate tile level of detail (zoom level) for a given geometric error near

--- a/Cesium3DTiles/include/Cesium3DTiles/Tile.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/Tile.h
@@ -23,7 +23,6 @@
 namespace Cesium3DTiles {
     class Tileset;
     class TileContent;
-    class RasterOverlayTileProvider;
     struct TileContentLoadResult;
 
     /**
@@ -137,12 +136,12 @@ namespace Cesium3DTiles {
          * and make sure that the resources that have been 
          * allocated by this tile can be freed.
          */
-        void prepareToDestroy();
+        void prepareToDestroy() noexcept;
 
         /**
          * @brief Returns the {@link Tileset} to which this tile belongs.
          */
-        Tileset* getTileset() { return this->_pContext->pTileset; }
+        Tileset* getTileset() noexcept { return this->_pContext->pTileset; }
 
         /** @copydoc Tile::getTileset() */
         const Tileset* getTileset() const { return this->_pContext->pTileset; }
@@ -196,7 +195,7 @@ namespace Cesium3DTiles {
          * 
          * @return The children of this tile.
          */
-        gsl::span<Tile> getChildren() { return gsl::span<Tile>(this->_children); }
+        gsl::span<Tile> getChildren() noexcept { return gsl::span<Tile>(this->_children); }
 
         /** @copydoc Tile::getChildren() */
         gsl::span<const Tile> getChildren() const { return gsl::span<const Tile>(this->_children); }
@@ -331,7 +330,7 @@ namespace Cesium3DTiles {
          *
          * @return The tile ID.
          */
-        const TileID& getTileID() const { return this->_id; }
+        const TileID& getTileID() const noexcept { return this->_id; }
 
         /**
          * @brief Set the {@link TileID} of this tile.
@@ -389,7 +388,7 @@ namespace Cesium3DTiles {
         /**
          * @brief Returns the {@link LoadState} of this tile.
          */
-        LoadState getState() const { return this->_state.load(std::memory_order::memory_order_acquire); }
+        LoadState getState() const noexcept { return this->_state.load(std::memory_order::memory_order_acquire); }
 
         /**
          * @brief Returns the content request that is currently in flight, if any.
@@ -461,7 +460,7 @@ namespace Cesium3DTiles {
          * 
          * @return Whether the content was unloaded.
          */
-        bool unloadContent();
+        bool unloadContent() noexcept;
 
         /**
          * @brief Gives this tile a chance to update itself each render frame.
@@ -481,12 +480,12 @@ namespace Cesium3DTiles {
          */
         void markPermanentlyFailed();
 
-    protected:
+    private:
 
         /**
          * @brief Set the {@link LoadState} of this tile.
          */
-        void setState(LoadState value);
+        void setState(LoadState value) noexcept;
 
         /**
          * @brief Will be called when the response for loading the tile content was received.
@@ -519,7 +518,6 @@ namespace Cesium3DTiles {
          */
         void upsampleParent(std::vector<CesiumGeospatial::Projection>&& projections);
 
-    private:
         // Position in bounding-volume hierarchy.
         TileContext* _pContext;
         Tile* _pParent;

--- a/Cesium3DTiles/include/Cesium3DTiles/Tileset.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/Tileset.h
@@ -190,7 +190,7 @@ namespace Cesium3DTiles {
         /**
          * @brief Gets the {@link TilesetExternals} that summarize the external interfaces used by this tileset.
          */
-        TilesetExternals& getExternals() { return this->_externals; }
+        TilesetExternals& getExternals() noexcept { return this->_externals; }
 
         /**
          * @brief Gets the {@link TilesetExternals} that summarize the external interfaces used by this tileset.

--- a/Cesium3DTiles/src/RasterOverlay.cpp
+++ b/Cesium3DTiles/src/RasterOverlay.cpp
@@ -14,7 +14,7 @@ namespace Cesium3DTiles {
     RasterOverlay::~RasterOverlay() {
     }
 
-    RasterOverlayTileProvider* RasterOverlay::getTileProvider() {
+    RasterOverlayTileProvider* RasterOverlay::getTileProvider() noexcept {
         return this->_pTileProvider ? this->_pTileProvider.get() : this->_pPlaceholder.get();
     }
 

--- a/Cesium3DTiles/src/RasterOverlayTileProvider.cpp
+++ b/Cesium3DTiles/src/RasterOverlayTileProvider.cpp
@@ -73,7 +73,7 @@ namespace Cesium3DTiles {
         return nullptr;
     }
 
-    uint32_t RasterOverlayTileProvider::getNumberOfTilesLoading() const {
+    uint32_t RasterOverlayTileProvider::getNumberOfTilesLoading() const noexcept {
         uint32_t count = 0;
 
         for (auto& pair : this->_tiles) {

--- a/Cesium3DTiles/src/Tile.cpp
+++ b/Cesium3DTiles/src/Tile.cpp
@@ -82,7 +82,7 @@ namespace Cesium3DTiles {
         return *this;
     }
 
-    void Tile::prepareToDestroy() {
+    void Tile::prepareToDestroy() noexcept {
         if (this->_pContentRequest) {
             this->_pContentRequest->cancel();
         }
@@ -231,7 +231,12 @@ namespace Cesium3DTiles {
         }
     }
 
-    bool Tile::unloadContent() {
+    bool Tile::unloadContent() noexcept {
+
+        if (this->getState() == Tile::LoadState::Unloaded) {
+            return true;
+        }
+
         // Cannot unload while an async operation is in progress.
         if (this->getState() == Tile::LoadState::ContentLoading) {
             return false;
@@ -507,7 +512,7 @@ namespace Cesium3DTiles {
         }
     }
 
-    void Tile::setState(LoadState value) {
+    void Tile::setState(LoadState value) noexcept {
         this->_state.store(value, std::memory_order::memory_order_release);
     }
 

--- a/Cesium3DTiles/src/Tileset.cpp
+++ b/Cesium3DTiles/src/Tileset.cpp
@@ -103,14 +103,6 @@ namespace Cesium3DTiles {
             this->_externals.pAssetAccessor->tick();
         }
 
-        // Now that no tiles are in the loading state, unload all tiles
-        pCurrent = this->_loadedTiles.head();
-        while (pCurrent) {
-            Tile* pNext = this->_loadedTiles.next(pCurrent);
-            pCurrent->unloadContent();
-            pCurrent = pNext;
-        }
-
         // Wait for all overlays to wrap up their loading, too.
         uint32_t tilesLoading = 1;
         while (tilesLoading > 0) {


### PR DESCRIPTION
Addresses https://github.com/CesiumGS/cesium-native/issues/47 :

The main change is that unloadContent is no longer called from the Tileset destructor (because it is already called from the Tile destructor), and that it returns immediately if the tile already is unloaded.

Also added `noexcept` for functions that are called from the Tileset or Tile destructor.

**NOTE:** This will make it necessary to add the `noexcept` also to the implementing classes in `cesium-unreal`!
