### PR TITLE
Correctly detach rasters when removing an overlay

### DIFF
--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTile.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTile.h
@@ -99,6 +99,11 @@ public:
   RasterOverlay& getOverlay() noexcept { return *this->_pOverlay; }
 
   /**
+   * @brief Returns the {@link RasterOverlay} of this instance.
+   */
+  const RasterOverlay& getOverlay() const noexcept { return *this->_pOverlay; }
+
+  /**
    * @brief Returns the {@link CesiumGeometry::QuadtreeTileID} that was given
    * during construction.
    */

--- a/CesiumUtility/include/CesiumUtility/IntrusivePointer.h
+++ b/CesiumUtility/include/CesiumUtility/IntrusivePointer.h
@@ -54,6 +54,17 @@ public:
   }
 
   /**
+   * @brief Move assignment operator.
+   */
+  IntrusivePointer& operator=(IntrusivePointer&& rhs) noexcept {
+    if (this->_p != rhs._p) {
+      std::swap(this->_p, rhs._p);
+    }
+
+    return *this;
+  }
+
+  /**
    * @brief Assignment operator.
    */
   IntrusivePointer& operator=(T* p) noexcept {


### PR DESCRIPTION
Fixes CesiumGS/cesium-unreal#123

This turned out to be not at all what I expected. My code to remove raster tiles from geometry tiles was just totally wrong, but in a kind of interesting way.

Ok so when we delete a `RasterOverlay`, we need to remove the corresponding `RasterMappedTo3DTile`s from every geometry tile. And before we remove them, we need to give the rendering engine (i.e. Cesium for Unreal) the chance to detach the doomed `RasterMappedTo3DTile` from the geometry. I thought I was being clever (we can see the problem already, eh?) and did it like this:

```
auto firstToRemove =
        std::remove_if(mapped.begin(), mapped.end(), removeCondition);

for (auto it = firstToRemove; it != mapped.end(); ++it) {
      it->detachFromTile(tile);
}

mapped.erase(firstToRemove, mapped.end());
```

Based on my understanding that `std::remove_if` doesn't actually remove anything from the collection, instead it swaps the "to be removed" elements to the end of the array and returns an iterator pointing at the first of these. So that's why you always have to follow up the `remove_if` with an `erase`.

Well, maybe that was true at some point (or maybe not), but it's definitely not true since at least C++11 (yeah yeah `remove_if` was added in C++17, but `remove` works the same way and has been around longer), because `std::remove_if` doesn't _swap_ elements to be deleted to the end, it instead _moves_ elements to be kept to the beginning. That distinction is really important. As cppreference.com [points out](https://en.cppreference.com/w/cpp/algorithm/remove):

> Iterators pointing to an element between the new logical end and the physical end of the range are still dereferenceable, but the elements themselves have unspecified values (as per MoveAssignable post-condition).

In other words, those values at the end are guaranteed to be in a valid state (so they can be destroyed; the `erase` is still needed), but their actual value is unspecified and at the whim of the move assignment operators involved.

So my code to detach the about-to-be-deleted elements is a total fail, because we're attempting to detach based on unspecified values.

So yeah, easy fix now that I know std::remove_if doesn't work at all the way I thought it did.