### PR TITLE
Added copyright and license information

### DIFF
--- a/Cesium3DTiles/include/Cesium3DTiles/BingMapsRasterOverlay.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/BingMapsRasterOverlay.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/Library.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/BoundingVolume.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/BoundingVolume.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include <variant>

--- a/Cesium3DTiles/include/Cesium3DTiles/CreditSystem.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/CreditSystem.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/Library.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/ExternalTilesetContent.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/ExternalTilesetContent.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/Library.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/Gltf.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/Gltf.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/Library.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/GltfContent.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/GltfContent.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/Gltf.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/IPrepareRendererResources.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/IPrepareRendererResources.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/Library.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/IonRasterOverlay.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/IonRasterOverlay.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/Library.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/Library.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/Library.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 /**

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterMappedTo3DTile.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterMappedTo3DTile.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/RasterOverlayTile.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlay.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlay.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/Library.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayCollection.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayCollection.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/Library.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayCutoutCollection.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayCutoutCollection.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/Library.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTile.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTile.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGltf/Model.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/CreditSystem.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/Tile.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/Tile.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/BoundingVolume.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/TileContentFactory.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileContentFactory.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/BoundingVolume.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/TileContentLoadInput.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileContentLoadInput.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/Library.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/TileContentLoadResult.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileContentLoadResult.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/Tile.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/TileContentLoader.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileContentLoader.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/TileContentLoadInput.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/TileContext.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileContext.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeometry/QuadtreeTileAvailability.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/TileID.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileID.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeometry/QuadtreeTileID.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/TileMapServiceRasterOverlay.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileMapServiceRasterOverlay.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/Library.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/TileRefine.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileRefine.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 namespace Cesium3DTiles {

--- a/Cesium3DTiles/include/Cesium3DTiles/TileSelectionState.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileSelectionState.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include <cstdint>

--- a/Cesium3DTiles/include/Cesium3DTiles/Tileset.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/Tileset.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/ViewState.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/TilesetExternals.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TilesetExternals.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/Library.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/ViewState.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/ViewState.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/BoundingVolume.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/ViewUpdateResult.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/ViewUpdateResult.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/Library.h"

--- a/Cesium3DTiles/include/Cesium3DTiles/registerAllTileContentTypes.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/registerAllTileContentTypes.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/Library.h"
 
 namespace Cesium3DTiles {

--- a/Cesium3DTiles/include/Cesium3DTiles/spdlog-cesium.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/spdlog-cesium.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #ifndef _MSC_VER

--- a/Cesium3DTiles/src/Batched3DModelContent.cpp
+++ b/Cesium3DTiles/src/Batched3DModelContent.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Batched3DModelContent.h"
 #include "Cesium3DTiles/GltfContent.h"
 #include "Cesium3DTiles/spdlog-cesium.h"

--- a/Cesium3DTiles/src/Batched3DModelContent.h
+++ b/Cesium3DTiles/src/Batched3DModelContent.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/BoundingVolume.h"

--- a/Cesium3DTiles/src/BingMapsRasterOverlay.cpp
+++ b/Cesium3DTiles/src/BingMapsRasterOverlay.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/BingMapsRasterOverlay.h"
 #include "Cesium3DTiles/RasterOverlayTile.h"
 #include "Cesium3DTiles/RasterOverlayTile.h"

--- a/Cesium3DTiles/src/BoundingVolume.cpp
+++ b/Cesium3DTiles/src/BoundingVolume.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/BoundingVolume.h"
 
 using namespace CesiumGeometry;

--- a/Cesium3DTiles/src/CompositeContent.cpp
+++ b/Cesium3DTiles/src/CompositeContent.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CompositeContent.h"
 #include "Cesium3DTiles/GltfContent.h"
 #include "Cesium3DTiles/spdlog-cesium.h"

--- a/Cesium3DTiles/src/CompositeContent.h
+++ b/Cesium3DTiles/src/CompositeContent.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/BoundingVolume.h"

--- a/Cesium3DTiles/src/CreditSystem.cpp
+++ b/Cesium3DTiles/src/CreditSystem.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/CreditSystem.h"
 #include <algorithm>
 

--- a/Cesium3DTiles/src/ExternalTilesetContent.cpp
+++ b/Cesium3DTiles/src/ExternalTilesetContent.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/ExternalTilesetContent.h"
 #include "Cesium3DTiles/spdlog-cesium.h"
 #include "Cesium3DTiles/Tile.h"

--- a/Cesium3DTiles/src/Gltf.cpp
+++ b/Cesium3DTiles/src/Gltf.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/Gltf.h"
 
 namespace Cesium3DTiles {

--- a/Cesium3DTiles/src/GltfContent.cpp
+++ b/Cesium3DTiles/src/GltfContent.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/GltfContent.h"
 #include "Cesium3DTiles/spdlog-cesium.h"
 #include "CesiumGltf/AccessorView.h"

--- a/Cesium3DTiles/src/IonRasterOverlay.cpp
+++ b/Cesium3DTiles/src/IonRasterOverlay.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/BingMapsRasterOverlay.h"
 #include "Cesium3DTiles/IonRasterOverlay.h"
 #include "Cesium3DTiles/RasterOverlayTile.h"

--- a/Cesium3DTiles/src/JsonHelpers.cpp
+++ b/Cesium3DTiles/src/JsonHelpers.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "JsonHelpers.h"
 #include <rapidjson/document.h>
 

--- a/Cesium3DTiles/src/JsonHelpers.h
+++ b/Cesium3DTiles/src/JsonHelpers.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include <optional>

--- a/Cesium3DTiles/src/QuantizedMeshContent.cpp
+++ b/Cesium3DTiles/src/QuantizedMeshContent.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/spdlog-cesium.h"
 #include "Cesium3DTiles/Tile.h"
 #include "Cesium3DTiles/Tileset.h"

--- a/Cesium3DTiles/src/QuantizedMeshContent.h
+++ b/Cesium3DTiles/src/QuantizedMeshContent.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/BoundingVolume.h"

--- a/Cesium3DTiles/src/RasterMappedTo3DTile.cpp
+++ b/Cesium3DTiles/src/RasterMappedTo3DTile.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/IPrepareRendererResources.h"
 #include "Cesium3DTiles/RasterMappedTo3DTile.h"
 #include "Cesium3DTiles/RasterOverlayCollection.h"

--- a/Cesium3DTiles/src/RasterOverlay.cpp
+++ b/Cesium3DTiles/src/RasterOverlay.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/RasterOverlay.h"
 #include "Cesium3DTiles/RasterOverlayCollection.h"
 #include "Cesium3DTiles/RasterOverlayTileProvider.h"

--- a/Cesium3DTiles/src/RasterOverlayCollection.cpp
+++ b/Cesium3DTiles/src/RasterOverlayCollection.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/RasterOverlayCollection.h"
 #include "Cesium3DTiles/Tileset.h"
 

--- a/Cesium3DTiles/src/RasterOverlayCutoutCollection.cpp
+++ b/Cesium3DTiles/src/RasterOverlayCutoutCollection.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/RasterOverlayCutoutCollection.h"
 
 namespace Cesium3DTiles {

--- a/Cesium3DTiles/src/RasterOverlayTile.cpp
+++ b/Cesium3DTiles/src/RasterOverlayTile.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/IPrepareRendererResources.h"
 #include "Cesium3DTiles/RasterOverlay.h"
 #include "Cesium3DTiles/RasterOverlayTile.h"

--- a/Cesium3DTiles/src/RasterOverlayTileProvider.cpp
+++ b/Cesium3DTiles/src/RasterOverlayTileProvider.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/IPrepareRendererResources.h"
 #include "Cesium3DTiles/RasterOverlay.h"
 #include "Cesium3DTiles/RasterOverlayTile.h"

--- a/Cesium3DTiles/src/SkirtMeshMetadata.cpp
+++ b/Cesium3DTiles/src/SkirtMeshMetadata.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "SkirtMeshMetadata.h"
 
 using namespace CesiumGltf;

--- a/Cesium3DTiles/src/SkirtMeshMetadata.h
+++ b/Cesium3DTiles/src/SkirtMeshMetadata.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGltf/JsonValue.h"
 #include <glm/vec3.hpp>
 #include <optional>

--- a/Cesium3DTiles/src/Tile.cpp
+++ b/Cesium3DTiles/src/Tile.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/GltfContent.h"
 #include "Cesium3DTiles/IPrepareRendererResources.h"
 #include "Cesium3DTiles/Tile.h"

--- a/Cesium3DTiles/src/TileContentFactory.cpp
+++ b/Cesium3DTiles/src/TileContentFactory.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/spdlog-cesium.h"
 #include "Cesium3DTiles/TileContentFactory.h"
 #include <algorithm>

--- a/Cesium3DTiles/src/TileMapServiceRasterOverlay.cpp
+++ b/Cesium3DTiles/src/TileMapServiceRasterOverlay.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/RasterOverlayTile.h"
 #include "Cesium3DTiles/RasterOverlayTileProvider.h"
 #include "Cesium3DTiles/spdlog-cesium.h"

--- a/Cesium3DTiles/src/TileUtilities.cpp
+++ b/Cesium3DTiles/src/TileUtilities.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "TileUtilities.h"
 
 #include <variant>

--- a/Cesium3DTiles/src/TileUtilities.h
+++ b/Cesium3DTiles/src/TileUtilities.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeospatial/GlobeRectangle.h"

--- a/Cesium3DTiles/src/Tileset.cpp
+++ b/Cesium3DTiles/src/Tileset.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/RasterMappedTo3DTile.h"
 #include "Cesium3DTiles/RasterOverlayTile.h"
 #include "Cesium3DTiles/ExternalTilesetContent.h"

--- a/Cesium3DTiles/src/TilesetExternals.cpp
+++ b/Cesium3DTiles/src/TilesetExternals.cpp
@@ -1,1 +1,3 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/TilesetExternals.h"

--- a/Cesium3DTiles/src/Uri.cpp
+++ b/Cesium3DTiles/src/Uri.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Uri.h"
 #include "uriparser/Uri.h"
 #include <stdexcept>

--- a/Cesium3DTiles/src/Uri.h
+++ b/Cesium3DTiles/src/Uri.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include <string>

--- a/Cesium3DTiles/src/ViewState.cpp
+++ b/Cesium3DTiles/src/ViewState.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 
 #include "Cesium3DTiles/ViewState.h"
 #include "CesiumGeometry/CullingVolume.h"

--- a/Cesium3DTiles/src/calcQuadtreeMaxGeometricError.cpp
+++ b/Cesium3DTiles/src/calcQuadtreeMaxGeometricError.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "calcQuadtreeMaxGeometricError.h"
 
 namespace Cesium3DTiles {

--- a/Cesium3DTiles/src/calcQuadtreeMaxGeometricError.h
+++ b/Cesium3DTiles/src/calcQuadtreeMaxGeometricError.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeospatial/Ellipsoid.h"

--- a/Cesium3DTiles/src/registerAllTileContentTypes.cpp
+++ b/Cesium3DTiles/src/registerAllTileContentTypes.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "Cesium3DTiles/registerAllTileContentTypes.h"
 #include "Cesium3DTiles/TileContentFactory.h"
 #include "Cesium3DTiles/GltfContent.h"

--- a/Cesium3DTiles/src/tinyxml2.h
+++ b/Cesium3DTiles/src/tinyxml2.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #ifndef _MSC_VER

--- a/Cesium3DTiles/src/upsampleGltfForRasterOverlays.cpp
+++ b/Cesium3DTiles/src/upsampleGltfForRasterOverlays.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeometry/clipTriangleAtAxisAlignedThreshold.h"
 #include "CesiumGeospatial/Cartographic.h"
 #include "CesiumGeospatial/Ellipsoid.h"

--- a/Cesium3DTiles/src/upsampleGltfForRasterOverlays.h
+++ b/Cesium3DTiles/src/upsampleGltfForRasterOverlays.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "Cesium3DTiles/Gltf.h"

--- a/CesiumAsync/include/CesiumAsync/AsyncSystem.h
+++ b/CesiumAsync/include/CesiumAsync/AsyncSystem.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumAsync/Library.h"

--- a/CesiumAsync/include/CesiumAsync/CacheItem.h
+++ b/CesiumAsync/include/CesiumAsync/CacheItem.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumAsync/Library.h"

--- a/CesiumAsync/include/CesiumAsync/CachingAssetAccessor.h
+++ b/CesiumAsync/include/CesiumAsync/CachingAssetAccessor.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumAsync/IAssetRequest.h"

--- a/CesiumAsync/include/CesiumAsync/HttpHeaders.h
+++ b/CesiumAsync/include/CesiumAsync/HttpHeaders.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include <string>

--- a/CesiumAsync/include/CesiumAsync/IAssetAccessor.h
+++ b/CesiumAsync/include/CesiumAsync/IAssetAccessor.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumAsync/Library.h"

--- a/CesiumAsync/include/CesiumAsync/IAssetRequest.h
+++ b/CesiumAsync/include/CesiumAsync/IAssetRequest.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumAsync/HttpHeaders.h"

--- a/CesiumAsync/include/CesiumAsync/IAssetResponse.h
+++ b/CesiumAsync/include/CesiumAsync/IAssetResponse.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumAsync/HttpHeaders.h"

--- a/CesiumAsync/include/CesiumAsync/ICacheDatabase.h
+++ b/CesiumAsync/include/CesiumAsync/ICacheDatabase.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumAsync/Library.h"

--- a/CesiumAsync/include/CesiumAsync/ITaskProcessor.h
+++ b/CesiumAsync/include/CesiumAsync/ITaskProcessor.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumAsync/Library.h"

--- a/CesiumAsync/include/CesiumAsync/Library.h
+++ b/CesiumAsync/include/CesiumAsync/Library.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 /**

--- a/CesiumAsync/include/CesiumAsync/SqliteCache.h
+++ b/CesiumAsync/include/CesiumAsync/SqliteCache.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumAsync/ICacheDatabase.h"

--- a/CesiumAsync/src/AsyncSystem.cpp
+++ b/CesiumAsync/src/AsyncSystem.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumAsync/AsyncSystem.h"
 #include "CesiumAsync/ITaskProcessor.h"
 #include <future>

--- a/CesiumAsync/src/CachingAssetAccessor.cpp
+++ b/CesiumAsync/src/CachingAssetAccessor.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumAsync/AsyncSystem.h"
 #include "CesiumAsync/CacheItem.h"
 #include "CesiumAsync/CachingAssetAccessor.h"

--- a/CesiumAsync/src/HttpHeaders.cpp
+++ b/CesiumAsync/src/HttpHeaders.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumAsync/HttpHeaders.h"
 #include <algorithm>
 

--- a/CesiumAsync/src/ResponseCacheControl.cpp
+++ b/CesiumAsync/src/ResponseCacheControl.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "ResponseCacheControl.h"
 #include <map>
 #include <set>

--- a/CesiumAsync/src/SqliteCache.cpp
+++ b/CesiumAsync/src/SqliteCache.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumAsync/IAssetResponse.h"
 #include "CesiumAsync/SqliteCache.h"
 #include "rapidjson/document.h"

--- a/CesiumGeometry/include/CesiumGeometry/BoundingSphere.h
+++ b/CesiumGeometry/include/CesiumGeometry/BoundingSphere.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include <glm/vec3.hpp>

--- a/CesiumGeometry/include/CesiumGeometry/CullingResult.h
+++ b/CesiumGeometry/include/CesiumGeometry/CullingResult.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeometry/Library.h"

--- a/CesiumGeometry/include/CesiumGeometry/CullingVolume.h
+++ b/CesiumGeometry/include/CesiumGeometry/CullingVolume.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeometry/Plane.h"

--- a/CesiumGeometry/include/CesiumGeometry/IntersectionTests.h
+++ b/CesiumGeometry/include/CesiumGeometry/IntersectionTests.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include <optional>

--- a/CesiumGeometry/include/CesiumGeometry/Library.h
+++ b/CesiumGeometry/include/CesiumGeometry/Library.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 /**

--- a/CesiumGeometry/include/CesiumGeometry/OctreeTileID.h
+++ b/CesiumGeometry/include/CesiumGeometry/OctreeTileID.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeometry/OctreeTileID.h"

--- a/CesiumGeometry/include/CesiumGeometry/OrientedBoundingBox.h
+++ b/CesiumGeometry/include/CesiumGeometry/OrientedBoundingBox.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include <glm/vec3.hpp>

--- a/CesiumGeometry/include/CesiumGeometry/Plane.h
+++ b/CesiumGeometry/include/CesiumGeometry/Plane.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include <glm/vec3.hpp>

--- a/CesiumGeometry/include/CesiumGeometry/QuadtreeTileAvailability.h
+++ b/CesiumGeometry/include/CesiumGeometry/QuadtreeTileAvailability.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeometry/Library.h"

--- a/CesiumGeometry/include/CesiumGeometry/QuadtreeTileID.h
+++ b/CesiumGeometry/include/CesiumGeometry/QuadtreeTileID.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeometry/Library.h"

--- a/CesiumGeometry/include/CesiumGeometry/QuadtreeTileRectangularRange.h
+++ b/CesiumGeometry/include/CesiumGeometry/QuadtreeTileRectangularRange.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include <cstdint>

--- a/CesiumGeometry/include/CesiumGeometry/QuadtreeTilingScheme.h
+++ b/CesiumGeometry/include/CesiumGeometry/QuadtreeTilingScheme.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeometry/Library.h"

--- a/CesiumGeometry/include/CesiumGeometry/Ray.h
+++ b/CesiumGeometry/include/CesiumGeometry/Ray.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include <glm/vec3.hpp>

--- a/CesiumGeometry/include/CesiumGeometry/Rectangle.h
+++ b/CesiumGeometry/include/CesiumGeometry/Rectangle.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeometry/Library.h"

--- a/CesiumGeometry/include/CesiumGeometry/clipTriangleAtAxisAlignedThreshold.h
+++ b/CesiumGeometry/include/CesiumGeometry/clipTriangleAtAxisAlignedThreshold.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include <vector>

--- a/CesiumGeometry/src/BoundingSphere.cpp
+++ b/CesiumGeometry/src/BoundingSphere.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeometry/BoundingSphere.h"
 #include <glm/geometric.hpp>
 #include "CesiumGeometry/Plane.h"

--- a/CesiumGeometry/src/CullingVolume.cpp
+++ b/CesiumGeometry/src/CullingVolume.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeometry/CullingVolume.h"
 
 #include <glm/glm.hpp>

--- a/CesiumGeometry/src/IntersectionTests.cpp
+++ b/CesiumGeometry/src/IntersectionTests.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeometry/IntersectionTests.h"
 #include <glm/geometric.hpp>
 #include "CesiumUtility/Math.h"

--- a/CesiumGeometry/src/OrientedBoundingBox.cpp
+++ b/CesiumGeometry/src/OrientedBoundingBox.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeometry/OrientedBoundingBox.h"
 #include <glm/geometric.hpp>
 #include <glm/ext/matrix_transform.hpp>

--- a/CesiumGeometry/src/Plane.cpp
+++ b/CesiumGeometry/src/Plane.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeometry/Plane.h"
 #include "CesiumUtility/Math.h"
 #include <glm/geometric.hpp>

--- a/CesiumGeometry/src/QuadtreeTileAvailability.cpp
+++ b/CesiumGeometry/src/QuadtreeTileAvailability.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeometry/QuadtreeTileAvailability.h"
 #include <algorithm>
 #include <glm/common.hpp>

--- a/CesiumGeometry/src/QuadtreeTileID.cpp
+++ b/CesiumGeometry/src/QuadtreeTileID.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeometry/QuadtreeTilingScheme.h"
 
 namespace CesiumGeometry {

--- a/CesiumGeometry/src/QuadtreeTilingScheme.cpp
+++ b/CesiumGeometry/src/QuadtreeTilingScheme.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeometry/QuadtreeTilingScheme.h"
 
 namespace CesiumGeometry {

--- a/CesiumGeometry/src/Ray.cpp
+++ b/CesiumGeometry/src/Ray.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeometry/Ray.h"
 #include "CesiumUtility/Math.h"
 #include <glm/geometric.hpp>

--- a/CesiumGeometry/src/Rectangle.cpp
+++ b/CesiumGeometry/src/Rectangle.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeometry/Rectangle.h"
 #include <glm/common.hpp>
 #include <glm/geometric.hpp>

--- a/CesiumGeometry/src/clipTriangleAtAxisAlignedThreshold.cpp
+++ b/CesiumGeometry/src/clipTriangleAtAxisAlignedThreshold.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeometry/clipTriangleAtAxisAlignedThreshold.h"
 
 namespace CesiumGeometry

--- a/CesiumGeospatial/include/CesiumGeospatial/BoundingRegion.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/BoundingRegion.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeospatial/Library.h"

--- a/CesiumGeospatial/include/CesiumGeospatial/BoundingRegionWithLooseFittingHeights.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/BoundingRegionWithLooseFittingHeights.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeospatial/Library.h"

--- a/CesiumGeospatial/include/CesiumGeospatial/Cartographic.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/Cartographic.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeospatial/Library.h"

--- a/CesiumGeospatial/include/CesiumGeospatial/Ellipsoid.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/Ellipsoid.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeospatial/Library.h"

--- a/CesiumGeospatial/include/CesiumGeospatial/EllipsoidTangentPlane.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/EllipsoidTangentPlane.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeospatial/Library.h"

--- a/CesiumGeospatial/include/CesiumGeospatial/GeographicProjection.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/GeographicProjection.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeospatial/Library.h"

--- a/CesiumGeospatial/include/CesiumGeospatial/GlobeRectangle.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/GlobeRectangle.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeospatial/Library.h"

--- a/CesiumGeospatial/include/CesiumGeospatial/Library.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/Library.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 /**

--- a/CesiumGeospatial/include/CesiumGeospatial/Projection.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/Projection.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeospatial/GeographicProjection.h"

--- a/CesiumGeospatial/include/CesiumGeospatial/Transforms.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/Transforms.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeospatial/Library.h"

--- a/CesiumGeospatial/include/CesiumGeospatial/WebMercatorProjection.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/WebMercatorProjection.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGeospatial/Ellipsoid.h"

--- a/CesiumGeospatial/src/BoundingRegion.cpp
+++ b/CesiumGeospatial/src/BoundingRegion.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeospatial/BoundingRegion.h"
 #include "CesiumGeometry/IntersectionTests.h"
 #include "CesiumGeometry/Ray.h"

--- a/CesiumGeospatial/src/BoundingRegionWithLooseFittingHeights.cpp
+++ b/CesiumGeospatial/src/BoundingRegionWithLooseFittingHeights.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeospatial/BoundingRegionWithLooseFittingHeights.h"
 
 namespace CesiumGeospatial {

--- a/CesiumGeospatial/src/Ellipsoid.cpp
+++ b/CesiumGeospatial/src/Ellipsoid.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeospatial/Ellipsoid.h"
 #include "CesiumUtility/Math.h"
 #include <glm/geometric.hpp>

--- a/CesiumGeospatial/src/EllipsoidTangentPlane.cpp
+++ b/CesiumGeospatial/src/EllipsoidTangentPlane.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeospatial/EllipsoidTangentPlane.h"
 #include "CesiumGeospatial/Transforms.h"
 #include "CesiumGeometry/Plane.h"

--- a/CesiumGeospatial/src/GeographicProjection.cpp
+++ b/CesiumGeospatial/src/GeographicProjection.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeospatial/GeographicProjection.h"
 #include "CesiumGeospatial/Cartographic.h"
 #include "CesiumUtility/Math.h"

--- a/CesiumGeospatial/src/GlobeRectangle.cpp
+++ b/CesiumGeospatial/src/GlobeRectangle.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeospatial/GlobeRectangle.h"
 #include "CesiumUtility/Math.h"
 

--- a/CesiumGeospatial/src/Projection.cpp
+++ b/CesiumGeospatial/src/Projection.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeospatial/Projection.h"
 #include <glm/trigonometric.hpp>
 

--- a/CesiumGeospatial/src/Transforms.cpp
+++ b/CesiumGeospatial/src/Transforms.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeospatial/Transforms.h"
 #include <glm/gtc/epsilon.hpp>
 #include "CesiumUtility/Math.h"

--- a/CesiumGeospatial/src/WebMercatorProjection.cpp
+++ b/CesiumGeospatial/src/WebMercatorProjection.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGeospatial/Cartographic.h"
 #include "CesiumGeospatial/WebMercatorProjection.h"
 #include "CesiumUtility/Math.h"

--- a/CesiumGltf/include/CesiumGltf/Accessor.h
+++ b/CesiumGltf/include/CesiumGltf/Accessor.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGltf/AccessorSpec.h"

--- a/CesiumGltf/include/CesiumGltf/AccessorView.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorView.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGltf/Model.h"

--- a/CesiumGltf/include/CesiumGltf/AccessorWriter.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorWriter.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGltf/AccessorView.h"

--- a/CesiumGltf/include/CesiumGltf/Buffer.h
+++ b/CesiumGltf/include/CesiumGltf/Buffer.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGltf/BufferCesium.h"

--- a/CesiumGltf/include/CesiumGltf/BufferCesium.h
+++ b/CesiumGltf/include/CesiumGltf/BufferCesium.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGltf/Library.h"

--- a/CesiumGltf/include/CesiumGltf/ExtensibleObject.h
+++ b/CesiumGltf/include/CesiumGltf/ExtensibleObject.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGltf/JsonValue.h"

--- a/CesiumGltf/include/CesiumGltf/Image.h
+++ b/CesiumGltf/include/CesiumGltf/Image.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGltf/ImageCesium.h"

--- a/CesiumGltf/include/CesiumGltf/ImageCesium.h
+++ b/CesiumGltf/include/CesiumGltf/ImageCesium.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGltf/Library.h"

--- a/CesiumGltf/include/CesiumGltf/JsonValue.h
+++ b/CesiumGltf/include/CesiumGltf/JsonValue.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGltf/Library.h"

--- a/CesiumGltf/include/CesiumGltf/Library.h
+++ b/CesiumGltf/include/CesiumGltf/Library.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 /**

--- a/CesiumGltf/include/CesiumGltf/Model.h
+++ b/CesiumGltf/include/CesiumGltf/Model.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGltf/Library.h"

--- a/CesiumGltf/include/CesiumGltf/NamedObject.h
+++ b/CesiumGltf/include/CesiumGltf/NamedObject.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGltf/ExtensibleObject.h"

--- a/CesiumGltf/src/Accessor.cpp
+++ b/CesiumGltf/src/Accessor.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGltf/Accessor.h"
 #include "CesiumGltf/Model.h"
 

--- a/CesiumGltf/src/JsonValue.cpp
+++ b/CesiumGltf/src/JsonValue.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGltf/JsonValue.h"
 
 using namespace CesiumGltf;

--- a/CesiumGltf/src/Model.cpp
+++ b/CesiumGltf/src/Model.cpp
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #include "CesiumGltf/Model.h"
 #include "CesiumGltf/KHR_draco_mesh_compression.h"
 #include <algorithm>

--- a/CesiumGltfReader/include/CesiumGltf/Reader.h
+++ b/CesiumGltfReader/include/CesiumGltf/Reader.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include "CesiumGltf/ReaderLibrary.h"

--- a/CesiumGltfReader/include/CesiumGltf/ReaderLibrary.h
+++ b/CesiumGltfReader/include/CesiumGltf/ReaderLibrary.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #if defined(_WIN32) && defined(CESIUM_SHARED)

--- a/CesiumUtility/include/CesiumUtility/DoublyLinkedList.h
+++ b/CesiumUtility/include/CesiumUtility/DoublyLinkedList.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 namespace CesiumUtility {

--- a/CesiumUtility/include/CesiumUtility/IntrusivePointer.h
+++ b/CesiumUtility/include/CesiumUtility/IntrusivePointer.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 namespace CesiumUtility {

--- a/CesiumUtility/include/CesiumUtility/Library.h
+++ b/CesiumUtility/include/CesiumUtility/Library.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 /**

--- a/CesiumUtility/include/CesiumUtility/Math.h
+++ b/CesiumUtility/include/CesiumUtility/Math.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include <glm/gtc/epsilon.hpp>

--- a/CesiumUtility/include/CesiumUtility/joinToString.h
+++ b/CesiumUtility/include/CesiumUtility/joinToString.h
@@ -1,3 +1,5 @@
+// Copyright CesiumGS, Inc. and Contributors
+
 #pragma once
 
 #include <numeric>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,177 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+


### PR DESCRIPTION
Assuming that the handling of copyright+license info will be the same in `cesium-native` as it is in `cesium-unreal`.

For further details, see https://github.com/CesiumGS/cesium-unreal/pull/171

---

Fun fact: I once wrote a utility for this. A colleague of mine had to open-source a library with hundreds of source files, and each required a proper header. I wrote a `HeaderInserter`, which included fancy heuristics to determine whether a given file might already contain some sort of header, and inserted the header from a template if not. However, here, I did this manually...

