### PR TITLE
Don't always report zero-length images as errors.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### v0.1.1 - ?
 
 - Gave glTFs created from quantized-mesh terrain tiles a more sensible material with a `metallicFactor` of 0.0 and a `roughnessFactor` of 1.0. Previously the default glTF material was used, which has a `metallicFactor` of 1.0, leading to an undesirable appearance.
+- Reported zero-length images as non-errors as `BingMapsRasterOverlay` purposely requests that the Bing servers return a zero-length image for non-existent tiles.
 
 ### v0.1.0 - 2021-03-30
 

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
@@ -27,6 +27,38 @@ struct CESIUM3DTILES_API LoadedRasterOverlayImage {
 };
 
 /**
+ * @brief Options for {@link RasterOverlayTileProvider::loadTileImageFromUrl}.
+ */
+struct LoadTileImageFromUrlOptions {
+  /**
+   * @brief The credits to display with this tile.
+   *
+   * This property is copied verbatim to the {@link
+   * LoadedRasterOverlayImage::credits} property.
+   */
+  std::vector<Credit> credits = {};
+
+  /**
+   * @brief Whether empty (zero length) images are accepted as a valid
+   * response.
+   *
+   * If true, an otherwise valid response with zero length will be accepted as
+   * a valid 0x0 image. If false, such a response will be reported as an
+   * error.
+   *
+   * {@link RasterOverlayTileProvider::loadTile} and {@link
+   * RasterOverlayTileProvider::loadTileThrottled} will treat such an image as
+   * "failed" and use the quadtree parent (or ancestor) image instead, but
+   * will not report any error.
+   *
+   * This flag should only be set to true when the tile source uses a
+   * zero-length response as an indication that this tile is - as expected -
+   * not available.
+   */
+  bool allowEmptyImages = false;
+};
+
+/**
  * @brief Provides individual tiles for a {@link RasterOverlay} on demand.
  *
  */
@@ -314,12 +346,13 @@ protected:
    *
    * @param url The URL.
    * @param headers The request headers.
+   * @param options Additional options for the load process.
    * @return A future that resolves to the image or error information.
    */
   CesiumAsync::Future<LoadedRasterOverlayImage> loadTileImageFromUrl(
       const std::string& url,
       const std::vector<CesiumAsync::IAssetAccessor::THeader>& headers = {},
-      const std::vector<Credit>& credits = {}) const;
+      const LoadTileImageFromUrlOptions& options = {}) const;
 
 private:
   void doLoad(RasterOverlayTile& tile, bool isThrottledLoad);

--- a/Cesium3DTiles/src/BingMapsRasterOverlay.cpp
+++ b/Cesium3DTiles/src/BingMapsRasterOverlay.cpp
@@ -164,7 +164,10 @@ protected:
             this->getProjection(),
             this->getTilingScheme().tileToRectangle(tileID));
 
-    std::vector<Credit> tileCredits;
+    LoadTileImageFromUrlOptions options;
+    options.allowEmptyImages = true;
+    std::vector<Credit>& tileCredits = options.credits;
+
     for (CreditAndCoverageAreas creditAndCoverageAreas : _credits) {
       for (CoverageArea coverageArea : creditAndCoverageAreas.coverageAreas) {
         if (coverageArea.zoomMin <= bingTileLevel &&
@@ -176,7 +179,7 @@ protected:
       }
     }
 
-    return this->loadTileImageFromUrl(url, {}, tileCredits);
+    return this->loadTileImageFromUrl(url, {}, options);
   }
 
 private:

