### PR TITLE
Comment fixes for clang formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
 
-# Based on the https://www.kernel.org/doc/Documentation/CodingStyle
+# Based on the LLVM coding style https://llvm.org/docs/CodingStandards.html
 BasedOnStyle: LLVM
 
 # Always add a line break after an opening bracket if the parameters 

--- a/.clang-format
+++ b/.clang-format
@@ -1,8 +1,37 @@
+
+# Based on the https://www.kernel.org/doc/Documentation/CodingStyle
 BasedOnStyle: LLVM
+
+# Always add a line break after an opening bracket if the parameters 
+# do not fit on a single line
 AlignAfterOpenBracket: AlwaysBreak
+
+# If arguments don't all fit on a single line, place each one in
+# a new line
 BinPackArguments: false
-BinPackParameters: false
-PointerAlignment: Left
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-AllowAllParametersOfDeclarationOnNextLine: false
+
+# If a function call or braced initializer list does not fit on a 
+# line, allow putting all arguments onto the next line
+# (even if BinPackArguments is false).
 AllowAllArgumentsOnNextLine: false
+
+# If parameters don't all fit on a single line, place each one in
+# a new line
+BinPackParameters: false
+
+# If the function declaration does not fit on a line, allow putting 
+# all parameters of a function declaration onto the next line
+# (even when BinPackParameters is false).
+AllowAllParametersOfDeclarationOnNextLine: false
+
+# Use 'int* a;' (instead of 'int *a;')
+PointerAlignment: Left
+
+# If the constructor initializers doe not fit on a line, put each 
+# initializer on its own line.
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+
+# Do not break comment lines that contain the given regex. This
+# is here to avoid breaking lines within "{@link SomeClass}"
+# which would cause doxygen to fail.
+CommentPragmas: '{.*}'

--- a/Cesium3DTiles/include/Cesium3DTiles/BingMapsRasterOverlay.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/BingMapsRasterOverlay.h
@@ -87,14 +87,15 @@ public:
    * @param url The url of the Bing Maps server hosting the imagery.
    * @param key The Bing Maps key for your application, which can be created at
    * https://www.bingmapsportal.com/.
-   * @param mapStyle The type of Bing Maps imagery to load. A value from {@link
-   * BingMapsStyle}, with {@link BingMapsStyle::AERIAL} being the default.
+   * @param mapStyle The type of Bing Maps imagery to load. A value from
+   * {@link BingMapsStyle}, with {@link BingMapsStyle::AERIAL} being the
+   * default.
    * @param culture The culture to use when requesting Bing Maps imagery. Not
    * all cultures are supported. See
    * http://msdn.microsoft.com/en-us/library/hh441729.aspx for information on
    * the supported cultures.
