### PR TITLE
Apply scale component of tile.transform to tile.geometricError

### DIFF
--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
@@ -27,6 +27,38 @@ struct CESIUM3DTILES_API LoadedRasterOverlayImage {
 };
 
 /**
+ * @brief Options for {@link RasterOverlayTileProvider::loadTileImageFromUrl}.
+ */
+struct LoadTileImageFromUrlOptions {
+  /**
+   * @brief The credits to display with this tile.
+   *
+   * This property is copied verbatim to the {@link
+   * LoadedRasterOverlayImage::credits} property.
+   */
+  std::vector<Credit> credits = {};
+
+  /**
+   * @brief Whether empty (zero length) images are accepted as a valid
+   * response.
+   *
+   * If true, an otherwise valid response with zero length will be accepted as
+   * a valid 0x0 image. If false, such a response will be reported as an
+   * error.
+   *
+   * {@link RasterOverlayTileProvider::loadTile} and {@link
+   * RasterOverlayTileProvider::loadTileThrottled} will treat such an image as
+   * "failed" and use the quadtree parent (or ancestor) image instead, but
+   * will not report any error.
+   *
+   * This flag should only be set to true when the tile source uses a
+   * zero-length response as an indication that this tile is - as expected -
+   * not available.
+   */
+  bool allowEmptyImages = false;
+};
+
+/**
  * @brief Provides individual tiles for a {@link RasterOverlay} on demand.
  *
  */
@@ -314,12 +346,13 @@ protected:
    *
    * @param url The URL.
    * @param headers The request headers.
+   * @param options Additional options for the load process.
    * @return A future that resolves to the image or error information.
    */
   CesiumAsync::Future<LoadedRasterOverlayImage> loadTileImageFromUrl(
       const std::string& url,
       const std::vector<CesiumAsync::IAssetAccessor::THeader>& headers = {},
-      const std::vector<Credit>& credits = {}) const;
+      const LoadTileImageFromUrlOptions& options = {}) const;
 
 private:
   void doLoad(RasterOverlayTile& tile, bool isThrottledLoad);

--- a/Cesium3DTiles/src/BingMapsRasterOverlay.cpp
+++ b/Cesium3DTiles/src/BingMapsRasterOverlay.cpp
@@ -164,7 +164,10 @@ protected:
             this->getProjection(),
             this->getTilingScheme().tileToRectangle(tileID));
 
-    std::vector<Credit> tileCredits;
+    LoadTileImageFromUrlOptions options;
+    options.allowEmptyImages = true;
+    std::vector<Credit>& tileCredits = options.credits;
+
     for (CreditAndCoverageAreas creditAndCoverageAreas : _credits) {
       for (CoverageArea coverageArea : creditAndCoverageAreas.coverageAreas) {
         if (coverageArea.zoomMin <= bingTileLevel &&
@@ -176,7 +179,7 @@ protected:
       }
     }
 
-    return this->loadTileImageFromUrl(url, {}, tileCredits);
+    return this->loadTileImageFromUrl(url, {}, options);
   }
 
 private:

--- a/Cesium3DTiles/src/RasterOverlayTileProvider.cpp
+++ b/Cesium3DTiles/src/RasterOverlayTileProvider.cpp
@@ -469,7 +469,7 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
             if (pResponse == nullptr) {
               return LoadedRasterOverlayImage{
                   std::nullopt,
-                  std::move(options.credits),
+                  options.credits,
                   {"Image request for " + url + " failed."},
                   {}};
             }
@@ -481,7 +481,7 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
                                     " for " + url;
               return LoadedRasterOverlayImage{
                   std::nullopt,
-                  std::move(options.credits),
+                  options.credits,
                   {message},
                   {}};
             }
@@ -490,13 +490,13 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
               if (options.allowEmptyImages) {
                 return LoadedRasterOverlayImage{
                     CesiumGltf::ImageCesium(),
-                    std::move(options.credits),
+                    options.credits,
                     {},
                     {}};
               } else {
                 return LoadedRasterOverlayImage{
                     std::nullopt,
-                    std::move(options.credits),
+                    options.credits,
                     {"Image response for " + url + " is empty."},
                     {}};
               }
@@ -515,7 +515,7 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
 
             return LoadedRasterOverlayImage{
                 loadedImage.image,
-                std::move(options.credits),
+                options.credits,
                 std::move(loadedImage.errors),
                 std::move(loadedImage.warnings)};
           });

--- a/Cesium3DTiles/src/Tileset.cpp
+++ b/Cesium3DTiles/src/Tileset.cpp
@@ -700,8 +700,13 @@ static std::optional<BoundingVolume> getBoundingVolumeProperty(
 
   tile.setBoundingVolume(
       transformBoundingVolume(transform, boundingVolume.value()));
-  // tile->setBoundingVolume(boundingVolume.value());
-  tile.setGeometricError(geometricError.value());
+
+  glm::dvec3 scale = glm::dvec3(
+      glm::length(transform[0]),
+      glm::length(transform[1]),
+      glm::length(transform[2]));
+  double maxScaleComponent = glm::max(scale.x, glm::max(scale.y, scale.z));
+  tile.setGeometricError(geometricError.value() * maxScaleComponent);
 
   std::optional<BoundingVolume> viewerRequestVolume =
       getBoundingVolumeProperty(tileJson, "viewerRequestVolume");

--- a/CesiumGltf/include/CesiumGltf/ImageCesium.h
+++ b/CesiumGltf/include/CesiumGltf/ImageCesium.h
@@ -13,22 +13,22 @@ struct CESIUMGLTF_API ImageCesium final {
   /**
    * @brief The width of the image in pixels.
    */
-  int32_t width;
+  int32_t width = 0;
 
   /**
    * @brief The height of the image in pixels.
    */
-  int32_t height;
+  int32_t height = 0;
 
   /**
    * @brief The number of channels per pixel.
    */
-  int32_t channels;
+  int32_t channels = 4;
 
   /**
    * @brief The number of bytes per channel.
    */
-  int32_t bytesPerChannel;
+  int32_t bytesPerChannel = 1;
 
   /**
    * @brief The raw pixel data.


### PR DESCRIPTION
Report in the forum https://community.cesium.com/t/lod-problems-with-photogrammetry-model/12861. 

The spec currently says tile.transform should not apply to geometric error, but it seems to be a bug on the specs. It was mentioned [here](https://github.com/CesiumGS/3d-tiles/issues/367). Also cesiumJS already applies the transform to the geometric error as well