### PR TITLE
Add very basic support for composite (CMPT) tiles

### DIFF
--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlay.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlay.h
@@ -32,7 +32,8 @@ namespace Cesium3DTiles {
         /**
          * @brief Gets the tile provider for this overlay.
          * 
-         * @return `nullptr` if {@link createTileProvider} has not yet been called.
+         * @return `nullptr` if {@link createTileProvider} has not yet been called or caused
+         * an error.
          * If {@link createTileProvider} has been called but the overlay is not yet ready to
          * provide tiles, a placeholder tile provider will be returned.
          */
@@ -44,7 +45,7 @@ namespace Cesium3DTiles {
         /**
          * @brief Gets the placeholder tile provider for this overlay.
          * 
-         * @return `nullptr` if {@link createTileProvider} has not yet been called.
+         * @return `nullptr` if {@link createTileProvider} has not yet been called or caused an error
          */
         RasterOverlayTileProvider* getPlaceholder() noexcept { return this->_pPlaceholder.get(); }
 
@@ -63,13 +64,6 @@ namespace Cesium3DTiles {
          * @brief Returns whether this overlay is in the process of being destroyed.
          */
         bool isBeingDestroyed() const noexcept { return this->_pSelf != nullptr; }
-
-        /**
-         * @brief A callback that receives the tile provider when it asynchronously becomes ready.
-         * 
-         * @param pTileProvider The newly-created tile provider.
-         */
-        typedef void CreateTileProviderCallback(std::unique_ptr<RasterOverlayTileProvider>&& pTileProvider);
 
         /**
          * @brief Begins asynchronous creation of the tile provider for this overlay and eventually makes it available directly from this instance.
@@ -100,7 +94,8 @@ namespace Cesium3DTiles {
          * @param pCreditSystem The {@link CreditSystem} to use when creating a per-TileProvider {@link Credit}.
          * @param pPrepareRendererResources The interface used to prepare raster images for rendering.
          * @param pOwner The overlay that owns this overlay, or nullptr if this overlay is not aggregated.
-         * @param callback The callback that receives the new tile provider when it is ready.
+         * @return The future that contains the tile provider when it is ready, or the `nullptr` in case
+         * of an error.
          */
         virtual CesiumAsync::Future<std::unique_ptr<RasterOverlayTileProvider>> createTileProvider(
             const CesiumAsync::AsyncSystem& asyncSystem,

--- a/Cesium3DTiles/src/Batched3DModelContent.cpp
+++ b/Cesium3DTiles/src/Batched3DModelContent.cpp
@@ -118,11 +118,10 @@ namespace Cesium3DTiles {
 			header.featureTableJsonByteLength = 0;
 			header.featureTableBinaryByteLength = 0;
 
-			// TODO
-			//Batched3DModel3DTileContent._deprecationWarning(
-			//	"b3dm-legacy-header",
-			//	"This b3dm header is using the legacy format [batchLength] [batchTableByteLength]. The new format is [featureTableJsonByteLength] [featureTableBinaryByteLength] [batchTableJsonByteLength] [batchTableBinaryByteLength] from https://github.com/CesiumGS/3d-tiles/tree/master/specification/TileFormats/Batched3DModel."
-			//);
+			SPDLOG_LOGGER_WARN(pLogger, 
+				"This b3dm header is using the legacy format[batchLength][batchTableByteLength]. "
+				"The new format is[featureTableJsonByteLength][featureTableBinaryByteLength][batchTableJsonByteLength][batchTableBinaryByteLength] "
+				"from https://github.com/CesiumGS/3d-tiles/tree/master/specification/TileFormats/Batched3DModel.");
 		}
 		else if (pHeader->batchTableBinaryByteLength >= 570425344) {
 			// Second legacy check
@@ -134,11 +133,11 @@ namespace Cesium3DTiles {
 			header.featureTableJsonByteLength = 0;
 			header.featureTableBinaryByteLength = 0;
 
-			// TODO
-			//Batched3DModel3DTileContent._deprecationWarning(
-			//	"b3dm-legacy-header",
-			//	"This b3dm header is using the legacy format [batchTableJsonByteLength] [batchTableBinaryByteLength] [batchLength]. The new format is [featureTableJsonByteLength] [featureTableBinaryByteLength] [batchTableJsonByteLength] [batchTableBinaryByteLength] from https://github.com/CesiumGS/3d-tiles/tree/master/specification/TileFormats/Batched3DModel."
-			//);
+			SPDLOG_LOGGER_WARN(pLogger, 
+				"This b3dm header is using the legacy format [batchTableJsonByteLength] [batchTableBinaryByteLength] [batchLength]. "
+				"The new format is [featureTableJsonByteLength] [featureTableBinaryByteLength] [batchTableJsonByteLength] [batchTableBinaryByteLength] "
+				"from https://github.com/CesiumGS/3d-tiles/tree/master/specification/TileFormats/Batched3DModel."
+			);
 		}
 
 		if (static_cast<uint32_t>(data.size()) < pHeader->byteLength) {

--- a/Cesium3DTiles/src/IonRasterOverlay.cpp
+++ b/Cesium3DTiles/src/IonRasterOverlay.cpp
@@ -56,7 +56,6 @@ namespace Cesium3DTiles {
 
             std::string type = JsonHelpers::getStringOrDefault(response, "type", "unknown");
             if (type != "IMAGERY") {
-                // TODO: report invalid imagery type.
                 SPDLOG_LOGGER_ERROR(pLogger, "Ion raster overlay metadata response type is not 'IMAGERY', but {}", type);
                 return nullptr;
             }
@@ -65,7 +64,6 @@ namespace Cesium3DTiles {
             if (externalType == "BING") {
                 auto optionsIt = response.FindMember("options");
                 if (optionsIt == response.MemberEnd() || !optionsIt->value.IsObject()) {
-                    // TODO: report incomplete Bing options
                     SPDLOG_LOGGER_ERROR(pLogger, "Cesium ion Bing Maps raster overlay metadata response does not contain 'options' or it is not an object.");
                     return nullptr;
                 }
@@ -98,7 +96,12 @@ namespace Cesium3DTiles {
             pPrepareRendererResources,
             pLogger
         ](std::unique_ptr<RasterOverlay> pAggregatedOverlay) {
-            return pAggregatedOverlay->createTileProvider(asyncSystem, pCreditSystem, pPrepareRendererResources, pLogger, pOwner);
+            // Handle the case that the code above bails out with an error, returning a nullptr.
+            if (pAggregatedOverlay) {
+                return pAggregatedOverlay->createTileProvider(asyncSystem, pCreditSystem, pPrepareRendererResources, pLogger, pOwner);
+            }
+            return asyncSystem.createResolvedFuture<std::unique_ptr<RasterOverlayTileProvider>>(nullptr);
+
         });
     }
 

--- a/Cesium3DTiles/src/RasterOverlay.cpp
+++ b/Cesium3DTiles/src/RasterOverlay.cpp
@@ -1,5 +1,6 @@
 #include "Cesium3DTiles/RasterOverlay.h"
 #include "Cesium3DTiles/RasterOverlayCollection.h"
+#include "Cesium3DTiles/spdlog-cesium.h"
 
 using namespace CesiumAsync;
 
@@ -51,7 +52,8 @@ namespace Cesium3DTiles {
         ).thenInMainThread([this](std::unique_ptr<RasterOverlayTileProvider> pProvider) {
             this->_pTileProvider = std::move(pProvider);
             this->_isLoadingTileProvider = false;
-        }).catchInMainThread([this](const std::exception& /*e*/) {
+        }).catchInMainThread([this, pLogger](const std::exception& e) {
+            SPDLOG_LOGGER_ERROR(pLogger, "Exception while creating tile provider: {0}", e.what());
             this->_pTileProvider.reset();
             this->_isLoadingTileProvider = false;
         });

--- a/Cesium3DTiles/src/Tileset.cpp
+++ b/Cesium3DTiles/src/Tileset.cpp
@@ -130,14 +130,12 @@ namespace Cesium3DTiles {
     void Tileset::_handleAssetResponse(std::unique_ptr<IAssetRequest>&& pRequest) {
         IAssetResponse* pResponse = pRequest->response();
         if (!pResponse) {
-            // TODO: report the lack of response. Network error? Can this even happen?
             SPDLOG_LOGGER_ERROR(this->_externals.pLogger, "No response received for asset request {}", pRequest->url());
             this->notifyTileDoneLoading(nullptr);
             return;
         }
 
         if (pResponse->statusCode() < 200 || pResponse->statusCode() >= 300) {
-            // TODO: report error response.
             SPDLOG_LOGGER_ERROR(this->_externals.pLogger, "Received status code {} for asset response {}", pResponse->statusCode(), pRequest->url());
             this->notifyTileDoneLoading(nullptr);
             return;
@@ -162,7 +160,6 @@ namespace Cesium3DTiles {
             url = Uri::resolve(url, "layer.json", true);
         }
         else if (type != "3DTILES") {
-            // TODO: report unsupported type.
             SPDLOG_LOGGER_ERROR(this->_externals.pLogger, "Received unsupported asset response type: {}", type);
             this->notifyTileDoneLoading(nullptr);
             return;
@@ -391,13 +388,11 @@ namespace Cesium3DTiles {
     /*static*/ Tileset::LoadResult Tileset::_handleTilesetResponse(std::unique_ptr<IAssetRequest>&& pRequest, std::unique_ptr<TileContext>&& pContext, const std::shared_ptr<spdlog::logger>& pLogger) {
         IAssetResponse* pResponse = pRequest->response();
         if (!pResponse) {
-            // TODO: report the lack of response. Network error? Can this even happen?
             SPDLOG_LOGGER_ERROR(pLogger, "Did not receive a valid response for tileset {}", pRequest->url());
             return LoadResult{ std::move(pContext), nullptr };
         }
 
         if (pResponse->statusCode() < 200 || pResponse->statusCode() >= 300) {
-            // TODO: report error response.
             SPDLOG_LOGGER_ERROR(pLogger, "Received status code {} for tileset {}", pResponse->statusCode(), pRequest->url());
             return LoadResult{ std::move(pContext), nullptr };
         }
@@ -466,14 +461,12 @@ namespace Cesium3DTiles {
 
         std::optional<BoundingVolume> boundingVolume = JsonHelpers::getBoundingVolumeProperty(tileJson, "boundingVolume");
         if (!boundingVolume) {
-            // TODO: report missing required property
             SPDLOG_LOGGER_ERROR(pLogger, "Tileset did not contain a boundingVolume");
             return;
         }
 
         std::optional<double> geometricError = JsonHelpers::getScalarProperty(tileJson, "geometricError");
         if (!geometricError) {
-            // TODO: report missing required property
             SPDLOG_LOGGER_ERROR(pLogger, "Tileset did not contain a geometricError");
             return;
         }
@@ -495,7 +488,6 @@ namespace Cesium3DTiles {
             } else if (refine == "ADD") {
                 tile.setRefine(TileRefine::Add);
             } else {
-                // TODO: report invalid value
                 SPDLOG_LOGGER_ERROR(pLogger, "Tileset contained an unknown refine value: {}", refine);
             }
         } else {
@@ -595,8 +587,6 @@ namespace Cesium3DTiles {
             quadtreeRectangleProjected = webMercator.project(quadtreeRectangleGlobe);
             quadtreeXTiles = 1;
         } else {
-            // Unsupported projection
-            // TODO: report error
             SPDLOG_LOGGER_ERROR(pLogger, "Tileset contained an unknown projection value: {}", projectionString);
             return;
         }

--- a/CesiumAsync/include/CesiumAsync/AsyncSystem.h
+++ b/CesiumAsync/include/CesiumAsync/AsyncSystem.h
@@ -291,7 +291,7 @@ namespace CesiumAsync {
         }
 
         template <class T>
-        Future<T> createResolvedFuture(T&& value) {
+        Future<T> createResolvedFuture(T&& value) const {
             return Future<T>(this->_pSchedulers, async::make_task<T>(std::forward<T>(value)));
         }
 


### PR DESCRIPTION
Builds on #102, merge that first.

We only support one of the inner tile types (b3dm), but with this PR we can at least load b3dm embedded inside cmpt.

The main limitation is that we can currently only load _one_ b3dm inside a cmpt. It seems our FBX tiler (possibly among others) creates cmpts with multiple embedded b3dms, so I'll write a separate issue for that. I didn't want to do it here against the tinygltf baseline.