### PR TITLE
Prevent distance squared from going to negative

### DIFF
--- a/Cesium3DTiles/src/Tileset.cpp
+++ b/Cesium3DTiles/src/Tileset.cpp
@@ -879,7 +879,7 @@ namespace Cesium3DTiles {
             }
         }
 
-        double distance = sqrt(viewState.computeDistanceSquaredToBoundingVolume(boundingVolume));
+        double distance = sqrt(glm::max(viewState.computeDistanceSquaredToBoundingVolume(boundingVolume), 0.0));
 
         // if we are still considering visiting this tile, check for fog occlusion
         if (shouldVisit && !isVisibleInFog(distance, frameState.fogDensity)) {


### PR DESCRIPTION
Distance square to bounding sphere can go to negative if position is inside it. This can make the distance to become nan and enable fog culling. 