### PR TITLE
First pass of clang tidy

### DIFF
--- a/Cesium3DTiles/include/Cesium3DTiles/ExternalTilesetContent.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/ExternalTilesetContent.h
@@ -43,7 +43,7 @@ private:
    * @return The {@link TileContentLoadResult}
    */
   static std::unique_ptr<TileContentLoadResult> load(
-      std::shared_ptr<spdlog::logger> pLogger,
+      const std::shared_ptr<spdlog::logger>& pLogger,
       const glm::dmat4& tileTransform,
       TileRefine tileRefine,
       const std::string& url,

--- a/Cesium3DTiles/include/Cesium3DTiles/GltfContent.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/GltfContent.h
@@ -41,7 +41,7 @@ public:
    * @return The {@link TileContentLoadResult}
    */
   static std::unique_ptr<TileContentLoadResult> load(
-      std::shared_ptr<spdlog::logger> pLogger,
+      const std::shared_ptr<spdlog::logger>& pLogger,
       const std::string& url,
       const gsl::span<const std::byte>& data);
 

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterMappedTo3DTile.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterMappedTo3DTile.h
@@ -49,7 +49,7 @@ public:
    * indicates the region that is covered by the raster overlay tile.
    */
   RasterMappedTo3DTile(
-      CesiumUtility::IntrusivePointer<RasterOverlayTile> pRasterTile,
+      const CesiumUtility::IntrusivePointer<RasterOverlayTile>& pRasterTile,
       const CesiumGeometry::Rectangle& textureCoordinateRectangle);
 
   /**

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
@@ -103,8 +103,9 @@ public:
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       std::optional<Credit> credit,
-      std::shared_ptr<IPrepareRendererResources> pPrepareRendererResources,
-      std::shared_ptr<spdlog::logger> pLogger,
+      const std::shared_ptr<IPrepareRendererResources>&
+          pPrepareRendererResources,
+      const std::shared_ptr<spdlog::logger>& pLogger,
       const CesiumGeospatial::Projection& projection,
       const CesiumGeometry::QuadtreeTilingScheme& tilingScheme,
       const CesiumGeometry::Rectangle& coverageRectangle,

--- a/Cesium3DTiles/src/Batched3DModelContent.cpp
+++ b/Cesium3DTiles/src/Batched3DModelContent.cpp
@@ -75,7 +75,7 @@ Batched3DModelContent::load(const TileContentLoadInput& input) {
 }
 
 std::unique_ptr<TileContentLoadResult> Batched3DModelContent::load(
-    std::shared_ptr<spdlog::logger> pLogger,
+    const std::shared_ptr<spdlog::logger>& pLogger,
     const std::string& url,
     const gsl::span<const std::byte>& data) {
   // TODO: actually use the b3dm payload

--- a/Cesium3DTiles/src/Batched3DModelContent.h
+++ b/Cesium3DTiles/src/Batched3DModelContent.h
@@ -41,7 +41,7 @@ private:
    * the `model`. All other properties will be uninitialized.
    */
   static std::unique_ptr<TileContentLoadResult> load(
-      std::shared_ptr<spdlog::logger> pLogger,
+      const std::shared_ptr<spdlog::logger>& pLogger,
       const std::string& url,
       const gsl::span<const std::byte>& data);
 };

--- a/Cesium3DTiles/src/BingMapsRasterOverlay.cpp
+++ b/Cesium3DTiles/src/BingMapsRasterOverlay.cpp
@@ -149,7 +149,8 @@ protected:
                 tileID.level,
                 tileID.x,
                 tileID.computeInvertedY(this->getTilingScheme()));
