### PR TITLE
Log tile ids

### DIFF
--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
@@ -357,7 +357,37 @@ protected:
       const LoadTileImageFromUrlOptions& options = {}) const;
 
 private:
+  struct LoadResult {
+    RasterOverlayTile::LoadState state = RasterOverlayTile::LoadState::Unloaded;
+    CesiumGltf::ImageCesium image = {};
+    std::vector<Credit> credits = {};
+    void* pRendererResources = nullptr;
+  };
+
   void doLoad(RasterOverlayTile& tile, bool isThrottledLoad);
+
+  /**
+   * @brief Processes the given `LoadedRasterOverlayImage`, producing a
+   * `LoadResult`.
+   *
+   * This function is intended to be called on the worker thread.
+   *
+   * If the given `loadedImage` contains no valid image data, then a
+   * `LoadResult` with the state `RasterOverlayTile::LoadState::Failed` will be
+   * returned.
+   *
+   * Otherwise, the image data will be passed to
+   * `IPrepareRendererResources::prepareRasterInLoadThread`, and the function
+   * will return a `LoadResult` with the image, the prepared renderer resources,
+   * and the state `RasterOverlayTile::LoadState::Loaded`.
+   *
+   * @param tileId The {@link TileID} - only used for logging
+   * @param loadedImage The `LoadedRasterOverlayImage`
+   * @return The `LoadResult`
+   */
+  LoadResult processLoadedImage(
+      const CesiumGeometry::QuadtreeTileID& tileId,
+      LoadedRasterOverlayImage&& loadedImage);
 
   /**
    * @brief Begins the process of loading of a tile.

--- a/Cesium3DTiles/include/Cesium3DTiles/TileID.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileID.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Cesium3DTiles/Library.h"
 #include "CesiumGeometry/OctreeTileID.h"
 #include "CesiumGeometry/QuadtreeTileID.h"
 #include <string>
@@ -35,5 +36,21 @@ typedef std::variant<
     CesiumGeometry::OctreeTileID,
     CesiumGeometry::UpsampledQuadtreeNode>
     TileID;
+
+struct CESIUM3DTILES_API TileIdUtilities {
+  /**
+   * @brief Creates an unspecified string representation of the given {@link
+   * TileID}.
+   *
+   * The returned string will contain information about the given tile ID,
+   * depending on its type. The exact format and contents of this string
+   * is not specified. This is mainly intended for printing informative
+   * log messages.
+   *
+   * @param tileId The tile ID
+   * @return The string
+   */
+  static std::string createTileIdString(const TileID& tileId);
+};
 
 } // namespace Cesium3DTiles

--- a/Cesium3DTiles/src/TileID.cpp
+++ b/Cesium3DTiles/src/TileID.cpp
@@ -1,0 +1,43 @@
+#include "Cesium3DTiles/TileID.h"
+
+#include <string>
+#include <variant>
+
+namespace Cesium3DTiles {
+
+/*static*/ std::string
+TileIdUtilities::createTileIdString(const TileID& tileId) {
+
+  struct Operation {
+
+    std::string operator()(const std::string& url) { return url; }
+
+    std::string
+    operator()(const CesiumGeometry::QuadtreeTileID& quadtreeTileId) {
+      // Strings of the form "L10-X23-Y144"
+      return "L" + std::to_string(quadtreeTileId.level) + "-" + "X" +
+             std::to_string(quadtreeTileId.x) + "-" + "Y" +
+             std::to_string(quadtreeTileId.y);
+    }
+
+    std::string operator()(const CesiumGeometry::OctreeTileID& octreeTileId) {
+      // Strings of the form "L10-X23-Y144-Z42"
+      return "L" + std::to_string(octreeTileId.level) + "-" + "X" +
+             std::to_string(octreeTileId.x) + "-" + "Y" +
+             std::to_string(octreeTileId.y) + "-" + "Z" +
+             std::to_string(octreeTileId.z);
+    }
+
+    std::string operator()(
+        const CesiumGeometry::UpsampledQuadtreeNode& upsampledQuadtreeNode) {
+      // Strings of the form "upsampled-L10-X23-Y144"
+      return "upsampled-L" +
+             std::to_string(upsampledQuadtreeNode.tileID.level) + "-" + "X" +
+             std::to_string(upsampledQuadtreeNode.tileID.x) + "-" + "Y" +
+             std::to_string(upsampledQuadtreeNode.tileID.y);
+    }
+  };
+  return std::visit(Operation{}, tileId);
+}
+
+} // namespace Cesium3DTiles

--- a/CesiumGeometry/include/CesiumGeometry/OctreeTileID.h
+++ b/CesiumGeometry/include/CesiumGeometry/OctreeTileID.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CesiumGeometry/Library.h"
+#include <cstdint>
 
 namespace CesiumGeometry {
 


### PR DESCRIPTION
Addressing and maybe fixing https://github.com/CesiumGS/cesium-native/issues/179 : 

There now is a function to create a `std::string` from a `TileID`. The warning/error messages from `RasterOverlayTileProvider::doLoad` now contain these tile IDs. (**If** the underlying implementation uses `loadTileImageFromUrl`, then all warnings/errors will also contain the URL, but that was already done in another PR). 

The current structure is (depending on the implementation, in pseudocode) 

    void doLoad(Tile tile) {
        Result result = loadTileImage(tile.getId());
        if (result.error) {
            // Log something here...
        }
    }
    virtual Result  loadTileImage(TileID tileID) { // Depends on implementation
        String url = createUrlFrom(tileId);
        return loadTileImageFromUrl(url);
    }
    Result loadTileImageFromUrl(String url) {
        Response response = request(url);
        return readImageData(response.data);
    }
    Result readImageData(vector<byte> data) {
        return stb_load(data);
    }


So the question of "What should be logged where?" could be answered:

- Networking errors (404s) are reported in `loadTileImageFromUrl`, which does the request/response handling, including the URL
- Loading errors (image could not be read) are reported in `doLoad`, including the the tile ID
- In order to "transport" low-level errors from stb, the `loadedImage.errors` can be used. Since this is implemented locally in a lambda, only for the `loadTileImageFromUrl` case, the URL can be added there directly.

In any case: If there is a problem with a tile, it now prints

```
LogCesium: Warning: [2021-04-26 17:52:21.040] [warning] [RasterOverlayTileProvider.cpp:552] Warnings while loading image for tile L8-X463-Y199:
- ...
```
