### PR TITLE
Add value_type typedef to GltfAccessor.

### DIFF
--- a/Cesium3DTiles/include/Cesium3DTiles/GltfAccessor.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/GltfAccessor.h
@@ -34,6 +34,7 @@ namespace Cesium3DTiles {
 		size_t _size;
 
 	public:
+		typedef T value_type;
 
 		/**
 		 * @brief Creates a new instance.


### PR DESCRIPTION
Bringing it to par with the version in cesium-unreal.