### PR TITLE
Add methods to get the parameters used to construct a CesiumIonClient::Connection

### DIFF
--- a/CesiumIonClient/include/CesiumIonClient/Connection.h
+++ b/CesiumIonClient/include/CesiumIonClient/Connection.h
@@ -65,6 +65,16 @@ namespace CesiumIonClient {
         );
 
         /**
+         * @brief Gets the async system used by this connection to do work in threads.
+         */
+        const CesiumAsync::AsyncSystem& getAsyncSystem() const { return this->_asyncSystem; }
+
+        /**
+         * @brief Gets the interface used by this connection to interact with the Cesium ion REST API.
+         */
+        const std::shared_ptr<CesiumAsync::IAssetAccessor>& getAssetAccessor() const { return this->_pAssetAccessor; }
+
+        /**
          * @brief Gets the access token used by this connection.
          */
         const std::string& getAccessToken() const { return this->_accessToken; }


### PR DESCRIPTION
Most importantly this allows access to the token, so that it can be squirreled away and reused later. This is needed for CesiumGS/cesium-unreal#174.
