### PR TITLE
Use correct layer.json version property name.

### DIFF
--- a/Cesium3DTiles/src/Tileset.cpp
+++ b/Cesium3DTiles/src/Tileset.cpp
@@ -800,7 +800,7 @@ static BoundingVolume createDefaultLooseEarthBoundingVolume(
       "application/vnd.quantized-mesh,application/octet-stream;q=0.9,*/"
       "*;q=0.01"));
 
-  auto tilesetVersionIt = layerJson.FindMember("tilesetVersion");
+  auto tilesetVersionIt = layerJson.FindMember("version");
   if (tilesetVersionIt != layerJson.MemberEnd() &&
       tilesetVersionIt->value.IsString()) {
     context.version = tilesetVersionIt->value.GetString();


### PR DESCRIPTION
It's `version` not `tilesetVersion`.
Fixes CesiumGS/cesium-unreal#234

Non-terrain tilesets were already including the version correctly because for 3D Tiles ion includes a version in its tiles URL template.