-          } else if (key == "subdomain") {
+          }
+          if (key == "subdomain") {
             size_t subdomainIndex =
                 (tileID.level + tileID.x + tileID.y) % this->_subdomains.size();
             return this->_subdomains[subdomainIndex];
@@ -168,7 +169,7 @@ protected:
     options.allowEmptyImages = true;
     std::vector<Credit>& tileCredits = options.credits;
 
-    for (CreditAndCoverageAreas creditAndCoverageAreas : _credits) {
+    for (const CreditAndCoverageAreas& creditAndCoverageAreas : _credits) {
       for (CoverageArea coverageArea : creditAndCoverageAreas.coverageAreas) {
         if (coverageArea.zoomMin <= bingTileLevel &&
             bingTileLevel <= coverageArea.zoomMax &&
@@ -184,7 +185,7 @@ protected:
 
 private:
   static std::string tileXYToQuadKey(uint32_t level, uint32_t x, uint32_t y) {
-    std::string quadkey = "";
+    std::string quadkey;
     for (int32_t i = static_cast<int32_t>(level); i >= 0; --i) {
       uint32_t bitmask = static_cast<uint32_t>(1 << i);
       uint32_t digit = 0;
@@ -250,7 +251,8 @@ BingMapsRasterOverlay::createTileProvider(
            pPrepareRendererResources,
            pLogger,
            baseUrl = this->_url,
-           culture = this->_culture](std::shared_ptr<IAssetRequest> pRequest)
+           culture =
+               this->_culture](const std::shared_ptr<IAssetRequest>& pRequest)
               -> std::unique_ptr<RasterOverlayTileProvider> {
             const IAssetResponse* pResponse = pRequest->response();
 

--- a/Cesium3DTiles/src/CompositeContent.cpp
+++ b/Cesium3DTiles/src/CompositeContent.cpp
@@ -130,32 +130,33 @@ CompositeContent::load(const TileContentLoadInput& input) {
     pos += pInner->byteLength;
   }
 
-  if (innerTiles.size() == 0) {
+  if (innerTiles.empty()) {
     if (pHeader->tilesLength > 0) {
       SPDLOG_LOGGER_WARN(
           pLogger,
           "Composite tile does not contain any loadable inner tiles.");
     }
     return nullptr;
-  } else if (innerTiles.size() == 1) {
+  }
+  if (innerTiles.size() == 1) {
     return std::move(innerTiles[0]);
-  } else {
-    std::unique_ptr<TileContentLoadResult> pResult = std::move(innerTiles[0]);
+  }
 
-    for (size_t i = 1; i < innerTiles.size(); ++i) {
-      if (!innerTiles[i]->model) {
-        continue;
-      }
+  std::unique_ptr<TileContentLoadResult> pResult = std::move(innerTiles[0]);
 
-      if (pResult->model) {
-        pResult->model.value().merge(std::move(innerTiles[i]->model.value()));
-      } else {
-        pResult->model = std::move(innerTiles[i]->model);
-      }
+  for (size_t i = 1; i < innerTiles.size(); ++i) {
+    if (!innerTiles[i]->model) {
+      continue;
     }
 
-    return pResult;
+    if (pResult->model) {
+      pResult->model.value().merge(std::move(innerTiles[i]->model.value()));
+    } else {
+      pResult->model = std::move(innerTiles[i]->model);
+    }
   }
+
+  return pResult;
 }
 
 } // namespace Cesium3DTiles

--- a/Cesium3DTiles/src/ExternalTilesetContent.cpp
+++ b/Cesium3DTiles/src/ExternalTilesetContent.cpp
@@ -19,7 +19,7 @@ ExternalTilesetContent::load(const TileContentLoadInput& input) {
 }
 
 /*static*/ std::unique_ptr<TileContentLoadResult> ExternalTilesetContent::load(
-    std::shared_ptr<spdlog::logger> pLogger,
+    const std::shared_ptr<spdlog::logger>& pLogger,
     const glm::dmat4& tileTransform,
     TileRefine tileRefine,
     const std::string& url,

--- a/Cesium3DTiles/src/Gltf.cpp
+++ b/Cesium3DTiles/src/Gltf.cpp
@@ -54,7 +54,7 @@ static void forEachPrimitiveInNodeObject(
     std::function<Gltf::ForEachPrimitiveInSceneConstCallback>& callback) {
   glm::dmat4x4 nodeTransform = transform;
 
-  if (node.matrix.size() > 0) {
+  if (!node.matrix.empty()) {
     const std::vector<double>& matrix = node.matrix;
 
     glm::dmat4x4 nodeTransformGltf(
@@ -65,8 +65,8 @@ static void forEachPrimitiveInNodeObject(
 
     nodeTransform = nodeTransform * nodeTransformGltf;
   } else if (
-      node.translation.size() > 0 || node.rotation.size() > 0 ||
-      node.scale.size() > 0) {
+      !node.translation.empty() || !node.rotation.empty() ||
+      !node.scale.empty()) {
     // TODO: handle this type of transformation
   }
 
@@ -128,14 +128,14 @@ static void forEachPrimitiveInSceneObject(
         gltf,
         gltf.scenes[static_cast<size_t>(gltf.scene)],
         callback);
-  } else if (gltf.scenes.size() > 0) {
+  } else if (!gltf.scenes.empty()) {
     // There's no default, so use the first scene
     const CesiumGltf::Scene& defaultScene = gltf.scenes[0];
     forEachPrimitiveInSceneObject(rootTransform, gltf, defaultScene, callback);
-  } else if (gltf.nodes.size() > 0) {
+  } else if (!gltf.nodes.empty()) {
     // No scenes at all, use the first node as the root node.
     forEachPrimitiveInNodeObject(rootTransform, gltf, gltf.nodes[0], callback);
-  } else if (gltf.meshes.size() > 0) {
+  } else if (!gltf.meshes.empty()) {
     // No nodes either, show all the meshes.
     for (const CesiumGltf::Mesh& mesh : gltf.meshes) {
       forEachPrimitiveInMeshObject(

--- a/Cesium3DTiles/src/GltfContent.cpp
+++ b/Cesium3DTiles/src/GltfContent.cpp
@@ -15,7 +15,7 @@ GltfContent::load(const TileContentLoadInput& input) {
 }
 
 /*static*/ std::unique_ptr<TileContentLoadResult> GltfContent::load(
-    std::shared_ptr<spdlog::logger> pLogger,
+    const std::shared_ptr<spdlog::logger>& pLogger,
     const std::string& url,
     const gsl::span<const std::byte>& data) {
   std::unique_ptr<TileContentLoadResult> pResult =

--- a/Cesium3DTiles/src/IonRasterOverlay.cpp
+++ b/Cesium3DTiles/src/IonRasterOverlay.cpp
@@ -42,7 +42,7 @@ IonRasterOverlay::createTileProvider(
 
   return pAssetAccessor->requestAsset(asyncSystem, ionUrl)
       .thenInWorkerThread(
-          [pLogger](std::shared_ptr<IAssetRequest> pRequest)
+          [pLogger](const std::shared_ptr<IAssetRequest>& pRequest)
               -> std::unique_ptr<RasterOverlay> {
             const IAssetResponse* pResponse = pRequest->response();
 
@@ -104,19 +104,18 @@ IonRasterOverlay::createTileProvider(
                   key,
                   mapStyle,
                   culture);
-            } else {
-              std::string url =
-                  JsonHelpers::getStringOrDefault(response, "url", "");
-              return std::make_unique<TileMapServiceRasterOverlay>(
-                  url,
-                  std::vector<CesiumAsync::IAssetAccessor::THeader>{
-                      std::make_pair(
-                          "Authorization",
-                          "Bearer " + JsonHelpers::getStringOrDefault(
-                                          response,
-                                          "accessToken",
-                                          ""))});
             }
+            std::string url =
+                JsonHelpers::getStringOrDefault(response, "url", "");
+            return std::make_unique<TileMapServiceRasterOverlay>(
+                url,
+                std::vector<CesiumAsync::IAssetAccessor::THeader>{
+                    std::make_pair(
+                        "Authorization",
+                        "Bearer " + JsonHelpers::getStringOrDefault(
+                                        response,
+                                        "accessToken",
+                                        ""))});
           })
       .thenInMainThread([asyncSystem,
                          pOwner,

--- a/Cesium3DTiles/src/QuantizedMeshContent.cpp
+++ b/Cesium3DTiles/src/QuantizedMeshContent.cpp
@@ -662,7 +662,7 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
 }
 
 /*static*/ std::unique_ptr<TileContentLoadResult> QuantizedMeshContent::load(
-    std::shared_ptr<spdlog::logger> pLogger,
+    const std::shared_ptr<spdlog::logger>& pLogger,
     const TileID& tileID,
     const BoundingVolume& tileBoundingVolume,
     const std::string& url,

--- a/Cesium3DTiles/src/QuantizedMeshContent.h
+++ b/Cesium3DTiles/src/QuantizedMeshContent.h
@@ -39,7 +39,7 @@ public:
    * @return The {@link TileContentLoadResult}
    */
   static std::unique_ptr<TileContentLoadResult> load(
-      std::shared_ptr<spdlog::logger> pLogger,
+      const std::shared_ptr<spdlog::logger>& pLogger,
       const TileID& tileID,
       const BoundingVolume& tileBoundingVolume,
       const std::string& url,

--- a/Cesium3DTiles/src/RasterMappedTo3DTile.cpp
+++ b/Cesium3DTiles/src/RasterMappedTo3DTile.cpp
@@ -10,7 +10,7 @@
 namespace Cesium3DTiles {
 
 RasterMappedTo3DTile::RasterMappedTo3DTile(
-    CesiumUtility::IntrusivePointer<RasterOverlayTile> pRasterTile,
+    const CesiumUtility::IntrusivePointer<RasterOverlayTile>& pRasterTile,
     const CesiumGeometry::Rectangle& textureCoordinateRectangle)
     : _pLoadingTile(pRasterTile),
       _pReadyTile(nullptr),
@@ -138,15 +138,14 @@ RasterMappedTo3DTile::update(Tile& tile) {
   // max level?
   if (this->_pLoadingTile) {
     return MoreDetailAvailable::Unknown;
-  } else {
-    return !this->_originalFailed && this->_pReadyTile &&
-                   this->_pReadyTile->getID().level <
-                       this->_pReadyTile->getOverlay()
-                           .getTileProvider()
-                           ->getMaximumLevel()
-               ? MoreDetailAvailable::Yes
-               : MoreDetailAvailable::No;
   }
+  return !this->_originalFailed && this->_pReadyTile &&
+                 this->_pReadyTile->getID().level <
+                     this->_pReadyTile->getOverlay()
+                         .getTileProvider()
+                         ->getMaximumLevel()
+             ? MoreDetailAvailable::Yes
+             : MoreDetailAvailable::No;
 }
 
 void RasterMappedTo3DTile::detachFromTile(Tile& tile) noexcept {

--- a/Cesium3DTiles/src/RasterOverlayCollection.cpp
+++ b/Cesium3DTiles/src/RasterOverlayCollection.cpp
@@ -4,10 +4,10 @@
 namespace Cesium3DTiles {
 
 RasterOverlayCollection::RasterOverlayCollection(Tileset& tileset) noexcept
-    : _pTileset(&tileset), _overlays() {}
+    : _pTileset(&tileset) {}
 
 RasterOverlayCollection::~RasterOverlayCollection() {
-  if (this->_overlays.size() > 0) {
+  if (!this->_overlays.empty()) {
     for (int64_t i = static_cast<int64_t>(this->_overlays.size() - 1); i >= 0;
          --i) {
       this->remove(this->_overlays[static_cast<size_t>(i)].get());

--- a/Cesium3DTiles/src/RasterOverlayTile.cpp
+++ b/Cesium3DTiles/src/RasterOverlayTile.cpp
@@ -15,9 +15,7 @@ namespace Cesium3DTiles {
 RasterOverlayTile::RasterOverlayTile(RasterOverlay& overlay) noexcept
     : _pOverlay(&overlay),
       _tileID(0, 0, 0),
-      _tileCredits(),
       _state(LoadState::Placeholder),
-      _image(),
       _pRendererResources(nullptr),
       _references(0) {}
 
@@ -26,9 +24,7 @@ RasterOverlayTile::RasterOverlayTile(
     const CesiumGeometry::QuadtreeTileID& tileID)
     : _pOverlay(&overlay),
       _tileID(tileID),
-      _tileCredits(),
       _state(LoadState::Unloaded),
-      _image(),
       _pRendererResources(nullptr),
       _references(0) {}
 

--- a/Cesium3DTiles/src/RasterOverlayTileProvider.cpp
+++ b/Cesium3DTiles/src/RasterOverlayTileProvider.cpp
@@ -47,8 +47,8 @@ RasterOverlayTileProvider::RasterOverlayTileProvider(
     const CesiumAsync::AsyncSystem& asyncSystem,
     const std::shared_ptr<IAssetAccessor>& pAssetAccessor,
     std::optional<Credit> credit,
-    std::shared_ptr<IPrepareRendererResources> pPrepareRendererResources,
-    std::shared_ptr<spdlog::logger> pLogger,
+    const std::shared_ptr<IPrepareRendererResources>& pPrepareRendererResources,
+    const std::shared_ptr<spdlog::logger>& pLogger,
     const CesiumGeospatial::Projection& projection,
     const CesiumGeometry::QuadtreeTilingScheme& tilingScheme,
     const CesiumGeometry::Rectangle& coverageRectangle,
@@ -487,20 +487,19 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
                   {}};
             }
 
-            if (pResponse->data().size() == 0) {
+            if (pResponse->data().empty()) {
               if (options.allowEmptyImages) {
                 return LoadedRasterOverlayImage{
                     CesiumGltf::ImageCesium(),
                     std::move(options.credits),
                     {},
                     {}};
-              } else {
-                return LoadedRasterOverlayImage{
-                    std::nullopt,
-                    std::move(options.credits),
-                    {"Image response for " + url + " is empty."},
-                    {}};
               }
+              return LoadedRasterOverlayImage{
+                  std::nullopt,
+                  std::move(options.credits),
+                  {"Image response for " + url + " is empty."},
+                  {}};
             }
 
             gsl::span<const std::byte> data = pResponse->data();
@@ -584,12 +583,11 @@ void RasterOverlayTileProvider::doLoad(
               result.credits = std::move(loadedImage.credits);
               result.pRendererResources = pRendererResources;
               return result;
-            } else {
-              LoadResult result;
-              result.pRendererResources = nullptr;
-              result.state = RasterOverlayTile::LoadState::Failed;
-              return result;
             }
+            LoadResult result;
+            result.pRendererResources = nullptr;
+            result.state = RasterOverlayTile::LoadState::Failed;
+            return result;
           })
       .thenInMainThread([this, &tile, isThrottledLoad](LoadResult&& result) {
         tile._pRendererResources = result.pRendererResources;

--- a/Cesium3DTiles/src/Tile.cpp
+++ b/Cesium3DTiles/src/Tile.cpp
@@ -54,7 +54,7 @@ Tile::Tile(Tile&& rhs) noexcept
 
 Tile& Tile::operator=(Tile&& rhs) noexcept {
   if (this != &rhs) {
-    this->_loadedTilesLinks = std::move(rhs._loadedTilesLinks);
+    this->_loadedTilesLinks = rhs._loadedTilesLinks;
     this->_pContext = rhs._pContext;
     this->_pParent = rhs._pParent;
     this->_children = std::move(rhs._children);
@@ -75,14 +75,14 @@ Tile& Tile::operator=(Tile&& rhs) noexcept {
 }
 
 void Tile::createChildTiles(size_t count) {
-  if (this->_children.size() > 0) {
+  if (!this->_children.empty()) {
     throw std::runtime_error("Children already created.");
   }
   this->_children.resize(count);
 }
 
 void Tile::createChildTiles(std::vector<Tile>&& children) {
-  if (this->_children.size() > 0) {
+  if (!this->_children.empty()) {
     throw std::runtime_error("Children already created.");
   }
   this->_children = std::move(children);
@@ -556,7 +556,7 @@ void Tile::update(
     if (this->_pContent) {
       // Apply children from content, but only if we don't already have
       // children.
-      if (this->_pContent->childTiles && this->getChildren().size() == 0) {
+      if (this->_pContent->childTiles && this->getChildren().empty()) {
         for (Tile& childTile : this->_pContent->childTiles.value()) {
           childTile.setParent(this);
         }
@@ -602,7 +602,7 @@ void Tile::update(
     this->setState(LoadState::Done);
   }
 
-  if (this->getContext()->implicitContext && this->getChildren().size() == 0 &&
+  if (this->getContext()->implicitContext && this->getChildren().empty() &&
       std::get_if<QuadtreeTileID>(&this->_id)) {
     // Check if any child tiles are known to be available, and create them if
     // they are.
@@ -685,7 +685,7 @@ void Tile::update(
     // If this tile still has no children after it's done loading, but it does
     // have raster tiles that are not the most detailed available, create fake
     // children to hang more detailed rasters on by subdividing this tile.
-    if (moreRasterDetailAvailable && this->_children.size() == 0) {
+    if (moreRasterDetailAvailable && this->_children.empty()) {
       createQuadtreeSubdividedChildren(*this);
     }
   }

--- a/Cesium3DTiles/src/TileMapServiceRasterOverlay.cpp
+++ b/Cesium3DTiles/src/TileMapServiceRasterOverlay.cpp
@@ -23,8 +23,9 @@ public:
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<IAssetAccessor>& pAssetAccessor,
       std::optional<Credit> credit,
-      std::shared_ptr<IPrepareRendererResources> pPrepareRendererResources,
-      std::shared_ptr<spdlog::logger> pLogger,
+      const std::shared_ptr<IPrepareRendererResources>&
+          pPrepareRendererResources,
+      const std::shared_ptr<spdlog::logger>& pLogger,
       const CesiumGeospatial::Projection& projection,
       const CesiumGeometry::QuadtreeTilingScheme& tilingScheme,
       const CesiumGeometry::Rectangle& coverageRectangle,
@@ -144,7 +145,8 @@ TileMapServiceRasterOverlay::createTileProvider(
            pLogger,
            options = this->_options,
            url = this->_url,
-           headers = this->_headers](std::shared_ptr<IAssetRequest> pRequest)
+           headers =
+               this->_headers](const std::shared_ptr<IAssetRequest>& pRequest)
               -> std::unique_ptr<RasterOverlayTileProvider> {
             const IAssetResponse* pResponse = pRequest->response();
             if (!pResponse) {
@@ -303,7 +305,7 @@ TileMapServiceRasterOverlay::createTileProvider(
                 coverageRectangle,
                 url,
                 headers,
-                fileExtension.size() > 0 ? "." + fileExtension : fileExtension,
+                !fileExtension.empty() ? "." + fileExtension : fileExtension,
                 tileWidth,
                 tileHeight,
                 minimumLevel,

--- a/Cesium3DTiles/src/Tileset.cpp
+++ b/Cesium3DTiles/src/Tileset.cpp
@@ -33,28 +33,19 @@ Tileset::Tileset(
     const TilesetExternals& externals,
     const std::string& url,
     const TilesetOptions& options)
-    : _contexts(),
-      _externals(externals),
+    : _externals(externals),
       _asyncSystem(externals.pTaskProcessor),
       _userCredit(
           (options.credit && externals.pCreditSystem)
               ? std::optional<Credit>(externals.pCreditSystem->createCredit(
                     options.credit.value()))
               : std::nullopt),
-      _tilesetCredits(),
       _url(url),
-      _ionAssetID(),
-      _ionAccessToken(),
       _isRefreshingIonToken(false),
       _options(options),
       _pRootTile(),
       _previousFrameNumber(0),
-      _updateResult(),
-      _loadQueueHigh(),
-      _loadQueueMedium(),
-      _loadQueueLow(),
       _loadsInProgress(0),
-      _loadedTiles(),
       _overlays(*this),
       _tileDataBytes(0),
       _supportsRasterOverlays(false) {
@@ -67,34 +58,26 @@ Tileset::Tileset(
     uint32_t ionAssetID,
     const std::string& ionAccessToken,
     const TilesetOptions& options)
-    : _contexts(),
-      _externals(externals),
+    : _externals(externals),
       _asyncSystem(externals.pTaskProcessor),
       _userCredit(
           (options.credit && externals.pCreditSystem)
               ? std::optional<Credit>(externals.pCreditSystem->createCredit(
                     options.credit.value()))
               : std::nullopt),
-      _tilesetCredits(),
-      _url(),
       _ionAssetID(ionAssetID),
       _ionAccessToken(ionAccessToken),
       _isRefreshingIonToken(false),
       _options(options),
       _pRootTile(),
       _previousFrameNumber(0),
-      _updateResult(),
-      _loadQueueHigh(),
-      _loadQueueMedium(),
-      _loadQueueLow(),
       _loadsInProgress(0),
-      _loadedTiles(),
       _overlays(*this),
       _tileDataBytes(0),
       _supportsRasterOverlays(false) {
   std::string ionUrl = "https://api.cesium.com/v1/assets/" +
                        std::to_string(ionAssetID) + "/endpoint";
-  if (ionAccessToken.size() > 0) {
+  if (!ionAccessToken.empty()) {
     ionUrl += "?access_token=" + ionAccessToken;
   }
 
@@ -246,7 +229,8 @@ static double computeFogDensity(
 
   if (nextIt == fogDensityTable.end()) {
     return fogDensityTable.back().fogDensity;
-  } else if (nextIt == fogDensityTable.begin()) {
+  }
+  if (nextIt == fogDensityTable.begin()) {
     return nextIt->fogDensity;
   }
 
@@ -1713,11 +1697,14 @@ std::string Tileset::getResolvedContentUrl(const Tile& tile) const {
           [this, &quadtreeID](const std::string& placeholder) -> std::string {
             if (placeholder == "level" || placeholder == "z") {
               return std::to_string(quadtreeID.level);
-            } else if (placeholder == "x") {
+            }
+            if (placeholder == "x") {
               return std::to_string(quadtreeID.x);
-            } else if (placeholder == "y") {
+            }
+            if (placeholder == "y") {
               return std::to_string(quadtreeID.y);
-            } else if (placeholder == "version") {
+            }
+            if (placeholder == "version") {
               return this->context.version.value_or(std::string());
             }
 
@@ -1735,13 +1722,17 @@ std::string Tileset::getResolvedContentUrl(const Tile& tile) const {
           [this, &octreeID](const std::string& placeholder) -> std::string {
             if (placeholder == "level") {
               return std::to_string(octreeID.level);
-            } else if (placeholder == "x") {
+            }
+            if (placeholder == "x") {
               return std::to_string(octreeID.x);
-            } else if (placeholder == "y") {
+            }
+            if (placeholder == "y") {
               return std::to_string(octreeID.y);
-            } else if (placeholder == "z") {
+            }
+            if (placeholder == "z") {
               return std::to_string(octreeID.z);
-            } else if (placeholder == "version") {
+            }
+            if (placeholder == "version") {
               return this->context.version.value_or(std::string());
             }
 

--- a/Cesium3DTiles/src/ViewState.cpp
+++ b/Cesium3DTiles/src/ViewState.cpp
@@ -127,10 +127,9 @@ double ViewState::computeDistanceSquaredToBoundingVolume(
         return boundingRegion.computeDistanceSquaredToPosition(
             viewState._positionCartographic.value(),
             viewState._position);
-      } else {
-        return boundingRegion.computeDistanceSquaredToPosition(
-            viewState._position);
       }
+      return boundingRegion.computeDistanceSquaredToPosition(
+          viewState._position);
     }
 
     double operator()(const BoundingSphere& boundingSphere) {
@@ -144,10 +143,9 @@ double ViewState::computeDistanceSquaredToBoundingVolume(
         return boundingRegion.computeConservativeDistanceSquaredToPosition(
             viewState._positionCartographic.value(),
             viewState._position);
-      } else {
-        return boundingRegion.computeConservativeDistanceSquaredToPosition(
-            viewState._position);
       }
+      return boundingRegion.computeConservativeDistanceSquaredToPosition(
+          viewState._position);
     }
   };
 

--- a/CesiumAsync/include/CesiumAsync/AsyncSystem.h
+++ b/CesiumAsync/include/CesiumAsync/AsyncSystem.h
@@ -253,7 +253,7 @@ public:
    * @param pTaskProcessor The interface used to run tasks in background
    * threads.
    */
-  AsyncSystem(std::shared_ptr<ITaskProcessor> pTaskProcessor) noexcept;
+  AsyncSystem(const std::shared_ptr<ITaskProcessor>& pTaskProcessor) noexcept;
 
   template <class T, class Func> Future<T> createFuture(Func&& f) const {
     std::shared_ptr<async::event_task<T>> pEvent =

--- a/CesiumAsync/src/AsyncSystem.cpp
+++ b/CesiumAsync/src/AsyncSystem.cpp
@@ -4,7 +4,7 @@
 
 namespace CesiumAsync {
 AsyncSystem::AsyncSystem(
-    std::shared_ptr<ITaskProcessor> pTaskProcessor) noexcept
+    const std::shared_ptr<ITaskProcessor>& pTaskProcessor) noexcept
     : _pSchedulers(
           std::make_shared<Impl::AsyncSystemSchedulers>(pTaskProcessor)) {}
 
@@ -15,7 +15,7 @@ void AsyncSystem::dispatchMainThreadTasks() {
 namespace Impl {
 AsyncSystemSchedulers::AsyncSystemSchedulers(
     std::shared_ptr<ITaskProcessor> pTaskProcessor_)
-    : pTaskProcessor(pTaskProcessor_), mainThreadScheduler() {}
+    : pTaskProcessor(std::move(pTaskProcessor_)) {}
 
 void AsyncSystemSchedulers::schedule(async::task_run_handle t) {
   struct Receiver {

--- a/CesiumAsync/src/CachingAssetAccessor.cpp
+++ b/CesiumAsync/src/CachingAssetAccessor.cpp
@@ -23,9 +23,8 @@ public:
     auto it = this->_pCacheItem->cacheResponse.headers.find("Content-Type");
     if (it == this->_pCacheItem->cacheResponse.headers.end()) {
       return std::string();
-    } else {
-      return it->second;
     }
+    return it->second;
   }
 
   virtual const HttpHeaders& headers() const override {

--- a/CesiumAsync/src/ResponseCacheControl.cpp
+++ b/CesiumAsync/src/ResponseCacheControl.cpp
@@ -39,9 +39,9 @@ ResponseCacheControl::parseFromResponseHeaders(const HttpHeaders& headers) {
   std::set<std::string, CaseInsensitiveCompare> directives;
   size_t last = 0;
   size_t next = 0;
-  while ((next = headerValue.find(",", last)) != std::string::npos) {
+  while ((next = headerValue.find(',', last)) != std::string::npos) {
     std::string directive = trimSpace(headerValue.substr(last, next - last));
-    size_t equalSize = directive.find("=");
+    size_t equalSize = directive.find('=');
     if (equalSize != std::string::npos) {
       parameterizedDirectives.insert(
           {trimSpace(directive.substr(0, equalSize)),
@@ -54,7 +54,7 @@ ResponseCacheControl::parseFromResponseHeaders(const HttpHeaders& headers) {
   }
 
   std::string directive = trimSpace(headerValue.substr(last));
-  size_t equalSize = directive.find("=");
+  size_t equalSize = directive.find('=');
   if (equalSize != std::string::npos) {
     parameterizedDirectives.insert(
         {trimSpace(directive.substr(0, equalSize)),

--- a/CesiumAsync/src/SqliteCache.cpp
+++ b/CesiumAsync/src/SqliteCache.cpp
@@ -106,7 +106,6 @@ SqliteCache::SqliteCache(
     : _pLogger(pLogger),
       _pConnection(nullptr),
       _maxItems(maxItems),
-      _mutex(),
       _getEntryStmtWrapper(),
       _updateLastAccessedTimeStmtWrapper(),
       _storeResponseStmtWrapper(),
@@ -480,9 +479,12 @@ bool SqliteCache::prune() {
 
     totalItemsQueryStatus =
         sqlite3_step(this->_totalItemsQueryStmtWrapper.get());
+
     if (totalItemsQueryStatus == SQLITE_DONE) {
       return true;
-    } else if (totalItemsQueryStatus != SQLITE_ROW) {
+    }
+
+    if (totalItemsQueryStatus != SQLITE_ROW) {
       SPDLOG_LOGGER_ERROR(
           this->_pLogger,
           sqlite3_errstr(totalItemsQueryStatus));

--- a/CesiumAsync/test/TestCacheAssetAccessor.cpp
+++ b/CesiumAsync/test/TestCacheAssetAccessor.cpp
@@ -80,7 +80,7 @@ public:
 
 class MockAssetAccessor : public IAssetAccessor {
 public:
-  MockAssetAccessor(std::shared_ptr<IAssetRequest> request)
+  MockAssetAccessor(const std::shared_ptr<IAssetRequest>& request)
       : testRequest{request} {}
 
   virtual CesiumAsync::Future<std::shared_ptr<IAssetRequest>> requestAsset(
@@ -525,25 +525,27 @@ TEST_CASE("Test serving cache item") {
             asyncSystem,
             "test.com",
             std::vector<IAssetAccessor::THeader>{})
-        .thenInMainThread([](std::shared_ptr<IAssetRequest> completedRequest) {
-          REQUIRE(completedRequest != nullptr);
-          REQUIRE(completedRequest->url() == "test.com");
-          REQUIRE(
-              completedRequest->headers() ==
-              HttpHeaders{{"Request-Header", "Request-Value"}});
-          REQUIRE(completedRequest->method() == "GET");
+        .thenInMainThread(
+            [](const std::shared_ptr<IAssetRequest>& completedRequest) {
+              REQUIRE(completedRequest != nullptr);
+              REQUIRE(completedRequest->url() == "test.com");
+              REQUIRE(
+                  completedRequest->headers() ==
+                  HttpHeaders{{"Request-Header", "Request-Value"}});
+              REQUIRE(completedRequest->method() == "GET");
 
-          const IAssetResponse* response = completedRequest->response();
-          REQUIRE(response != nullptr);
-          REQUIRE(
-              response->headers().at("Response-Header") == "Response-Value");
-          REQUIRE(response->statusCode() == 200);
-          REQUIRE(response->contentType() == "app/json");
-          REQUIRE(response->data().empty());
-          REQUIRE(!ResponseCacheControl::parseFromResponseHeaders(
-                       response->headers())
-                       .has_value());
-        });
+              const IAssetResponse* response = completedRequest->response();
+              REQUIRE(response != nullptr);
+              REQUIRE(
+                  response->headers().at("Response-Header") ==
+                  "Response-Value");
+              REQUIRE(response->statusCode() == 200);
+              REQUIRE(response->contentType() == "app/json");
+              REQUIRE(response->data().empty());
+              REQUIRE(!ResponseCacheControl::parseFromResponseHeaders(
+                           response->headers())
+                           .has_value());
+            });
     asyncSystem.dispatchMainThreadTasks();
   }
 
@@ -603,38 +605,39 @@ TEST_CASE("Test serving cache item") {
             asyncSystem,
             "test.com",
             std::vector<IAssetAccessor::THeader>{})
-        .thenInMainThread([](std::shared_ptr<IAssetRequest> completedRequest) {
-          REQUIRE(completedRequest != nullptr);
-          REQUIRE(completedRequest->url() == "cache.com");
-          REQUIRE(
-              completedRequest->headers() ==
-              HttpHeaders{{"Cache-Request-Header", "Cache-Request-Value"}});
-          REQUIRE(completedRequest->method() == "GET");
+        .thenInMainThread(
+            [](const std::shared_ptr<IAssetRequest>& completedRequest) {
+              REQUIRE(completedRequest != nullptr);
+              REQUIRE(completedRequest->url() == "cache.com");
+              REQUIRE(
+                  completedRequest->headers() ==
+                  HttpHeaders{{"Cache-Request-Header", "Cache-Request-Value"}});
+              REQUIRE(completedRequest->method() == "GET");
 
-          const IAssetResponse* response = completedRequest->response();
-          REQUIRE(response != nullptr);
-          REQUIRE(
-              response->headers().at("Cache-Response-Header") ==
-              "Cache-Response-Value");
-          REQUIRE(response->statusCode() == 200);
-          REQUIRE(response->contentType() == "app/json");
-          REQUIRE(response->data().empty());
+              const IAssetResponse* response = completedRequest->response();
+              REQUIRE(response != nullptr);
+              REQUIRE(
+                  response->headers().at("Cache-Response-Header") ==
+                  "Cache-Response-Value");
+              REQUIRE(response->statusCode() == 200);
+              REQUIRE(response->contentType() == "app/json");
+              REQUIRE(response->data().empty());
 
-          std::optional<ResponseCacheControl> cacheControl =
-              ResponseCacheControl::parseFromResponseHeaders(
-                  response->headers());
+              std::optional<ResponseCacheControl> cacheControl =
+                  ResponseCacheControl::parseFromResponseHeaders(
+                      response->headers());
 
-          REQUIRE(cacheControl.has_value());
-          REQUIRE(cacheControl->mustRevalidate() == false);
-          REQUIRE(cacheControl->noCache() == false);
-          REQUIRE(cacheControl->noStore() == false);
-          REQUIRE(cacheControl->noTransform() == false);
-          REQUIRE(cacheControl->accessControlPublic() == false);
-          REQUIRE(cacheControl->accessControlPrivate() == true);
-          REQUIRE(cacheControl->proxyRevalidate() == false);
-          REQUIRE(cacheControl->maxAge() == 100);
-          REQUIRE(cacheControl->sharedMaxAge() == 0);
-        });
+              REQUIRE(cacheControl.has_value());
+              REQUIRE(cacheControl->mustRevalidate() == false);
+              REQUIRE(cacheControl->noCache() == false);
+              REQUIRE(cacheControl->noStore() == false);
+              REQUIRE(cacheControl->noTransform() == false);
+              REQUIRE(cacheControl->accessControlPublic() == false);
+              REQUIRE(cacheControl->accessControlPrivate() == true);
+              REQUIRE(cacheControl->proxyRevalidate() == false);
+              REQUIRE(cacheControl->maxAge() == 100);
+              REQUIRE(cacheControl->sharedMaxAge() == 0);
+            });
     asyncSystem.dispatchMainThreadTasks();
   }
 
@@ -695,42 +698,43 @@ TEST_CASE("Test serving cache item") {
             asyncSystem,
             "test.com",
             std::vector<IAssetAccessor::THeader>{})
-        .thenInMainThread([](std::shared_ptr<IAssetRequest> completedRequest) {
-          REQUIRE(completedRequest != nullptr);
-          REQUIRE(completedRequest->url() == "cache.com");
-          REQUIRE(
-              completedRequest->headers() ==
-              HttpHeaders{{"Cache-Request-Header", "Cache-Request-Value"}});
-          REQUIRE(completedRequest->method() == "GET");
+        .thenInMainThread(
+            [](const std::shared_ptr<IAssetRequest>& completedRequest) {
+              REQUIRE(completedRequest != nullptr);
+              REQUIRE(completedRequest->url() == "cache.com");
+              REQUIRE(
+                  completedRequest->headers() ==
+                  HttpHeaders{{"Cache-Request-Header", "Cache-Request-Value"}});
+              REQUIRE(completedRequest->method() == "GET");
 
-          // check response header is updated
-          const IAssetResponse* response = completedRequest->response();
-          REQUIRE(response != nullptr);
-          REQUIRE(
-              response->headers().at("Revalidation-Response-Header") ==
-              "Revalidation-Response-Value");
-          REQUIRE(
-              response->headers().at("Cache-Response-Header") ==
-              "Cache-Response-Value");
-          REQUIRE(response->statusCode() == 200);
-          REQUIRE(response->contentType() == "app/json");
-          REQUIRE(response->data().empty());
+              // check response header is updated
+              const IAssetResponse* response = completedRequest->response();
+              REQUIRE(response != nullptr);
+              REQUIRE(
+                  response->headers().at("Revalidation-Response-Header") ==
+                  "Revalidation-Response-Value");
+              REQUIRE(
+                  response->headers().at("Cache-Response-Header") ==
+                  "Cache-Response-Value");
+              REQUIRE(response->statusCode() == 200);
+              REQUIRE(response->contentType() == "app/json");
+              REQUIRE(response->data().empty());
 
-          // check cache control is updated
-          std::optional<ResponseCacheControl> cacheControl =
-              ResponseCacheControl::parseFromResponseHeaders(
-                  response->headers());
-          REQUIRE(cacheControl.has_value());
-          REQUIRE(cacheControl->mustRevalidate() == true);
-          REQUIRE(cacheControl->noCache() == false);
-          REQUIRE(cacheControl->noStore() == false);
-          REQUIRE(cacheControl->noTransform() == false);
-          REQUIRE(cacheControl->accessControlPublic() == false);
-          REQUIRE(cacheControl->accessControlPrivate() == true);
-          REQUIRE(cacheControl->proxyRevalidate() == false);
-          REQUIRE(cacheControl->maxAge() == 300);
-          REQUIRE(cacheControl->sharedMaxAge() == 0);
-        });
+              // check cache control is updated
+              std::optional<ResponseCacheControl> cacheControl =
+                  ResponseCacheControl::parseFromResponseHeaders(
+                      response->headers());
+              REQUIRE(cacheControl.has_value());
+              REQUIRE(cacheControl->mustRevalidate() == true);
+              REQUIRE(cacheControl->noCache() == false);
+              REQUIRE(cacheControl->noStore() == false);
+              REQUIRE(cacheControl->noTransform() == false);
+              REQUIRE(cacheControl->accessControlPublic() == false);
+              REQUIRE(cacheControl->accessControlPrivate() == true);
+              REQUIRE(cacheControl->proxyRevalidate() == false);
+              REQUIRE(cacheControl->maxAge() == 300);
+              REQUIRE(cacheControl->sharedMaxAge() == 0);
+            });
     asyncSystem.dispatchMainThreadTasks();
   }
 
@@ -790,25 +794,26 @@ TEST_CASE("Test serving cache item") {
             asyncSystem,
             "test.com",
             std::vector<IAssetAccessor::THeader>{})
-        .thenInMainThread([](std::shared_ptr<IAssetRequest> completedRequest) {
-          REQUIRE(completedRequest != nullptr);
-          REQUIRE(completedRequest->url() == "test.com");
-          REQUIRE(completedRequest->headers() == HttpHeaders{});
-          REQUIRE(completedRequest->method() == "GET");
+        .thenInMainThread(
+            [](const std::shared_ptr<IAssetRequest>& completedRequest) {
+              REQUIRE(completedRequest != nullptr);
+              REQUIRE(completedRequest->url() == "test.com");
+              REQUIRE(completedRequest->headers().empty());
+              REQUIRE(completedRequest->method() == "GET");
 
-          const IAssetResponse* response = completedRequest->response();
-          REQUIRE(response != nullptr);
+              const IAssetResponse* response = completedRequest->response();
+              REQUIRE(response != nullptr);
 
-          REQUIRE(
-              response->headers().at("Revalidation-Response-Header") ==
-              "Revalidation-Response-Value");
-          REQUIRE(response->statusCode() == 200);
-          REQUIRE(response->contentType() == "app/json");
-          REQUIRE(response->data().empty());
-          REQUIRE(!ResponseCacheControl::parseFromResponseHeaders(
-                       response->headers())
-                       .has_value());
-        });
+              REQUIRE(
+                  response->headers().at("Revalidation-Response-Header") ==
+                  "Revalidation-Response-Value");
+              REQUIRE(response->statusCode() == 200);
+              REQUIRE(response->contentType() == "app/json");
+              REQUIRE(response->data().empty());
+              REQUIRE(!ResponseCacheControl::parseFromResponseHeaders(
+                           response->headers())
+                           .has_value());
+            });
     asyncSystem.dispatchMainThreadTasks();
   }
 }

--- a/CesiumGeometry/src/BoundingSphere.cpp
+++ b/CesiumGeometry/src/BoundingSphere.cpp
@@ -13,7 +13,8 @@ BoundingSphere::intersectPlane(const Plane& plane) const noexcept {
   if (distanceToPlane < -radius) {
     // The center point is negative side of the plane normal
     return CullingResult::Outside;
-  } else if (distanceToPlane < radius) {
+  }
+  if (distanceToPlane < radius) {
     // The center point is positive side of the plane, but radius extends beyond
     // it; partial overlap
     return CullingResult::Intersecting;

--- a/CesiumGeometry/src/OrientedBoundingBox.cpp
+++ b/CesiumGeometry/src/OrientedBoundingBox.cpp
@@ -36,7 +36,8 @@ OrientedBoundingBox::intersectPlane(const Plane& plane) const noexcept {
   if (distanceToPlane <= -radEffective) {
     // The entire box is on the negative side of the plane normal
     return CullingResult::Outside;
-  } else if (distanceToPlane >= radEffective) {
+  }
+  if (distanceToPlane >= radEffective) {
     // The entire box is on the positive side of the plane normal
     return CullingResult::Inside;
   }

--- a/CesiumGeometry/src/QuadtreeTileAvailability.cpp
+++ b/CesiumGeometry/src/QuadtreeTileAvailability.cpp
@@ -95,7 +95,7 @@ bool QuadtreeTileAvailability::isTileAvailable(
     }
   }
 
-  if (pNode->rectangles.size() == 0 ||
+  if (pNode->rectangles.empty() ||
       pNode->rectangles.back().level <= rectangle.level) {
     pNode->rectangles.push_back(rectangle);
   } else {
@@ -154,7 +154,8 @@ bool QuadtreeTileAvailability::isTileAvailable(
             findMaxLevelFromNode(pNode, *pNode->ur, position));
       }
       break;
-    } else if (ll) {
+    }
+    if (ll) {
       pNode = pNode->ll.get();
     } else if (lr) {
       pNode = pNode->lr.get();

--- a/CesiumGeometry/src/Rectangle.cpp
+++ b/CesiumGeometry/src/Rectangle.cpp
@@ -32,13 +32,13 @@ Rectangle::computeSignedDistance(const glm::dvec2& position) const noexcept {
   if (maxDistance.x <= 0.0 && maxDistance.y <= 0.0) {
     // Inside, report closest edge.
     return glm::max(maxDistance.x, maxDistance.y);
-  } else if (maxDistance.x > 0.0 && maxDistance.y > 0.0) {
+  }
+  if (maxDistance.x > 0.0 && maxDistance.y > 0.0) {
     // Outside in both directions, closest point is a corner
     return glm::length(maxDistance);
-  } else {
-    // Outside in one direction, report the distance in that direction.
-    return glm::max(maxDistance.x, maxDistance.y);
   }
+  // Outside in one direction, report the distance in that direction.
+  return glm::max(maxDistance.x, maxDistance.y);
 }
 
 std::optional<Rectangle>

--- a/CesiumGeometry/src/clipTriangleAtAxisAlignedThreshold.cpp
+++ b/CesiumGeometry/src/clipTriangleAtAxisAlignedThreshold.cpp
@@ -99,8 +99,6 @@ void clipTriangleAtAxisAlignedThreshold(
     result.emplace_back(i2);
   }
   // else completely behind threshold
-
-  return;
 }
 
 } // namespace CesiumGeometry

--- a/CesiumGeospatial/src/Transforms.cpp
+++ b/CesiumGeospatial/src/Transforms.cpp
@@ -17,8 +17,8 @@ namespace CesiumGeospatial {
         glm::dvec4(-1.0, 0.0, 0.0, 0.0),
         glm::dvec4(0.0, 0.0, 1.0, 0.0),
         glm::dvec4(origin, 1.0));
-  } else if (
-      Math::equalsEpsilon(origin.x, 0.0, Math::EPSILON14) &&
+  }
+  if (Math::equalsEpsilon(origin.x, 0.0, Math::EPSILON14) &&
       Math::equalsEpsilon(origin.y, 0.0, Math::EPSILON14)) {
     // If x and y are zero, assume origin is at a pole, which is a special case.
     double sign = Math::sign(origin.z);
@@ -27,17 +27,17 @@ namespace CesiumGeospatial {
         glm::dvec4(-1.0 * sign, 0.0, 0.0, 0.0),
         glm::dvec4(0.0, 0.0, 1.0 * sign, 0.0),
         glm::dvec4(origin, 1.0));
-  } else {
-    glm::dvec3 up = ellipsoid.geodeticSurfaceNormal(origin);
-    glm::dvec3 east = glm::normalize(glm::dvec3(-origin.y, origin.x, 0.0));
-    glm::dvec3 north = glm::cross(up, east);
-
-    return glm::dmat4x4(
-        glm::dvec4(east, 0.0),
-        glm::dvec4(north, 0.0),
-        glm::dvec4(up, 0.0),
-        glm::dvec4(origin, 1.0));
   }
+
+  glm::dvec3 up = ellipsoid.geodeticSurfaceNormal(origin);
+  glm::dvec3 east = glm::normalize(glm::dvec3(-origin.y, origin.x, 0.0));
+  glm::dvec3 north = glm::cross(up, east);
+
+  return glm::dmat4x4(
+      glm::dvec4(east, 0.0),
+      glm::dvec4(north, 0.0),
+      glm::dvec4(up, 0.0),
+      glm::dvec4(origin, 1.0));
 }
 
 } // namespace CesiumGeospatial

--- a/CesiumGltf/src/Accessor.cpp
+++ b/CesiumGltf/src/Accessor.cpp
@@ -13,7 +13,6 @@ Accessor::computeNumberOfComponents(CesiumGltf::Accessor::Type type) {
   case CesiumGltf::Accessor::Type::VEC3:
     return 3;
   case CesiumGltf::Accessor::Type::VEC4:
-    return 4;
   case CesiumGltf::Accessor::Type::MAT2:
     return 4;
   case CesiumGltf::Accessor::Type::MAT3:
@@ -63,8 +62,7 @@ int64_t Accessor::computeByteStride(const CesiumGltf::Model& model) const {
 
   if (pBufferView->byteStride) {
     return pBufferView->byteStride.value();
-  } else {
-    return computeNumberOfComponents(this->type) *
-           computeByteSizeOfComponent(this->componentType);
   }
+  return computeNumberOfComponents(this->type) *
+         computeByteSizeOfComponent(this->componentType);
 }

--- a/CesiumGltf/src/JsonValue.cpp
+++ b/CesiumGltf/src/JsonValue.cpp
@@ -6,27 +6,24 @@ double JsonValue::getNumber(double defaultValue) const {
   const double* p = std::get_if<Number>(&this->value);
   if (p) {
     return *p;
-  } else {
-    return defaultValue;
   }
+  return defaultValue;
 }
 
 bool JsonValue::getBool(bool defaultValue) const {
   const bool* p = std::get_if<Bool>(&this->value);
   if (p) {
     return *p;
-  } else {
-    return defaultValue;
   }
+  return defaultValue;
 }
 
 std::string JsonValue::getString(const std::string& defaultValue) const {
   const std::string* p = std::get_if<String>(&this->value);
   if (p) {
     return *p;
-  } else {
-    return defaultValue;
   }
+  return defaultValue;
 }
 
 const JsonValue* JsonValue::getValueForKey(const std::string& key) const {

--- a/CesiumGltfReader/src/DictionaryJsonHandler.h
+++ b/CesiumGltfReader/src/DictionaryJsonHandler.h
@@ -29,11 +29,11 @@ public:
       auto it = this->_pDictionary1->emplace(str, T()).first;
 
       return this->property(it->first.c_str(), this->_item, it->second);
-    } else {
-      auto it = this->_pDictionary2->emplace(str, T()).first;
-
-      return this->property(it->first.c_str(), this->_item, it->second);
     }
+
+    auto it = this->_pDictionary2->emplace(str, T()).first;
+
+    return this->property(it->first.c_str(), this->_item, it->second);
   }
 
 private:

--- a/CesiumGltfReader/src/JsonObjectJsonHandler.cpp
+++ b/CesiumGltfReader/src/JsonObjectJsonHandler.cpp
@@ -123,7 +123,6 @@ IJsonHandler* JsonObjectJsonHandler::doneElement() {
   if (!pArray) {
     this->_stack.pop_back();
     return this->_stack.empty() ? this->parent() : this;
-  } else {
-    return this;
   }
+  return this;
 }

--- a/CesiumGltfReader/src/ObjectJsonHandler.cpp
+++ b/CesiumGltfReader/src/ObjectJsonHandler.cpp
@@ -17,8 +17,8 @@ IJsonHandler* ObjectJsonHandler::EndObject(size_t memberCount) {
 
   if (this->_depth > 0)
     return this->EndSubObject(memberCount);
-  else
-    return this->parent();
+
+  return this->parent();
 }
 
 IJsonHandler* ObjectJsonHandler::StartSubObject() { return nullptr; }

--- a/CesiumGltfReader/src/Reader.cpp
+++ b/CesiumGltfReader/src/Reader.cpp
@@ -293,7 +293,7 @@ ModelReaderResult readBinaryModel(const gsl::span<const std::byte>& data) {
   if (result.model && !binaryChunk.empty()) {
     Model& model = result.model.value();
 
-    if (model.buffers.size() == 0) {
+    if (model.buffers.empty()) {
       result.errors.emplace_back(
           "GLB has a binary chunk but the JSON does not define any buffers.");
       return result;

--- a/CesiumUtility/src/JsonHelpers.cpp
+++ b/CesiumUtility/src/JsonHelpers.cpp
@@ -97,9 +97,8 @@ std::string JsonHelpers::getStringOrDefault(
     const std::string& defaultValue) {
   if (json.IsString()) {
     return json.GetString();
-  } else {
-    return defaultValue;
   }
+  return defaultValue;
 }
 
 double JsonHelpers::getDoubleOrDefault(
@@ -117,9 +116,8 @@ double JsonHelpers::getDoubleOrDefault(
     double defaultValue) {
   if (json.IsDouble()) {
     return json.GetDouble();
-  } else {
-    return defaultValue;
   }
+  return defaultValue;
 }
 
 uint32_t JsonHelpers::getUint32OrDefault(
@@ -137,9 +135,8 @@ uint32_t JsonHelpers::getUint32OrDefault(
     uint32_t defaultValue) {
   if (json.IsUint()) {
     return json.GetUint();
-  } else {
-    return defaultValue;
   }
+  return defaultValue;
 }
 
 int32_t JsonHelpers::getInt32OrDefault(
@@ -157,9 +154,8 @@ int32_t JsonHelpers::getInt32OrDefault(
     int32_t defaultValue) {
   if (json.IsInt()) {
     return json.GetInt();
-  } else {
-    return defaultValue;
   }
+  return defaultValue;
 }
 
 uint64_t JsonHelpers::getUint64OrDefault(
@@ -177,9 +173,8 @@ uint64_t JsonHelpers::getUint64OrDefault(
     uint64_t defaultValue) {
   if (json.IsUint()) {
     return json.GetUint();
-  } else {
-    return defaultValue;
   }
+  return defaultValue;
 }
 
 int64_t JsonHelpers::getInt64OrDefault(
@@ -197,9 +192,8 @@ int64_t JsonHelpers::getInt64OrDefault(
     int64_t defaultValue) {
   if (json.IsInt()) {
     return json.GetInt();
-  } else {
-    return defaultValue;
   }
+  return defaultValue;
 }
 
 bool JsonHelpers::getBoolOrDefault(
@@ -217,9 +211,8 @@ bool JsonHelpers::getBoolOrDefault(
     bool defaultValue) {
   if (json.IsBool()) {
     return json.GetBool();
-  } else {
-    return defaultValue;
   }
+  return defaultValue;
 }
 
 std::vector<std::string>

--- a/CesiumUtility/src/Uri.cpp
+++ b/CesiumUtility/src/Uri.cpp
@@ -86,9 +86,8 @@ std::string Uri::addQuery(
   // TODO
   if (uri.find('?') != std::string::npos) {
     return uri + "&" + key + "=" + value;
-  } else {
-    return uri + "?" + key + "=" + value;
   }
+  return uri + "?" + key + "=" + value;
   // UriUriA baseUri;
 
   // if (uriParseSingleUriA(&baseUri, uri.c_str(), nullptr) != URI_SUCCESS)


### PR DESCRIPTION
Mainly caching else after return, not using empty() instead of size() == 0, missing const references to avoid copies and removing redundant initializations. 

There are still missing several fixes that I left for following passes if we accept this first one, including:
* Incosistent case style for global constants
* Inconsistent case style for parameters/variables
* Differing parameters names between headers and sources
* Code that may throw exceptions in no-except declared functions
* Following rule of five if rule of zero can't be followed (Up to discussion on how to act on this)

Some of the changes explanation for reference:
https://clang.llvm.org/extra/clang-tidy/checks/performance-move-const-arg.html
https://clang.llvm.org/extra/clang-tidy/checks/performance-faster-string-find.html
https://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-value-param.html
https://clang.llvm.org/extra/clang-tidy/checks/bugprone-branch-clone.html
https://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-member-init.html
https://clang.llvm.org/extra/clang-tidy/checks/readability-simplify-boolean-expr.html