### PR TITLE
Fix memory leak in GltfReader.cpp

### DIFF
--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -368,6 +368,7 @@ GltfReader::readImage(const gsl::span<const std::byte>& data) const {
     std::uint8_t* u8Pointer =
         reinterpret_cast<std::uint8_t*>(image.pixelData.data());
     std::copy(pImage, pImage + lastByte, u8Pointer);
+    free(pImage);
   } else {
     result.image.reset();
     result.errors.emplace_back(stbi_failure_reason());


### PR DESCRIPTION
`pImage` isn't being freed after being copied. This fixes that leak: We're running into out of memory crashes without it :grimacing: 