### PR TITLE
Allow use of createAccessorView with a simple lambda.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 ##### Fixes :wrench:
 
 - Matched draco's decoded indices to gltf primitive if indices attribute does not match with the decompressed indices.
+- `createAccessorView` now creates an (invalid) `AccessorView` with a standard numeric type on error, rather than creating `AccessorView<nullptr_t>`. This makes it easier to use a simple lambda as the callback.
 
 ### v0.3.1 - 2021-05-13
 

--- a/CesiumGltf/include/CesiumGltf/AccessorView.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorView.h
@@ -456,7 +456,7 @@ createAccessorView(
  * @return The value returned by the callback.
  */
 template <typename TCallback>
-std::invoke_result_t<TCallback, AccessorView<float>> createAccessorView(
+std::invoke_result_t<TCallback, AccessorView<AccessorTypes::SCALAR<float>>> createAccessorView(
     const Model& model,
     int32_t accessorIndex,
     TCallback&& callback) {

--- a/CesiumGltf/include/CesiumGltf/AccessorView.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorView.h
@@ -456,7 +456,8 @@ createAccessorView(
  * @return The value returned by the callback.
  */
 template <typename TCallback>
-std::invoke_result_t<TCallback, AccessorView<AccessorTypes::SCALAR<float>>> createAccessorView(
+std::invoke_result_t<TCallback, AccessorView<AccessorTypes::SCALAR<float>>>
+createAccessorView(
     const Model& model,
     int32_t accessorIndex,
     TCallback&& callback) {

--- a/CesiumGltf/test/TestAccessorView.cpp
+++ b/CesiumGltf/test/TestAccessorView.cpp
@@ -37,3 +37,37 @@ TEST_CASE("AccessorView construct and read example") {
 
   CHECK(firstPosition == glm::vec3(1.0f, 2.0f, 3.0f));
 }
+
+TEST_CASE("Create AccessorView of unknown type with lambda") {
+  using namespace CesiumGltf;
+
+  Model model;
+
+  Buffer& buffer = model.buffers.emplace_back();
+  buffer.cesium.data.resize(4);
+  buffer.cesium.data[0] = std::byte(1);
+  buffer.cesium.data[1] = std::byte(2);
+  buffer.cesium.data[2] = std::byte(3);
+  buffer.cesium.data[3] = std::byte(4);
+  buffer.byteLength = buffer.cesium.data.size();
+
+  BufferView& bufferView = model.bufferViews.emplace_back();
+  bufferView.buffer = 0;
+  bufferView.byteLength = buffer.byteLength;
+
+  Accessor& accessor = model.accessors.emplace_back();
+  accessor.bufferView = 0;
+  accessor.count = 1;
+  
+  accessor.componentType = Accessor::ComponentType::UNSIGNED_INT;
+  createAccessorView(model, accessor, [](const auto& accessorView) {
+    CHECK(accessorView.status() == AccessorViewStatus::Valid);
+    CHECK(accessorView[0].value[0] == 0x04030201);
+  });
+
+  accessor.componentType = Accessor::ComponentType::UNSIGNED_SHORT;
+  createAccessorView(model, accessor, [](const auto& accessorView) {
+    CHECK(accessorView.status() == AccessorViewStatus::Valid);
+    CHECK(accessorView[0].value[0] == 0x0201);
+  });
+}

--- a/CesiumGltf/test/TestAccessorView.cpp
+++ b/CesiumGltf/test/TestAccessorView.cpp
@@ -58,7 +58,7 @@ TEST_CASE("Create AccessorView of unknown type with lambda") {
   Accessor& accessor = model.accessors.emplace_back();
   accessor.bufferView = 0;
   accessor.count = 1;
-  
+
   accessor.componentType = Accessor::ComponentType::UNSIGNED_INT;
   createAccessorView(model, accessor, [](const auto& accessorView) {
     CHECK(accessorView.status() == AccessorViewStatus::Valid);


### PR DESCRIPTION
`createAccessorView` is a handy way to create an `AccessorView` for a glTF `Accessor` of unknown `type` and `componentType`, and dispatch it a function with overloads for each type. You can even use a template to capture some of the possible accessor types. Since C++14 (I think), you can use `auto` in a lambda to effectively create a template. But unfortunately it was hard to use such a generic lambda with `createAccessorView` because, on error (e.g. the Accessor's `componentType` isn't valid at all), `createAccessorView` would create an `AccessorView<nullptr_t>`. nullptr_t isn't a normal numeric type, so it was somewhere between impossible and a huge hassle to write generic code that would work with both numeric types and with nullptr_t.

So this PR changes `createAccessorView` to instead create a regular old numeric AccessorView on error, so it's much easier to use such generic lambdas. AccessorView already has a `status` method that tells you if it's valid, and it's designed to be semi-usable even when invalid (size() just reports 0), so there's really no downside to this.

If all that doesn't make much sense, check out the test in the PR and hopefully it'll be clearer.

I added this as a step in bringing the tangent computations from cesium-unreal to cesium-native, but then changed directions. Still, I wanted to open a PR for this because it's a good change.