### PR TITLE
fix: missing includes cstdint

### DIFF
--- a/CesiumGeometry/include/CesiumGeometry/QuadtreeTileID.h
+++ b/CesiumGeometry/include/CesiumGeometry/QuadtreeTileID.h
@@ -2,6 +2,7 @@
 
 #include "CesiumGeometry/Library.h"
 #include <functional>
+#include <cstdint>
 
 namespace CesiumGeometry {
 class QuadtreeTilingScheme;

--- a/CesiumGeometry/include/CesiumGeometry/QuadtreeTileID.h
+++ b/CesiumGeometry/include/CesiumGeometry/QuadtreeTileID.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "CesiumGeometry/Library.h"
-#include <functional>
 #include <cstdint>
+#include <functional>
 
 namespace CesiumGeometry {
 class QuadtreeTilingScheme;


### PR DESCRIPTION
File `CesiumGeometry/include/CesiumGeometry/QuadtreeTileID.h` misses <cstdint> to use `uint32_t`. So I add this line.

```c++
#include <cstdint>
```