### PR TITLE
Do not throw exceptions from geometry classes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,17 @@
 
 ##### Breaking Changes :mega:
 
+- The `CesiumGeometry::Plane` and `CesiumGeometry::Ray` classes now offer factory
+  methods to avoid throwing an `invalid_argument` exception in case of errors.
+  They offer a `createUnchecked` method that assumes valid input, a `createOptional`
+  method that returns an `std::optional` in case of errors, and a `createThrowing`
+  method that throws an exception in case of errors. This has the effect of other
+  classes also no longer throwing: The internal usage of these classes has been
+  changed to generally use the `createUnchecked` method, because the preconditions
+  for the exception to be thrown could not sensibly be propagated to the user.
+  This means that the `CullingVolume` and `EllipsoidTangentPlane` do no longer
+  throw for invalid inputs, but may return results that contain `NaN` values.
+
 ##### Additions :tada:
 
 - Added `Cesium3DTiles::TileIdUtilities` with a `createTileIdString` function to create logging/debugging strings for `TileID` objects.

--- a/Cesium3DTiles/src/ViewState.cpp
+++ b/Cesium3DTiles/src/ViewState.cpp
@@ -43,7 +43,7 @@ ViewState::ViewState(
       _verticalFieldOfView(verticalFieldOfView),
       _sseDenominator(2.0 * glm::tan(0.5 * verticalFieldOfView)),
       _positionCartographic(positionCartographic),
-      _cullingVolume(createCullingVolume(
+      _cullingVolume(CullingVolume::createUnchecked(
           position,
           direction,
           up,

--- a/CesiumGeometry/include/CesiumGeometry/CullingVolume.h
+++ b/CesiumGeometry/include/CesiumGeometry/CullingVolume.h
@@ -35,32 +35,35 @@ struct CullingVolume final {
    *
    * Defaults to (0,0,1), with a distance of 0.
    */
-  CesiumGeometry::Plane leftPlane = CesiumGeometry::Plane::createUnchecked(glm::dvec3(0.0, 0.0, 1.0), 0.0);
+  CesiumGeometry::Plane leftPlane =
+      CesiumGeometry::Plane::createUnchecked(glm::dvec3(0.0, 0.0, 1.0), 0.0);
 
   /**
    * @brief The right plane of the culling volume.
    *
    * Defaults to (0,0,1), with a distance of 0.
    */
-  CesiumGeometry::Plane rightPlane = CesiumGeometry::Plane::createUnchecked(glm::dvec3(0.0, 0.0, 1.0), 0.0);
+  CesiumGeometry::Plane rightPlane =
+      CesiumGeometry::Plane::createUnchecked(glm::dvec3(0.0, 0.0, 1.0), 0.0);
 
   /**
    * @brief The top plane of the culling volume.
    *
    * Defaults to (0,0,1), with a distance of 0.
    */
-  CesiumGeometry::Plane topPlane = CesiumGeometry::Plane::createUnchecked(glm::dvec3(0.0, 0.0, 1.0), 0.0);
+  CesiumGeometry::Plane topPlane =
+      CesiumGeometry::Plane::createUnchecked(glm::dvec3(0.0, 0.0, 1.0), 0.0);
 
   /**
    * @brief The bottom plane of the culling volume.
    *
    * Defaults to (0,0,1), with a distance of 0.
    */
-  CesiumGeometry::Plane bottomPlane = CesiumGeometry::Plane::createUnchecked(glm::dvec3(0.0, 0.0, 1.0), 0.0);
+  CesiumGeometry::Plane bottomPlane =
+      CesiumGeometry::Plane::createUnchecked(glm::dvec3(0.0, 0.0, 1.0), 0.0);
 
 private:
   CullingVolume();
-
 };
 
 } // namespace Cesium3DTiles

--- a/CesiumGeometry/include/CesiumGeometry/CullingVolume.h
+++ b/CesiumGeometry/include/CesiumGeometry/CullingVolume.h
@@ -14,48 +14,53 @@ namespace Cesium3DTiles {
 struct CullingVolume final {
 
   /**
+   * @brief Creates a {@link CullingVolume} for a perspective frustum.
+   *
+   * @param position The eye position
+   * @param direction The viewing direction
+   * @param up The up-vector of the frustum
+   * @param fovx The horizontal Field-Of-View angle, in radians
+   * @param fovy The vertical Field-Of-View angle, in radians
+   * @return The {@link CullingVolume}
+   */
+  static CullingVolume createUnchecked(
+      const glm::dvec3& position,
+      const glm::dvec3& direction,
+      const glm::dvec3& up,
+      double fovx,
+      double fovy) noexcept;
+
+  /**
    * @brief The left plane of the culling volume.
    *
    * Defaults to (0,0,1), with a distance of 0.
    */
-  CesiumGeometry::Plane leftPlane{glm::dvec3(0.0, 0.0, 1.0), 0.0};
+  CesiumGeometry::Plane leftPlane = CesiumGeometry::Plane::createUnchecked(glm::dvec3(0.0, 0.0, 1.0), 0.0);
 
   /**
    * @brief The right plane of the culling volume.
    *
    * Defaults to (0,0,1), with a distance of 0.
    */
-  CesiumGeometry::Plane rightPlane{glm::dvec3(0.0, 0.0, 1.0), 0.0};
+  CesiumGeometry::Plane rightPlane = CesiumGeometry::Plane::createUnchecked(glm::dvec3(0.0, 0.0, 1.0), 0.0);
 
   /**
    * @brief The top plane of the culling volume.
    *
    * Defaults to (0,0,1), with a distance of 0.
    */
-  CesiumGeometry::Plane topPlane{glm::dvec3(0.0, 0.0, 1.0), 0.0};
+  CesiumGeometry::Plane topPlane = CesiumGeometry::Plane::createUnchecked(glm::dvec3(0.0, 0.0, 1.0), 0.0);
 
   /**
    * @brief The bottom plane of the culling volume.
    *
    * Defaults to (0,0,1), with a distance of 0.
    */
-  CesiumGeometry::Plane bottomPlane{glm::dvec3(0.0, 0.0, 1.0), 0.0};
+  CesiumGeometry::Plane bottomPlane = CesiumGeometry::Plane::createUnchecked(glm::dvec3(0.0, 0.0, 1.0), 0.0);
+
+private:
+  CullingVolume();
+
 };
 
-/**
- * @brief Creates a {@link CullingVolume} for a perspective frustum.
- *
- * @param position The eye position
- * @param direction The viewing direction
- * @param up The up-vector of the frustum
- * @param fovx The horizontal Field-Of-View angle, in radians
- * @param fovy The vertical Field-Of-View angle, in radians
- * @return The {@link CullingVolume}
- */
-CullingVolume createCullingVolume(
-    const glm::dvec3& position,
-    const glm::dvec3& direction,
-    const glm::dvec3& up,
-    double fovx,
-    double fovy) noexcept;
 } // namespace Cesium3DTiles

--- a/CesiumGeometry/include/CesiumGeometry/Plane.h
+++ b/CesiumGeometry/include/CesiumGeometry/Plane.h
@@ -10,7 +10,7 @@ namespace CesiumGeometry {
 
 /**
  * @brief A plane in Hessian Normal Format.
- * 
+ *
  * The plane is defined by:
  * ```
  * ax + by + cz + d = 0
@@ -18,45 +18,46 @@ namespace CesiumGeometry {
  * where (a, b, c) is the plane's `normal`, d is the signed
  * `distance` to the plane, and (x, y, z) is any point on
  * the plane.
- * 
- * The sign of `distance` determines which side of the plane the origin is on. 
+ *
+ * The sign of `distance` determines which side of the plane the origin is on.
  * If `distance` is positive, the origin is in the half-space in the direction
  * of the normal; if negative, the origin is in the half-space opposite to the
  * normal; if zero, the plane passes through the origin.
  */
 class CESIUMGEOMETRY_API Plane final {
 public:
-
   /**
    * @brief Creates a plane from the given parameters.
-   * 
+   *
    * The caller is responsible to make sure that the given normal is normalized.
-   * 
+   *
    * @param normal The normal.
    * @param distance The distance.
    * @return The plane.
    */
-  static Plane createUnchecked(const glm::dvec3& normal, double distance) noexcept;
+  static Plane
+  createUnchecked(const glm::dvec3& normal, double distance) noexcept;
 
   /**
    * @brief Creates a plane from the given parameters.
-   * 
+   *
    * If the given normal is not normalized (i.e. when it does not have a length
-   * of 1.0, within a small machine epsilon), then an empty optional will be 
+   * of 1.0, within a small machine epsilon), then an empty optional will be
    * returned.
-   * 
+   *
    * @param normal The normal.
    * @param distance The distance.
    * @return The plane.
    */
-  static std::optional<Plane> createOptional(const glm::dvec3& normal, double distance) noexcept;
+  static std::optional<Plane>
+  createOptional(const glm::dvec3& normal, double distance) noexcept;
 
   /**
    * @brief Creates a plane from the given parameters.
-   * 
+   *
    * If the given normal is not normalized (i.e. when it does not have a length
    * of 1.0, within a small machine epsilon), then an exception will be thrown.
-   * 
+   *
    * @param normal The normal.
    * @param distance The distance.
    * @return The plane.
@@ -99,12 +100,11 @@ public:
   glm::dvec3 projectPointOntoPlane(const glm::dvec3& point) const noexcept;
 
 private:
-
   /**
    * @brief Constructs a new plane from a normal and a distance from the origin.
    *
    * @param normal The plane's normal
-   * @param distance The shortest distance from the origin to the plane. 
+   * @param distance The shortest distance from the origin to the plane.
    */
   Plane(const glm::dvec3& normal, double distance);
 

--- a/CesiumGeometry/include/CesiumGeometry/Plane.h
+++ b/CesiumGeometry/include/CesiumGeometry/Plane.h
@@ -29,6 +29,12 @@ public:
 
   static Plane createUnchecked(const glm::dvec3& normal, double distance) noexcept;
   static std::optional<Plane> createOptional(const glm::dvec3& normal, double distance) noexcept;
+
+  /**
+  * TODO
+     * @exception std::exception `normal` must be normalized.
+* 
+   */
   static Plane createThrowing(const glm::dvec3& normal, double distance);
 
   /**

--- a/CesiumGeometry/include/CesiumGeometry/Plane.h
+++ b/CesiumGeometry/include/CesiumGeometry/Plane.h
@@ -27,13 +27,40 @@ namespace CesiumGeometry {
 class CESIUMGEOMETRY_API Plane final {
 public:
 
+  /**
+   * @brief Creates a plane from the given parameters.
+   * 
+   * The caller is responsible to make sure that the given normal is normalized.
+   * 
+   * @param normal The normal.
+   * @param distance The distance.
+   * @return The plane.
+   */
   static Plane createUnchecked(const glm::dvec3& normal, double distance) noexcept;
+
+  /**
+   * @brief Creates a plane from the given parameters.
+   * 
+   * If the given normal is not normalized (i.e. when it does not have a length
+   * of 1.0, within a small machine epsilon), then an empty optional will be 
+   * returned.
+   * 
+   * @param normal The normal.
+   * @param distance The distance.
+   * @return The plane.
+   */
   static std::optional<Plane> createOptional(const glm::dvec3& normal, double distance) noexcept;
 
   /**
-  * TODO
-     * @exception std::exception `normal` must be normalized.
-* 
+   * @brief Creates a plane from the given parameters.
+   * 
+   * If the given normal is not normalized (i.e. when it does not have a length
+   * of 1.0, within a small machine epsilon), then an exception will be thrown.
+   * 
+   * @param normal The normal.
+   * @param distance The distance.
+   * @return The plane.
+   * @exception std::exception If the normal is not normalized
    */
   static Plane createThrowing(const glm::dvec3& normal, double distance);
 

--- a/CesiumGeometry/include/CesiumGeometry/Plane.h
+++ b/CesiumGeometry/include/CesiumGeometry/Plane.h
@@ -1,53 +1,35 @@
 #pragma once
 
 #include "CesiumGeometry/Library.h"
+
+#include <optional>
+
 #include <glm/vec3.hpp>
 
 namespace CesiumGeometry {
 
 /**
  * @brief A plane in Hessian Normal Format.
+ * 
+ * The plane is defined by:
+ * ```
+ * ax + by + cz + d = 0
+ * ```
+ * where (a, b, c) is the plane's `normal`, d is the signed
+ * `distance` to the plane, and (x, y, z) is any point on
+ * the plane.
+ * 
+ * The sign of `distance` determines which side of the plane the origin is on. 
+ * If `distance` is positive, the origin is in the half-space in the direction
+ * of the normal; if negative, the origin is in the half-space opposite to the
+ * normal; if zero, the plane passes through the origin.
  */
 class CESIUMGEOMETRY_API Plane final {
 public:
-  /**
-   * @brief Constructs a new plane from a normal and a distance from the origin.
-   *
-   * The plane is defined by:
-   * ```
-   * ax + by + cz + d = 0
-   * ```
-   * where (a, b, c) is the plane's `normal`, d is the signed
-   * `distance` to the plane, and (x, y, z) is any point on
-   * the plane.
-   *
-   * @param normal The plane's normal (normalized).
-   * @param distance The shortest distance from the origin to the plane. The
-   * sign of `distance` determines which side of the plane the origin is on. If
-   * `distance` is positive, the origin is in the half-space in the direction of
-   * the normal; if negative, the origin is in the half-space opposite to the
-   * normal; if zero, the plane passes through the origin.
-   *
-   * @exception std::exception `normal` must be normalized.
-   *
-   * Example:
-   * @snippet TestPlane.cpp constructor-normal-distance
-   */
-  Plane(const glm::dvec3& normal, double distance);
 
-  /**
-   * @brief Construct a new plane from a point in the plane and the plane's
-   * normal.
-   *
-   * @param point The point on the plane.
-   * @param normal The plane's normal (normalized).
-   *
-   * @exception std::exception `normal` must be normalized.
-   *
-   * Example:
-   * @snippet TestPlane.cpp constructor-point-normal
-   */
-  Plane(const glm::dvec3& point, const glm::dvec3& normal);
+  static Plane createUnchecked(const glm::dvec3& normal, double distance) noexcept;
+  static std::optional<Plane> createOptional(const glm::dvec3& normal, double distance) noexcept;
+  static Plane createThrowing(const glm::dvec3& normal, double distance);
 
   /**
    * @brief Gets the plane's normal.
@@ -84,6 +66,15 @@ public:
   glm::dvec3 projectPointOntoPlane(const glm::dvec3& point) const noexcept;
 
 private:
+
+  /**
+   * @brief Constructs a new plane from a normal and a distance from the origin.
+   *
+   * @param normal The plane's normal
+   * @param distance The shortest distance from the origin to the plane. 
+   */
+  Plane(const glm::dvec3& normal, double distance);
+
   glm::dvec3 _normal;
   double _distance;
 };

--- a/CesiumGeometry/include/CesiumGeometry/Ray.h
+++ b/CesiumGeometry/include/CesiumGeometry/Ray.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "CesiumGeometry/Library.h"
+
+#include <optional>
+
 #include <glm/vec3.hpp>
 
 namespace CesiumGeometry {
@@ -11,15 +14,16 @@ namespace CesiumGeometry {
  */
 class CESIUMGEOMETRY_API Ray final {
 public:
+
+  static Ray createUnchecked(const glm::dvec3& origin, const glm::dvec3& direction) noexcept;
+  static std::optional<Ray> createOptional(const glm::dvec3& origin, const glm::dvec3& direction) noexcept;
+
   /**
-   * @brief Construct a new ray.
-   *
-   * @param origin The origin of the ray.
-   * @param direction The direction of the ray (normalized).
-   *
-   * @exception std::exception `direction` must be normalized.
+  * TODO
+     * @exception std::exception `direction` must be normalized.
+* 
    */
-  Ray(const glm::dvec3& origin, const glm::dvec3& direction);
+  static Ray createThrowing(const glm::dvec3& origin, const glm::dvec3& direction);
 
   /**
    * @brief Gets the origin of the ray.
@@ -37,6 +41,15 @@ public:
   Ray operator-() const noexcept;
 
 private:
+
+  /**
+   * @brief Construct a new ray.
+   *
+   * @param origin The origin of the ray.
+   * @param direction The direction of the ray
+   */
+  Ray(const glm::dvec3& origin, const glm::dvec3& direction);
+
   glm::dvec3 _origin;
   glm::dvec3 _direction;
 };

--- a/CesiumGeometry/include/CesiumGeometry/Ray.h
+++ b/CesiumGeometry/include/CesiumGeometry/Ray.h
@@ -14,44 +14,49 @@ namespace CesiumGeometry {
  */
 class CESIUMGEOMETRY_API Ray final {
 public:
-
   /**
    * @brief Creates a ray from the given parameters.
-   * 
+   *
    * The caller is responsible to make sure that the given direction vector is
    * normalized.
-   * 
+   *
    * @param origin The origin.
    * @param direction The direction.
    * @return The ray.
    */
-  static Ray createUnchecked(const glm::dvec3& origin, const glm::dvec3& direction) noexcept;
+  static Ray createUnchecked(
+      const glm::dvec3& origin,
+      const glm::dvec3& direction) noexcept;
 
   /**
    * @brief Creates a ray from the given parameters.
-   * 
-   * If the given direction is not normalized (i.e. when it does not have a length
-   * of 1.0, within a small machine epsilon), then an empty optional will be 
-   * returned.
-   * 
+   *
+   * If the given direction is not normalized (i.e. when it does not have a
+   * length of 1.0, within a small machine epsilon), then an empty optional will
+   * be returned.
+   *
    * @param origin The origin.
    * @param direction The direction.
    * @return The ray.
    */
-  static std::optional<Ray> createOptional(const glm::dvec3& origin, const glm::dvec3& direction) noexcept;
+  static std::optional<Ray> createOptional(
+      const glm::dvec3& origin,
+      const glm::dvec3& direction) noexcept;
 
   /**
    * @brief Creates a ray from the given parameters.
-   * 
-   * If the given direction is not normalized (i.e. when it does not have a length
-   * of 1.0, within a small machine epsilon), then an exception will be thrown.
-   * 
+   *
+   * If the given direction is not normalized (i.e. when it does not have a
+   * length of 1.0, within a small machine epsilon), then an exception will be
+   * thrown.
+   *
    * @param origin The origin.
    * @param direction The direction.
    * @return The ray.
    * @exception std::exception If the direction is not normalized
    */
-  static Ray createThrowing(const glm::dvec3& origin, const glm::dvec3& direction);
+  static Ray
+  createThrowing(const glm::dvec3& origin, const glm::dvec3& direction);
 
   /**
    * @brief Gets the origin of the ray.
@@ -69,7 +74,6 @@ public:
   Ray operator-() const noexcept;
 
 private:
-
   /**
    * @brief Construct a new ray.
    *

--- a/CesiumGeometry/include/CesiumGeometry/Ray.h
+++ b/CesiumGeometry/include/CesiumGeometry/Ray.h
@@ -15,13 +15,41 @@ namespace CesiumGeometry {
 class CESIUMGEOMETRY_API Ray final {
 public:
 
+  /**
+   * @brief Creates a ray from the given parameters.
+   * 
+   * The caller is responsible to make sure that the given direction vector is
+   * normalized.
+   * 
+   * @param origin The origin.
+   * @param direction The direction.
+   * @return The ray.
+   */
   static Ray createUnchecked(const glm::dvec3& origin, const glm::dvec3& direction) noexcept;
+
+  /**
+   * @brief Creates a ray from the given parameters.
+   * 
+   * If the given direction is not normalized (i.e. when it does not have a length
+   * of 1.0, within a small machine epsilon), then an empty optional will be 
+   * returned.
+   * 
+   * @param origin The origin.
+   * @param direction The direction.
+   * @return The ray.
+   */
   static std::optional<Ray> createOptional(const glm::dvec3& origin, const glm::dvec3& direction) noexcept;
 
   /**
-  * TODO
-     * @exception std::exception `direction` must be normalized.
-* 
+   * @brief Creates a ray from the given parameters.
+   * 
+   * If the given direction is not normalized (i.e. when it does not have a length
+   * of 1.0, within a small machine epsilon), then an exception will be thrown.
+   * 
+   * @param origin The origin.
+   * @param direction The direction.
+   * @return The ray.
+   * @exception std::exception If the direction is not normalized
    */
   static Ray createThrowing(const glm::dvec3& origin, const glm::dvec3& direction);
 

--- a/CesiumGeometry/src/CullingVolume.cpp
+++ b/CesiumGeometry/src/CullingVolume.cpp
@@ -39,7 +39,9 @@ CullingVolume CullingVolume::createUnchecked(
   normal = glm::cross(normal, up);
   normal = glm::normalize(normal);
 
-  result.leftPlane = CesiumGeometry::Plane::createUnchecked(normal, -glm::dot(normal, position));
+  result.leftPlane = CesiumGeometry::Plane::createUnchecked(
+      normal,
+      -glm::dot(normal, position));
 
   // Right plane computation
   normal = right * r;
@@ -48,7 +50,9 @@ CullingVolume CullingVolume::createUnchecked(
   normal = glm::cross(up, normal);
   normal = glm::normalize(normal);
 
-  result.rightPlane = CesiumGeometry::Plane::createUnchecked(normal, -glm::dot(normal, position));
+  result.rightPlane = CesiumGeometry::Plane::createUnchecked(
+      normal,
+      -glm::dot(normal, position));
 
   // Bottom plane computation
   normal = up * b;
@@ -57,7 +61,9 @@ CullingVolume CullingVolume::createUnchecked(
   normal = glm::cross(right, normal);
   normal = glm::normalize(normal);
 
-  result.bottomPlane = CesiumGeometry::Plane::createUnchecked(normal, -glm::dot(normal, position));
+  result.bottomPlane = CesiumGeometry::Plane::createUnchecked(
+      normal,
+      -glm::dot(normal, position));
 
   // Top plane computation
   normal = up * t;
@@ -66,12 +72,11 @@ CullingVolume CullingVolume::createUnchecked(
   normal = glm::cross(normal, right);
   normal = glm::normalize(normal);
 
-  result.topPlane = CesiumGeometry::Plane::createUnchecked(normal, -glm::dot(normal, position));
+  result.topPlane = CesiumGeometry::Plane::createUnchecked(
+      normal,
+      -glm::dot(normal, position));
 
   return result;
 }
-
-
-
 
 } // namespace Cesium3DTiles

--- a/CesiumGeometry/src/CullingVolume.cpp
+++ b/CesiumGeometry/src/CullingVolume.cpp
@@ -6,7 +6,9 @@
 
 namespace Cesium3DTiles {
 
-CullingVolume createCullingVolume(
+CullingVolume::CullingVolume() {}
+
+CullingVolume CullingVolume::createUnchecked(
     const glm::dvec3& position,
     const glm::dvec3& direction,
     const glm::dvec3& up,
@@ -18,6 +20,8 @@ CullingVolume createCullingVolume(
   double l = -r;
 
   double n = 1.0;
+
+  CullingVolume result;
 
   // TODO: this is all ported directly from CesiumJS, can probably be refactored
   // to be more efficient with GLM.
@@ -35,7 +39,7 @@ CullingVolume createCullingVolume(
   normal = glm::cross(normal, up);
   normal = glm::normalize(normal);
 
-  CesiumGeometry::Plane leftPlane(normal, -glm::dot(normal, position));
+  result.leftPlane = CesiumGeometry::Plane::createUnchecked(normal, -glm::dot(normal, position));
 
   // Right plane computation
   normal = right * r;
@@ -44,7 +48,7 @@ CullingVolume createCullingVolume(
   normal = glm::cross(up, normal);
   normal = glm::normalize(normal);
 
-  CesiumGeometry::Plane rightPlane(normal, -glm::dot(normal, position));
+  result.rightPlane = CesiumGeometry::Plane::createUnchecked(normal, -glm::dot(normal, position));
 
   // Bottom plane computation
   normal = up * b;
@@ -53,7 +57,7 @@ CullingVolume createCullingVolume(
   normal = glm::cross(right, normal);
   normal = glm::normalize(normal);
 
-  CesiumGeometry::Plane bottomPlane(normal, -glm::dot(normal, position));
+  result.bottomPlane = CesiumGeometry::Plane::createUnchecked(normal, -glm::dot(normal, position));
 
   // Top plane computation
   normal = up * t;
@@ -62,8 +66,12 @@ CullingVolume createCullingVolume(
   normal = glm::cross(normal, right);
   normal = glm::normalize(normal);
 
-  CesiumGeometry::Plane topPlane(normal, -glm::dot(normal, position));
+  result.topPlane = CesiumGeometry::Plane::createUnchecked(normal, -glm::dot(normal, position));
 
-  return {leftPlane, rightPlane, topPlane, bottomPlane};
+  return result;
 }
+
+
+
+
 } // namespace Cesium3DTiles

--- a/CesiumGeometry/src/Plane.cpp
+++ b/CesiumGeometry/src/Plane.cpp
@@ -7,17 +7,28 @@ using namespace CesiumUtility;
 
 namespace CesiumGeometry {
 
-Plane::Plane(const glm::dvec3& normal, double distance)
-    : _normal(normal), _distance(distance) {
-  //>>includeStart('debug', pragmas.debug);
+Plane Plane::createUnchecked(const glm::dvec3& normal, double distance) noexcept {
+  return Plane(normal, distance);
+}
+
+std::optional<Plane> Plane::createOptional(const glm::dvec3& normal, double distance) noexcept {
+  if (!Math::equalsEpsilon(glm::length(normal), 1.0, Math::EPSILON6)) {
+    return std::nullopt;
+  }
+  return Plane(normal, distance);
+}
+
+Plane Plane::createThrowing(const glm::dvec3& normal, double distance) {
   if (!Math::equalsEpsilon(glm::length(normal), 1.0, Math::EPSILON6)) {
     throw std::invalid_argument("normal must be normalized.");
   }
-  //>>includeEnd('debug');
+  return Plane(normal, distance);
 }
 
-Plane::Plane(const glm::dvec3& point, const glm::dvec3& normal)
-    : Plane(normal, -glm::dot(normal, point)) {}
+
+Plane::Plane(const glm::dvec3& normal, double distance)
+    : _normal(normal), _distance(distance) {
+}
 
 double Plane::getPointDistance(const glm::dvec3& point) const noexcept {
   return glm::dot(this->_normal, point) + this->_distance;

--- a/CesiumGeometry/src/Plane.cpp
+++ b/CesiumGeometry/src/Plane.cpp
@@ -7,11 +7,14 @@ using namespace CesiumUtility;
 
 namespace CesiumGeometry {
 
-Plane Plane::createUnchecked(const glm::dvec3& normal, double distance) noexcept {
+Plane Plane::createUnchecked(
+    const glm::dvec3& normal,
+    double distance) noexcept {
   return Plane(normal, distance);
 }
 
-std::optional<Plane> Plane::createOptional(const glm::dvec3& normal, double distance) noexcept {
+std::optional<Plane>
+Plane::createOptional(const glm::dvec3& normal, double distance) noexcept {
   if (!Math::equalsEpsilon(glm::length(normal), 1.0, Math::EPSILON6)) {
     return std::nullopt;
   }
@@ -25,10 +28,8 @@ Plane Plane::createThrowing(const glm::dvec3& normal, double distance) {
   return Plane(normal, distance);
 }
 
-
 Plane::Plane(const glm::dvec3& normal, double distance)
-    : _normal(normal), _distance(distance) {
-}
+    : _normal(normal), _distance(distance) {}
 
 double Plane::getPointDistance(const glm::dvec3& point) const noexcept {
   return glm::dot(this->_normal, point) + this->_distance;

--- a/CesiumGeometry/src/Ray.cpp
+++ b/CesiumGeometry/src/Ray.cpp
@@ -7,13 +7,26 @@ using namespace CesiumUtility;
 
 namespace CesiumGeometry {
 
+  Ray Ray::createUnchecked(const glm::dvec3& origin, const glm::dvec3& direction) noexcept {
+    return Ray(origin, direction);
+  }
+  std::optional<Ray> Ray::createOptional(const glm::dvec3& origin, const glm::dvec3& direction) noexcept {
+    if (!Math::equalsEpsilon(glm::length(direction), 1.0, Math::EPSILON6)) {
+      return std::nullopt;
+    }
+    return Ray(origin, direction);
+  }
+
+  Ray Ray::createThrowing(const glm::dvec3& origin, const glm::dvec3& direction) {
+    if (!Math::equalsEpsilon(glm::length(direction), 1.0, Math::EPSILON6)) {
+      throw std::invalid_argument("direction must be normalized.");
+    }
+    return Ray(origin, direction);
+  }
+
+
 Ray::Ray(const glm::dvec3& origin, const glm::dvec3& direction)
     : _origin(origin), _direction(direction) {
-  //>>includeStart('debug', pragmas.debug);
-  if (!Math::equalsEpsilon(glm::length(direction), 1.0, Math::EPSILON6)) {
-    throw std::invalid_argument("direction must be normalized.");
-  }
-  //>>includeEnd('debug');
 }
 
 Ray Ray::operator-() const noexcept {

--- a/CesiumGeometry/src/Ray.cpp
+++ b/CesiumGeometry/src/Ray.cpp
@@ -7,27 +7,29 @@ using namespace CesiumUtility;
 
 namespace CesiumGeometry {
 
-  Ray Ray::createUnchecked(const glm::dvec3& origin, const glm::dvec3& direction) noexcept {
-    return Ray(origin, direction);
+Ray Ray::createUnchecked(
+    const glm::dvec3& origin,
+    const glm::dvec3& direction) noexcept {
+  return Ray(origin, direction);
+}
+std::optional<Ray> Ray::createOptional(
+    const glm::dvec3& origin,
+    const glm::dvec3& direction) noexcept {
+  if (!Math::equalsEpsilon(glm::length(direction), 1.0, Math::EPSILON6)) {
+    return std::nullopt;
   }
-  std::optional<Ray> Ray::createOptional(const glm::dvec3& origin, const glm::dvec3& direction) noexcept {
-    if (!Math::equalsEpsilon(glm::length(direction), 1.0, Math::EPSILON6)) {
-      return std::nullopt;
-    }
-    return Ray(origin, direction);
-  }
+  return Ray(origin, direction);
+}
 
-  Ray Ray::createThrowing(const glm::dvec3& origin, const glm::dvec3& direction) {
-    if (!Math::equalsEpsilon(glm::length(direction), 1.0, Math::EPSILON6)) {
-      throw std::invalid_argument("direction must be normalized.");
-    }
-    return Ray(origin, direction);
+Ray Ray::createThrowing(const glm::dvec3& origin, const glm::dvec3& direction) {
+  if (!Math::equalsEpsilon(glm::length(direction), 1.0, Math::EPSILON6)) {
+    throw std::invalid_argument("direction must be normalized.");
   }
-
+  return Ray(origin, direction);
+}
 
 Ray::Ray(const glm::dvec3& origin, const glm::dvec3& direction)
-    : _origin(origin), _direction(direction) {
-}
+    : _origin(origin), _direction(direction) {}
 
 Ray Ray::operator-() const noexcept {
   return Ray(this->_origin, -this->_direction);

--- a/CesiumGeospatial/include/CesiumGeospatial/EllipsoidTangentPlane.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/EllipsoidTangentPlane.h
@@ -93,10 +93,14 @@ public:
 private:
   /**
    * Computes the matrix that is used for the constructor (if the origin
-   * and ellipsoid are given), but throws an `std::invalid_argument` if
-   * the origin is at the center of the ellipsoid.
+   * and ellipsoid are given). If the origin is at the center of the 
+   * ellipsoid, then an identity matrix will be returned.
+   * 
+   * @param origin The origin
+   * @param ellipsoid The {@link Ellipsoid}
+   * @return The matrix
    */
-  static glm::dmat4 computeEastNorthUpToFixedFrame(
+  static glm::dmat4 computeEastNorthUpToFixedFrameUnchecked(
       const glm::dvec3& origin,
       const Ellipsoid& ellipsoid);
 

--- a/CesiumGeospatial/include/CesiumGeospatial/EllipsoidTangentPlane.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/EllipsoidTangentPlane.h
@@ -104,7 +104,7 @@ private:
   glm::dvec3 _origin;
   glm::dvec3 _xAxis;
   glm::dvec3 _yAxis;
-  CesiumGeometry::Plane _plane;
+  CesiumGeometry::Plane _plane = CesiumGeometry::Plane::createUnchecked({ 0, 0, 0 }, 0.0 );
 };
 
 } // namespace CesiumGeospatial

--- a/CesiumGeospatial/include/CesiumGeospatial/EllipsoidTangentPlane.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/EllipsoidTangentPlane.h
@@ -93,9 +93,9 @@ public:
 private:
   /**
    * Computes the matrix that is used for the constructor (if the origin
-   * and ellipsoid are given). If the origin is at the center of the 
+   * and ellipsoid are given). If the origin is at the center of the
    * ellipsoid, then an identity matrix will be returned.
-   * 
+   *
    * @param origin The origin
    * @param ellipsoid The {@link Ellipsoid}
    * @return The matrix
@@ -108,7 +108,8 @@ private:
   glm::dvec3 _origin;
   glm::dvec3 _xAxis;
   glm::dvec3 _yAxis;
-  CesiumGeometry::Plane _plane = CesiumGeometry::Plane::createUnchecked({ 0, 0, 0 }, 0.0 );
+  CesiumGeometry::Plane _plane =
+      CesiumGeometry::Plane::createUnchecked({0, 0, 0}, 0.0);
 };
 
 } // namespace CesiumGeospatial

--- a/CesiumGeospatial/src/BoundingRegion.cpp
+++ b/CesiumGeospatial/src/BoundingRegion.cpp
@@ -73,7 +73,8 @@ BoundingRegion::BoundingRegion(
             (rectangle.getWest() + rectangle.getEast()) * 0.5,
             south,
             0.0));
-    double westDistance =  -glm::dot(this->_westNormal, this->_southwestCornerCartesian);
+    double westDistance =
+        -glm::dot(this->_westNormal, this->_southwestCornerCartesian);
     Plane westPlane = Plane::createUnchecked(this->_westNormal, westDistance);
 
     // Find a point that is on the west and the south planes
@@ -105,7 +106,8 @@ BoundingRegion::BoundingRegion(
             (rectangle.getWest() + rectangle.getEast()) * 0.5,
             north,
             0.0));
-    double eastDistance = -glm::dot(this->_eastNormal, this->_northeastCornerCartesian);
+    double eastDistance =
+        -glm::dot(this->_eastNormal, this->_northeastCornerCartesian);
     Plane eastPlane = Plane::createUnchecked(this->_eastNormal, eastDistance);
 
     // Find a point that is on the east and the north planes
@@ -394,7 +396,7 @@ static OrientedBoundingBox fromPlaneExtents(
       !isPole ? glm::normalize(planeOrigin) : glm::dvec3(1.0, 0.0, 0.0);
   glm::dvec3 planeYAxis(0.0, 0.0, 1.0);
   glm::dvec3 planeXAxis = glm::cross(planeNormal, planeYAxis);
-  double planeDistance =  -glm::dot(planeNormal, planeOrigin); 
+  double planeDistance = -glm::dot(planeNormal, planeOrigin);
   plane = Plane::createUnchecked(planeNormal, planeDistance);
 
   // Get the horizon point relative to the center. This will be the farthest

--- a/CesiumGeospatial/src/BoundingRegion.cpp
+++ b/CesiumGeospatial/src/BoundingRegion.cpp
@@ -73,7 +73,8 @@ BoundingRegion::BoundingRegion(
             (rectangle.getWest() + rectangle.getEast()) * 0.5,
             south,
             0.0));
-    Plane westPlane(this->_southwestCornerCartesian, this->_westNormal);
+    double westDistance =  -glm::dot(this->_westNormal, this->_southwestCornerCartesian);
+    Plane westPlane = Plane::createUnchecked(this->_westNormal, westDistance);
 
     // Find a point that is on the west and the south planes
     std::optional<glm::dvec3> intersection = IntersectionTests::rayPlane(
@@ -104,8 +105,8 @@ BoundingRegion::BoundingRegion(
             (rectangle.getWest() + rectangle.getEast()) * 0.5,
             north,
             0.0));
-
-    Plane eastPlane(this->_northeastCornerCartesian, this->_eastNormal);
+    double eastDistance = -glm::dot(this->_eastNormal, this->_northeastCornerCartesian);
+    Plane eastPlane = Plane::createUnchecked(this->_eastNormal, eastDistance);
 
     // Find a point that is on the east and the north planes
     std::optional<glm::dvec3> intersection = IntersectionTests::rayPlane(
@@ -271,7 +272,7 @@ static OrientedBoundingBox fromPlaneExtents(
   //>>includeEnd('debug');
 
   double minX, maxX, minY, maxY, minZ, maxZ;
-  Plane plane(glm::dvec3(0.0, 0.0, 1.0), 0.0);
+  Plane plane = Plane::createUnchecked(glm::dvec3(0.0, 0.0, 1.0), 0.0);
 
   if (rectangle.computeWidth() <= Math::ONE_PI) {
     // The bounding box will be aligned with the tangent plane at the center of
@@ -393,7 +394,8 @@ static OrientedBoundingBox fromPlaneExtents(
       !isPole ? glm::normalize(planeOrigin) : glm::dvec3(1.0, 0.0, 0.0);
   glm::dvec3 planeYAxis(0.0, 0.0, 1.0);
   glm::dvec3 planeXAxis = glm::cross(planeNormal, planeYAxis);
-  plane = Plane(planeOrigin, planeNormal);
+  double planeDistance =  -glm::dot(planeNormal, planeOrigin); 
+  plane = Plane::createUnchecked(planeNormal, planeDistance);
 
   // Get the horizon point relative to the center. This will be the farthest
   // extent in the plane's X dimension.

--- a/CesiumGeospatial/src/BoundingRegion.cpp
+++ b/CesiumGeospatial/src/BoundingRegion.cpp
@@ -78,7 +78,7 @@ BoundingRegion::BoundingRegion(
 
     // Find a point that is on the west and the south planes
     std::optional<glm::dvec3> intersection = IntersectionTests::rayPlane(
-        Ray(southCenterCartesian, eastWestNormal),
+        Ray::createUnchecked(southCenterCartesian, eastWestNormal),
         westPlane);
 
     if (!intersection) {
@@ -110,7 +110,7 @@ BoundingRegion::BoundingRegion(
 
     // Find a point that is on the east and the north planes
     std::optional<glm::dvec3> intersection = IntersectionTests::rayPlane(
-        Ray(northCenterCartesian, -eastWestNormal),
+        Ray::createUnchecked(northCenterCartesian, -eastWestNormal),
         eastPlane);
 
     if (!intersection) {

--- a/CesiumGeospatial/src/EllipsoidTangentPlane.cpp
+++ b/CesiumGeospatial/src/EllipsoidTangentPlane.cpp
@@ -23,8 +23,7 @@ EllipsoidTangentPlane::EllipsoidTangentPlane(
     : _ellipsoid(ellipsoid),
       _origin(eastNorthUpToFixedFrame[3]),
       _xAxis(eastNorthUpToFixedFrame[0]),
-      _yAxis(eastNorthUpToFixedFrame[1]) 
-{
+      _yAxis(eastNorthUpToFixedFrame[1]) {
   const glm::dvec3& point = eastNorthUpToFixedFrame[3];
   const glm::dvec3& normal = eastNorthUpToFixedFrame[2];
   double distance = -glm::dot(normal, point);
@@ -48,7 +47,8 @@ glm::dvec2 EllipsoidTangentPlane::projectPointToNearestOnPlane(
   return glm::dvec2(glm::dot(this->_xAxis, v), glm::dot(this->_yAxis, v));
 }
 
-/* static */ glm::dmat4 EllipsoidTangentPlane::computeEastNorthUpToFixedFrameUnchecked(
+/* static */ glm::dmat4
+EllipsoidTangentPlane::computeEastNorthUpToFixedFrameUnchecked(
     const glm::dvec3& origin,
     const Ellipsoid& ellipsoid) {
   const auto scaledOrigin = ellipsoid.scaleToGeodeticSurface(origin);

--- a/CesiumGeospatial/src/EllipsoidTangentPlane.cpp
+++ b/CesiumGeospatial/src/EllipsoidTangentPlane.cpp
@@ -14,7 +14,7 @@ EllipsoidTangentPlane::EllipsoidTangentPlane(
     const glm::dvec3& origin,
     const Ellipsoid& ellipsoid)
     : EllipsoidTangentPlane(
-          computeEastNorthUpToFixedFrame(origin, ellipsoid),
+          computeEastNorthUpToFixedFrameUnchecked(origin, ellipsoid),
           ellipsoid) {}
 
 EllipsoidTangentPlane::EllipsoidTangentPlane(
@@ -48,13 +48,12 @@ glm::dvec2 EllipsoidTangentPlane::projectPointToNearestOnPlane(
   return glm::dvec2(glm::dot(this->_xAxis, v), glm::dot(this->_yAxis, v));
 }
 
-/* static */ glm::dmat4 EllipsoidTangentPlane::computeEastNorthUpToFixedFrame(
+/* static */ glm::dmat4 EllipsoidTangentPlane::computeEastNorthUpToFixedFrameUnchecked(
     const glm::dvec3& origin,
     const Ellipsoid& ellipsoid) {
   const auto scaledOrigin = ellipsoid.scaleToGeodeticSurface(origin);
   if (!scaledOrigin) {
-    throw std::invalid_argument(
-        "The origin must not be near the center of the ellipsoid.");
+    return glm::dmat4(1.0);
   }
   return Transforms::eastNorthUpToFixedFrame(scaledOrigin.value(), ellipsoid);
 }

--- a/CesiumGeospatial/src/EllipsoidTangentPlane.cpp
+++ b/CesiumGeospatial/src/EllipsoidTangentPlane.cpp
@@ -33,7 +33,7 @@ EllipsoidTangentPlane::EllipsoidTangentPlane(
 
 glm::dvec2 EllipsoidTangentPlane::projectPointToNearestOnPlane(
     const glm::dvec3& cartesian) const noexcept {
-  Ray ray(cartesian, this->_plane.getNormal());
+  Ray ray = Ray::createUnchecked(cartesian, this->_plane.getNormal());
 
   std::optional<glm::dvec3> intersectionPoint =
       IntersectionTests::rayPlane(ray, this->_plane);

--- a/CesiumGeospatial/src/EllipsoidTangentPlane.cpp
+++ b/CesiumGeospatial/src/EllipsoidTangentPlane.cpp
@@ -23,8 +23,13 @@ EllipsoidTangentPlane::EllipsoidTangentPlane(
     : _ellipsoid(ellipsoid),
       _origin(eastNorthUpToFixedFrame[3]),
       _xAxis(eastNorthUpToFixedFrame[0]),
-      _yAxis(eastNorthUpToFixedFrame[1]),
-      _plane(eastNorthUpToFixedFrame[3], eastNorthUpToFixedFrame[2]) {}
+      _yAxis(eastNorthUpToFixedFrame[1]) 
+{
+  const glm::dvec3& point = eastNorthUpToFixedFrame[3];
+  const glm::dvec3& normal = eastNorthUpToFixedFrame[2];
+  double distance = -glm::dot(normal, point);
+  _plane = Plane::createUnchecked(normal, distance);
+}
 
 glm::dvec2 EllipsoidTangentPlane::projectPointToNearestOnPlane(
     const glm::dvec3& cartesian) const noexcept {


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium-native/issues/205

As mentioned in the CHANGES.md:

> The `CesiumGeometry::Plane` and `CesiumGeometry::Ray` classes now offer factory
  methods to avoid throwing an `invalid_argument` exception in case of errors.
  They offer a `createUnchecked` method that assumes valid input, a `createOptional`
  method that returns an `std::optional` in case of errors, and a `createThrowing`
  method that throws an exception in case of errors. This has the effect of other
  classes also no longer throwing: The internal usage of these classes has been
  changed to generally use the `createUnchecked` method, because the preconditions
  for the exception to be thrown could not sensibly be propagated to the user.
  This means that the `CullingVolume` and `EllipsoidTangentPlane` do no longer
  throw for invalid inputs, but may return results that contain `NaN` values.


(Somewhat surprisingly, this does not seem to affect `cesium-unreal` on an API level: These classes had apparently not be used *directly*)
