### PR TITLE
Remove redundant `hasRootObject` from writeJsonValue

### DIFF
--- a/CesiumGltfWriter/src/AccessorSparseWriter.cpp
+++ b/CesiumGltfWriter/src/AccessorSparseWriter.cpp
@@ -32,7 +32,7 @@ void writeAccessorSparseIndices(
 
   if (!indices.extras.empty()) {
     j.Key("extras");
-    writeJsonValue(indices.extras, j, false);
+    writeJsonValue(indices.extras, j);
   }
 }
 

--- a/CesiumGltfWriter/src/AccessorWriter.cpp
+++ b/CesiumGltfWriter/src/AccessorWriter.cpp
@@ -77,7 +77,7 @@ void CesiumGltf::writeAccessor(
 
     if (!accessor.extras.empty()) {
       j.Key("extras");
-      writeJsonValue(accessor.extras, j, false);
+      writeJsonValue(accessor.extras, j);
     }
 
     j.EndObject();

--- a/CesiumGltfWriter/src/AnimationWriter.cpp
+++ b/CesiumGltfWriter/src/AnimationWriter.cpp
@@ -30,7 +30,7 @@ void writeAnimationChannel(
 
     if (!animationChannel.target.extras.empty()) {
       j.Key("extras");
-      CesiumGltf::writeJsonValue(animationChannel.target.extras, j, false);
+      CesiumGltf::writeJsonValue(animationChannel.target.extras, j);
     }
   }
   j.EndObject();
@@ -54,7 +54,7 @@ void writeAnimationSampler(
 
   if (!animationSampler.extras.empty()) {
     j.Key("extras");
-    CesiumGltf::writeJsonValue(animationSampler.extras, j, false);
+    CesiumGltf::writeJsonValue(animationSampler.extras, j);
   }
 
   j.EndObject();
@@ -105,7 +105,7 @@ void CesiumGltf::writeAnimation(
 
     if (!animation.extras.empty()) {
       j.Key("extras");
-      writeJsonValue(animation.extras, j, false);
+      writeJsonValue(animation.extras, j);
     }
 
     j.EndObject();

--- a/CesiumGltfWriter/src/AssetWriter.cpp
+++ b/CesiumGltfWriter/src/AssetWriter.cpp
@@ -30,7 +30,7 @@ void CesiumGltf::writeAsset(
 
   if (!asset.extras.empty()) {
     j.Key("extras");
-    writeJsonValue(asset.extras, j, false);
+    writeJsonValue(asset.extras, j);
   }
 
   j.EndObject();

--- a/CesiumGltfWriter/src/BufferViewWriter.cpp
+++ b/CesiumGltfWriter/src/BufferViewWriter.cpp
@@ -51,7 +51,7 @@ void CesiumGltf::writeBufferView(
 
     if (!bufferView.extras.empty()) {
       j.Key("extras");
-      writeJsonValue(bufferView.extras, j, false);
+      writeJsonValue(bufferView.extras, j);
     }
 
     j.EndObject();

--- a/CesiumGltfWriter/src/BufferWriter.cpp
+++ b/CesiumGltfWriter/src/BufferWriter.cpp
@@ -115,7 +115,7 @@ void CesiumGltf::writeBuffer(
 
     if (!buffer.extras.empty()) {
       j.Key("extras");
-      writeJsonValue(buffer.extras, j, false);
+      writeJsonValue(buffer.extras, j);
     }
 
     if (!buffer.extensions.empty()) {

--- a/CesiumGltfWriter/src/CameraWriter.cpp
+++ b/CesiumGltfWriter/src/CameraWriter.cpp
@@ -31,7 +31,7 @@ void writeOrthographicCamera(
 
   if (!cameraOrthographic.extras.empty()) {
     j.Key("extras");
-    CesiumGltf::writeJsonValue(cameraOrthographic.extras, j, false);
+    CesiumGltf::writeJsonValue(cameraOrthographic.extras, j);
   }
 
   j.EndObject();
@@ -61,7 +61,7 @@ void writePerspectiveCamera(
 
   if (!cameraPerspective.extras.empty()) {
     j.Key("extras");
-    CesiumGltf::writeJsonValue(cameraPerspective.extras, j, false);
+    CesiumGltf::writeJsonValue(cameraPerspective.extras, j);
   }
 
   j.EndObject();
@@ -104,7 +104,7 @@ void CesiumGltf::writeCamera(
 
     if (!camera.extras.empty()) {
       j.Key("extras");
-      writeJsonValue(camera.extras, j, false);
+      writeJsonValue(camera.extras, j);
     }
 
     j.EndObject();

--- a/CesiumGltfWriter/src/ExtensionWriter.cpp
+++ b/CesiumGltfWriter/src/ExtensionWriter.cpp
@@ -16,10 +16,27 @@ void CesiumGltf::writeExtensions(
   j.StartObject();
 
   for (const auto& extension : extensions) {
-    if (extension.second.type() == typeid(JsonValue)) {
-      const auto& object = std::any_cast<JsonValue>(extension.second);
-      j.Key(extension.first);
+    const auto isObject = extension.second.type() == typeid(JsonValue::Object);
+    const auto isArray = extension.second.type() == typeid(JsonValue::Array);
+    const auto isPrimitive = extension.second.type() == typeid(JsonValue);
+
+    // Always assume we're inside of an object, ExtensibleObject::extensions
+    // forces extensions to be in a key / value setup.
+    j.Key(extension.first);
+
+    if (isObject) {
+      const auto& object = std::any_cast<JsonValue::Object>(extension.second);
       writeJsonValue(object, jsonWriter);
+    }
+
+    else if (isArray) {
+      const auto& array = std::any_cast<JsonValue::Array>(extension.second);
+      writeJsonValue(array, jsonWriter);
+    }
+
+    else if (isPrimitive) {
+      const auto& primitive = std::any_cast<JsonValue>(extension.second);
+      writeJsonValue(primitive, jsonWriter);
     }
   }
 

--- a/CesiumGltfWriter/src/ImageWriter.cpp
+++ b/CesiumGltfWriter/src/ImageWriter.cpp
@@ -109,7 +109,7 @@ void CesiumGltf::writeImage(
 
     if (!image.extras.empty()) {
       j.Key("extras");
-      writeJsonValue(image.extras, j, false);
+      writeJsonValue(image.extras, j);
     }
 
     if (!image.extensions.empty()) {

--- a/CesiumGltfWriter/src/JsonObjectWriter.cpp
+++ b/CesiumGltfWriter/src/JsonObjectWriter.cpp
@@ -15,8 +15,7 @@ void recursiveArrayWriter(
     CesiumGltf::JsonWriter& j);
 void recursiveObjectWriter(
     const JsonValue::Object& object,
-    CesiumGltf::JsonWriter& j,
-    bool hasRootObject = false);
+    CesiumGltf::JsonWriter& j);
 
 void primitiveWriter(const JsonValue& item, CesiumGltf::JsonWriter& j) {
   if (item.isBool()) {
@@ -66,15 +65,12 @@ void recursiveArrayWriter(
 
 void recursiveObjectWriter(
     const JsonValue::Object& object,
-    CesiumGltf::JsonWriter& j,
-    bool hasRootObject) {
+    CesiumGltf::JsonWriter& j) {
 
-  if (!hasRootObject) {
-    j.StartObject();
-  }
+  j.StartObject();
 
   for (const auto& [key, item] : object) {
-    j.Key(key.c_str());
+    j.Key(key);
     if (item.isArray()) {
       recursiveArrayWriter(std::get<JsonValue::Array>(item.value), j);
     }
@@ -88,22 +84,17 @@ void recursiveObjectWriter(
     }
   }
 
-  if (!hasRootObject) {
-    j.EndObject();
-  }
+  j.EndObject();
 }
 
 void CesiumGltf::writeJsonValue(
     const JsonValue& value,
-    CesiumGltf::JsonWriter& jsonWriter,
-    bool hasRootObject) {
+    CesiumGltf::JsonWriter& jsonWriter) {
+
   if (value.isArray()) {
     recursiveArrayWriter(std::get<JsonValue::Array>(value.value), jsonWriter);
   } else if (value.isObject()) {
-    recursiveObjectWriter(
-        std::get<JsonValue::Object>(value.value),
-        jsonWriter,
-        hasRootObject);
+    recursiveObjectWriter(std::get<JsonValue::Object>(value.value), jsonWriter);
   } else {
     primitiveWriter(value, jsonWriter);
   }

--- a/CesiumGltfWriter/src/JsonObjectWriter.h
+++ b/CesiumGltfWriter/src/JsonObjectWriter.h
@@ -6,6 +6,5 @@
 namespace CesiumGltf {
 void writeJsonValue(
     const CesiumUtility::JsonValue& value,
-    CesiumGltf::JsonWriter& writer,
-    bool hasRootObject = true);
+    CesiumGltf::JsonWriter& writer);
 }

--- a/CesiumGltfWriter/src/MaterialWriter.cpp
+++ b/CesiumGltfWriter/src/MaterialWriter.cpp
@@ -57,7 +57,7 @@ void writePbrMetallicRoughness(
 
   if (!pbr.extras.empty()) {
     j.Key("extras");
-    CesiumGltf::writeJsonValue(pbr.extras, j, false);
+    CesiumGltf::writeJsonValue(pbr.extras, j);
   }
 
   j.EndObject();
@@ -87,7 +87,7 @@ void writeNormalTexture(
 
   if (!normalTexture.extras.empty()) {
     j.Key("extras");
-    CesiumGltf::writeJsonValue(normalTexture.extras, j, false);
+    CesiumGltf::writeJsonValue(normalTexture.extras, j);
   }
 
   j.EndObject();
@@ -119,7 +119,7 @@ void writeOcclusionTexture(
 
   if (!occlusionTexture.extras.empty()) {
     j.Key("extras");
-    CesiumGltf::writeJsonValue(occlusionTexture.extras, j, false);
+    CesiumGltf::writeJsonValue(occlusionTexture.extras, j);
   }
 
   j.EndObject();
@@ -143,7 +143,7 @@ void writeEmissiveTexture(
 
   if (!emissiveTexture.extras.empty()) {
     j.Key("extras");
-    CesiumGltf::writeJsonValue(emissiveTexture.extras, j, false);
+    CesiumGltf::writeJsonValue(emissiveTexture.extras, j);
   }
 
   j.EndObject();
@@ -212,7 +212,7 @@ void CesiumGltf::writeMaterial(
 
     if (!material.extras.empty()) {
       j.Key("extras");
-      writeJsonValue(material.extras, j, false);
+      writeJsonValue(material.extras, j);
     }
 
     j.EndObject();

--- a/CesiumGltfWriter/src/MeshWriter.cpp
+++ b/CesiumGltfWriter/src/MeshWriter.cpp
@@ -57,7 +57,7 @@ void writePrimitive(
 
   if (!primitive.extras.empty()) {
     j.Key("extras");
-    CesiumGltf::writeJsonValue(primitive.extras, j, false);
+    CesiumGltf::writeJsonValue(primitive.extras, j);
   }
   j.EndObject();
 }
@@ -104,7 +104,7 @@ void CesiumGltf::writeMesh(
 
     if (!mesh.extras.empty()) {
       j.Key("extras");
-      writeJsonValue(mesh.extras, j, false);
+      writeJsonValue(mesh.extras, j);
     }
 
     j.EndObject();

--- a/CesiumGltfWriter/src/NodeWriter.cpp
+++ b/CesiumGltfWriter/src/NodeWriter.cpp
@@ -107,7 +107,7 @@ void CesiumGltf::writeNode(
 
     if (!node.extras.empty()) {
       j.Key("extras");
-      writeJsonValue(node.extras, j, false);
+      writeJsonValue(node.extras, j);
     }
 
     j.EndObject();

--- a/CesiumGltfWriter/src/SamplerWriter.cpp
+++ b/CesiumGltfWriter/src/SamplerWriter.cpp
@@ -47,7 +47,7 @@ void CesiumGltf::writeSampler(
 
     if (!sampler.extras.empty()) {
       j.Key("extras");
-      writeJsonValue(sampler.extras, j, false);
+      writeJsonValue(sampler.extras, j);
     }
 
     j.EndObject();

--- a/CesiumGltfWriter/src/SceneWriter.cpp
+++ b/CesiumGltfWriter/src/SceneWriter.cpp
@@ -35,7 +35,7 @@ void CesiumGltf::writeScene(
 
     if (!scene.extras.empty()) {
       j.Key("extras");
-      writeJsonValue(scene.extras, j, false);
+      writeJsonValue(scene.extras, j);
     }
 
     j.EndObject();

--- a/CesiumGltfWriter/src/SkinWriter.cpp
+++ b/CesiumGltfWriter/src/SkinWriter.cpp
@@ -44,7 +44,7 @@ void CesiumGltf::writeSkin(
 
     if (!skin.extras.empty()) {
       j.Key("extras");
-      writeJsonValue(skin.extras, j, false);
+      writeJsonValue(skin.extras, j);
     }
 
     j.EndObject();

--- a/CesiumGltfWriter/src/TextureWriter.cpp
+++ b/CesiumGltfWriter/src/TextureWriter.cpp
@@ -37,7 +37,7 @@ void CesiumGltf::writeTexture(
 
     if (!texture.extras.empty()) {
       j.Key("extras");
-      writeJsonValue(texture.extras, j, false);
+      writeJsonValue(texture.extras, j);
     }
 
     j.EndObject();

--- a/CesiumGltfWriter/test/TestJsonObjectWriter.cpp
+++ b/CesiumGltfWriter/test/TestJsonObjectWriter.cpp
@@ -19,7 +19,7 @@ TEST_CASE("TestJsonObjectWriter") {
     CesiumGltf::JsonWriter writer;
     const auto extrasObject =
         Object{{"extras", Array{Object{}, Object{}, Object{}}}};
-    writeJsonValue(extrasObject, writer, false);
+    writeJsonValue(extrasObject, writer);
     REQUIRE(writer.toStringView() == R"({"extras":[{},{},{}]})");
   }
 
@@ -27,14 +27,14 @@ TEST_CASE("TestJsonObjectWriter") {
     CesiumGltf::JsonWriter writer;
     const auto extrasObject =
         Array{std::int64_t(0), std::uint64_t(1), double(2.5)};
-    writeJsonValue(extrasObject, writer, false);
+    writeJsonValue(extrasObject, writer);
     REQUIRE(writer.toStringView() == R"([0,1,2.5])");
   }
 
   SECTION("[👀]") {
     CesiumGltf::JsonWriter writer;
     writer.StartArray();
-    writeJsonValue(JsonValue("👀"), writer, true);
+    writeJsonValue(JsonValue("👀"), writer);
     writer.EndArray();
     REQUIRE(writer.toStringView() == "[\"👀\"]");
   }
@@ -53,7 +53,7 @@ TEST_CASE("TestJsonObjectWriter") {
         }};
     // clang-format on
 
-    writeJsonValue(extrasObject, writer, false);
+    writeJsonValue(extrasObject, writer);
     REQUIRE(writer.toStringView() == R"({"extras":{"A":{"B":{"C":{}}}}})");
   }
 
@@ -67,7 +67,7 @@ TEST_CASE("TestJsonObjectWriter") {
         }};
     // clang-format on
 
-    writeJsonValue(extrasObject, writer, false);
+    writeJsonValue(extrasObject, writer);
     REQUIRE(
         writer.toStringView() ==
         R"({"extras":[[[1.0,-2.0,false,null,true,{"emojis":"😂👽🇵🇷"}]]]})");
@@ -75,7 +75,7 @@ TEST_CASE("TestJsonObjectWriter") {
 
   SECTION("Empty object is serialized correctly") {
     CesiumGltf::JsonWriter writer;
-    writeJsonValue(Object{}, writer, false);
+    writeJsonValue(Object{}, writer);
     REQUIRE(writer.toStringView() == "{}");
   }
 }


### PR DESCRIPTION
This parmaeter is ultimately unnecessary. The caller should be responsible
for ensuring that the CesiumGltf::JsonWriter state is balanced before calling
writeJsonValue. This should simplify our internal API.