### PR TITLE
Fix development package crash when shut down

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ##### Fixes :wrench:
 
+- Fixed a bug where development package crashes when exit due to use-after-free bug in `RasterOverlayTile` destructor.
+
 ### v0.3.0 - 2021-05-03
 
 ##### Breaking Changes :mega:

--- a/Cesium3DTiles/src/RasterOverlay.cpp
+++ b/Cesium3DTiles/src/RasterOverlay.cpp
@@ -36,7 +36,14 @@ RasterOverlay::RasterOverlay(const RasterOverlayOptions& options)
       _isLoadingTileProvider(false),
       _options(options) {}
 
-RasterOverlay::~RasterOverlay() {}
+RasterOverlay::~RasterOverlay() {
+  // explicitly set those to nullptr, because RasterOverlayTile destructor relies on nullptr check to retrieve
+  // the correct provider. If we let unique_ptr() destructor called implicitly, pTileProvider will get destructed first, but
+  // it will never set to be nullptr. So when _pPlaceholder is destroyed, its _pPlaceholder and _tiles member destructor will 
+  // retrieve _pTileProvider instead of _pPlaceholder and it crashes
+  this->_pTileProvider = nullptr;
+  this->_pPlaceholder = nullptr;
+}
 
 RasterOverlayTileProvider* RasterOverlay::getTileProvider() noexcept {
   return this->_pTileProvider ? this->_pTileProvider.get()

--- a/Cesium3DTiles/src/RasterOverlay.cpp
+++ b/Cesium3DTiles/src/RasterOverlay.cpp
@@ -37,10 +37,12 @@ RasterOverlay::RasterOverlay(const RasterOverlayOptions& options)
       _options(options) {}
 
 RasterOverlay::~RasterOverlay() {
-  // explicitly set those to nullptr, because RasterOverlayTile destructor relies on nullptr check to retrieve
-  // the correct provider. If we let unique_ptr() destructor called implicitly, pTileProvider will get destructed first, but
-  // it will never set to be nullptr. So when _pPlaceholder is destroyed, its _pPlaceholder and _tiles member destructor will 
-  // retrieve _pTileProvider instead of _pPlaceholder and it crashes
+  // explicitly set those to nullptr, because RasterOverlayTile destructor
+  // relies on nullptr check to retrieve the correct provider. If we let
+  // unique_ptr() destructor called implicitly, pTileProvider will get
+  // destructed first, but it will never set to be nullptr. So when
+  // _pPlaceholder is destroyed, its _pPlaceholder and _tiles member destructor
+  // will retrieve _pTileProvider instead of _pPlaceholder and it crashes
   this->_pTileProvider = nullptr;
   this->_pPlaceholder = nullptr;
 }


### PR DESCRIPTION
Explicitly set `RasterOverlayProvider` owned by `RasterOverlay` to be `nullptr` instead of letting `unique_ptr` destructor get called implicitly. If we let `unique_ptr()` destructor called implicitly, `_pTileProvider` will get destructed first, but it will never set to be `nullptr`. So when `_pPlaceholder` is destroyed, its `_pPlaceholder` tile and _tiles member destructor will retrieve _pTileProvider instead of _pPlaceholder and it crashes
