### PR TITLE
Add hint about formatting in README

### DIFF
--- a/doc/style-guide.md
+++ b/doc/style-guide.md
@@ -21,7 +21,7 @@ A change to C++ Core Guidelines [NL.17](http://isocpp.github.io/CppCoreGuideline
 
 Use `clang-format` and the `.clang-format` configuration in the root of this repo. Easy. If you're using Visual Studio Code with the C/C++ extension installed, just run the "Format Document" command.
 
-To format the source code from the command line, install npm from [https://nodejs.org/](https://nodejs.org/), and run `npm install`.
+To format the source code from the command line, install node.js from [https://nodejs.org/](https://nodejs.org/), and run `npm install` in the project root directory.
 Then, in order to apply the formatting, run `npm run format`. 
 
 We believe that source code should be readable and even beautiful, but that automated formatting is more important than either concern. Especially when readability is largely a matter of what we're used to, and beauty is mostly subjective. For our JavaScript / TypeScript code, we format our code with the ubiquitous [Prettier](https://prettier.io/) tool. In C++, clang-format is widely used but there's no de facto style, and so we've created a clang-format style that tracks as close to Prettier as possible. We will be able to get closer once this [clang-format patch](https://reviews.llvm.org/D33029) is merged.


### PR DESCRIPTION
This might later go into some contributors guide (c.f. https://github.com/CesiumGS/cesium-unreal/issues/125 ), but ... I just received a build error, and had to look up the exact syntax for the formatting in the slack history - it should be mentioned somewhere in the repo.
