### PR TITLE
Regenerate glTF classes and re-run the formatter.

### DIFF
--- a/CesiumGltf/include/CesiumGltf/AccessorSpec.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorSpec.h
@@ -148,8 +148,7 @@ struct CESIUMGLTF_API AccessorSpec : public NamedObject {
 
 private:
   /**
-   * @brief This class is not mean to be instantiated directly. Use {@link
-   * Accessor} instead.
+   * @brief This class is not mean to be instantiated directly. Use {@link Accessor} instead.
    */
   AccessorSpec() = default;
   friend struct Accessor;

--- a/CesiumGltf/include/CesiumGltf/BufferSpec.h
+++ b/CesiumGltf/include/CesiumGltf/BufferSpec.h
@@ -30,8 +30,7 @@ struct CESIUMGLTF_API BufferSpec : public NamedObject {
 
 private:
   /**
-   * @brief This class is not mean to be instantiated directly. Use {@link
-   * Buffer} instead.
+   * @brief This class is not mean to be instantiated directly. Use {@link Buffer} instead.
    */
   BufferSpec() = default;
   friend struct Buffer;

--- a/CesiumGltf/include/CesiumGltf/ImageSpec.h
+++ b/CesiumGltf/include/CesiumGltf/ImageSpec.h
@@ -47,8 +47,7 @@ struct CESIUMGLTF_API ImageSpec : public NamedObject {
 
 private:
   /**
-   * @brief This class is not mean to be instantiated directly. Use {@link
-   * Image} instead.
+   * @brief This class is not mean to be instantiated directly. Use {@link Image} instead.
    */
   ImageSpec() = default;
   friend struct Image;

--- a/CesiumGltf/include/CesiumGltf/ModelSpec.h
+++ b/CesiumGltf/include/CesiumGltf/ModelSpec.h
@@ -135,8 +135,7 @@ struct CESIUMGLTF_API ModelSpec : public ExtensibleObject {
 
 private:
   /**
-   * @brief This class is not mean to be instantiated directly. Use {@link
-   * Model} instead.
+   * @brief This class is not mean to be instantiated directly. Use {@link Model} instead.
    */
   ModelSpec() = default;
   friend struct Model;


### PR DESCRIPTION
The only changes are to incorrectly-wrapped comments, now that comments no longer get incorrectly wrapped. I'm going to insta-merge this because it's super trivial.