### PR TITLE
Added a mutex to CreditSystem

### DIFF
--- a/Cesium3DTiles/include/Cesium3DTiles/CreditSystem.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/CreditSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Cesium3DTiles/Library.h"
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -81,6 +82,11 @@ private:
     std::string html;
     int32_t lastFrameNumber;
   };
+
+  /**
+   * The mutex that is used to synchronize all methods of this class
+   */
+  mutable std::mutex _mutex;
 
   std::vector<HtmlAndLastFrameNumber> _credits;
 

--- a/Cesium3DTiles/src/CreditSystem.cpp
+++ b/Cesium3DTiles/src/CreditSystem.cpp
@@ -1,9 +1,13 @@
 #include "Cesium3DTiles/CreditSystem.h"
 #include <algorithm>
+#include <mutex>
 
 namespace Cesium3DTiles {
 
 Credit CreditSystem::createCredit(const std::string& html) {
+
+  std::lock_guard<std::mutex> lock(_mutex);
+
   // if this credit already exists, return a Credit handle to it
   for (size_t id = 0; id < _credits.size(); ++id) {
     if (_credits[id].html == html) {
@@ -19,6 +23,7 @@ Credit CreditSystem::createCredit(const std::string& html) {
 }
 
 const std::string& CreditSystem::getHtml(Credit credit) const {
+  std::lock_guard<std::mutex> lock(_mutex);
   if (credit.id < _credits.size()) {
     return _credits[credit.id].html;
   }
@@ -26,6 +31,7 @@ const std::string& CreditSystem::getHtml(Credit credit) const {
 }
 
 void CreditSystem::addCreditToFrame(Credit credit) {
+  std::lock_guard<std::mutex> lock(_mutex);
   // if this credit has already been added to the current frame, there's nothing
   // to do
   if (_credits[credit.id].lastFrameNumber == _currentFrameNumber) {
@@ -51,6 +57,7 @@ void CreditSystem::addCreditToFrame(Credit credit) {
 }
 
 void CreditSystem::startNextFrame() {
+  std::lock_guard<std::mutex> lock(_mutex);
   _creditsToNoLongerShowThisFrame.swap(_creditsToShowThisFrame);
   _creditsToShowThisFrame.clear();
   _currentFrameNumber++;

--- a/Cesium3DTiles/test/TestCreditSystem.cpp
+++ b/Cesium3DTiles/test/TestCreditSystem.cpp
@@ -1,6 +1,12 @@
 #include "Cesium3DTiles/CreditSystem.h"
 #include "catch2/catch.hpp"
 
+//#define TEST_THREADED 1
+
+#ifdef TEST_THREADED
+#include <thread>
+#endif // TEST_THREADED
+
 using namespace Cesium3DTiles;
 
 TEST_CASE("Test basic credit handling") {
@@ -79,3 +85,30 @@ TEST_CASE("Test wrong credit handling") {
 
   REQUIRE(creditSystemB.getHtml(creditA1) != html1);
 }
+
+#ifdef TEST_THREADED
+TEST_CASE("Test threaded credit handling") {
+
+  CreditSystem creditSystem;
+  try {
+    const int numWorkers = 20;
+    std::vector<std::thread> workers;
+    for (int w = 0; w < numWorkers; w++) {
+      INFO("Start worker " + std::to_string(w));
+      workers.push_back(std::thread([&creditSystem, w]() {
+        for (int i = 0; i < 100; i++) {
+          creditSystem.createCredit("html" + std::to_string(i));
+        }
+      }));
+    }
+
+    for (int w = 0; w < numWorkers; w++) {
+      INFO("Join worker " + std::to_string(w));
+      workers[w].join();
+    };
+    INFO("Test threaded credit handling done");
+  } catch (...) {
+    FAIL("Caught an error in threaded credit handling");
+  }
+}
+#endif // TEST_THREADED


### PR DESCRIPTION
As mentioned in https://github.com/CesiumGS/cesium-native/issues/215 

This (until now) only adds a mutex/lock to all methods of `CreditSystem`. And I think that's what has to be done to be really thread-safe. 

In a deeper analysis, one could remove the mutex/lock for some cases, and add disclaimers and say in a comment that it is *assumed* that, for example, `addCreditToFrame` and `startNextFrame` are always called from the same thread. 

Another step further, I'm not entirely sure about the conventions: `getCreditsToShowThisFrame` returns a reference to the vector. The caveats of having *one* thread operating on such a vector, and *another* thread modifying the vector (via any of the methods) are probably beyond what we can sensibly address...

BTW: I have added a ""test case"", but it looks crude: It just creates a pile of threads that all create credits like mad, and essentially expects the whole thing to *not* crash. *Without* the mutexes, this crashed pretty reliably (at different places). With the mutex, it never crashed. But there's probably some better, idiomatic way of testing this, so the text case is currently omitted via `#ifdef`. Any hint about how to test this sensibly is appreciated (otherwise, I'd try to find some infos on that, but that would probably not be in the scope of this PR)





