### PR TITLE
Copy url when capturing it in the lambda

### DIFF
--- a/Cesium3DTiles/src/Tileset.cpp
+++ b/Cesium3DTiles/src/Tileset.cpp
@@ -497,7 +497,7 @@ void Tileset::_loadTilesetJson(
         this->_pRootTile = std::move(loadResult.pRootTile);
         this->notifyTileDoneLoading(nullptr);
       })
-      .catchInMainThread([this, &url](const std::exception& e) {
+      .catchInMainThread([this, url](const std::exception& e) {
         SPDLOG_LOGGER_ERROR(
             this->_externals.pLogger,
             "Unhandled error for tileset {}: {}",


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium-unreal/issues/239

Local url being captured by reference in the lambda leads to dangling pointer