### PR TITLE
Fixed apparent typo (copy+paste error)

### DIFF
--- a/CesiumGltf/CMakeLists.txt
+++ b/CesiumGltf/CMakeLists.txt
@@ -3,7 +3,7 @@ configure_cesium_library(CesiumGltf)
 
 cesium_glob_files(CESIUM_GLTF_SOURCES src/*.cpp)
 cesium_glob_files(CESIUM_GLTF_HEADERS src/*.h src/*.hpp)
-cesium_glob_files(CESIUM_GLTF_PUBLIC_HEADERS include/CesiumGeometry/*.h)
+cesium_glob_files(CESIUM_GLTF_PUBLIC_HEADERS include/CesiumGltf/*.h)
 cesium_glob_files(CESIUM_GLTF_TEST_SOURCES test/*.cpp)
 cesium_glob_files(CESIUM_GLTF_TEST_HEADERS test/*.h)
 


### PR DESCRIPTION
The headers of CesiumGltf had been 

    cesium_glob_files(CESIUM_GLTF_PUBLIC_HEADERS include/CesiumGeometry/*.h)

but should probably be

    cesium_glob_files(CESIUM_GLTF_PUBLIC_HEADERS include/CesiumGltf/*.h)

I know that there's some turmoil around the CMake structure right now, so this does not have to be merged, but rather opened to have a record - it may be integrated manually by someone who creates the next, large CMake-Related PR to be merged.
