### PR TITLE
Added option to test reading the glTF sample models

### DIFF
--- a/CesiumGltfReader/test/GltfTestUtils.cpp
+++ b/CesiumGltfReader/test/GltfTestUtils.cpp
@@ -15,7 +15,7 @@ namespace CesiumGltfTest
 		file.seekg(0, std::ios::end);
 		std::ifstream::pos_type size = file.tellg();
 		file.seekg(0, std::ios::beg);
-		vec.resize(size);
+		vec.resize(size_t(size));
 		file.read(&vec[0], size);
 		return vec;
 	}

--- a/CesiumGltfReader/test/GltfTestUtils.cpp
+++ b/CesiumGltfReader/test/GltfTestUtils.cpp
@@ -1,0 +1,156 @@
+#include "GltfTestUtils.h"
+
+#include "CesiumGltf/Reader.h"
+#include <iostream>
+
+namespace CesiumGltfTest
+{
+	std::vector<std::byte> readFile(const std::string& filename)
+	{
+		std::vector<std::byte> vec;
+		std::basic_ifstream<std::byte> file(filename.c_str(), std::ios::binary);
+		if (!file) {
+			return vec;
+		}
+		file.seekg(0, std::ios::end);
+		std::ifstream::pos_type size = file.tellg();
+		file.seekg(0, std::ios::beg);
+		vec.resize(size);
+		file.read(&vec[0], size);
+		return vec;
+	}
+
+	DataReader createFileReader(const std::string& basePath)
+	{
+		DataReader dataReader = [&basePath](const std::string& relativePath) {
+			std::string fullPath = basePath + relativePath;
+			std::vector<std::byte> data = readFile(fullPath.c_str());
+			return data;
+		};
+		return dataReader;
+	}
+
+	std::vector<SampleModel> readSampleModels(const DataReader& dataReader)
+	{
+		std::vector<SampleModel> sampleModels;
+
+		std::vector<std::byte> indexFileData = dataReader("model-index.json");
+		rapidjson::Document document;
+		document.Parse(reinterpret_cast<const char*>(indexFileData.data()), indexFileData.size());
+		if (document.HasParseError()) {
+			std::cerr << "Could not read model-index.json" << std::endl;
+			return sampleModels;
+		}
+		if (!document.IsArray()) {
+			std::cerr << "Index file result is not an array" << std::endl;
+			return sampleModels;
+		}
+		for (rapidjson::SizeType i = 0; i < document.Size(); i++) {
+			const rapidjson::Value& entry = document[i];
+
+			std::optional sampleModel = processSampleModel(i, entry);
+			if (sampleModel.has_value()) {
+				sampleModels.push_back(sampleModel.value());
+			}
+		}
+		return sampleModels;
+	}
+
+	std::optional<SampleModel> processSampleModel(rapidjson::SizeType index, const rapidjson::Value& entry)
+	{
+		if (!entry.IsObject()) {
+			std::cerr << "Entry " << index << " is not an object" << std::endl;
+			return std::nullopt;
+		}
+
+		if (!entry.HasMember("name")) {
+			std::cerr << "Entry " << index << " has no name" << std::endl;
+			return std::nullopt;
+		}
+		const rapidjson::Value& nameValue = entry["name"];
+		if (!nameValue.IsString()) {
+			std::cerr << "Entry " << index << " does not have a name string" << std::endl;
+			return std::nullopt;
+		}
+		std::string name = entry["name"].GetString();
+
+		if (!entry.HasMember("variants")) {
+			std::cerr << "Entry " << index << " has no variants" << std::endl;
+			return std::nullopt;
+		}
+		const rapidjson::Value& variants = entry["variants"];
+		if (!variants.IsObject()) {
+			std::cerr << "Entry " << index << " has no valid variants" << std::endl;
+			return std::nullopt;
+		}
+
+		std::vector<SampleModelVariant> sampleModelVariants = processVariants(name, variants);
+		return std::optional<SampleModel>({ name, sampleModelVariants });
+	}
+
+	std::vector<SampleModelVariant> processVariants(const std::string& name, const rapidjson::Value& variants)
+	{
+		std::vector<SampleModelVariant> sampleModelVariants;
+		for (rapidjson::Value::ConstMemberIterator itr = variants.MemberBegin(); itr != variants.MemberEnd(); ++itr) {
+			std::string variantName = itr->name.GetString();
+			const rapidjson::Value& variantFileNameValue = itr->value;
+			if (!variantFileNameValue.IsString()) {
+				std::cerr << "Variant in " << name << " does not have a valid name" << std::endl;
+				continue;
+			}
+			std::string variantFileName = variantFileNameValue.GetString();
+			sampleModelVariants.push_back({ variantName, variantFileName });
+		}
+		return sampleModelVariants;
+	}
+
+
+	bool testReadModel(const DataReader& dataReader, const std::string& name, const std::string& variantName, const std::string& variantFileName)
+	{
+		std::string subPath = name + "/" + variantName + "/" + variantFileName;
+		std::vector<std::byte> data = dataReader(subPath);
+		try
+		{
+			const uint8_t *dataBegin = reinterpret_cast<const uint8_t*>(data.data());
+			CesiumGltf::ModelReaderResult result = CesiumGltf::readModel(gsl::span(dataBegin, data.size()));
+			bool success = result.model.has_value();
+			std::cout << "model " << name << " variant " << variantName << " " << (success ? "PASSED" : " !!! FAILED !!! ") << std::endl;
+			return success;
+		}
+		catch (...)
+		{
+			std::cout << "model " << name << " variant " << variantName << " caused an error and !!! FAILED !!! " << std::endl;
+			return false;
+		}
+	}
+
+	bool testReadSampleModels(const std::string& basePath)
+	{
+		bool allPassed = true;
+
+		std::vector<std::string> variantsToTest { "glTF", "glTF-Binary", "glTF-Embedded", "glTF-Draco" };
+
+		DataReader dataReader = createFileReader(basePath);
+		std::vector<SampleModel> sampleModels = readSampleModels(dataReader);
+		for(const auto& sampleModel : sampleModels) {
+
+			const std::string& name = sampleModel.name;
+			//std::cout << "Processing " << name << std::endl;
+
+			const auto& variants = sampleModel.sampleModelVariants;
+
+			for(const auto& variant : variants) {
+
+				const std::string& variantName = variant.variantName;
+				const std::string& variantFileName = variant.variantFileName;
+				if (std::find(variantsToTest.begin(), variantsToTest.end(), variantName) != variantsToTest.end()) {
+
+					//std::cout << "  Testing model " << name << " variant " << variantName << std::endl;
+					allPassed &= testReadModel(dataReader, name, variantName, variantFileName);
+				}
+			}
+		}
+		return allPassed;
+	}
+}
+

