### PR TITLE
Marked classes final

### DIFF
--- a/Cesium3DTiles/include/Cesium3DTiles/BingMapsRasterOverlay.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/BingMapsRasterOverlay.h
@@ -14,7 +14,7 @@ namespace Cesium3DTiles {
      * Constants that can be passed to a {@link BingMapsRasterOverlay} to
      * indicate the overlays that should be painted.
      */
-    struct BingMapsStyle {
+    struct BingMapsStyle final {
         /**
          * @brief Aerial imagery.
          */
@@ -75,7 +75,7 @@ namespace Cesium3DTiles {
     /**
      * @brief A {@link RasterOverlay} that uses Bing Maps as the source for the imagery data.
      */
-    class CESIUM3DTILES_API BingMapsRasterOverlay : public RasterOverlay {
+    class CESIUM3DTILES_API BingMapsRasterOverlay final : public RasterOverlay {
     public:
 
         /**

--- a/Cesium3DTiles/include/Cesium3DTiles/Camera.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/Camera.h
@@ -16,7 +16,7 @@ namespace Cesium3DTiles {
      *
      * A camera is defined by a position, orientation and the view frustum.
      */
-    class CESIUM3DTILES_API Camera {
+    class CESIUM3DTILES_API Camera final {
     public:
         // TODO: Add support for orthographic and off-center perspective frustums
 

--- a/Cesium3DTiles/include/Cesium3DTiles/ExternalTilesetContent.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/ExternalTilesetContent.h
@@ -15,7 +15,7 @@ namespace Cesium3DTiles {
     /**
      * @brief Creates a {@link TileContentLoadResult} from 3D Tiles external tileset.json data.
      */
-    class CESIUM3DTILES_API ExternalTilesetContent {
+    class CESIUM3DTILES_API ExternalTilesetContent final {
     public:
 
         /**

--- a/Cesium3DTiles/include/Cesium3DTiles/Gltf.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/Gltf.h
@@ -15,7 +15,7 @@ namespace Cesium3DTiles {
      * instances, and for processing the mesh primitives that appear in the resulting 
      * models.
      */
-    class CESIUM3DTILES_API Gltf {
+    class CESIUM3DTILES_API Gltf final {
 
     public:
 

--- a/Cesium3DTiles/include/Cesium3DTiles/GltfAccessor.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/GltfAccessor.h
@@ -23,7 +23,7 @@ namespace Cesium3DTiles {
 	 * @tparam T The type of the elements in the accessor.
 	 */
 	template <class T>
-	class GltfAccessor {
+	class GltfAccessor final {
 	private:
 		const tinygltf::Buffer* _pGltfBuffer;
 		const tinygltf::BufferView* _pGltfBufferView;

--- a/Cesium3DTiles/include/Cesium3DTiles/GltfContent.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/GltfContent.h
@@ -16,7 +16,7 @@ namespace Cesium3DTiles {
     /**
      * @brief Creates {@link TileContentLoadResult} from glTF data.
      */
-    class CESIUM3DTILES_API GltfContent {
+    class CESIUM3DTILES_API GltfContent final {
     public:
         /** @copydoc ExternalTilesetContent::load */
         static std::unique_ptr<TileContentLoadResult> load(

--- a/Cesium3DTiles/include/Cesium3DTiles/GltfWriter.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/GltfWriter.h
@@ -11,7 +11,7 @@ namespace Cesium3DTiles {
 	 * @brief Provides write access to a {@link GltfAccessor}.
 	 */
 	template <class T>
-	class GltfWriter {
+	class GltfWriter final {
 	private:
 		GltfAccessor<T> _accessor;
 

--- a/Cesium3DTiles/include/Cesium3DTiles/IonRasterOverlay.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/IonRasterOverlay.h
@@ -11,7 +11,7 @@ namespace Cesium3DTiles {
     /**
      * @brief A {@link RasterOverlay} that obtains imagery data from Cesium ion.
      */
-    class CESIUM3DTILES_API IonRasterOverlay : public RasterOverlay {
+    class CESIUM3DTILES_API IonRasterOverlay final : public RasterOverlay {
     public:
 
         /**

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterMappedTo3DTile.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterMappedTo3DTile.h
@@ -16,7 +16,7 @@ namespace Cesium3DTiles {
      * imagery data that is given as {@link RasterOverlayTile} instances 
      * to the 2D region that is covered by the tile geometry. 
      */
-    class RasterMappedTo3DTile {
+    class RasterMappedTo3DTile final {
     public:
 
         /**

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayCollection.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayCollection.h
@@ -21,7 +21,7 @@ namespace Cesium3DTiles {
      * instances will be passed to the {@link RasterOverlayTile} instances that
      * they create when the tiles are updated.
      */
-    class CESIUM3DTILES_API RasterOverlayCollection {
+    class CESIUM3DTILES_API RasterOverlayCollection final {
     public:
 
         /** 

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayCutoutCollection.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayCutoutCollection.h
@@ -12,7 +12,7 @@ namespace Cesium3DTiles {
     /**
      * @brief A collection of rectangular areas cut out (not shown) from a {@link Tileset} with a {@link RasterOverlay}.
      */
-    class CESIUM3DTILES_API RasterOverlayCutoutCollection {
+    class CESIUM3DTILES_API RasterOverlayCutoutCollection final {
     public:
         RasterOverlayCutoutCollection() noexcept;
 

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTile.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTile.h
@@ -22,7 +22,7 @@ namespace Cesium3DTiles {
      * raster overlay tile with texture coordinates, to map the
      * image on the geometry of a {@link Tile}.
      */
-    class RasterOverlayTile {
+    class RasterOverlayTile final {
     public:
 
         /**

--- a/Cesium3DTiles/include/Cesium3DTiles/Tile.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/Tile.h
@@ -48,7 +48,7 @@ namespace Cesium3DTiles {
      * by the {@link Tile::getContentBoundingVolume} function.
      * 
      */
-    class CESIUM3DTILES_API Tile {
+    class CESIUM3DTILES_API Tile final {
     public:
         /**
          * The current state of this tile in the loading process.

--- a/Cesium3DTiles/include/Cesium3DTiles/TileContentFactory.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileContentFactory.h
@@ -28,7 +28,7 @@ namespace Cesium3DTiles {
      * header. Based on this header or the content type of the network response, 
      * the function that will be used for processing that raw data can be looked up.
      */
-    class CESIUM3DTILES_API TileContentFactory {
+    class CESIUM3DTILES_API TileContentFactory final {
     public:
         TileContentFactory() = delete;
 

--- a/Cesium3DTiles/include/Cesium3DTiles/TileContext.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileContext.h
@@ -18,7 +18,7 @@ namespace Cesium3DTiles {
      * specification. The URLs for the individual tiles are computed from the base URL of
      * the tileset. 
      */
-    class ImplicitTilingContext {
+    class ImplicitTilingContext final {
     public:
 
         /**
@@ -99,7 +99,7 @@ namespace Cesium3DTiles {
      * Tilesets that contain terrain tiles may additionally create
      * an {@link ImplicitTilingContext}.
      */
-    class TileContext {
+    class TileContext final {
     public:
 
         /**

--- a/Cesium3DTiles/include/Cesium3DTiles/TileMapServiceRasterOverlay.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileMapServiceRasterOverlay.h
@@ -89,7 +89,7 @@ namespace Cesium3DTiles {
     /**
      * @brief A {@link RasterOverlay} based on tile map service imagery.
      */
-    class CESIUM3DTILES_API TileMapServiceRasterOverlay : public RasterOverlay {
+    class CESIUM3DTILES_API TileMapServiceRasterOverlay final : public RasterOverlay {
     public:
 
         /**

--- a/Cesium3DTiles/include/Cesium3DTiles/TileSelectionState.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileSelectionState.h
@@ -14,7 +14,7 @@ namespace Cesium3DTiles {
      * process. The {@link Tileset} updates this state while traversing the tile hierarchy,
      * tracking whether a tile was rendered, culled, or refined in the last frame.
      */
-    class TileSelectionState {
+    class TileSelectionState final {
     public:
 
         /**

--- a/Cesium3DTiles/include/Cesium3DTiles/Tileset.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/Tileset.h
@@ -142,7 +142,7 @@ namespace Cesium3DTiles {
      * @brief A <a href="https://github.com/CesiumGS/3d-tiles/tree/master/specification">3D Tiles tileset</a>,
      * used for streaming massive heterogeneous 3D geospatial datasets.
      */
-    class CESIUM3DTILES_API Tileset {
+    class CESIUM3DTILES_API Tileset final {
     public:
         /**
          * @brief Constructs a new instance with a given `tileset.json` URL.

--- a/Cesium3DTiles/include/Cesium3DTiles/TilesetExternals.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TilesetExternals.h
@@ -16,7 +16,7 @@ namespace Cesium3DTiles {
      * 
      * Not supposed to be used by clients.
      */
-    class CESIUM3DTILES_API TilesetExternals {
+    class CESIUM3DTILES_API TilesetExternals final {
     public:
 
         /**

--- a/Cesium3DTiles/include/Cesium3DTiles/ViewUpdateResult.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/ViewUpdateResult.h
@@ -16,7 +16,7 @@ namespace Cesium3DTiles {
      * process, and use this structure to provide information about the state
      * changes of tiles to clients.
      */
-    class CESIUM3DTILES_API ViewUpdateResult {
+    class CESIUM3DTILES_API ViewUpdateResult final {
     public:
 
         /**

--- a/Cesium3DTiles/src/Batched3DModelContent.h
+++ b/Cesium3DTiles/src/Batched3DModelContent.h
@@ -15,7 +15,7 @@ namespace Cesium3DTiles {
     /**
      * @brief Creates a {@link TileContentLoadResult} from B3DM data.
      */
-    class CESIUM3DTILES_API Batched3DModelContent {
+    class CESIUM3DTILES_API Batched3DModelContent final {
     public:
         /** @copydoc ExternalTilesetContent::load */
         static std::unique_ptr<TileContentLoadResult> load(

--- a/Cesium3DTiles/src/BingMapsRasterOverlay.cpp
+++ b/Cesium3DTiles/src/BingMapsRasterOverlay.cpp
@@ -27,7 +27,7 @@ namespace Cesium3DTiles {
     const std::string BingMapsStyle::ORDNANCE_SURVEY = "OrdnanceSurvey";
     const std::string BingMapsStyle::COLLINS_BART = "CollinsBart";
 
-    class BingMapsTileProvider : public RasterOverlayTileProvider {
+    class BingMapsTileProvider final : public RasterOverlayTileProvider {
     public:
         BingMapsTileProvider(
             RasterOverlay& owner,

--- a/Cesium3DTiles/src/QuantizedMeshContent.h
+++ b/Cesium3DTiles/src/QuantizedMeshContent.h
@@ -9,7 +9,7 @@ namespace Cesium3DTiles {
     /**
      * @brief Creates a {@link TileContentLoadResult} from `quantized-mesh-1.0` data.
      */
-    class CESIUM3DTILES_API QuantizedMeshContent {
+    class CESIUM3DTILES_API QuantizedMeshContent final {
     public:
         static std::string CONTENT_TYPE;
 

--- a/Cesium3DTiles/src/TileMapServiceRasterOverlay.cpp
+++ b/Cesium3DTiles/src/TileMapServiceRasterOverlay.cpp
@@ -14,7 +14,7 @@ using namespace CesiumAsync;
 
 namespace Cesium3DTiles {
 
-    class TileMapServiceTileProvider : public RasterOverlayTileProvider {
+    class TileMapServiceTileProvider final : public RasterOverlayTileProvider {
     public:
         TileMapServiceTileProvider(
             RasterOverlay& owner,

--- a/Cesium3DTiles/src/TilesetJson.h
+++ b/Cesium3DTiles/src/TilesetJson.h
@@ -6,7 +6,7 @@
 
 namespace Cesium3DTiles {
 
-    class TilesetJson {
+    class TilesetJson final {
     public:
         static std::optional<BoundingVolume> getBoundingVolumeProperty(const nlohmann::json& tileJson, const std::string& key);
         static std::optional<double> getScalarProperty(const nlohmann::json& tileJson, const std::string& key);

--- a/Cesium3DTiles/src/Uri.h
+++ b/Cesium3DTiles/src/Uri.h
@@ -3,7 +3,7 @@
 #include <string>
 #include <functional>
 
-class Uri
+class Uri final
 {
 public:
 	static std::string resolve(const std::string& base, const std::string& relative, bool useBaseQuery = false);

--- a/CesiumAsync/include/CesiumAsync/AsyncSystem.h
+++ b/CesiumAsync/include/CesiumAsync/AsyncSystem.h
@@ -109,7 +109,7 @@ namespace CesiumAsync {
      * @tparam T The type of the value.
      */
     template <class T>
-    class Future {
+    class Future final {
     public:
         Future(Future<T>&& rhs) noexcept :
             _pSchedulers(std::move(rhs._pSchedulers)),
@@ -219,7 +219,7 @@ namespace CesiumAsync {
      * 
      * Instances of this class may be safely and efficiently stored and passed around by value.
      */
-    class CESIUMASYNC_API AsyncSystem {
+    class CESIUMASYNC_API AsyncSystem final {
     public:
         /**
          * @brief Constructs a new instance.

--- a/CesiumGeometry/include/CesiumGeometry/BoundingSphere.h
+++ b/CesiumGeometry/include/CesiumGeometry/BoundingSphere.h
@@ -11,7 +11,7 @@ namespace CesiumGeometry {
     /**
      * @brief A bounding sphere with a center and a radius.
      */
-    class CESIUMGEOMETRY_API BoundingSphere {
+    class CESIUMGEOMETRY_API BoundingSphere final {
     public:
         /**
          * @brief Construct a new instance.

--- a/CesiumGeometry/include/CesiumGeometry/IntersectionTests.h
+++ b/CesiumGeometry/include/CesiumGeometry/IntersectionTests.h
@@ -11,7 +11,7 @@ namespace CesiumGeometry {
     /**
      * @brief Functions for computing the intersection between geometries such as rays, planes, triangles, and ellipsoids.
      */
-    class CESIUMGEOMETRY_API IntersectionTests {
+    class CESIUMGEOMETRY_API IntersectionTests final {
     public:
         /**
          * @brief Computes the intersection of a ray and a plane.

--- a/CesiumGeometry/include/CesiumGeometry/OrientedBoundingBox.h
+++ b/CesiumGeometry/include/CesiumGeometry/OrientedBoundingBox.h
@@ -15,7 +15,7 @@ namespace CesiumGeometry {
      * @see BoundingSphere
      * @see BoundingRegion
      */
-    class CESIUMGEOMETRY_API OrientedBoundingBox {
+    class CESIUMGEOMETRY_API OrientedBoundingBox final {
     public:
         /**
          * @brief Constructs a new instance.

--- a/CesiumGeometry/include/CesiumGeometry/Plane.h
+++ b/CesiumGeometry/include/CesiumGeometry/Plane.h
@@ -8,7 +8,7 @@ namespace CesiumGeometry {
     /**
      * @brief A plane in Hessian Normal Format.
      */
-    class CESIUMGEOMETRY_API Plane {
+    class CESIUMGEOMETRY_API Plane final {
     public:
         /**
          * @brief Constructs a new plane from a normal and a distance from the origin.

--- a/CesiumGeometry/include/CesiumGeometry/QuadtreeTileAvailability.h
+++ b/CesiumGeometry/include/CesiumGeometry/QuadtreeTileAvailability.h
@@ -13,7 +13,7 @@ namespace CesiumGeometry {
     /**
      * @brief Manages information about the availability of tiles in a quadtree.
      */
-    class CESIUMGEOMETRY_API QuadtreeTileAvailability {
+    class CESIUMGEOMETRY_API QuadtreeTileAvailability final {
     public:
 
         /**

--- a/CesiumGeometry/include/CesiumGeometry/QuadtreeTileID.h
+++ b/CesiumGeometry/include/CesiumGeometry/QuadtreeTileID.h
@@ -40,7 +40,7 @@ namespace CesiumGeometry {
      * the x- and y-coordinate of the tile, referring to a grid coordinate system at
      * the respective level.
      */
-    struct CESIUMGEOMETRY_API QuadtreeTileID {
+    struct CESIUMGEOMETRY_API QuadtreeTileID final {
 
         /**
          * @brief Creates a new instance.

--- a/CesiumGeometry/include/CesiumGeometry/QuadtreeTilingScheme.h
+++ b/CesiumGeometry/include/CesiumGeometry/QuadtreeTilingScheme.h
@@ -11,7 +11,7 @@ namespace CesiumGeometry {
     /**
      * @brief Defines how a rectangular region is divided into quadtree tiles.
      */
-    class CESIUMGEOMETRY_API QuadtreeTilingScheme {
+    class CESIUMGEOMETRY_API QuadtreeTilingScheme final {
     public:
         /**
          * @brief Constructs a new instance.

--- a/CesiumGeometry/include/CesiumGeometry/Ray.h
+++ b/CesiumGeometry/include/CesiumGeometry/Ray.h
@@ -8,7 +8,7 @@ namespace CesiumGeometry {
     /**
      * @brief A ray that extends infinitely from the provided origin in the provided direction.
      */
-    class CESIUMGEOMETRY_API Ray {
+    class CESIUMGEOMETRY_API Ray final {
     public:
         /**
          * @brief Construct a new ray.

--- a/CesiumGeometry/include/CesiumGeometry/Rectangle.h
+++ b/CesiumGeometry/include/CesiumGeometry/Rectangle.h
@@ -9,7 +9,7 @@ namespace CesiumGeometry {
     /**
      * @brief A 2D rectangle
      */
-    struct CESIUMGEOMETRY_API Rectangle {
+    struct CESIUMGEOMETRY_API Rectangle final {
         /**
          * @brief Creates a new instance.
          *

--- a/CesiumGeospatial/include/CesiumGeospatial/BoundingRegion.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/BoundingRegion.h
@@ -16,7 +16,7 @@ namespace CesiumGeospatial {
     /**
      * @brief A bounding volume specified as a longitude/latitude bounding box and a minimum and maximum height.
      */
-    class CESIUMGEOSPATIAL_API BoundingRegion {
+    class CESIUMGEOSPATIAL_API BoundingRegion final {
     public:
         /**
          * @brief Constructs a new bounding region.

--- a/CesiumGeospatial/include/CesiumGeospatial/BoundingRegionWithLooseFittingHeights.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/BoundingRegionWithLooseFittingHeights.h
@@ -13,7 +13,7 @@ namespace CesiumGeospatial {
      * has a {@link BoundingRegionWithLooseFittingHeights::computeConservativeDistanceSquaredToPosition} method to compute
      * the conservative distance metric.
      */
-    class CESIUMGEOSPATIAL_API BoundingRegionWithLooseFittingHeights {
+    class CESIUMGEOSPATIAL_API BoundingRegionWithLooseFittingHeights final {
     public:
         /**
          * @brief Constructs a new bounding region.

--- a/CesiumGeospatial/include/CesiumGeospatial/Cartographic.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/Cartographic.h
@@ -8,7 +8,7 @@ namespace CesiumGeospatial {
     /**
      * @brief A position defined by longitude, latitude, and height.
      */
-    class CESIUMGEOSPATIAL_API Cartographic {
+    class CESIUMGEOSPATIAL_API Cartographic final {
     public:
 
         /**

--- a/CesiumGeospatial/include/CesiumGeospatial/Ellipsoid.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/Ellipsoid.h
@@ -16,7 +16,7 @@ namespace CesiumGeospatial {
      * Rather than constructing this object directly, one of the provided constants 
      * is normally used.
      */
-    class CESIUMGEOSPATIAL_API Ellipsoid {
+    class CESIUMGEOSPATIAL_API Ellipsoid final {
     public:
         /**
          * @brief An Ellipsoid instance initialized to the WGS84 standard.

--- a/CesiumGeospatial/include/CesiumGeospatial/EllipsoidTangentPlane.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/EllipsoidTangentPlane.h
@@ -15,7 +15,7 @@ namespace CesiumGeospatial {
      * If the origin is not on the surface of the ellipsoid, its surface projection 
      * will be used. 
      */
-    class CESIUMGEOSPATIAL_API EllipsoidTangentPlane {
+    class CESIUMGEOSPATIAL_API EllipsoidTangentPlane final {
     public:
 
         /**

--- a/CesiumGeospatial/include/CesiumGeospatial/GeographicProjection.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/GeographicProjection.h
@@ -20,7 +20,7 @@ namespace CesiumGeospatial {
      * 
      * @see WebMercatorProjection
      */
-    class CESIUMGEOSPATIAL_API GeographicProjection {
+    class CESIUMGEOSPATIAL_API GeographicProjection final {
     public:
         /**
          * @brief The maximum bounding rectangle of the geographic projection,

--- a/CesiumGeospatial/include/CesiumGeospatial/GlobeRectangle.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/GlobeRectangle.h
@@ -15,7 +15,7 @@ namespace CesiumGeospatial {
      * 
      * @see CesiumGeometry::Rectangle
      */
-    class CESIUMGEOSPATIAL_API GlobeRectangle {
+    class CESIUMGEOSPATIAL_API GlobeRectangle final {
     public:
         /**
          * @brief Constructs a new instance.

--- a/CesiumGeospatial/include/CesiumGeospatial/Transforms.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/Transforms.h
@@ -10,7 +10,7 @@ namespace CesiumGeospatial {
     /**
      * @brief Transforms positions to various reference frames.
      */
-    class CESIUMGEOSPATIAL_API Transforms {
+    class CESIUMGEOSPATIAL_API Transforms final {
     public:
 
         /**

--- a/CesiumGeospatial/include/CesiumGeospatial/WebMercatorProjection.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/WebMercatorProjection.h
@@ -18,7 +18,7 @@ namespace CesiumGeospatial {
      *
      * @see GeographicProjection
      */
-    class CESIUMGEOSPATIAL_API WebMercatorProjection {
+    class CESIUMGEOSPATIAL_API WebMercatorProjection final {
     public:
         /**
          * @brief The maximum latitude (both North and South) supported by a Web Mercator

--- a/CesiumUtility/include/CesiumUtility/DoublyLinkedList.h
+++ b/CesiumUtility/include/CesiumUtility/DoublyLinkedList.h
@@ -6,7 +6,7 @@ namespace CesiumUtility {
      * @brief Contains the previous and next pointers for an element in a {@link DoublyLinkedList}.
      */
     template <class T>
-    class DoublyLinkedListPointers {
+    class DoublyLinkedListPointers final {
     public:
 
         /** 
@@ -54,7 +54,7 @@ namespace CesiumUtility {
      * @tparam (T::*Pointers) A member pointer to the field that holds the links to the previous and next nodes.
      */
     template <class T, DoublyLinkedListPointers<T> (T::*Pointers)>
-    class DoublyLinkedList {
+    class DoublyLinkedList final {
     public:
 
         /**

--- a/CesiumUtility/include/CesiumUtility/IntrusivePointer.h
+++ b/CesiumUtility/include/CesiumUtility/IntrusivePointer.h
@@ -8,7 +8,7 @@ namespace CesiumUtility {
      * @tparam T The type of object controlled.
      */
     template <class T>
-    class IntrusivePointer {
+    class IntrusivePointer final {
     public:
         IntrusivePointer(T* p = nullptr) noexcept :
             _p(p)

--- a/CesiumUtility/include/CesiumUtility/Math.h
+++ b/CesiumUtility/include/CesiumUtility/Math.h
@@ -8,7 +8,7 @@ namespace CesiumUtility {
     /**
      * @brief Mathematical constants and functions
      */
-    class CESIUMUTILITY_API Math {
+    class CESIUMUTILITY_API Math final {
     public:
 
         /** @brief 0.1 */


### PR DESCRIPTION
Fixes #65 

All classes marked final except for `RasterOverlay`, `RasterOverlayTileProvider`, `ITaskProcessor`, `IPrepareRendererResources`, and the `IAsset*` interfaces.