### PR TITLE
Fix typo: _CESIUM_OVERLAY -> _CESIUMOVERLAY

### DIFF
--- a/Cesium3DTiles/src/upsampleGltfForRasterOverlays.cpp
+++ b/Cesium3DTiles/src/upsampleGltfForRasterOverlays.cpp
@@ -236,7 +236,7 @@ namespace Cesium3DTiles {
                 continue;
             }
 
-            if (attribute.first.find("_CESIUM_OVERLAY_") == 0) {
+            if (attribute.first.find("_CESIUMOVERLAY_") == 0) {
                 // Do not include _CESIUMOVERLAY_*, it will be generated later.
                 toRemove.push_back(attribute.first);
                 continue;


### PR DESCRIPTION
I noticed this typo while reviewing #97. If we ever had more than one set of raster overlay texture coordinates, they'd be incorrectly copied to the upsampled children.