### PR TITLE
Add an option to prefix all sqlite3 symbols with `cesium_`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 - Added `Cesium3DTiles::TileIdUtilities` with a `createTileIdString` function to create logging/debugging strings for `TileID` objects.
 - Accessing the same Bing Maps layer multiple times in a single application run now reuses the same Bing Maps session instead of starting a new one each time.
+- Add a configure-time build option, `PRIVATE_CESIUM_SQLITE`, to rename all `sqlite3*` symbols to `cesium_sqlite3*`.
 
 ##### Fixes :wrench:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ project(cesium-native
     LANGUAGES CXX
 )
 
+option(PRIVATE_CESIUM_SQLITE "ON to rename SQLite symbols to cesium_sqlite3_* so they won't conflict with other SQLite implemenentations" OFF)
+
 # Add Modules
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/extern/cmake-modules/")
 

--- a/CesiumAsync/CMakeLists.txt
+++ b/CesiumAsync/CMakeLists.txt
@@ -32,9 +32,6 @@ target_include_directories(
     CesiumAsync
     SYSTEM PUBLIC
         ${CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR}
-        # SQLITE3 does not attach its include directory to
-        # its target
-        ${CESIUM_NATIVE_SQLITE3_INCLUDE_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/include
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/src/

--- a/CesiumAsync/include/CesiumAsync/SqliteCache.h
+++ b/CesiumAsync/include/CesiumAsync/SqliteCache.h
@@ -1,17 +1,11 @@
 #pragma once
 
-#define sqlite3 cqlite3
-
 #include "CesiumAsync/ICacheDatabase.h"
 #include <cstddef>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <spdlog/fwd.h>
 #include <string>
-
-struct sqlite3;
-struct sqlite3_stmt;
 
 namespace CesiumAsync {
 
@@ -36,6 +30,7 @@ public:
       const std::shared_ptr<spdlog::logger>& pLogger,
       const std::string& databaseName,
       uint64_t maxItems = 4096);
+  ~SqliteCache();
 
   /** @copydoc ICacheDatabase::getEntry*/
   virtual std::optional<CacheItem>
@@ -59,32 +54,7 @@ public:
   virtual bool clearAll() override;
 
 private:
-  struct DeleteSqliteConnection {
-    void operator()(sqlite3* pConnection) noexcept;
-  };
-
-  struct DeleteSqliteStatement {
-    void operator()(sqlite3_stmt* pStmt) noexcept;
-  };
-
-  using SqliteConnectionPtr = std::unique_ptr<sqlite3, DeleteSqliteConnection>;
-  using SqliteStatementPtr =
-      std::unique_ptr<sqlite3_stmt, DeleteSqliteStatement>;
-
-  static SqliteStatementPtr prepareStatement(
-      const SqliteConnectionPtr& pConnection,
-      const std::string& sql);
-
-  std::shared_ptr<spdlog::logger> _pLogger;
-  SqliteConnectionPtr _pConnection;
-  uint64_t _maxItems;
-  mutable std::mutex _mutex;
-  SqliteStatementPtr _getEntryStmtWrapper;
-  SqliteStatementPtr _updateLastAccessedTimeStmtWrapper;
-  SqliteStatementPtr _storeResponseStmtWrapper;
-  SqliteStatementPtr _totalItemsQueryStmtWrapper;
-  SqliteStatementPtr _deleteExpiredStmtWrapper;
-  SqliteStatementPtr _deleteLRUStmtWrapper;
-  SqliteStatementPtr _clearAllStmtWrapper;
+  struct Impl;
+  std::unique_ptr<Impl> _pImpl;
 };
 } // namespace CesiumAsync

--- a/CesiumAsync/include/CesiumAsync/SqliteCache.h
+++ b/CesiumAsync/include/CesiumAsync/SqliteCache.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#define sqlite3 cqlite3
+
 #include "CesiumAsync/ICacheDatabase.h"
 #include <cstddef>
 #include <memory>

--- a/CesiumAsync/src/SqliteCache.cpp
+++ b/CesiumAsync/src/SqliteCache.cpp
@@ -3,30 +3,32 @@
 #include "rapidjson/document.h"
 #include "rapidjson/rapidjson.h"
 #include "rapidjson/writer.h"
+#include <cesium-sqlite3.h>
 #include <cstddef>
 #include <spdlog/spdlog.h>
 #include <sqlite3.h>
 #include <stdexcept>
 #include <utility>
 