-   * @param ellipsoid The ellipsoid. Default value: {@link
-   * CesiumGeospatial::Ellipsoid::WGS84}.
+   * @param ellipsoid The ellipsoid. Default value:
+   * {@link CesiumGeospatial::Ellipsoid::WGS84}.
    */
   BingMapsRasterOverlay(
       const std::string& url,

--- a/Cesium3DTiles/include/Cesium3DTiles/CreditSystem.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/CreditSystem.h
@@ -9,8 +9,8 @@ namespace Cesium3DTiles {
 
 /**
  * @brief Represents an HTML string that should be shown on screen to attribute
- * third parties for used data, imagery, etc. Acts as a handle into a {@link
- * CreditSystem} object that actually holds the credit string.
+ * third parties for used data, imagery, etc. Acts as a handle into a
+ * {@link CreditSystem} object that actually holds the credit string.
  */
 struct CESIUM3DTILES_API Credit {
 public:

--- a/Cesium3DTiles/include/Cesium3DTiles/ExternalTilesetContent.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/ExternalTilesetContent.h
@@ -17,7 +17,7 @@ class Tileset;
 
 /**
  * @brief Creates a {@link TileContentLoadResult} from 3D Tiles external
- * tileset.json data.
+ * `tileset.json` data.
  */
 class CESIUM3DTILES_API ExternalTilesetContent final
     : public TileContentLoader {

--- a/Cesium3DTiles/include/Cesium3DTiles/GltfContent.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/GltfContent.h
@@ -52,10 +52,10 @@ public:
    *
    * This is not supposed to be called by clients.
    *
-   * It will be called for all {@link RasterMappedTo3DTile} objects of a {@link
-   * Tile}, and extend the accessors of the given glTF model with accessors that
-   * contain the texture coordinate sets for different projections. Further
-   * details are not specified here.
+   * It will be called for all {@link RasterMappedTo3DTile} objects of a
+   * {@link Tile}, and extend the accessors of the given glTF model with
+   * accessors that contain the texture coordinate sets for different
+   * projections. Further details are not specified here.
    *
    * @param gltf The glTF model.
    * @param textureCoordinateID The texture coordinate ID.

--- a/Cesium3DTiles/include/Cesium3DTiles/IPrepareRendererResources.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/IPrepareRendererResources.h
@@ -54,12 +54,12 @@ public:
    * @brief Further prepares renderer resources.
    *
    * This is called after {@link prepareInLoadThread}, and unlike that method,
-   * this one is called from the same thread that called {@link
-   * Tileset::updateView}.
+   * this one is called from the same thread that called
+   * {@link Tileset::updateView}.
    *
    * @param tile The tile to prepare.
-   * @param pLoadThreadResult The value returned from {@link
-   * prepareInLoadThread}.
+   * @param pLoadThreadResult The value returned from
+   * {@link prepareInLoadThread}.
    * @returns Arbitrary data representing the result of the load process.
    * Note that the value returned by {@link prepareInLoadThread} will _not_ be
    * automatically preserved and passed to {@link free}. If you need to free
@@ -71,16 +71,16 @@ public:
   /**
    * @brief Frees previously-prepared renderer resources.
    *
-   * This method is always called from the thread that called {@link
-   * Tileset::updateView} or deleted the tileset.
+   * This method is always called from the thread that called
+   * {@link Tileset::updateView} or deleted the tileset.
    *
    * @param tile The tile for which to free renderer resources.
-   * @param pLoadThreadResult The result returned by {@link
-   * prepareInLoadThread}. If {@link prepareInMainThread} has already been
-   * called, this parameter will be `nullptr`.
-   * @param pMainThreadResult The result returned by {@link
-   * prepareInMainThread}. If {@link prepareInMainThread} has not yet been
-   * called, this parameter will be `nullptr`.
+   * @param pLoadThreadResult The result returned by
+   * {@link prepareInLoadThread}. If {@link prepareInMainThread} has
+   * already been called, this parameter will be `nullptr`.
+   * @param pMainThreadResult The result returned by
+   * {@link prepareInMainThread}. If {@link prepareInMainThread} has
+   * not yet been called, this parameter will be `nullptr`.
    */
   virtual void free(
       Tile& tile,
@@ -104,12 +104,12 @@ public:
    * @brief Further preprares a raster overlay tile.
    *
    * This is called after {@link prepareRasterInLoadThread}, and unlike that
-   * method, this one is called from the same thread that called {@link
-   * Tileset::updateView}.
+   * method, this one is called from the same thread that called
+   * {@link Tileset::updateView}.
    *
    * @param rasterTile The raster tile to prepare.
-   * @param pLoadThreadResult The value returned from {@link
-   * prepareInLoadThread}.
+   * @param pLoadThreadResult The value returned from
+   * {@link prepareInLoadThread}.
    * @returns Arbitrary data representing the result of the load process. Note
    * that the value returned by {@link prepareRasterInLoadThread} will _not_ be
    * automatically preserved and passed to {@link free}. If you need to free
@@ -123,16 +123,16 @@ public:
   /**
    * @brief Frees previously-prepared renderer resources for a raster tile.
    *
-   * This method is always called from the thread that called {@link
-   * Tileset::updateView} or deleted the tileset.
+   * This method is always called from the thread that called
+   * {@link Tileset::updateView} or deleted the tileset.
    *
    * @param rasterTile The tile for which to free renderer resources.
-   * @param pLoadThreadResult The result returned by {@link
-   * prepareRasterInLoadThread}. If {@link prepareRasterInMainThread} has
-   * already been called, this parameter will be `nullptr`.
-   * @param pMainThreadResult The result returned by {@link
-   * prepareRasterInMainThread}. If {@link prepareRasterInMainThread} has not
-   * yet been called, this parameter will be `nullptr`.
+   * @param pLoadThreadResult The result returned by
+   * {@link prepareRasterInLoadThread}. If {@link prepareRasterInMainThread}
+   * has already been called, this parameter will be `nullptr`.
+   * @param pMainThreadResult The result returned by
+   * {@link prepareRasterInMainThread}. If {@link prepareRasterInMainThread}
+   * has not yet been called, this parameter will be `nullptr`.
    */
   virtual void freeRaster(
       const RasterOverlayTile& rasterTile,
@@ -146,12 +146,10 @@ public:
    * @param overlayTextureCoordinateID The ID of the overlay texture coordinate
    * set to use.
    * @param rasterTile The raster overlay tile to add. The raster tile will have
-   * been previously prepared with a call to
-   *        {@link prepareRasterInLoadThread} followed by {@link
-   * prepareRasterInMainThread}.
+   * been previously prepared with a call to {@link prepareRasterInLoadThread}
+   * followed by {@link prepareRasterInMainThread}.
    * @param pMainThreadRendererResources The renderer resources for this raster
-   * tile, as created and returned by
-   *        {@link prepareRasterInMainThread}.
+   * tile, as created and returned by {@link prepareRasterInMainThread}.
    * @param textureCoordinateRectangle Defines the range of texture coordinates
    * in which this raster tile should be applied, in the order west, south, east
    * north. Each coordinate is in the range 0.0 (southwest corner) to 1.0
@@ -182,8 +180,7 @@ public:
    * set to which the raster tile was previously attached.
    * @param rasterTile The raster overlay tile to remove.
    * @param pMainThreadRendererResources The renderer resources for this raster
-   * tile, as created and returned by
-   *        {@link prepareRasterInMainThread}.
+   * tile, as created and returned by {@link prepareRasterInMainThread}.
    * @param textureCoordinateRectangle Defines the range of texture coordinates
    * in which this raster tile should be applied, in the order west, south, east
    * north. Each coordinate is in the range 0.0 (southwest corner) to 1.0

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlay.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlay.h
@@ -13,6 +13,9 @@ class IPrepareRendererResources;
 class RasterOverlayTileProvider;
 class RasterOverlayCollection;
 
+/**
+ * @brief Options for loading raster overlays.
+ */
 struct CESIUM3DTILES_API RasterOverlayOptions {
   /**
    * @brief The maximum number of overlay tiles that may simultaneously be in
@@ -34,6 +37,11 @@ struct CESIUM3DTILES_API RasterOverlayOptions {
  */
 class RasterOverlay {
 public:
+  /**
+   * @brief Creates a new instance.
+   *
+   * @param options The {@link RasterOverlayOptions} for this instance.
+   */
   RasterOverlay(const RasterOverlayOptions& options = RasterOverlayOptions());
   virtual ~RasterOverlay();
 
@@ -82,8 +90,8 @@ public:
    * @brief Begins asynchronous creation of the tile provider for this overlay
    * and eventually makes it available directly from this instance.
    *
-   * When the tile provider is ready, it will be returned by {@link
-   * getTileProvider}.
+   * When the tile provider is ready, it will be returned by
+   * {@link getTileProvider}.
    *
    * This method does nothing if the tile provider has already been created or
    * is already in the process of being created.

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTile.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTile.h
@@ -63,8 +63,8 @@ public:
   /**
    * @brief Constructs a placeholder tile for the tile provider.
    *
-   * The {@link getState} of this instance will always be {@link
-   * LoadState::Placeholder}.
+   * The {@link getState} of this instance will always be
+   * {@link LoadState::Placeholder}.
    *
    * @param overlay The {@link RasterOverlay}.
    */
@@ -75,16 +75,16 @@ public:
    *
    * This is called by a {@link RasterOverlayTileProvider} when a new,
    * previously unknown tile is reqested. It receives the request for the image
-   * data, and the {@link getState} will initially be {@link LoadState
-   * `Loading`}. The constructor will attach a callback to this request.  When
+   * data, and the {@link getState} will initially be
+   * {@link LoadState `Loading`}.
+   * The constructor will attach a callback to this request.  When
    * the request completes successfully and the {@link getImage} data can be
-   * created, the state of this instance will change to {@link LoadState
-   * `Loaded`}. Otherwise, the state will become {@link LoadState `Failed`}.
+   * created, the state of this instance will change to
+   * {@link LoadState `Loaded`}.
+   * Otherwise, the state will become {@link LoadState `Failed`}.
    *
    * @param overlay The {@link RasterOverlay}.
    * @param tileID The {@link CesiumGeometry::QuadtreeTileID} for this tile.
-   * @param tileCredits The list of {@link Credit}s needed for this tile.
-   * @param imageRequest The pending request for the image data.
    */
   RasterOverlayTile(
       RasterOverlay& overlay,
@@ -140,9 +140,9 @@ public:
    *
    * If the {@link getState} of this tile is not {@link LoadState `Loaded`},
    * then nothing will be done. Otherwise, the renderer resources will be
-   * prepared, so that they may later be obtained with {@link
-   * getRendererResources}, and the {@link getState} of this tile will change to
-   * {@link LoadState `Done`}.
+   * prepared, so that they may later be obtained with
+   * {@link getRendererResources}, and the {@link getState} of this tile
+   * will change to {@link LoadState `Done`}.
    */
   void loadInMainThread();
 

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
@@ -20,10 +20,38 @@ class RasterOverlay;
 class RasterOverlayTile;
 class IPrepareRendererResources;
 
+/**
+ * @brief Summarizes the result of loading an image of a {@link RasterOverlay}.
+ */
 struct CESIUM3DTILES_API LoadedRasterOverlayImage {
+
+  /**
+   * @brief The loaded image.
+   *
+   * This will be an empty optional if the loading failed. In this case,
+   * the `errors` vector will contain the corresponding error messages.
+   */
   std::optional<CesiumGltf::ImageCesium> image;
+
+  /**
+   * @brief The {@link Credit} objects that decribe the attributions that
+   * are required when using the image.
+   */
   std::vector<Credit> credits;
+
+  /**
+   * @brief Error messages from loading the image.
+   *
+   * If the image was loaded successfully, this should be empty.
+   */
   std::vector<std::string> errors;
+
+  /**
+   * @brief Warnings from loading the image.
+   */
+  // Implementation note: In the current implementation, this will
+  // always be empty, but it might contain warnings in the future,
+  // when other image types or loaders are used.
   std::vector<std::string> warnings;
 };
 
@@ -34,8 +62,8 @@ struct LoadTileImageFromUrlOptions {
   /**
    * @brief The credits to display with this tile.
    *
-   * This property is copied verbatim to the {@link
-   * LoadedRasterOverlayImage::credits} property.
+   * This property is copied verbatim to the
+   * {@link LoadedRasterOverlayImage::credits} property.
    */
   std::vector<Credit> credits = {};
 
@@ -47,12 +75,12 @@ struct LoadTileImageFromUrlOptions {
    * a valid 0x0 image. If false, such a response will be reported as an
    * error.
    *
-   * {@link RasterOverlayTileProvider::loadTile} and {@link
-   * RasterOverlayTileProvider::loadTileThrottled} will treat such an image as
-   * "failed" and use the quadtree parent (or ancestor) image instead, but
-   * will not report any error.
+   * {@link RasterOverlayTileProvider::loadTile} and
+   * {@link RasterOverlayTileProvider::loadTileThrottled} will treat such an
+   * image as "failed" and use the quadtree parent (or ancestor) image
+   * instead, but will not report any error.
    *
-   * This flag should only be set to true when the tile source uses a
+   * This flag should only be set to `true` when the tile source uses a
    * zero-length response as an indication that this tile is - as expected -
    * not available.
    */

--- a/Cesium3DTiles/include/Cesium3DTiles/Tile.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/Tile.h
@@ -35,9 +35,9 @@ struct TileContentLoadResult;
  * and {@link Tile::getChildren} functions.
  *
  * The renderable content is provided as a {@link TileContentLoadResult}
- * from the {@link Tile::getContent} function. The {@link
- * Tile::getGeometricError} function returns the geometric error of the
- * representation of the renderable content of a tile.
+ * from the {@link Tile::getContent} function.
+ * The {@link Tile::getGeometricError} function returns the geometric
+ * error of the representation of the renderable content of a tile.
  *
  * The {@link BoundingVolume} is given by the {@link Tile::getBoundingVolume}
  * function. This bounding volume encloses the renderable content of the
@@ -470,30 +470,31 @@ public:
    *
    * This function is not supposed to be called by clients.
    *
-   * If this tile is not in its initial state (indicated by the {@link
-   * Tile::getState} of this tile being *not* {@link
-   * Tile::LoadState::Unloaded}), then nothing will be done.
+   * If this tile is not in its initial state (indicated by the
+   * {@link Tile::getState} of this tile being *not*
+   * {@link Tile::LoadState::Unloaded}), then nothing will be done.
    *
-   * Otherwise, the tile will go into the {@link
-   * Tile::LoadState::ContentLoading} state, and the request for loading the
-   * tile content will be sent out. The function will then return, and the
-   * response of the request will be received asynchronously. Depending on the
-   * type of the tile and the response, the tile will eventually go into the
-   * {@link Tile::LoadState::ContentLoaded} state, and the {@link
-   * Tile::getContent} will be available.
+   * Otherwise, the tile will go into the
+   * {@link Tile::LoadState::ContentLoading} state, and the request for
+   * loading the tile content will be sent out.
+   * The function will then return, and the response of the request will
+   * be received asynchronously. Depending on the type of the tile and
+   * the response, the tile will eventually go into the
+   * {@link Tile::LoadState::ContentLoaded} state, and the
+   * {@link Tile::getContent} will be available.
    */
   void loadContent();
 
   /**
-   * @brief Frees all resources that have been allocated for the {@link
-   * Tile::getContent}.
+   * @brief Frees all resources that have been allocated for the
+   * {@link Tile::getContent}.
    *
    * This function is not supposed to be called by clients.
    *
    * If the operation for loading the tile content is currently in progress, as
-   * indicated by the {@link Tile::getState} of this tile being {@link
-   * Tile::LoadState::ContentLoading}), then nothing will be done, and `false`
-   * will be returned.
+   * indicated by the {@link Tile::getState} of this tile being
+   * {@link Tile::LoadState::ContentLoading}), then nothing will be done,
+   * and `false` will be returned.
    *
    * Otherwise, the resources that have been allocated for the tile content will
    * be freed.

--- a/Cesium3DTiles/include/Cesium3DTiles/TileContentFactory.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileContentFactory.h
@@ -22,17 +22,19 @@ class TileContent;
 class Tileset;
 
 /**
- * @brief Creates {@link TileContentLoadResult} objects from a {@link
- * TileContentLoadInput}.
+ * @brief Creates {@link TileContentLoadResult} objects from a
+ * {@link TileContentLoadInput}.
  *
- * The class offers a lookup functionality for registering {@link
- * TileContentLoader} instances that can create {@link TileContentLoadResult}
- * instances from a {@link TileContentLoadInput}.
+ * The class offers a lookup functionality for registering
+ * {@link TileContentLoader} instances that can create
+ * {@link TileContentLoadResult} instances from a
+ * {@link TileContentLoadInput}.
  *
  * The loaders are registered based on the magic header or the content type
- * of the input data. The raw data (i.e. the `data` of the {@link
- * TileContentLoadInput}) is usually received as a response to a  network
- * request, and the first four bytes of the raw data form the magic header.
+ * of the input data. The raw data (i.e. the `data` of the
+ * {@link TileContentLoadInput}) is usually received as a response to a
+ * network request, and the first four bytes of the raw data form the magic
+ * header.
  * Based on this header or the content type of the network response, the loader
  * that will be used for processing the input can be looked up.
  */
@@ -71,8 +73,8 @@ public:
       const std::shared_ptr<TileContentLoader>& pLoader);
 
   /**
-   * @brief Creates the {@link TileContentLoadResult} from the given {@link
-   * TileContentLoadInput}.
+   * @brief Creates the {@link TileContentLoadResult} from the given
+   * {@link TileContentLoadInput}.
    *
    * This will look up the {@link TileContentLoader} that can be used to
    * process the given input data, based on all loaders that

--- a/Cesium3DTiles/include/Cesium3DTiles/TileContentLoadInput.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileContentLoadInput.h
@@ -88,7 +88,6 @@ struct CESIUM3DTILES_API TileContentLoadInput {
    * @param contentType_ The content type, if the data was received via a
    * network response
    * @param url_ The URL that the data was loaded from
-   * @param context_ The {@link TileContext}
    * @param tileID_ The {@link TileID}
    * @param tileBoundingVolume_ The tile {@link BoundingVolume}
    * @param tileContentBoundingVolume_ The tile content {@link BoundingVolume}

--- a/Cesium3DTiles/include/Cesium3DTiles/TileContentLoadResult.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileContentLoadResult.h
@@ -17,9 +17,9 @@ class Tile;
  * structure encapsulates all of those possibilities. Each possible result is
  * therefore provided as an `std::optional`.
  *
- * Instances of this structure are created internally, by the {@link
- * TileContentFactory}, when the response to a network request for loading the
- * tile content was received.
+ * Instances of this structure are created internally, by the
+ * {@link TileContentFactory}, when the response to a network request for
+ * loading the tile content was received.
  */
 struct TileContentLoadResult {
   /**

--- a/Cesium3DTiles/include/Cesium3DTiles/TileContentLoader.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileContentLoader.h
@@ -5,8 +5,8 @@
 
 namespace Cesium3DTiles {
 /**
- * @brief Can create a {@link TileContentLoadResult} from a {@link
- * TileContentLoadInput}.
+ * @brief Can create a {@link TileContentLoadResult} from a
+ * {@link TileContentLoadInput}.
  */
 class CESIUM3DTILES_API TileContentLoader {
 
@@ -16,7 +16,7 @@ public:
   /**
    * @brief Loads the tile content from the given input.
    *
-   * @param The {@link TileContentLoadInput}
+   * @param input The {@link TileContentLoadInput}
    * @return The {@link TileContentLoadResult}. This may be the `nullptr` if the
    * tile content could not be loaded.
    */

--- a/Cesium3DTiles/include/Cesium3DTiles/TileContext.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileContext.h
@@ -91,8 +91,8 @@ typedef void ContextInitializerSignature(
     TileContext& currentContext);
 
 /**
- * @brief A function that serves as a callback for initializing a new {@link
- * TileContext} from properties of the parent context.
+ * @brief A function that serves as a callback for initializing a new
+ * {@link TileContext} from properties of the parent context.
  */
 typedef std::function<ContextInitializerSignature> ContextInitializerCallback;
 

--- a/Cesium3DTiles/include/Cesium3DTiles/TileSelectionState.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/TileSelectionState.h
@@ -9,8 +9,9 @@ namespace Cesium3DTiles {
  * @brief A description of the state of a {@link Tile} during the rendering
  * process
  *
- * Instances of this class combine a frame number and a {@link
- * TileSelectionState::Result} that describes the actual state of the tile.
+ * Instances of this class combine a frame number and a
+ * {@link TileSelectionState::Result} that describes the actual state of the
+ * tile.
  * Instances of this class are stored in a {@link Tile}, and are used to track
  * the state of the tile during the rendering process. The {@link Tileset}
  * updates this state while traversing the tile hierarchy, tracking whether a
@@ -64,15 +65,15 @@ public:
   };
 
   /**
-   * @brief Initializes a new instance with {@link
-   * TileSelectionState::Result::None}
+   * @brief Initializes a new instance with
+   * {@link TileSelectionState::Result::None}
    */
   constexpr TileSelectionState() noexcept
       : _frameNumber(0), _result(Result::None) {}
 
   /**
-   * @brief Initializes a new instance with a given {@link
-   * TileSelectionState::Result}.
+   * @brief Initializes a new instance with a given
+   * {@link TileSelectionState::Result}.
    *
    * @param frameNumber The frame number in which the selection took place.
    * @param result The result of the selection.
@@ -108,9 +109,9 @@ public:
    * @brief Determines if this tile or its descendents were kicked from the
    * render list.
    *
-   * In other words, if its last selection result was {@link
-   * TileSelectionState::Result::RenderedAndKicked} or {@link
-   * TileSelectionState::Result::RefinedAndKicked}.
+   * In other words, if its last selection result was
+   * {@link TileSelectionState::Result::RenderedAndKicked} or
+   * {@link TileSelectionState::Result::RefinedAndKicked}.
    *
    * @param frameNumber The previous frame number.
    * @return `true` if the tile was kicked, and `false` otherwise

--- a/CesiumAsync/include/CesiumAsync/AsyncSystem.h
+++ b/CesiumAsync/include/CesiumAsync/AsyncSystem.h
@@ -85,8 +85,8 @@ template <class Func> auto unwrapFuture(Func&& f) {
 } // namespace Impl
 
 /**
- * @brief A value that will be available in the future, as produced by {@link
- * AsyncSystem}.
+ * @brief A value that will be available in the future, as produced by
+ * {@link AsyncSystem}.
  *
  * @tparam T The type of the value.
  */
@@ -233,12 +233,27 @@ private:
  */
 class CESIUMASYNC_API AsyncSystem final {
 public:
+  /**
+   * @brief A promise that can be resolved or rejected by an asynchronous task.
+   *
+   * @tparam T The type of the object that the promise will be resolved with.
+   */
   template <typename T> struct Promise {
     Promise(const std::shared_ptr<async::event_task<T>>& pEvent)
         : _pEvent(pEvent) {}
 
+    /**
+     * @brief Will be called when the task completed successfully.
+     *
+     * @param value The value that was computed by the asynchronous task.
+     */
     void resolve(T&& value) const { this->_pEvent->set(std::move(value)); }
 
+    /**
+     * @brief Will be called when the task failed.
+     *
+     * @param error The error that caused the task to fail.
+     */
     void reject(std::exception&& error) const {
       this->_pEvent->set_exception(std::make_exception_ptr(error));
     }

--- a/CesiumAsync/include/CesiumAsync/CacheItem.h
+++ b/CesiumAsync/include/CesiumAsync/CacheItem.h
@@ -53,8 +53,8 @@ public:
   /**
    * @brief Constructor.
    * @param cacheHeaders the headers of the request
-   * @param method the method of the request
-   * @param url the url of the request
+   * @param cacheMethod the method of the request
+   * @param cacheUrl the url of the request
    */
   CacheRequest(
       HttpHeaders&& cacheHeaders,

--- a/CesiumAsync/include/CesiumAsync/CachingAssetAccessor.h
+++ b/CesiumAsync/include/CesiumAsync/CachingAssetAccessor.h
@@ -30,7 +30,7 @@ public:
    * retrieve assets that are not in the cache.
    * @param pCacheDatabase The database in which to cache requests and
    * responses.
-   * @param requestsPerCacheClean The number of requests to handle before each
+   * @param requestsPerCachePrune The number of requests to handle before each
    * {@link ICacheDatabase::prune} of old cached results from the database.
    */
   CachingAssetAccessor(

--- a/CesiumAsync/include/CesiumAsync/HttpHeaders.h
+++ b/CesiumAsync/include/CesiumAsync/HttpHeaders.h
@@ -4,6 +4,15 @@
 #include <string>
 
 namespace CesiumAsync {
+
+/**
+ * @brief A case-insensitive `less-then` string comparison.
+ *
+ * This can be used as a `Compare` function, for example for a `std::map`.
+ * It will compare strings case-insensitively, by converting them to
+ * lower-case and comparing the results (leaving the exact behavior for
+ * non-ASCII strings unspecified).
+ */
 struct CaseInsensitiveCompare {
   bool operator()(const std::string& s1, const std::string& s2) const;
 };

--- a/CesiumGeometry/include/CesiumGeometry/QuadtreeTileID.h
+++ b/CesiumGeometry/include/CesiumGeometry/QuadtreeTileID.h
@@ -92,8 +92,8 @@ namespace std {
 template <> struct hash<CesiumGeometry::QuadtreeTileID> {
 
   /**
-   * @brief A specialization of the `std::hash` template for {@link
-   * CesiumGeometry::QuadtreeTileID} objects.
+   * @brief A specialization of the `std::hash` template for
+   * {@link CesiumGeometry::QuadtreeTileID} objects.
    */
   size_t operator()(const CesiumGeometry::QuadtreeTileID& key) const noexcept {
     // TODO: is this hash function any good? Probably not.

--- a/CesiumGeospatial/include/CesiumGeospatial/BoundingRegionWithLooseFittingHeights.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/BoundingRegionWithLooseFittingHeights.h
@@ -11,8 +11,8 @@ namespace CesiumGeospatial {
  * computations.
  *
  * An instance of this class serves as a marker of the imprecision of the
- * heights in a {@link BoundingRegion}, and also has a {@link
- * BoundingRegionWithLooseFittingHeights::computeConservativeDistanceSquaredToPosition}
+ * heights in a {@link BoundingRegion}, and also has a
+ * {@link BoundingRegionWithLooseFittingHeights::computeConservativeDistanceSquaredToPosition}
  * method to compute the conservative distance metric.
  */
 class CESIUMGEOSPATIAL_API BoundingRegionWithLooseFittingHeights final {

--- a/CesiumGeospatial/include/CesiumGeospatial/GeographicProjection.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/GeographicProjection.h
@@ -39,8 +39,8 @@ public:
    * @brief Computes the maximum rectangle that can be covered with this
    * projection
    *
-   * @param ellipsoid The {@link Ellipsoid}. Default value: {@link
-   * Ellipsoid::WGS84}.
+   * @param ellipsoid The {@link Ellipsoid}. Default value:
+   * {@link Ellipsoid::WGS84}.
    * @return The rectangle
    */
   static constexpr CesiumGeometry::Rectangle computeMaximumProjectedRectangle(
@@ -94,9 +94,9 @@ public:
   /**
    * @brief Converts geographic coordinates to geodetic ellipsoid coordinates.
    *
-   * Converts geographic X and Y coordinates, expressed in meters, to a {@link
-   * Cartographic} containing geodetic ellipsoid coordinates. The height is set
-   * to 0.0.
+   * Converts geographic X and Y coordinates, expressed in meters, to a
+   * {@link Cartographic} containing geodetic ellipsoid coordinates.
+   * The height is set to 0.0.
    *
    * @param projectedCoordinates The geographic projected coordinates to
    * unproject.
@@ -107,9 +107,9 @@ public:
   /**
    * @brief Converts geographic coordinates to geodetic ellipsoid coordinates.
    *
-   * Converts geographic X, Y coordinates, expressed in meters, to a {@link
-   * Cartographic} containing geodetic ellipsoid coordinates. The Z coordinate
-   * is copied unmodified to the height.
+   * Converts geographic X, Y coordinates, expressed in meters, to a
+   * {@link Cartographic} containing geodetic ellipsoid coordinates.
+   * The Z coordinate is copied unmodified to the height.
    *
    * @param projectedCoordinates The geographic projected coordinates to
    * unproject, with height (z) in meters.

--- a/CesiumGeospatial/include/CesiumGeospatial/Projection.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/Projection.h
@@ -29,8 +29,8 @@ glm::dvec3
 projectPosition(const Projection& projection, const Cartographic& position);
 
 /**
- * @brief Unprojects a position from the globe using the given {@link
- * Projection}.
+ * @brief Unprojects a position from the globe using the given
+ * {@link Projection}.
  *
  * @param projection The projection.
  * @param position The coordinates of the point, in meters.

--- a/CesiumGeospatial/include/CesiumGeospatial/WebMercatorProjection.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/WebMercatorProjection.h
@@ -49,8 +49,8 @@ public:
    * @brief Computes the maximum rectangle that can be covered with this
    * projection
    *
-   * @param ellipsoid The {@link Ellipsoid}. Default value: {@link
-   * Ellipsoid::WGS84}.
+   * @param ellipsoid The {@link Ellipsoid}. Default value:
+   * {@link Ellipsoid::WGS84}.
    * @return The rectangle
    */
   static constexpr CesiumGeometry::Rectangle computeMaximumProjectedRectangle(
@@ -97,9 +97,9 @@ public:
   /**
    * @brief Converts Web Mercator coordinates to geodetic ellipsoid coordinates.
    *
-   * Converts Web Mercator X and Y coordinates, expressed in meters, to a {@link
-   * Cartographic} containing geodetic ellipsoid coordinates. The height is set
-   * to 0.0.
+   * Converts Web Mercator X and Y coordinates, expressed in meters, to a
+   * {@link Cartographic} containing geodetic ellipsoid coordinates.
+   * The height is set to 0.0.
    *
    * @param projectedCoordinates The web mercator projected coordinates to
    * unproject.
@@ -110,9 +110,9 @@ public:
   /**
    * @brief Converts Web Mercator coordinates to geodetic ellipsoid coordinates.
    *
-   * Converts Web Mercator X, Y coordinates, expressed in meters, to a {@link
-   * Cartographic} containing geodetic ellipsoid coordinates. The Z coordinate
-   * is copied unmodified to the height.
+   * Converts Web Mercator X, Y coordinates, expressed in meters, to a
+   * {@link Cartographic} containing geodetic ellipsoid coordinates.
+   * The Z coordinate is copied unmodified to the height.
    *
    * @param projectedCoordinates The web mercator projected coordinates to
    * unproject, with height (z) in meters.

--- a/CesiumGltf/include/CesiumGltf/Accessor.h
+++ b/CesiumGltf/include/CesiumGltf/Accessor.h
@@ -28,8 +28,8 @@ struct CESIUMGLTF_API Accessor final : public AccessorSpec {
    * bytes while `CesiumGltf::Accessor::ComponentType::FLOAT` is 4 bytes.
    *
    * @param componentType The accessor component type.
-   * @return The number of bytes for the component type. Returns 0 if {@link
-   * Accessor::componentType} is not a valid enumation value.
+   * @return The number of bytes for the component type. Returns 0 if
+   * {@link Accessor::componentType} is not a valid enumeration value.
    */
   static int8_t
   computeByteSizeOfComponent(CesiumGltf::Accessor::ComponentType componentType);
@@ -63,13 +63,13 @@ struct CESIUMGLTF_API Accessor final : public AccessorSpec {
   /**
    * @brief Computes the total number of bytes for this accessor in each vertex.
    *
-   * This is computed by multiplying {@link
-   * Accessor::computeByteSizeOfComponent} by {@link
-   * Accessor::computeNumberOfComponents}.
+   * This is computed by multiplying
+   * {@link Accessor::computeByteSizeOfComponent} by
+   * {@link Accessor::computeNumberOfComponents}.
    *
    * @return The total number of bytes for this accessor in each vertex. Returns
    * 0 if this accessor's {@link Accessor::type} or
-   *         {@link Accessor::componentType} does not have a valid enumeration
+   * {@link Accessor::componentType} does not have a valid enumeration
    * value.
    */
   int64_t computeBytesPerVertex() const;
@@ -78,19 +78,17 @@ struct CESIUMGLTF_API Accessor final : public AccessorSpec {
    * @brief Computes this accessor's stride.
    *
    * The stride is the number of bytes between the same elements of successive
-   * vertices. The returned value will be at least as large as {@link
-   * Accessor::computeBytesPerVertex}, but maybe be larger if this accessor's
-   * data is interleaved with other accessors.
+   * vertices. The returned value will be at least as large as
+   * {@link Accessor::computeBytesPerVertex}, but maybe be larger if this
+   * accessor's data is interleaved with other accessors.
    *
    * The behavior is undefined if this accessor is not part of the given model.
    *
    * @param model The model that this accessor is a part of.
-   * @return The stride in bytes. Returns 0 if this accessor's {@link
-   * Accessor::type} or
-   *         {@link Accessor::componentType} does not have a valid enumeration
-   * value, or if
-   *         {@link Accessor::bufferView} does not refer to a valid {@link
-   * BufferView}.
+   * @return The stride in bytes. Returns 0 if this accessor's
+   * {@link Accessor::type} or {@link Accessor::componentType} does not have
+   * a valid enumeration value, or if {@link Accessor::bufferView} does not
+   * refer to a valid {@link BufferView}.
    */
   int64_t computeByteStride(const CesiumGltf::Model& model) const;
 };

--- a/CesiumGltf/include/CesiumGltf/AccessorView.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorView.h
@@ -48,8 +48,8 @@ enum class AccessorViewStatus {
   BufferTooSmall,
 
   /**
-   * @brief The `sizeof(T)` does not match the accessor's {@link
-   * Accessor::computeBytesPerVertex}.
+   * @brief The `sizeof(T)` does not match the accessor's
+   * {@link Accessor::computeBytesPerVertex}.
    */
   WrongSizeT,
 };
@@ -434,8 +434,8 @@ std::invoke_result_t<TCallback, AccessorView<float>> createAccessorView(
  *
  * @tparam TCallback The callback.
  * @param model The model to access.
- * @param accessorIndex The index of the accessor to view in {@link
- * Model::accessors}.
+ * @param accessorIndex The index of the accessor to view in
+ * {@link Model::accessors}.
  * @param callback The callback that receives the created accessor.
  * @return The value returned by the callback.
  */

--- a/CesiumGltf/include/CesiumGltf/ExtensibleObject.h
+++ b/CesiumGltf/include/CesiumGltf/ExtensibleObject.h
@@ -34,7 +34,8 @@ struct CESIUMGLTF_API ExtensibleObject {
   }
 
   /**
-   * @brief Gets a generic extension with the given name as a {@link JsonValue}.
+   * @brief Gets a generic extension with the given name as a
+   * {@link CesiumUtility::JsonValue}.
    *
    * If the extension exists but has a static type, this method will retur
    * nullptr. Use {@link getExtension} to retrieve a statically-typed extension.

--- a/CesiumGltfReader/include/CesiumGltf/GltfReader.h
+++ b/CesiumGltfReader/include/CesiumGltf/GltfReader.h
@@ -17,7 +17,8 @@ namespace CesiumGltf {
 struct ReaderContext;
 
 /**
- * @brief The result of reading a glTF model with {@link readModel}.
+ * @brief The result of reading a glTF model with
+ * {@link GltfReader::readModel}.
  */
 struct CESIUMGLTFREADER_API ModelReaderResult {
   /**
@@ -37,7 +38,8 @@ struct CESIUMGLTFREADER_API ModelReaderResult {
 };
 
 /**
- * @brief The result of reading an image with {@link readImage}.
+ * @brief The result of reading an image with
+ * {@link GltfReader::readImage}.
  */
 struct CESIUMGLTFREADER_API ImageReaderResult {
 
@@ -67,13 +69,14 @@ enum class ExtensionState {
    * @brief The extension is enabled.
    *
    * If a statically-typed class is available for the extension, it will be
-   * used. Otherwise the extension will be represented as a {@link JsonValue}.
+   * used. Otherwise the extension will be represented as a
+   * {@link CesiumUtility::JsonValue}.
    */
   Enabled,
 
   /**
-   * @brief The extension is enabled but will always be deserialized as a {@link
-   * JsonValue}.
+   * @brief The extension is enabled but will always be deserialized as a
+   * {@link CesiumUtility::JsonValue}.
    *
    * Even if a statically-typed class is available for the extension, it will
    * not be used.
@@ -137,7 +140,8 @@ public:
    * @brief Registers an extension for a glTF object.
    *
    * @tparam TExtended The glTF object to extend.
-   * @tparam TExtensionHandler The extension's {@link JsonHandler}.
+   * @tparam TExtensionHandler The extension's
+   * {@link CesiumJsonReader::JsonHandler}.
    * @param extensionName The name of the extension.
    */
   template <typename TExtended, typename TExtensionHandler>
@@ -157,7 +161,8 @@ public:
    * The extension name is obtained from `TExtensionHandler::ExtensionName`.
    *
    * @tparam TExtended The glTF object to extend.
-   * @tparam TExtensionHandler The extension's {@link JsonHandler}.
+   * @tparam TExtensionHandler The extension's
+   * {@link CesiumJsonReader::JsonHandler}.
    */
   template <typename TExtended, typename TExtensionHandler>
   void registerExtension() {
@@ -177,14 +182,15 @@ public:
    *
    * By default, all extensions are enabled. When an enabled extension is
    * encountered in the source glTF, it is read into a statically-typed
-   * extension class, if one is registered, or into a {@link JsonValue} if not.
+   * extension class, if one is registered, or into a
+   * {@link CesiumUtility::JsonValue} if not.
    *
    * When a disabled extension is encountered in the source glTF, it is ignored
    * completely.
    *
    * An extension may also be set to `ExtensionState::JsonOnly`, in which case
-   * it will be read into a
-   * {@link JsonValue} even if a statically-typed extension class is registered.
+   * it will be read into a {@link CesiumUtility::JsonValue} even if a
+   * statically-typed extension class is registered.
    *
    * @param extensionName The name of the extension to be enabled or disabled.
    * @param newState The new state for the extension.

--- a/CesiumGltfWriter/include/CesiumGltf/Writer.h
+++ b/CesiumGltfWriter/include/CesiumGltf/Writer.h
@@ -39,8 +39,9 @@ namespace CesiumGltf {
  * contains an external file uri and its `cesium.data` or `cesium.pixelData`
  * vector is empty, a MissingDataSource error will be returned.
  * - If a {@link CesiumGltf::Buffer} or {@link CesiumGltf::Image}
- * contains an external file uri, it will be ignored (use {@link
- * CesiumGltf::writeModelAndExternalFiles} for external file support).
+ * contains an external file uri, it will be ignored (use
+ * {@link CesiumGltf::writeModelAndExternalFiles} for external file
+ * support).
  */
 
 CESIUMGLTFWRITER_API WriteModelResult
@@ -48,31 +49,28 @@ writeModelAsEmbeddedBytes(const Model& model, const WriteModelOptions& options);
 
 /**
  * @brief Write a glTF or glb asset and its associated external images and
- buffers to
- * multiple files via user provided callback.
-
+ * buffers to multiple files via user provided callback.
+ *
  * @returns A {@link CesiumGltf::WriteModelResult} containing a list of
  * errors, warnings, and the final generated std::vector<std::byte> of the
  * glTF asset (as a GLB or GLTF).
  *
  * @param model Final assembled glTF asset, ready for serialization.
- * @param flags Bitset flags used to control writing glTF serialization
- behavior.
+ * @param options Options to use for exporting the asset.
  * @param filename Filename of the final glTF / GLB asset or an encountered
- external
- * {@link CesiumGltf::ImageCesium} / {@link CesiumGltf::BufferCesium} during the
- serialization process
+ * external {@link CesiumGltf::ImageCesium} / {@link CesiumGltf::BufferCesium}
+ * during the serialization process
  * @param writeGLTFCallback Callback the user must implement. The serializer
- will invoke this callback everytime it encounters
- a {@link CesiumGltf::Buffer} or {@link CesiumGltf::Image}
+ * will invoke this callback everytime it encounters
+ * a {@link CesiumGltf::Buffer} or {@link CesiumGltf::Image}
  * with an external file uri, giving the callback a chance to write the asset to
- disk. The callback will be called a final time with the provided filename
- string when its time to serialize the final `glb` or `gltf` to disk.
+ * disk. The callback will be called a final time with the provided filename
+ * string when its time to serialize the final `glb` or `gltf` to disk.
  * @details Simialr to {@link CesiumGltf::writeModelAsEmbeddedBytes}, with the
  * key variation that a filename will be automatically generated
- for your {@link CesiumGltf::Buffer}
- * or {@link CesiumGltf::Image}  if no uri is provided but `buffer.cesium.data`
- or `image.cesium.pixelData` is non-empty.
+ * for your {@link CesiumGltf::Buffer} or {@link CesiumGltf::Image}  if no
+ * uri is provided but `buffer.cesium.data` or `image.cesium.pixelData`
+ * is non-empty.
  */
 
 CESIUMGLTFWRITER_API WriteModelResult writeModelAndExternalFiles(

--- a/CesiumUtility/include/CesiumUtility/DoublyLinkedList.h
+++ b/CesiumUtility/include/CesiumUtility/DoublyLinkedList.h
@@ -5,8 +5,8 @@
 namespace CesiumUtility {
 
 /**
- * @brief Contains the previous and next pointers for an element in a {@link
- * DoublyLinkedList}.
+ * @brief Contains the previous and next pointers for an element in
+ * a {@link DoublyLinkedList}.
  */
 template <class T> class DoublyLinkedListPointers final {
 public:


### PR DESCRIPTION
Fixes the doxygen errors that had been introduced by https://github.com/CesiumGS/cesium-native/issues/218

Added/fixed minor missing comments, and minor changes (e.g. from renamed parameters and such). 
