### PR TITLE
Require Future::then and catch to be called on an rvalue ref.

### DIFF
--- a/Cesium3DTiles/src/RasterOverlayTile.cpp
+++ b/Cesium3DTiles/src/RasterOverlayTile.cpp
@@ -56,7 +56,7 @@ namespace Cesium3DTiles {
 
             RasterOverlayTileProvider* pTileProvider = overlay.getTileProvider();
 
-            imageRequest.thenInWorkerThread([
+            std::move(imageRequest).thenInWorkerThread([
                 tileRectangle = pTileProvider->getTilingScheme().tileToRectangle(this->getID()),
                 projection = pTileProvider->getProjection(),
                 cutoutsCollection = overlay.getCutouts(),

--- a/Cesium3DTiles/src/Tile.cpp
+++ b/Cesium3DTiles/src/Tile.cpp
@@ -224,7 +224,7 @@ namespace Cesium3DTiles {
             void* pRendererResources;
         };
 
-        maybeRequestFuture.value().thenInWorkerThread([
+        std::move(maybeRequestFuture.value()).thenInWorkerThread([
             pContext = this->getContext(),
             tileID = this->getTileID(),
             boundingVolume = this->getBoundingVolume(),

--- a/CesiumAsync/include/CesiumAsync/AsyncSystem.h
+++ b/CesiumAsync/include/CesiumAsync/AsyncSystem.h
@@ -62,7 +62,7 @@ namespace CesiumAsync {
          * @return A future that resolves after the supplied function completes.
          */
         template <class Func>
-        Future<typename Impl::RemoveFuture<typename std::invoke_result<Func, T>::type>::type> thenInWorkerThread(Func&& f) {
+        Future<typename Impl::RemoveFuture<typename std::invoke_result<Func, T>::type>::type> thenInWorkerThread(Func&& f) && {
             return Future<typename Impl::RemoveFuture<typename std::invoke_result<Func, T>::type>::type>(
                 this->_pSchedulers,
                 _task.then(*this->_pSchedulers, Impl::unwrapFuture<Func, T>(std::forward<Func>(f)))
@@ -83,7 +83,7 @@ namespace CesiumAsync {
          * @return A future that resolves after the supplied function completes.
          */
         template <class Func>
-        Future<typename Impl::RemoveFuture<typename std::invoke_result<Func, T>::type>::type> thenInMainThread(Func&& f) {
+        Future<typename Impl::RemoveFuture<typename std::invoke_result<Func, T>::type>::type> thenInMainThread(Func&& f) && {
             return Future<typename Impl::RemoveFuture<typename std::invoke_result<Func, T>::type>::type>(
                 this->_pSchedulers,
                 _task.then(this->_pSchedulers->mainThreadScheduler, Impl::unwrapFuture<Func, T>(std::forward<Func>(f)))
@@ -106,7 +106,7 @@ namespace CesiumAsync {
          * @return A future that resolves after the supplied function completes.
          */
         template <class Func>
-        Future<T> catchInMainThread(Func&& f) {
+        Future<T> catchInMainThread(Func&& f) && {
             auto catcher = [f = std::move(f)](async::task<T>&& t) {
                 try {
                     return t.get();
@@ -216,7 +216,7 @@ namespace CesiumAsync {
 
         template <class T>
         Future<T> createResolvedFuture(T&& value) {
-            return Future<T>(this->_pSchedulers, async::make_task<T>(std::move(value)));
+            return Future<T>(this->_pSchedulers, async::make_task<T>(std::forward<T>(value)));
         }
 
         /**


### PR DESCRIPTION
Like Async++, calling `.then` on one of our Futures invalidates that Future. You can form arbitrarily-long continuation chains, but only a single continuation can be attached to each Future. Multiple continuations are only rarely useful, and disallowing them makes that implementation for efficient. Async++ has a way to explicit create a "shared" future without this limitation, but we haven't needed it yet.

Anyway, this PR makes this requirement more explicit in the type system by adding a "reference qualifier" to the .then and .catch methods, meaning they can only be called on rvalues (or lvalues converted to rvalues using std::move).