-namespace CesiumAsync {
+using namespace CesiumAsync;
+
+namespace {
 // Cache table column names
-static const std::string CACHE_TABLE = "CacheItemTable";
-static const std::string CACHE_TABLE_KEY_COLUMN = "key";
-static const std::string CACHE_TABLE_EXPIRY_TIME_COLUMN = "expiryTime";
-static const std::string CACHE_TABLE_LAST_ACCESSED_TIME_COLUMN =
-    "lastAccessedTime";
-static const std::string CACHE_TABLE_RESPONSE_HEADER_COLUMN = "responseHeaders";
-static const std::string CACHE_TABLE_RESPONSE_STATUS_CODE_COLUMN =
+const std::string CACHE_TABLE = "CacheItemTable";
+const std::string CACHE_TABLE_KEY_COLUMN = "key";
+const std::string CACHE_TABLE_EXPIRY_TIME_COLUMN = "expiryTime";
+const std::string CACHE_TABLE_LAST_ACCESSED_TIME_COLUMN = "lastAccessedTime";
+const std::string CACHE_TABLE_RESPONSE_HEADER_COLUMN = "responseHeaders";
+const std::string CACHE_TABLE_RESPONSE_STATUS_CODE_COLUMN =
     "responseStatusCode";
-static const std::string CACHE_TABLE_RESPONSE_DATA_COLUMN = "responseData";
-static const std::string CACHE_TABLE_REQUEST_HEADER_COLUMN = "requestHeader";
-static const std::string CACHE_TABLE_REQUEST_METHOD_COLUMN = "requestMethod";
-static const std::string CACHE_TABLE_REQUEST_URL_COLUMN = "requestUrl";
-static const std::string CACHE_TABLE_VIRTUAL_TOTAL_ITEMS_COLUMN = "totalItems";
+const std::string CACHE_TABLE_RESPONSE_DATA_COLUMN = "responseData";
+const std::string CACHE_TABLE_REQUEST_HEADER_COLUMN = "requestHeader";
+const std::string CACHE_TABLE_REQUEST_METHOD_COLUMN = "requestMethod";
+const std::string CACHE_TABLE_REQUEST_URL_COLUMN = "requestUrl";
+const std::string CACHE_TABLE_VIRTUAL_TOTAL_ITEMS_COLUMN = "totalItems";
 
 // Sql commands for setting up database
-static const std::string CREATE_CACHE_TABLE_SQL =
+const std::string CREATE_CACHE_TABLE_SQL =
     "CREATE TABLE IF NOT EXISTS " + CACHE_TABLE + "(" + CACHE_TABLE_KEY_COLUMN +
     " TEXT PRIMARY KEY NOT NULL," + CACHE_TABLE_EXPIRY_TIME_COLUMN +
     " DATETIME NOT NULL," + CACHE_TABLE_LAST_ACCESSED_TIME_COLUMN +
@@ -37,14 +39,14 @@ static const std::string CREATE_CACHE_TABLE_SQL =
     CACHE_TABLE_REQUEST_METHOD_COLUMN + " TEXT NOT NULL," +
     CACHE_TABLE_REQUEST_URL_COLUMN + " TEXT NOT NULL)";
 
-static const std::string PRAGMA_WAL_SQL = "PRAGMA journal_mode=WAL";
+const std::string PRAGMA_WAL_SQL = "PRAGMA journal_mode=WAL";
 
-static const std::string PRAGMA_SYNC_SQL = "PRAGMA synchronous=OFF";
+const std::string PRAGMA_SYNC_SQL = "PRAGMA synchronous=OFF";
 
-static const std::string PRAGMA_PAGE_SIZE_SQL = "PRAGMA page_size=4096";
+const std::string PRAGMA_PAGE_SIZE_SQL = "PRAGMA page_size=4096";
 
 // Sql commands for getting entry from database
-static const std::string GET_ENTRY_SQL =
+const std::string GET_ENTRY_SQL =
     "SELECT rowid, " + CACHE_TABLE_EXPIRY_TIME_COLUMN + ", " +
     CACHE_TABLE_RESPONSE_HEADER_COLUMN + ", " +
     CACHE_TABLE_RESPONSE_STATUS_CODE_COLUMN + ", " +
@@ -53,12 +55,12 @@ static const std::string GET_ENTRY_SQL =
     CACHE_TABLE_REQUEST_METHOD_COLUMN + ", " + CACHE_TABLE_REQUEST_URL_COLUMN +
     " FROM " + CACHE_TABLE + " WHERE " + CACHE_TABLE_KEY_COLUMN + "=?";
 
-static const std::string UPDATE_LAST_ACCESSED_TIME_SQL =
+const std::string UPDATE_LAST_ACCESSED_TIME_SQL =
     "UPDATE " + CACHE_TABLE + " SET " + CACHE_TABLE_LAST_ACCESSED_TIME_COLUMN +
     " = strftime('%s','now') WHERE " + CACHE_TABLE_KEY_COLUMN + " =?";
 
 // Sql commands for storing response
-static const std::string STORE_RESPONSE_SQL =
+const std::string STORE_RESPONSE_SQL =
     "REPLACE INTO " + CACHE_TABLE + " (" + CACHE_TABLE_EXPIRY_TIME_COLUMN +
     ", " + CACHE_TABLE_LAST_ACCESSED_TIME_COLUMN + ", " +
     CACHE_TABLE_RESPONSE_HEADER_COLUMN + ", " +
@@ -69,518 +71,21 @@ static const std::string STORE_RESPONSE_SQL =
     ", " + CACHE_TABLE_KEY_COLUMN + ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
 // Sql commands for prunning the database
-static const std::string TOTAL_ITEMS_QUERY_SQL =
+const std::string TOTAL_ITEMS_QUERY_SQL =
     "SELECT COUNT(*) " + CACHE_TABLE_VIRTUAL_TOTAL_ITEMS_COLUMN + " FROM " +
     CACHE_TABLE;
 
-static const std::string DELETE_EXPIRED_ITEMS_SQL =
+const std::string DELETE_EXPIRED_ITEMS_SQL =
     "DELETE FROM " + CACHE_TABLE + " WHERE " + CACHE_TABLE_EXPIRY_TIME_COLUMN +
     " < strftime('%s','now')";
 
-static const std::string DELETE_LRU_ITEMS_SQL =
+const std::string DELETE_LRU_ITEMS_SQL =
     "DELETE FROM " + CACHE_TABLE + " WHERE rowid " + " IN (SELECT rowid FROM " +
     CACHE_TABLE + " ORDER BY " + CACHE_TABLE_LAST_ACCESSED_TIME_COLUMN +
     " ASC " + " LIMIT ?)";
 
 // Sql commands for clean all items
-static const std::string CLEAR_ALL_SQL = "DELETE FROM " + CACHE_TABLE;
-
-static std::string convertHeadersToString(const HttpHeaders& headers);
-
-static HttpHeaders convertStringToHeaders(const std::string& serializedHeaders);
-
-void SqliteCache::DeleteSqliteConnection::operator()(
-    sqlite3* pConnection) noexcept {
-  sqlite3_close_v2(pConnection);
-}
-
-void SqliteCache::DeleteSqliteStatement::operator()(
-    sqlite3_stmt* pStatement) noexcept {
-  sqlite3_finalize(pStatement);
-}
-
-SqliteCache::SqliteCache(
-    const std::shared_ptr<spdlog::logger>& pLogger,
-    const std::string& databaseName,
-    uint64_t maxItems)
-    : _pLogger(pLogger),
-      _pConnection(nullptr),
-      _maxItems(maxItems),
-      _getEntryStmtWrapper(),
-      _updateLastAccessedTimeStmtWrapper(),
-      _storeResponseStmtWrapper(),
-      _totalItemsQueryStmtWrapper(),
-      _deleteExpiredStmtWrapper(),
-      _deleteLRUStmtWrapper(),
-      _clearAllStmtWrapper() {
-  sqlite3* pConnection;
-  int status = sqlite3_open(databaseName.c_str(), &pConnection);
-  if (status != SQLITE_OK) {
-    throw std::runtime_error(sqlite3_errstr(status));
-  }
-
-  this->_pConnection =
-      std::unique_ptr<sqlite3, DeleteSqliteConnection>(pConnection);
-
-  // create cache tables if not exist. Key -> Cache table: one-to-many
-  // relationship
-  char* createTableError = nullptr;
-  status = sqlite3_exec(
-      this->_pConnection.get(),
-      CREATE_CACHE_TABLE_SQL.c_str(),
-      nullptr,
-      nullptr,
-      &createTableError);
-  if (status != SQLITE_OK) {
-    std::string errorStr(createTableError);
-    sqlite3_free(createTableError);
-    throw std::runtime_error(errorStr);
-  }
-
-  // turn on WAL mode
-  char* walError = nullptr;
-  status = sqlite3_exec(
-      this->_pConnection.get(),
-      PRAGMA_WAL_SQL.c_str(),
-      nullptr,
-      nullptr,
-      &walError);
-  if (status != SQLITE_OK) {
-    std::string errorStr(walError);
-    sqlite3_free(walError);
-    throw std::runtime_error(errorStr);
-  }
-
-  // turn off synchronous mode
-  char* syncError = nullptr;
-  status = sqlite3_exec(
-      this->_pConnection.get(),
-      PRAGMA_SYNC_SQL.c_str(),
-      nullptr,
-      nullptr,
-      &syncError);
-  if (status != SQLITE_OK) {
-    std::string errorStr(syncError);
-    sqlite3_free(syncError);
-    throw std::runtime_error(errorStr);
-  }
-
-  // increase page size
-  char* pageSizeError = nullptr;
-  status = sqlite3_exec(
-      this->_pConnection.get(),
-      PRAGMA_PAGE_SIZE_SQL.c_str(),
-      nullptr,
-      nullptr,
-      &pageSizeError);
-  if (status != SQLITE_OK) {
-    std::string errorStr(pageSizeError);
-    sqlite3_free(pageSizeError);
-    throw std::runtime_error(errorStr);
-  }
-
-  // get entry based on key
-  this->_getEntryStmtWrapper =
-      prepareStatement(this->_pConnection, GET_ENTRY_SQL);
-
-  // update last accessed for entry
-  this->_updateLastAccessedTimeStmtWrapper =
-      prepareStatement(this->_pConnection, UPDATE_LAST_ACCESSED_TIME_SQL);
-
-  // store response
-  this->_storeResponseStmtWrapper =
-      prepareStatement(this->_pConnection, STORE_RESPONSE_SQL);
-
-  // query total items
-  this->_totalItemsQueryStmtWrapper =
-      prepareStatement(this->_pConnection, TOTAL_ITEMS_QUERY_SQL);
-
-  // delete expired items
-  this->_deleteExpiredStmtWrapper =
-      prepareStatement(this->_pConnection, DELETE_EXPIRED_ITEMS_SQL);
-
-  // delete expired items
-  this->_deleteLRUStmtWrapper =
-      prepareStatement(this->_pConnection, DELETE_LRU_ITEMS_SQL);
-
-  // clear all items
-  this->_clearAllStmtWrapper =
-      prepareStatement(this->_pConnection, CLEAR_ALL_SQL);
-}
-
-std::optional<CacheItem> SqliteCache::getEntry(const std::string& key) const {
-  std::lock_guard<std::mutex> guard(this->_mutex);
-
-  // get entry based on key
-  int status = sqlite3_reset(this->_getEntryStmtWrapper.get());
-  if (status != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return std::nullopt;
-  }
-
-  status = sqlite3_clear_bindings(this->_getEntryStmtWrapper.get());
-  if (status != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return std::nullopt;
-  }
-
-  status = sqlite3_bind_text(
-      this->_getEntryStmtWrapper.get(),
-      1,
-      key.c_str(),
-      -1,
-      SQLITE_STATIC);
-  if (status != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return std::nullopt;
-  }
-
-  status = sqlite3_step(this->_getEntryStmtWrapper.get());
-  if (status == SQLITE_DONE) {
-    // Cache miss
-    return std::nullopt;
-  }
-
-  if (status != SQLITE_ROW) {
-    // Something went wrong.
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return std::nullopt;
-  }
-
-  // Cache hit - unpack and return it.
-  int64_t itemIndex = sqlite3_column_int64(this->_getEntryStmtWrapper.get(), 0);
-
-  // parse cache item metadata
-  std::time_t expiryTime =
-      sqlite3_column_int64(this->_getEntryStmtWrapper.get(), 1);
-
-  // parse response cache
-  std::string serializedResponseHeaders = reinterpret_cast<const char*>(
-      sqlite3_column_text(this->_getEntryStmtWrapper.get(), 2));
-  HttpHeaders responseHeaders =
-      convertStringToHeaders(serializedResponseHeaders);
-
-  uint16_t statusCode = static_cast<uint16_t>(
-      sqlite3_column_int(this->_getEntryStmtWrapper.get(), 3));
-
-  const std::byte* rawResponseData = reinterpret_cast<const std::byte*>(
-      sqlite3_column_blob(this->_getEntryStmtWrapper.get(), 4));
-  int responseDataSize =
-      sqlite3_column_bytes(this->_getEntryStmtWrapper.get(), 4);
-  std::vector<std::byte> responseData(
-      rawResponseData,
-      rawResponseData + responseDataSize);
-
-  // parse request
-  std::string serializedRequestHeaders = reinterpret_cast<const char*>(
-      sqlite3_column_text(this->_getEntryStmtWrapper.get(), 5));
-  HttpHeaders requestHeaders = convertStringToHeaders(serializedRequestHeaders);
-
-  std::string requestMethod = reinterpret_cast<const char*>(
-      sqlite3_column_text(this->_getEntryStmtWrapper.get(), 6));
-
-  std::string requestUrl = reinterpret_cast<const char*>(
-      sqlite3_column_text(this->_getEntryStmtWrapper.get(), 7));
-
-  // update the last accessed time
-  int updateStatus =
-      sqlite3_reset(this->_updateLastAccessedTimeStmtWrapper.get());
-  if (updateStatus != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(updateStatus));
-    return std::nullopt;
-  }
-
-  updateStatus =
-      sqlite3_clear_bindings(this->_updateLastAccessedTimeStmtWrapper.get());
-  if (updateStatus != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(updateStatus));
-    return std::nullopt;
-  }
-
-  updateStatus = sqlite3_bind_int64(
-      this->_updateLastAccessedTimeStmtWrapper.get(),
-      1,
-      itemIndex);
-  if (updateStatus != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(updateStatus));
-    return std::nullopt;
-  }
-
-  updateStatus = sqlite3_step(this->_updateLastAccessedTimeStmtWrapper.get());
-  if (updateStatus != SQLITE_DONE) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(updateStatus));
-    return std::nullopt;
-  }
-
-  return CacheItem{
-      expiryTime,
-      CacheRequest{
-          std::move(requestHeaders),
-          std::move(requestMethod),
-          std::move(requestUrl)},
-      CacheResponse{
-          statusCode,
-          std::move(responseHeaders),
-          std::move(responseData)}};
-}
-
-bool SqliteCache::storeEntry(
-    const std::string& key,
-    std::time_t expiryTime,
-    const std::string& url,
-    const std::string& requestMethod,
-    const HttpHeaders& requestHeaders,
-    uint16_t statusCode,
-    const HttpHeaders& responseHeaders,
-    const gsl::span<const std::byte>& responseData) {
-  std::lock_guard<std::mutex> guard(this->_mutex);
-
-  // cache the request with the key
-  int status = sqlite3_reset(this->_storeResponseStmtWrapper.get());
-  if (status != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return false;
-  }
-
-  status = sqlite3_clear_bindings(this->_storeResponseStmtWrapper.get());
-  if (status != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return false;
-  }
-
-  status = sqlite3_bind_int64(
-      this->_storeResponseStmtWrapper.get(),
-      1,
-      static_cast<int64_t>(expiryTime));
-  if (status != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return false;
-  }
-
-  status = sqlite3_bind_int64(
-      this->_storeResponseStmtWrapper.get(),
-      2,
-      static_cast<int64_t>(std::time(nullptr)));
-  if (status != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return false;
-  }
-
-  std::string responseHeaderString = convertHeadersToString(responseHeaders);
-  status = sqlite3_bind_text(
-      this->_storeResponseStmtWrapper.get(),
-      3,
-      responseHeaderString.c_str(),
-      -1,
-      SQLITE_STATIC);
-  if (status != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return false;
-  }
-
-  status = sqlite3_bind_int(
-      this->_storeResponseStmtWrapper.get(),
-      4,
-      static_cast<int>(statusCode));
-  if (status != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return false;
-  }
-
-  status = sqlite3_bind_blob(
-      this->_storeResponseStmtWrapper.get(),
-      5,
-      responseData.data(),
-      static_cast<int>(responseData.size()),
-      SQLITE_STATIC);
-  if (status != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return false;
-  }
-
-  std::string requestHeaderString = convertHeadersToString(requestHeaders);
-  status = sqlite3_bind_text(
-      this->_storeResponseStmtWrapper.get(),
-      6,
-      requestHeaderString.c_str(),
-      -1,
-      SQLITE_STATIC);
-  if (status != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return false;
-  }
-
-  status = sqlite3_bind_text(
-      this->_storeResponseStmtWrapper.get(),
-      7,
-      requestMethod.c_str(),
-      -1,
-      SQLITE_STATIC);
-  if (status != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return false;
-  }
-
-  status = sqlite3_bind_text(
-      this->_storeResponseStmtWrapper.get(),
-      8,
-      url.c_str(),
-      -1,
-      SQLITE_STATIC);
-  if (status != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return false;
-  }
-
-  status = sqlite3_bind_text(
-      this->_storeResponseStmtWrapper.get(),
-      9,
-      key.c_str(),
-      -1,
-      SQLITE_STATIC);
-  if (status != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return false;
-  }
-
-  status = sqlite3_step(this->_storeResponseStmtWrapper.get());
-  if (status != SQLITE_DONE) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return false;
-  }
-
-  return true;
-}
-
-bool SqliteCache::prune() {
-  std::lock_guard<std::mutex> guard(this->_mutex);
-
-  int64_t totalItems = 0;
-
-  // query total size of response's data
-  {
-    int totalItemsQueryStatus =
-        sqlite3_reset(this->_totalItemsQueryStmtWrapper.get());
-    if (totalItemsQueryStatus != SQLITE_OK) {
-      SPDLOG_LOGGER_ERROR(
-          this->_pLogger,
-          sqlite3_errstr(totalItemsQueryStatus));
-      return false;
-    }
-
-    totalItemsQueryStatus =
-        sqlite3_clear_bindings(this->_totalItemsQueryStmtWrapper.get());
-    if (totalItemsQueryStatus != SQLITE_OK) {
-      SPDLOG_LOGGER_ERROR(
-          this->_pLogger,
-          sqlite3_errstr(totalItemsQueryStatus));
-      return false;
-    }
-
-    totalItemsQueryStatus =
-        sqlite3_step(this->_totalItemsQueryStmtWrapper.get());
-
-    if (totalItemsQueryStatus == SQLITE_DONE) {
-      return true;
-    }
-
-    if (totalItemsQueryStatus != SQLITE_ROW) {
-      SPDLOG_LOGGER_ERROR(
-          this->_pLogger,
-          sqlite3_errstr(totalItemsQueryStatus));
-      return false;
-    }
-
-    // prune the rows if over maximum
-    totalItems =
-        sqlite3_column_int64(this->_totalItemsQueryStmtWrapper.get(), 0);
-    if (totalItems > 0 && totalItems <= static_cast<int64_t>(_maxItems)) {
-      return true;
-    }
-  }
-
-  // delete expired rows first
-  {
-    int deleteExpiredStatus =
-        sqlite3_reset(this->_deleteExpiredStmtWrapper.get());
-    if (deleteExpiredStatus != SQLITE_OK) {
-      SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(deleteExpiredStatus));
-      return false;
-    }
-
-    deleteExpiredStatus =
-        sqlite3_clear_bindings(this->_deleteExpiredStmtWrapper.get());
-    if (deleteExpiredStatus != SQLITE_OK) {
-      SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(deleteExpiredStatus));
-      return false;
-    }
-
-    deleteExpiredStatus = sqlite3_step(this->_deleteExpiredStmtWrapper.get());
-    if (deleteExpiredStatus != SQLITE_DONE) {
-      SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(deleteExpiredStatus));
-      return false;
-    }
-  }
-
-  // check if we should delete more
-  int deletedRows = sqlite3_changes(this->_pConnection.get());
-  if (totalItems - deletedRows < static_cast<int>(this->_maxItems)) {
-    return true;
-  }
-
-  totalItems -= deletedRows;
-
-  // delete rows LRU if we are still over maximum
-  {
-    int deleteLLRUStatus = sqlite3_reset(this->_deleteLRUStmtWrapper.get());
-    if (deleteLLRUStatus != SQLITE_OK) {
-      SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(deleteLLRUStatus));
-      return false;
-    }
-
-    deleteLLRUStatus =
-        sqlite3_clear_bindings(this->_deleteLRUStmtWrapper.get());
-    if (deleteLLRUStatus != SQLITE_OK) {
-      SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(deleteLLRUStatus));
-      return false;
-    }
-
-    deleteLLRUStatus = sqlite3_bind_int64(
-        this->_deleteLRUStmtWrapper.get(),
-        1,
-        totalItems - static_cast<int64_t>(this->_maxItems));
-    if (deleteLLRUStatus != SQLITE_OK) {
-      SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(deleteLLRUStatus));
-      return false;
-    }
-
-    deleteLLRUStatus = sqlite3_step(this->_deleteLRUStmtWrapper.get());
-    if (deleteLLRUStatus != SQLITE_DONE) {
-      SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(deleteLLRUStatus));
-      return false;
-    }
-  }
-
-  return true;
-}
-
-bool SqliteCache::clearAll() {
-  std::lock_guard<std::mutex> guard(this->_mutex);
-
-  int status = sqlite3_reset(this->_clearAllStmtWrapper.get());
-  if (status != SQLITE_OK) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return false;
-  }
-
-  status = sqlite3_step(this->_clearAllStmtWrapper.get());
-  if (status != SQLITE_DONE) {
-    SPDLOG_LOGGER_ERROR(this->_pLogger, sqlite3_errstr(status));
-    return false;
-  }
-
-  return true;
-}
+const std::string CLEAR_ALL_SQL = "DELETE FROM " + CACHE_TABLE;
 
 std::string convertHeadersToString(const HttpHeaders& headers) {
   rapidjson::Document document;
@@ -614,19 +119,623 @@ HttpHeaders convertStringToHeaders(const std::string& serializedHeaders) {
   return headers;
 }
 
-/*static*/ SqliteCache::SqliteStatementPtr SqliteCache::prepareStatement(
-    const SqliteCache::SqliteConnectionPtr& pConnection,
+struct DeleteSqliteConnection {
+  void operator()(CESIUM_SQLITE(sqlite3*) pConnection) noexcept {
+    CESIUM_SQLITE(sqlite3_close_v2)(pConnection);
+  }
+};
+
+struct DeleteSqliteStatement {
+  void operator()(CESIUM_SQLITE(sqlite3_stmt*) pStatement) noexcept {
+    CESIUM_SQLITE(sqlite3_finalize)(pStatement);
+  }
+};
+
+using SqliteConnectionPtr =
+    std::unique_ptr<CESIUM_SQLITE(sqlite3), DeleteSqliteConnection>;
+using SqliteStatementPtr =
+    std::unique_ptr<CESIUM_SQLITE(sqlite3_stmt), DeleteSqliteStatement>;
+
+SqliteStatementPtr prepareStatement(
+    const SqliteConnectionPtr& pConnection,
     const std::string& sql) {
-  sqlite3_stmt* pStmt;
-  int status = sqlite3_prepare_v2(
+  CESIUM_SQLITE(sqlite3_stmt*) pStmt;
+  int status = CESIUM_SQLITE(sqlite3_prepare_v2)(
       pConnection.get(),
       sql.c_str(),
       int(sql.size()),
       &pStmt,
       nullptr);
   if (status != SQLITE_OK) {
-    throw std::runtime_error(std::string(sqlite3_errstr(status)));
+    throw std::runtime_error(
+        std::string(CESIUM_SQLITE(sqlite3_errstr)(status)));
   }
   return SqliteStatementPtr(pStmt);
 }
+
+} // namespace
+
+namespace CesiumAsync {
+
+struct SqliteCache::Impl {
+  Impl(const std::shared_ptr<spdlog::logger>& pLogger, uint64_t maxItems)
+      : _pLogger(pLogger),
+        _pConnection(nullptr),
+        _maxItems(maxItems),
+        _getEntryStmtWrapper(),
+        _updateLastAccessedTimeStmtWrapper(),
+        _storeResponseStmtWrapper(),
+        _totalItemsQueryStmtWrapper(),
+        _deleteExpiredStmtWrapper(),
+        _deleteLRUStmtWrapper(),
+        _clearAllStmtWrapper() {}
+
+  std::shared_ptr<spdlog::logger> _pLogger;
+  SqliteConnectionPtr _pConnection;
+  uint64_t _maxItems;
+  mutable std::mutex _mutex;
+  SqliteStatementPtr _getEntryStmtWrapper;
+  SqliteStatementPtr _updateLastAccessedTimeStmtWrapper;
+  SqliteStatementPtr _storeResponseStmtWrapper;
+  SqliteStatementPtr _totalItemsQueryStmtWrapper;
+  SqliteStatementPtr _deleteExpiredStmtWrapper;
+  SqliteStatementPtr _deleteLRUStmtWrapper;
+  SqliteStatementPtr _clearAllStmtWrapper;
+};
+
+SqliteCache::SqliteCache(
+    const std::shared_ptr<spdlog::logger>& pLogger,
+    const std::string& databaseName,
+    uint64_t maxItems)
+    : _pImpl(std::make_unique<Impl>(pLogger, maxItems)) {
+  CESIUM_SQLITE(sqlite3*) pConnection;
+  int status = CESIUM_SQLITE(sqlite3_open)(databaseName.c_str(), &pConnection);
+  if (status != SQLITE_OK) {
+    throw std::runtime_error(CESIUM_SQLITE(sqlite3_errstr)(status));
+  }
+
+  this->_pImpl->_pConnection =
+      std::unique_ptr<CESIUM_SQLITE(sqlite3), DeleteSqliteConnection>(
+          pConnection);
+
+  // create cache tables if not exist. Key -> Cache table: one-to-many
+  // relationship
+  char* createTableError = nullptr;
+  status = CESIUM_SQLITE(sqlite3_exec)(
+      this->_pImpl->_pConnection.get(),
+      CREATE_CACHE_TABLE_SQL.c_str(),
+      nullptr,
+      nullptr,
+      &createTableError);
+  if (status != SQLITE_OK) {
+    std::string errorStr(createTableError);
+    CESIUM_SQLITE(sqlite3_free)(createTableError);
+    throw std::runtime_error(errorStr);
+  }
+
+  // turn on WAL mode
+  char* walError = nullptr;
+  status = CESIUM_SQLITE(sqlite3_exec)(
+      this->_pImpl->_pConnection.get(),
+      PRAGMA_WAL_SQL.c_str(),
+      nullptr,
+      nullptr,
+      &walError);
+  if (status != SQLITE_OK) {
+    std::string errorStr(walError);
+    CESIUM_SQLITE(sqlite3_free)(walError);
+    throw std::runtime_error(errorStr);
+  }
+
+  // turn off synchronous mode
+  char* syncError = nullptr;
+  status = CESIUM_SQLITE(sqlite3_exec)(
+      this->_pImpl->_pConnection.get(),
+      PRAGMA_SYNC_SQL.c_str(),
+      nullptr,
+      nullptr,
+      &syncError);
+  if (status != SQLITE_OK) {
+    std::string errorStr(syncError);
+    CESIUM_SQLITE(sqlite3_free)(syncError);
+    throw std::runtime_error(errorStr);
+  }
+
+  // increase page size
+  char* pageSizeError = nullptr;
+  status = CESIUM_SQLITE(sqlite3_exec)(
+      this->_pImpl->_pConnection.get(),
+      PRAGMA_PAGE_SIZE_SQL.c_str(),
+      nullptr,
+      nullptr,
+      &pageSizeError);
+  if (status != SQLITE_OK) {
+    std::string errorStr(pageSizeError);
+    CESIUM_SQLITE(sqlite3_free)(pageSizeError);
+    throw std::runtime_error(errorStr);
+  }
+
+  // get entry based on key
+  this->_pImpl->_getEntryStmtWrapper =
+      prepareStatement(this->_pImpl->_pConnection, GET_ENTRY_SQL);
+
+  // update last accessed for entry
+  this->_pImpl->_updateLastAccessedTimeStmtWrapper = prepareStatement(
+      this->_pImpl->_pConnection,
+      UPDATE_LAST_ACCESSED_TIME_SQL);
+
+  // store response
+  this->_pImpl->_storeResponseStmtWrapper =
+      prepareStatement(this->_pImpl->_pConnection, STORE_RESPONSE_SQL);
+
+  // query total items
+  this->_pImpl->_totalItemsQueryStmtWrapper =
+      prepareStatement(this->_pImpl->_pConnection, TOTAL_ITEMS_QUERY_SQL);
+
+  // delete expired items
+  this->_pImpl->_deleteExpiredStmtWrapper =
+      prepareStatement(this->_pImpl->_pConnection, DELETE_EXPIRED_ITEMS_SQL);
+
+  // delete expired items
+  this->_pImpl->_deleteLRUStmtWrapper =
+      prepareStatement(this->_pImpl->_pConnection, DELETE_LRU_ITEMS_SQL);
+
+  // clear all items
+  this->_pImpl->_clearAllStmtWrapper =
+      prepareStatement(this->_pImpl->_pConnection, CLEAR_ALL_SQL);
+}
+
+SqliteCache::~SqliteCache() = default;
+
+std::optional<CacheItem> SqliteCache::getEntry(const std::string& key) const {
+  std::lock_guard<std::mutex> guard(this->_pImpl->_mutex);
+
+  // get entry based on key
+  int status =
+      CESIUM_SQLITE(sqlite3_reset)(this->_pImpl->_getEntryStmtWrapper.get());
+  if (status != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return std::nullopt;
+  }
+
+  status = CESIUM_SQLITE(sqlite3_clear_bindings)(
+      this->_pImpl->_getEntryStmtWrapper.get());
+  if (status != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return std::nullopt;
+  }
+
+  status = CESIUM_SQLITE(sqlite3_bind_text)(
+      this->_pImpl->_getEntryStmtWrapper.get(),
+      1,
+      key.c_str(),
+      -1,
+      SQLITE_STATIC);
+  if (status != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return std::nullopt;
+  }
+
+  status =
+      CESIUM_SQLITE(sqlite3_step)(this->_pImpl->_getEntryStmtWrapper.get());
+  if (status == SQLITE_DONE) {
+    // Cache miss
+    return std::nullopt;
+  }
+
+  if (status != SQLITE_ROW) {
+    // Something went wrong.
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return std::nullopt;
+  }
+
+  // Cache hit - unpack and return it.
+  int64_t itemIndex = CESIUM_SQLITE(
+      sqlite3_column_int64)(this->_pImpl->_getEntryStmtWrapper.get(), 0);
+
+  // parse cache item metadata
+  std::time_t expiryTime = CESIUM_SQLITE(
+      sqlite3_column_int64)(this->_pImpl->_getEntryStmtWrapper.get(), 1);
+
+  // parse response cache
+  std::string serializedResponseHeaders =
+      reinterpret_cast<const char*>(CESIUM_SQLITE(
+          sqlite3_column_text)(this->_pImpl->_getEntryStmtWrapper.get(), 2));
+  HttpHeaders responseHeaders =
+      convertStringToHeaders(serializedResponseHeaders);
+
+  uint16_t statusCode = static_cast<uint16_t>(CESIUM_SQLITE(
+      sqlite3_column_int)(this->_pImpl->_getEntryStmtWrapper.get(), 3));
+
+  const std::byte* rawResponseData =
+      reinterpret_cast<const std::byte*>(CESIUM_SQLITE(
+          sqlite3_column_blob)(this->_pImpl->_getEntryStmtWrapper.get(), 4));
+  int responseDataSize = CESIUM_SQLITE(
+      sqlite3_column_bytes)(this->_pImpl->_getEntryStmtWrapper.get(), 4);
+  std::vector<std::byte> responseData(
+      rawResponseData,
+      rawResponseData + responseDataSize);
+
+  // parse request
+  std::string serializedRequestHeaders =
+      reinterpret_cast<const char*>(CESIUM_SQLITE(
+          sqlite3_column_text)(this->_pImpl->_getEntryStmtWrapper.get(), 5));
+  HttpHeaders requestHeaders = convertStringToHeaders(serializedRequestHeaders);
+
+  std::string requestMethod = reinterpret_cast<const char*>(CESIUM_SQLITE(
+      sqlite3_column_text)(this->_pImpl->_getEntryStmtWrapper.get(), 6));
+
+  std::string requestUrl = reinterpret_cast<const char*>(CESIUM_SQLITE(
+      sqlite3_column_text)(this->_pImpl->_getEntryStmtWrapper.get(), 7));
+
+  // update the last accessed time
+  int updateStatus = CESIUM_SQLITE(sqlite3_reset)(
+      this->_pImpl->_updateLastAccessedTimeStmtWrapper.get());
+  if (updateStatus != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(updateStatus));
+    return std::nullopt;
+  }
+
+  updateStatus = CESIUM_SQLITE(sqlite3_clear_bindings)(
+      this->_pImpl->_updateLastAccessedTimeStmtWrapper.get());
+  if (updateStatus != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(updateStatus));
+    return std::nullopt;
+  }
+
+  updateStatus = CESIUM_SQLITE(sqlite3_bind_int64)(
+      this->_pImpl->_updateLastAccessedTimeStmtWrapper.get(),
+      1,
+      itemIndex);
+  if (updateStatus != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(updateStatus));
+    return std::nullopt;
+  }
+
+  updateStatus = CESIUM_SQLITE(sqlite3_step)(
+      this->_pImpl->_updateLastAccessedTimeStmtWrapper.get());
+  if (updateStatus != SQLITE_DONE) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(updateStatus));
+    return std::nullopt;
+  }
+
+  return CacheItem{
+      expiryTime,
+      CacheRequest{
+          std::move(requestHeaders),
+          std::move(requestMethod),
+          std::move(requestUrl)},
+      CacheResponse{
+          statusCode,
+          std::move(responseHeaders),
+          std::move(responseData)}};
+}
+
+bool SqliteCache::storeEntry(
+    const std::string& key,
+    std::time_t expiryTime,
+    const std::string& url,
+    const std::string& requestMethod,
+    const HttpHeaders& requestHeaders,
+    uint16_t statusCode,
+    const HttpHeaders& responseHeaders,
+    const gsl::span<const std::byte>& responseData) {
+  std::lock_guard<std::mutex> guard(this->_pImpl->_mutex);
+
+  // cache the request with the key
+  int status = CESIUM_SQLITE(sqlite3_reset)(
+      this->_pImpl->_storeResponseStmtWrapper.get());
+  if (status != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return false;
+  }
+
+  status = CESIUM_SQLITE(sqlite3_clear_bindings)(
+      this->_pImpl->_storeResponseStmtWrapper.get());
+  if (status != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return false;
+  }
+
+  status = CESIUM_SQLITE(sqlite3_bind_int64)(
+      this->_pImpl->_storeResponseStmtWrapper.get(),
+      1,
+      static_cast<int64_t>(expiryTime));
+  if (status != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return false;
+  }
+
+  status = CESIUM_SQLITE(sqlite3_bind_int64)(
+      this->_pImpl->_storeResponseStmtWrapper.get(),
+      2,
+      static_cast<int64_t>(std::time(nullptr)));
+  if (status != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return false;
+  }
+
+  std::string responseHeaderString = convertHeadersToString(responseHeaders);
+  status = CESIUM_SQLITE(sqlite3_bind_text)(
+      this->_pImpl->_storeResponseStmtWrapper.get(),
+      3,
+      responseHeaderString.c_str(),
+      -1,
+      SQLITE_STATIC);
+  if (status != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return false;
+  }
+
+  status = CESIUM_SQLITE(sqlite3_bind_int)(
+      this->_pImpl->_storeResponseStmtWrapper.get(),
+      4,
+      static_cast<int>(statusCode));
+  if (status != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return false;
+  }
+
+  status = CESIUM_SQLITE(sqlite3_bind_blob)(
+      this->_pImpl->_storeResponseStmtWrapper.get(),
+      5,
+      responseData.data(),
+      static_cast<int>(responseData.size()),
+      SQLITE_STATIC);
+  if (status != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return false;
+  }
+
+  std::string requestHeaderString = convertHeadersToString(requestHeaders);
+  status = CESIUM_SQLITE(sqlite3_bind_text)(
+      this->_pImpl->_storeResponseStmtWrapper.get(),
+      6,
+      requestHeaderString.c_str(),
+      -1,
+      SQLITE_STATIC);
+  if (status != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return false;
+  }
+
+  status = CESIUM_SQLITE(sqlite3_bind_text)(
+      this->_pImpl->_storeResponseStmtWrapper.get(),
+      7,
+      requestMethod.c_str(),
+      -1,
+      SQLITE_STATIC);
+  if (status != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return false;
+  }
+
+  status = CESIUM_SQLITE(sqlite3_bind_text)(
+      this->_pImpl->_storeResponseStmtWrapper.get(),
+      8,
+      url.c_str(),
+      -1,
+      SQLITE_STATIC);
+  if (status != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return false;
+  }
+
+  status = CESIUM_SQLITE(sqlite3_bind_text)(
+      this->_pImpl->_storeResponseStmtWrapper.get(),
+      9,
+      key.c_str(),
+      -1,
+      SQLITE_STATIC);
+  if (status != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return false;
+  }
+
+  status = CESIUM_SQLITE(sqlite3_step)(
+      this->_pImpl->_storeResponseStmtWrapper.get());
+  if (status != SQLITE_DONE) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return false;
+  }
+
+  return true;
+}
+
+bool SqliteCache::prune() {
+  std::lock_guard<std::mutex> guard(this->_pImpl->_mutex);
+
+  int64_t totalItems = 0;
+
+  // query total size of response's data
+  {
+    int totalItemsQueryStatus = CESIUM_SQLITE(sqlite3_reset)(
+        this->_pImpl->_totalItemsQueryStmtWrapper.get());
+    if (totalItemsQueryStatus != SQLITE_OK) {
+      SPDLOG_LOGGER_ERROR(
+          this->_pImpl->_pLogger,
+          CESIUM_SQLITE(sqlite3_errstr)(totalItemsQueryStatus));
+      return false;
+    }
+
+    totalItemsQueryStatus = CESIUM_SQLITE(sqlite3_clear_bindings)(
+        this->_pImpl->_totalItemsQueryStmtWrapper.get());
+    if (totalItemsQueryStatus != SQLITE_OK) {
+      SPDLOG_LOGGER_ERROR(
+          this->_pImpl->_pLogger,
+          CESIUM_SQLITE(sqlite3_errstr)(totalItemsQueryStatus));
+      return false;
+    }
+
+    totalItemsQueryStatus = CESIUM_SQLITE(sqlite3_step)(
+        this->_pImpl->_totalItemsQueryStmtWrapper.get());
+
+    if (totalItemsQueryStatus == SQLITE_DONE) {
+      return true;
+    }
+
+    if (totalItemsQueryStatus != SQLITE_ROW) {
+      SPDLOG_LOGGER_ERROR(
+          this->_pImpl->_pLogger,
+          CESIUM_SQLITE(sqlite3_errstr)(totalItemsQueryStatus));
+      return false;
+    }
+
+    // prune the rows if over maximum
+    totalItems = CESIUM_SQLITE(sqlite3_column_int64)(
+        this->_pImpl->_totalItemsQueryStmtWrapper.get(),
+        0);
+    if (totalItems > 0 &&
+        totalItems <= static_cast<int64_t>(this->_pImpl->_maxItems)) {
+      return true;
+    }
+  }
+
+  // delete expired rows first
+  {
+    int deleteExpiredStatus = CESIUM_SQLITE(sqlite3_reset)(
+        this->_pImpl->_deleteExpiredStmtWrapper.get());
+    if (deleteExpiredStatus != SQLITE_OK) {
+      SPDLOG_LOGGER_ERROR(
+          this->_pImpl->_pLogger,
+          CESIUM_SQLITE(sqlite3_errstr)(deleteExpiredStatus));
+      return false;
+    }
+
+    deleteExpiredStatus = CESIUM_SQLITE(sqlite3_clear_bindings)(
+        this->_pImpl->_deleteExpiredStmtWrapper.get());
+    if (deleteExpiredStatus != SQLITE_OK) {
+      SPDLOG_LOGGER_ERROR(
+          this->_pImpl->_pLogger,
+          CESIUM_SQLITE(sqlite3_errstr)(deleteExpiredStatus));
+      return false;
+    }
+
+    deleteExpiredStatus = CESIUM_SQLITE(sqlite3_step)(
+        this->_pImpl->_deleteExpiredStmtWrapper.get());
+    if (deleteExpiredStatus != SQLITE_DONE) {
+      SPDLOG_LOGGER_ERROR(
+          this->_pImpl->_pLogger,
+          CESIUM_SQLITE(sqlite3_errstr)(deleteExpiredStatus));
+      return false;
+    }
+  }
+
+  // check if we should delete more
+  int deletedRows =
+      CESIUM_SQLITE(sqlite3_changes)(this->_pImpl->_pConnection.get());
+  if (totalItems - deletedRows < static_cast<int>(this->_pImpl->_maxItems)) {
+    return true;
+  }
+
+  totalItems -= deletedRows;
+
+  // delete rows LRU if we are still over maximum
+  {
+    int deleteLLRUStatus =
+        CESIUM_SQLITE(sqlite3_reset)(this->_pImpl->_deleteLRUStmtWrapper.get());
+    if (deleteLLRUStatus != SQLITE_OK) {
+      SPDLOG_LOGGER_ERROR(
+          this->_pImpl->_pLogger,
+          CESIUM_SQLITE(sqlite3_errstr)(deleteLLRUStatus));
+      return false;
+    }
+
+    deleteLLRUStatus = CESIUM_SQLITE(sqlite3_clear_bindings)(
+        this->_pImpl->_deleteLRUStmtWrapper.get());
+    if (deleteLLRUStatus != SQLITE_OK) {
+      SPDLOG_LOGGER_ERROR(
+          this->_pImpl->_pLogger,
+          CESIUM_SQLITE(sqlite3_errstr)(deleteLLRUStatus));
+      return false;
+    }
+
+    deleteLLRUStatus = CESIUM_SQLITE(sqlite3_bind_int64)(
+        this->_pImpl->_deleteLRUStmtWrapper.get(),
+        1,
+        totalItems - static_cast<int64_t>(this->_pImpl->_maxItems));
+    if (deleteLLRUStatus != SQLITE_OK) {
+      SPDLOG_LOGGER_ERROR(
+          this->_pImpl->_pLogger,
+          CESIUM_SQLITE(sqlite3_errstr)(deleteLLRUStatus));
+      return false;
+    }
+
+    deleteLLRUStatus =
+        CESIUM_SQLITE(sqlite3_step)(this->_pImpl->_deleteLRUStmtWrapper.get());
+    if (deleteLLRUStatus != SQLITE_DONE) {
+      SPDLOG_LOGGER_ERROR(
+          this->_pImpl->_pLogger,
+          CESIUM_SQLITE(sqlite3_errstr)(deleteLLRUStatus));
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool SqliteCache::clearAll() {
+  std::lock_guard<std::mutex> guard(this->_pImpl->_mutex);
+
+  int status =
+      CESIUM_SQLITE(sqlite3_reset)(this->_pImpl->_clearAllStmtWrapper.get());
+  if (status != SQLITE_OK) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return false;
+  }
+
+  status =
+      CESIUM_SQLITE(sqlite3_step)(this->_pImpl->_clearAllStmtWrapper.get());
+  if (status != SQLITE_DONE) {
+    SPDLOG_LOGGER_ERROR(
+        this->_pImpl->_pLogger,
+        CESIUM_SQLITE(sqlite3_errstr)(status));
+    return false;
+  }
+
+  return true;
+}
+
 } // namespace CesiumAsync

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -56,10 +56,6 @@ set(CESIUM_NATIVE_SPDLOG_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/spdlog/include" 
     "Include directory for spdlog"
 )
 
-set(CESIUM_NATIVE_SQLITE3_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/sqlite3/" CACHE INTERNAL
-    "Include directory for sqlite3"
-)
-
 set(CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/rapidjson/include" CACHE INTERNAL
     "Include directory for rapidjson"
 )

--- a/extern/sqlite3/CMakeLists.txt
+++ b/extern/sqlite3/CMakeLists.txt
@@ -1,10 +1,38 @@
 project(sqlite3)
 
-add_library(sqlite3 STATIC sqlite3.c)
+add_library(sqlite3 STATIC "")
 set_target_properties(sqlite3 PROPERTIES COMPILE_DEFINITIONS SQLITE_OMIT_LOAD_EXTENSION)
 target_compile_definitions(sqlite3 PUBLIC SQLITE_THREADSAFE=1)
+
+# Optionally rename all of the public symbols in sqlite3 so they don't conflict with Unreal Engine's version of sqlite.
+# We do this by renaming sqlite3* to cesium_sqlite3* in the sqlite amalgamation source and header files.
+# We also #define PRIVATE_CESIUM_SQLITE to cue clients to use the new names.
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/sqlite3.h SQLITE3_HEADER_CONTENTS)
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/sqlite3.c SQLITE3_SOURCE_CONTENTS)
+
+if (PRIVATE_CESIUM_SQLITE)
+    string(REPLACE sqlite3 cesium_sqlite3 SQLITE3_HEADER_CONTENTS "${SQLITE3_HEADER_CONTENTS}")
+    string(REPLACE sqlite3 cesium_sqlite3 SQLITE3_SOURCE_CONTENTS "${SQLITE3_SOURCE_CONTENTS}")
+    target_compile_definitions(sqlite3 PUBLIC PRIVATE_CESIUM_SQLITE)
+endif()
+
+file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/sqlite3/sqlite3.h CONTENT "${SQLITE3_HEADER_CONTENTS}")
+file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/sqlite3/sqlite3.c CONTENT "${SQLITE3_SOURCE_CONTENTS}")
+file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/sqlite3/cesium-sqlite3.h INPUT ${CMAKE_CURRENT_SOURCE_DIR}/cesium-sqlite3.h)
+
+target_sources(
+    sqlite3
+    PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR}/sqlite3/sqlite3.c
+)
+
 target_include_directories(
     sqlite3
     SYSTEM PUBLIC
-        ${CMAKE_CURRENT_LIST_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}/sqlite3
+)
+
+install(TARGETS sqlite3
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/sqlite3
 )

