### PR TITLE
Assign a better material for quantized-mesh tiles.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,9 @@
+# Change Log
+
+### v0.1.1 - ?
+
+- Gave glTFs created from quantized-mesh terrain tiles a more sensible material with a `metallicFactor` of 0.0 and a `roughnessFactor` of 1.0. Previously the default glTF material was used, which has a `metallicFactor` of 1.0, leading to an undesirable appearance.
+
+### v0.1.0 - 2021-03-30
+
+- Initial release.

--- a/Cesium3DTiles/src/QuantizedMeshContent.cpp
+++ b/Cesium3DTiles/src/QuantizedMeshContent.cpp
@@ -942,6 +942,11 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
   pResult->model.emplace();
   CesiumGltf::Model& model = pResult->model.value();
 
+  CesiumGltf::Material& material = model.materials.emplace_back();
+  CesiumGltf::MaterialPBRMetallicRoughness& pbr = material.pbrMetallicRoughness.emplace();
+  pbr.metallicFactor = 0.0;
+  pbr.roughnessFactor = 1.0;
+
   size_t meshId = model.meshes.size();
   model.meshes.emplace_back();
   CesiumGltf::Mesh& mesh = model.meshes[meshId];

--- a/Cesium3DTiles/src/QuantizedMeshContent.cpp
+++ b/Cesium3DTiles/src/QuantizedMeshContent.cpp
@@ -943,7 +943,8 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
   CesiumGltf::Model& model = pResult->model.value();
 
   CesiumGltf::Material& material = model.materials.emplace_back();
-  CesiumGltf::MaterialPBRMetallicRoughness& pbr = material.pbrMetallicRoughness.emplace();
+  CesiumGltf::MaterialPBRMetallicRoughness& pbr =
+      material.pbrMetallicRoughness.emplace();
   pbr.metallicFactor = 0.0;
   pbr.roughnessFactor = 1.0;
 


### PR DESCRIPTION
Gave glTFs created from quantized-mesh terrain tiles a more sensible material with a `metallicFactor` of 0.0 and a `roughnessFactor` of 1.0. Previously the default glTF material was used, which has a `metallicFactor` of 1.0, leading to an undesirable appearance.

Also added `CHANGES.md`.

In Cesium for Unreal, before this PR (not shininess at the horizon, starting where the photogrammetry ends):
![image](https://user-images.githubusercontent.com/924374/113261102-c3e61280-931a-11eb-9aaa-1e7fbb8f37b7.png)

After this PR (no more shininess):
![image](https://user-images.githubusercontent.com/924374/113260896-884b4880-931a-11eb-946e-dfd0892f9a11.png)