--- a/Cesium3DTiles/src/RasterOverlayTileProvider.cpp
+++ b/Cesium3DTiles/src/RasterOverlayTileProvider.cpp
@@ -464,7 +464,8 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
   return this->getAssetAccessor()
       ->requestAsset(this->getAsyncSystem(), url, headers)
       .thenInWorkerThread(
-          [url, options = options](std::shared_ptr<IAssetRequest>&& pRequest) mutable {
+          [url, options = options](
+              std::shared_ptr<IAssetRequest>&& pRequest) mutable {
             const IAssetResponse* pResponse = pRequest->response();
             if (pResponse == nullptr) {
               return LoadedRasterOverlayImage{

--- a/Cesium3DTiles/src/RasterOverlayTileProvider.cpp
+++ b/Cesium3DTiles/src/RasterOverlayTileProvider.cpp
@@ -464,12 +464,12 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
   return this->getAssetAccessor()
       ->requestAsset(this->getAsyncSystem(), url, headers)
       .thenInWorkerThread(
-          [url, options](std::shared_ptr<IAssetRequest>&& pRequest) mutable {
+          [url, options = options](std::shared_ptr<IAssetRequest>&& pRequest) mutable {
             const IAssetResponse* pResponse = pRequest->response();
             if (pResponse == nullptr) {
               return LoadedRasterOverlayImage{
                   std::nullopt,
-                  options.credits,
+                  std::move(options.credits),
                   {"Image request for " + url + " failed."},
                   {}};
             }
@@ -481,7 +481,7 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
                                     " for " + url;
               return LoadedRasterOverlayImage{
                   std::nullopt,
-                  options.credits,
+                  std::move(options.credits),
                   {message},
                   {}};
             }
@@ -490,13 +490,13 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
               if (options.allowEmptyImages) {
                 return LoadedRasterOverlayImage{
                     CesiumGltf::ImageCesium(),
-                    options.credits,
+                    std::move(options.credits),
                     {},
                     {}};
               } else {
                 return LoadedRasterOverlayImage{
                     std::nullopt,
-                    options.credits,
+                    std::move(options.credits),
                     {"Image response for " + url + " is empty."},
                     {}};
               }
@@ -515,7 +515,7 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
 
             return LoadedRasterOverlayImage{
                 loadedImage.image,
-                options.credits,
+                std::move(options.credits),
                 std::move(loadedImage.errors),
                 std::move(loadedImage.warnings)};
           });

--- a/Cesium3DTiles/src/RasterOverlayTileProvider.cpp
+++ b/Cesium3DTiles/src/RasterOverlayTileProvider.cpp
@@ -469,7 +469,7 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
             if (pResponse == nullptr) {
               return LoadedRasterOverlayImage{
                   std::nullopt,
-                  std::move(options.credits),
+                  options.credits,
                   {"Image request for " + url + " failed."},
                   {}};
             }
@@ -481,7 +481,7 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
                                     " for " + url;
               return LoadedRasterOverlayImage{
                   std::nullopt,
-                  std::move(options.credits),
+                  options.credits,
                   {message},
                   {}};
             }
@@ -490,13 +490,13 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
               if (options.allowEmptyImages) {
                 return LoadedRasterOverlayImage{
                     CesiumGltf::ImageCesium(),
-                    std::move(options.credits),
+                    options.credits,
                     {},
                     {}};
               } else {
                 return LoadedRasterOverlayImage{
                     std::nullopt,
-                    std::move(options.credits),
+                    options.credits,
                     {"Image response for " + url + " is empty."},
                     {}};
               }
@@ -515,7 +515,7 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
 
             return LoadedRasterOverlayImage{
                 loadedImage.image,
-                std::move(options.credits),
+                options.credits,
                 std::move(loadedImage.errors),
                 std::move(loadedImage.warnings)};
           });

--- a/CesiumGltf/include/CesiumGltf/ImageCesium.h
+++ b/CesiumGltf/include/CesiumGltf/ImageCesium.h
@@ -13,22 +13,22 @@ struct CESIUMGLTF_API ImageCesium final {
   /**
    * @brief The width of the image in pixels.
    */
-  int32_t width;
+  int32_t width = 0;
 
   /**
    * @brief The height of the image in pixels.
    */
-  int32_t height;
+  int32_t height = 0;
 
   /**
    * @brief The number of channels per pixel.
    */
-  int32_t channels;
+  int32_t channels = 4;
 
   /**
    * @brief The number of bytes per channel.
    */
-  int32_t bytesPerChannel;
+  int32_t bytesPerChannel = 1;
 
   /**
    * @brief The raw pixel data.


### PR DESCRIPTION
`BingMapsRasterOverlay` purposely requests that the Bing servers return a zero-length image for non-existent tiles. That's what the `n=z` query parameter does. So we shouldn't report these zero-length images as a problem.