--- a/extern/sqlite3/CMakeLists.txt
+++ b/extern/sqlite3/CMakeLists.txt
@@ -3,4 +3,8 @@ project(sqlite3)
 add_library(sqlite3 STATIC sqlite3.c)
 set_target_properties(sqlite3 PROPERTIES COMPILE_DEFINITIONS SQLITE_OMIT_LOAD_EXTENSION)
 target_compile_definitions(sqlite3 PUBLIC SQLITE_THREADSAFE=1)
-
+target_include_directories(
+    sqlite3
+    SYSTEM PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}
+)

--- a/extern/sqlite3/cesium-sqlite3.h
+++ b/extern/sqlite3/cesium-sqlite3.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#if PRIVATE_CESIUM_SQLITE
+#define CESIUM_SQLITE(name) cesium_##name
+#else
+#define CESIUM_SQLITE(name) name
+#endif

--- a/extern/sqlite3/sqlite3.h
+++ b/extern/sqlite3/sqlite3.h
@@ -34,8 +34,6 @@
 #define SQLITE3_H
 #include <stdarg.h>     /* Needed for the definition of va_list */
 
-#define sqlite3 cqlite3
-
 /*
 ** Make sure we can call this stuff from C++.
 */

--- a/extern/sqlite3/sqlite3.h
+++ b/extern/sqlite3/sqlite3.h
@@ -34,6 +34,8 @@
 #define SQLITE3_H
 #include <stdarg.h>     /* Needed for the definition of va_list */
 
+#define sqlite3 cqlite3
+
 /*
 ** Make sure we can call this stuff from C++.
 */


### PR DESCRIPTION
This helps us avoid a conflict with other sqlite implementations, notably the limited one built into Unreal Engine.

The way it works is by, at configure time, reading sqlite3.c and sqlite3.h, doing a search/replace of `sqlite3` with `cesium_sqlite3`, and writing the output to the build directory. The rewritten files are then added as the sqlite3 target's source and include files. They're written using `file(GENERATE OUTPUT ...)` so they won't be rewritten (and thus recompiled) unless they actually change.

Now in our code, we wrap all use of SQLite symbols in a macro, `CESIUM_SQLITE`, defined in `cesium-sqlite3.h`, which prefixes the symbol with `cesium_` only if the build is configured to rename the sqlite symbols. The end result is a configure-time selection of whether to privatize the sqlite3 symbols or not.

I also refactored `SqlCache` slightly to use the pimpl idiom to avoid exposing sqlite types in a public header file. This way we don't expose the renaming (or lack of renaming) to users of cesium-native.