### PR TITLE
Cmake fix for cpp-httplib

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -33,6 +33,8 @@ endif()
 add_subdirectory(modp_b64)
 
 set(HTTPLIB_USE_BROTLI_IF_AVAILABLE OFF CACHE BOOL "Don't use Brotli")
+set(HTTPLIB_USE_ZLIB_IF_AVAILABLE OFF CACHE BOOL "Don't use Zlib") 
+set(HTTPLIB_USE_OPENSSL_IF_AVAILABLE OFF CACHE BOOL "Don't use OpenSSL")
 add_subdirectory(cpp-httplib)
 
 add_subdirectory(magic_enum)


### PR DESCRIPTION
Possibly fixes: #251. 

Tells `cpp-httplib` not to look for zlib or openssl. Quoting @baothientran for what the issue may have been:
>hm good chance is your dev environment have zlib and openssl installed and httplib link against them when building. But those libraries are not copied in to unreal third party and it didn't know how to link against those symbol 

I'm not going to pretend I understand cmake or what exactly httplib, zlib, and openssl do, but this change finally solved a very painful issue I was stuck on for the last two days :). The issue does not happen in everybody's dev environment, so I think Bao's idea makes a lot of sense. 

@jtorresfabra @kring 