### PR TITLE
Updated and extended error messages

### DIFF
--- a/Cesium3DTiles/src/Tileset.cpp
+++ b/Cesium3DTiles/src/Tileset.cpp
@@ -687,14 +687,14 @@ static std::optional<BoundingVolume> getBoundingVolumeProperty(
   std::optional<BoundingVolume> boundingVolume =
       getBoundingVolumeProperty(tileJson, "boundingVolume");
   if (!boundingVolume) {
-    SPDLOG_LOGGER_ERROR(pLogger, "Tileset did not contain a boundingVolume");
+    SPDLOG_LOGGER_ERROR(pLogger, "Tile did not contain a boundingVolume");
     return;
   }
 
   std::optional<double> geometricError =
       JsonHelpers::getScalarProperty(tileJson, "geometricError");
   if (!geometricError) {
-    SPDLOG_LOGGER_ERROR(pLogger, "Tileset did not contain a geometricError");
+    SPDLOG_LOGGER_ERROR(pLogger, "Tile did not contain a geometricError");
     return;
   }
 
@@ -720,7 +720,7 @@ static std::optional<BoundingVolume> getBoundingVolumeProperty(
     } else {
       SPDLOG_LOGGER_ERROR(
           pLogger,
-          "Tileset contained an unknown refine value: {}",
+          "Tile contained an unknown refine value: {}",
           refine);
     }
   } else {

--- a/CesiumGltfReader/src/Reader.cpp
+++ b/CesiumGltfReader/src/Reader.cpp
@@ -4,7 +4,9 @@
 #include "decodeDataUrls.h"
 #include "decodeDraco.h"
 #include <cstddef>
+#include <iomanip>
 #include <rapidjson/reader.h>
+#include <sstream>
 #include <string>
 
 #define STB_IMAGE_IMPLEMENTATION
@@ -178,6 +180,28 @@ ModelReaderResult readJsonModel(const gsl::span<const std::byte>& data) {
   return result;
 }
 
+namespace {
+/**
+ * @brief Creates a string representation for the given magic value.
+ *
+ * The details are not specified, but the output will include a
+ * hex representation of the given value, as well as the result
+ * of interpreting the value as 4 unsigned characters.
+ *
+ * @param i The value
+ * @return The string
+ */
+std::string toMagicString(uint32_t i) {
+  unsigned char c0 = i & 0xFF;
+  unsigned char c1 = (i >> 8) & 0xFF;
+  unsigned char c2 = (i >> 16) & 0xFF;
+  unsigned char c3 = (i >> 24) & 0xFF;
+  std::stringstream stream;
+  stream << c0 << c1 << c2 << c3 << " (0x" << std::hex << i << ")";
+  return stream.str();
+}
+} // namespace
+
 ModelReaderResult readBinaryModel(const gsl::span<const std::byte>& data) {
   if (data.size() < sizeof(GlbHeader) + sizeof(ChunkHeader)) {
     return {std::nullopt, {"Too short to be a valid GLB."}, {}};
@@ -187,16 +211,26 @@ ModelReaderResult readBinaryModel(const gsl::span<const std::byte>& data) {
   if (pHeader->magic != 0x46546C67) {
     return {
         std::nullopt,
-        {"GLB does not start with the expected magic value 'glTF'."},
+        {"GLB does not start with the expected magic value 'glTF', but " +
+         toMagicString(pHeader->magic)},
         {}};
   }
 
   if (pHeader->version != 2) {
-    return {std::nullopt, {"Only binary glTF version 2 is supported."}, {}};
+    return {
+        std::nullopt,
+        {"Only binary glTF version 2 is supported, found version " +
+         std::to_string(pHeader->version)},
+        {}};
   }
 
   if (pHeader->length > data.size()) {
-    return {std::nullopt, {"GLB extends past the end of the buffer."}, {}};
+    return {
+        std::nullopt,
+        {"GLB extends past the end of the buffer, header size " +
+         std::to_string(pHeader->length) + ", data size " +
+         std::to_string(data.size())},
+        {}};
   }
 
   gsl::span<const std::byte> glbData = data.subspan(0, pHeader->length);
@@ -206,7 +240,8 @@ ModelReaderResult readBinaryModel(const gsl::span<const std::byte>& data) {
   if (pJsonChunkHeader->chunkType != 0x4E4F534A) {
     return {
         std::nullopt,
-        {"GLB JSON chunk does not have the expected chunkType."},
+        {"GLB JSON chunk does not have the expected chunkType 'JSON', but " +
+         toMagicString(pJsonChunkHeader->chunkType)},
         {}};
   }
 
@@ -216,7 +251,9 @@ ModelReaderResult readBinaryModel(const gsl::span<const std::byte>& data) {
   if (jsonEnd > glbData.size()) {
     return {
         std::nullopt,
-        {"GLB JSON chunk extends past the end of the buffer."},
+        {"GLB JSON chunk extends past the end of the buffer, JSON end at " +
+         std::to_string(jsonEnd) + ", data size " +
+         std::to_string(glbData.size())},
         {}};
   }
 
@@ -230,7 +267,8 @@ ModelReaderResult readBinaryModel(const gsl::span<const std::byte>& data) {
     if (pBinaryChunkHeader->chunkType != 0x004E4942) {
       return {
           std::nullopt,
-          {"GLB binary chunk does not have the expected chunkType."},
+          {"GLB binary chunk does not have the expected chunkType 'BIN', but " +
+           toMagicString(pBinaryChunkHeader->chunkType)},
           {}};
     }
 
@@ -240,7 +278,10 @@ ModelReaderResult readBinaryModel(const gsl::span<const std::byte>& data) {
     if (binaryEnd > glbData.size()) {
       return {
           std::nullopt,
-          {"GLB binary chunk extends past the end of the buffer."},
+          {"GLB binary chunk extends past the end of the buffer, binary end "
+           "at " +
+           std::to_string(binaryEnd) + ", data size " +
+           std::to_string(glbData.size())},
           {}};
     }
 
@@ -299,7 +340,12 @@ void postprocess(
       if (bufferView.byteOffset + bufferView.byteLength >
           static_cast<int64_t>(buffer.cesium.data.size())) {
         readModel.warnings.emplace_back(
-            "Image bufferView's byteLength is more than the available bytes.");
+            "Image bufferView's byte offset is " +
+            std::to_string(bufferView.byteOffset) + " and the byteLength is " +
+            std::to_string(bufferView.byteLength) + ", the result is " +
+            std::to_string(bufferView.byteOffset + bufferView.byteLength) +
+            ", which is more than the available " +
+            std::to_string(buffer.cesium.data.size()) + " bytes.");
         continue;
       }
 

--- a/CesiumGltfReader/src/Reader.cpp
+++ b/CesiumGltfReader/src/Reader.cpp
@@ -192,7 +192,7 @@ namespace {
  * @return The string
  */
 std::string toMagicString(uint32_t i) {
-  unsigned char c0 = static_cast<unsigned char>(i & 0xFF));
+  unsigned char c0 = static_cast<unsigned char>(i & 0xFF);
   unsigned char c1 = static_cast<unsigned char>((i >> 8) & 0xFF);
   unsigned char c2 = static_cast<unsigned char>((i >> 16) & 0xFF);
   unsigned char c3 = static_cast<unsigned char>((i >> 24) & 0xFF);

--- a/CesiumGltfReader/src/Reader.cpp
+++ b/CesiumGltfReader/src/Reader.cpp
@@ -192,10 +192,10 @@ namespace {
  * @return The string
  */
 std::string toMagicString(uint32_t i) {
-  unsigned char c0 = i & 0xFF;
-  unsigned char c1 = (i >> 8) & 0xFF;
-  unsigned char c2 = (i >> 16) & 0xFF;
-  unsigned char c3 = (i >> 24) & 0xFF;
+  unsigned char c0 = static_cast<unsigned char>(i & 0xFF));
+  unsigned char c1 = static_cast<unsigned char>((i >> 8) & 0xFF);
+  unsigned char c2 = static_cast<unsigned char>((i >> 16) & 0xFF);
+  unsigned char c3 = static_cast<unsigned char>((i >> 24) & 0xFF);
   std::stringstream stream;
   stream << c0 << c1 << c2 << c3 << " (0x" << std::hex << i << ")";
   return stream.str();


### PR DESCRIPTION
- Some error messages mentioned a `Tileset`, although they referred to a `Tile`
- The error messages in the glTF `Reader` class have been extended, generally from "Something is wrong" to "This-and-that is wrong" (e.g. printing actual and expected values or actual sizes and limits)