--- a/CesiumGltfReader/test/GltfTestUtils.h
+++ b/CesiumGltfReader/test/GltfTestUtils.h
@@ -1,0 +1,38 @@
+#pragma once
+ 
+#include <rapidjson/document.h>
+
+#include <vector>
+#include <fstream>
+#include <optional>
+#include <functional>
+
+namespace CesiumGltfTest
+{
+	struct SampleModelVariant
+	{
+		std::string variantName;
+		std::string variantFileName;
+	};
+
+	struct SampleModel
+	{
+		std::string name;
+		std::vector<SampleModelVariant> sampleModelVariants;
+	};
+
+	typedef std::function<std::vector<std::byte>(const std::string& relativePath)> DataReader;
+
+	std::vector<std::byte> readFile(const std::string& filename);
+
+	DataReader createFileReader(const std::string& basePath);
+
+	std::vector<SampleModel> readSampleModels(const DataReader& dataReader);
+	std::optional<SampleModel> processSampleModel(rapidjson::SizeType index, const rapidjson::Value& entry);
+	std::vector<SampleModelVariant> processVariants(const std::string& name, const rapidjson::Value& variants);
+
+	bool testReadModel(const DataReader& dataReader, const std::string& name, const std::string& variantName, const std::string& variantFileName);
+
+	bool testReadSampleModels(const std::string& basePath);
+}
+

--- a/CesiumGltfReader/test/TestReaderSampleModels.cpp
+++ b/CesiumGltfReader/test/TestReaderSampleModels.cpp
@@ -1,0 +1,11 @@
+#include "catch2/catch.hpp"
+
+#include "CesiumGltf/Reader.h"
+#include "GltfTestUtils.h"
+
+TEST_CASE("Read glTF Sample Models") {
+
+    std::string basePath = "../CesiumGltfReader/test/data/2.0/";
+    //basePath = "C:/Develop/KhronosGroup/glTF-Sample-Models/2.0/";
+    CHECK(CesiumGltfTest::testReadSampleModels(basePath));
+}


### PR DESCRIPTION
This PR is (probably) not supposed to be merged so soon. 

It contains some infrastructure for doing a batch-run and try to read the glTF sample models from the [glTF-Sample-Models repo](https://github.com/KhronosGroup/glTF-Sample-Models) using the `CesiumGltfReader`. 

It reads the `model-index.json` file from the sample models repo, which contains information about the available sample models and their variants (plain, embedded, binary, draco), and stores that info as some

	vector{ name, vector{ variantName, variantFileName } }

structure. These `SampleModel` objects can then be processed further. (E.g they could be filtered based on the variant or name - right now, the `variantsToTest` includes all variants)

The current process is that the test simply tries to load the models, and reports when there is any error while doing so.

This is wrapped into a test, as of https://github.com/CesiumGS/cesium-native/compare/gltf-sample-models-read-test#diff-326bf15b729481bb3ceb378fd5463b179c0d85b400a26512257be82e4566f980R6 , **but** this is not a sensible "unit test", of course: It takes quite a while to read all models, and the question of *where* the models should be read from remains open. 

(Right now, they are read from a local file, with the path essentially being hard-wired in the test case. The option to extend this to read the models from the repo exists, but would require adding some `libcurl` or so, and that would be *really* slow...)

This test originally was only intended as a basic litmus test/validation for the reader. Whether or not this (or parts of this) will become "real" tests can be decided later. 

