### PR TITLE
Parse and collect Ion tileset credits

### DIFF
--- a/Cesium3DTiles/include/Cesium3DTiles/Tileset.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/Tileset.h
@@ -491,8 +491,8 @@ namespace Cesium3DTiles {
 
         // per-tileset credit passed in explicitly by the user through `TilesetOptions`
         std::optional<Credit> _userCredit;
-        //  credit provided with the tileset from Cesium Ion
-        std::optional<Credit> _tilesetCredit;
+        //  credits provided with the tileset from Cesium Ion
+        std::vector<Credit> _tilesetCredits;
 
         std::optional<std::string> _url;
         std::optional<uint32_t> _ionAssetID;


### PR DESCRIPTION
Parses the Ion response to collect the per-tileset html credits the user must show when displaying the asset. 

Thanks for catching this issue @kring! I had a misunderstanding about where per-tileset credits were originating from, but I think this fixes it. Can you review when you get the chance?

PS, it's becoming more apparent to me, now that I'm understanding Ion credits, that there should be a way to force certain credits to appear on screen as opposed to on an expandable panel. I'll start an issue for it, but let me know what priority it would have (my guess is post-release, since the only credit that would need to be forced to screen currently is Ion iirc, which we've hardcoded on screen for now). 