### PR TITLE
Handle the case that images are not found

### DIFF
--- a/Cesium3DTiles/src/RasterOverlayTileProvider.cpp
+++ b/Cesium3DTiles/src/RasterOverlayTileProvider.cpp
@@ -462,8 +462,9 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
         }
 
         if (pResponse->statusCode() < 200 || pResponse->statusCode() >= 300) {
-          std::string message =
-              "Image response code " + std::to_string(pResponse->statusCode()) + " for " + url;
+          std::string message = "Image response code " +
+                                std::to_string(pResponse->statusCode()) +
+                                " for " + url;
           return LoadedRasterOverlayImage{std::nullopt, credits, {message}, {}};
         }
 


### PR DESCRIPTION
When the source of `IMAGERY` data cannot be found, it originally printed that the image could not be read, because it tried to decode the response data...

```
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>assets/107358/12/3767/1639.png</Key><RequestId>3DHH5Z55C5ZABPGV</RequestId><HostId>icMQQEJHvVcSpMOBm2yZXreLkQl+sIATMahH0kudr6lKeeMDwTk9AFZ3o/WX6xVxtTWsxHSAyoM=</HostId></Error>
```
... as an image.

**BUT**: This should not be merged as-it-is: Although it now prints a sensible message (namely, that the response `404` was received), it prints **hundreds** of them for certain `IMAGERY` assets.

Should these missing images just be ignored? I doubt it. It should probably not send out the corresponding requests here in the first place. 

I can investigate this further, but if someone already knows "how to do this", any hint would be appreciated.


---

Unrelated: I also removed the use of `std::move`, which according to https://github.com/CesiumGS/cesium-native/commit/3e238cec80f4149a2ff32e963faa3bead17053e2#r47473476 , did not make any sense there.

