### PR TITLE
Scale geometric error with tile transform

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Added diagnostic details to error messages for invalid glTF inputs
 - Added an `Axis` enum and `AxisTransforms` class for coordinate system transforms
 - Added support for the legacy `gltfUpVector` string property in the `asset` part of tilesets. The up vector is read and passed as an `Axis` in the `extras["gltfUpVector"]` property, so that receivers may rotate the glTF model's up-vector to match the Z-up convention of 3D Tiles.
+- 3D Tiles geometric error is now scaled by the tile's transform.
 
 ### v0.1.0 - 2021-03-30
 

--- a/Cesium3DTiles/src/Tileset.cpp
+++ b/Cesium3DTiles/src/Tileset.cpp
@@ -700,8 +700,12 @@ static std::optional<BoundingVolume> getBoundingVolumeProperty(
 
   tile.setBoundingVolume(
       transformBoundingVolume(transform, boundingVolume.value()));
-  // tile->setBoundingVolume(boundingVolume.value());
-  tile.setGeometricError(geometricError.value());
+  glm::dvec3 scale = glm::dvec3(
+      glm::length(transform[0]),
+      glm::length(transform[1]),
+      glm::length(transform[2]));
+  double maxScaleComponent = glm::max(scale.x, glm::max(scale.y, scale.z));
+  tile.setGeometricError(geometricError.value() * maxScaleComponent);
 
   std::optional<BoundingVolume> viewerRequestVolume =
       getBoundingVolumeProperty(tileJson, "viewerRequestVolume");


### PR DESCRIPTION
Report in the forum https://community.cesium.com/t/lod-problems-with-photogrammetry-model/12861. 

The spec currently says tile.transform should not apply to geometric error, but it seems to be a bug on the specs. It was mentioned [here](https://github.com/CesiumGS/3d-tiles/issues/367). Also cesiumJS already applied the transform's scale component to the geometric error as well