### PR TITLE
Moved credit creation into main thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,12 +42,8 @@ jobs:
       # We're using Clang 10 instead of the default (Clang 7) because of std::variant related failures
       # on Clang 7, possibly related to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90397
       install:
-        - sudo apt-get check
-        - sudo apt-get clean
         - sudo apt-get update
-        - sudo apt-get clean
-        - sudo apt-get check
-        - sudo apt-get -V -f install clang-10 cmake doxygen
+        - sudo apt-get install clang-10 cmake doxygen
       env:
         - CC=clang-10
         - CXX=clang++-10

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
       # on Clang 7, possibly related to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90397
       install:
         - sudo apt-get update
-        - sudo apt-get install clang-10 cmake doxygen
+        - sudo apt-get install libclang-common-10-dev clang-10 cmake doxygen
       env:
         - CC=clang-10
         - CXX=clang++-10

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,9 @@ jobs:
       # on Clang 7, possibly related to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90397
       install:
         - sudo apt-get check
+        - sudo apt-get clean
         - sudo apt-get update
+        - sudo apt-get clean
         - sudo apt-get check
         - sudo apt-get -V -f install clang-10 cmake doxygen
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,10 @@ jobs:
       # We're using Clang 10 instead of the default (Clang 7) because of std::variant related failures
       # on Clang 7, possibly related to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90397
       install:
+        - sudo apt-get check
         - sudo apt-get update
-        - sudo apt-get install libclang-common-10-dev clang-10 cmake doxygen
+        - sudo apt-get check
+        - sudo apt-get -V install clang-10 cmake doxygen
       env:
         - CC=clang-10
         - CXX=clang++-10

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
         - sudo apt-get check
         - sudo apt-get update
         - sudo apt-get check
-        - sudo apt-get -V install clang-10 cmake doxygen
+        - sudo apt-get -V -f install clang-10 cmake doxygen
       env:
         - CC=clang-10
         - CXX=clang++-10


### PR DESCRIPTION
As suggested in https://github.com/CesiumGS/cesium-native/pull/227#issuecomment-828201482 , the call in `BingMapsRasterOverlay::createTileProvider` that callled `CreditSystem::createCredit` has been moved from the worker thread to the main thread.

As a ... (hacky? or pragmatic?) ... well, as a "layer of validation", I added some 
```
std::string currentThreadString() {
    std::ostringstream ss;  
    ss << std::this_thread::get_id();
    return ss.str();
}
Credit CreditSystem::createCredit(const std::string& html) {

  SPDLOG_WARN("Called createCredit on {}", currentThreadString());
```
(and to all other functions of `CreditSystem`), and indeed, *most* functions had been called by the same thread *most* of the time, *except* for that few `createCredit` calls. After this change, **all** calls to the `CreditSystem` had been made on the same thread.

