### PR TITLE
Fix off-by-one error and likely memory leak.

### DIFF
--- a/Cesium3DTiles/src/RasterOverlayCollection.cpp
+++ b/Cesium3DTiles/src/RasterOverlayCollection.cpp
@@ -11,7 +11,7 @@ namespace Cesium3DTiles {
 
     RasterOverlayCollection::~RasterOverlayCollection() {
         if (this->_overlays.size() > 0) {
-            for (int64_t i = static_cast<int64_t>(this->_overlays.size()); i >= 0; --i) {
+            for (int64_t i = static_cast<int64_t>(this->_overlays.size() - 1); i >= 0; --i) {
                 this->remove(this->_overlays[static_cast<size_t>(i)].get());
             }
         }

--- a/Cesium3DTiles/src/RasterOverlayTile.cpp
+++ b/Cesium3DTiles/src/RasterOverlayTile.cpp
@@ -160,7 +160,7 @@ namespace Cesium3DTiles {
                     return result;
                 }
             }).thenInMainThread([this](LoadResult&& result) {
-                result.pRendererResources = result.pRendererResources;
+                this->_pRendererResources = result.pRendererResources;
                 this->_image = std::move(result.image);
                 this->setState(result.state);
 


### PR DESCRIPTION
Fixes two problems identified by @javagl in #130.

One is an off-by-one error described in #133 that is likely causing memory corruption.
Fixes #133

The other is a failure to properly store the renderer resources for a raster overlay tile, likely causing a memory leak. This is already fixed in #119 but it's worthwhile to get it into master ahead of that the full disk cache implementation.