### PR TITLE
Use uint32_t instand of int32_t as count of tiles and use const T& not const T

### DIFF
--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlay.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlay.h
@@ -21,7 +21,7 @@ struct CESIUM3DTILES_API RasterOverlayOptions {
    * @brief The maximum number of overlay tiles that may simultaneously be in
    * the process of loading.
    */
-  int32_t maximumSimultaneousTileLoads = 20;
+  uint32_t maximumSimultaneousTileLoads = 20;
 };
 
 /**

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlay.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlay.h
@@ -21,7 +21,7 @@ struct CESIUM3DTILES_API RasterOverlayOptions {
    * @brief The maximum number of overlay tiles that may simultaneously be in
    * the process of loading.
    */
-  uint32_t maximumSimultaneousTileLoads = 20;
+  int32_t maximumSimultaneousTileLoads = 20;
 };
 
 /**

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
@@ -318,7 +318,7 @@ public:
   /**
    * @brief Get the per-TileProvider {@link Credit} if one exists.
    */
-  const std::optional<Credit> getCredit() const noexcept { return _credit; }
+  const std::optional<Credit>& getCredit() const noexcept { return _credit; }
 
   /**
    * @brief Loads a tile immediately, without throttling requests.

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
@@ -427,8 +427,8 @@ private:
       _tiles;
   std::unique_ptr<RasterOverlayTile> _pPlaceholder;
   int64_t _tileDataBytes;
-  int32_t _totalTilesCurrentlyLoading;
-  int32_t _throttledTilesCurrentlyLoading;
+  uint32_t _totalTilesCurrentlyLoading;
+  uint32_t _throttledTilesCurrentlyLoading;
 
   static CesiumGltf::GltfReader _gltfReader;
 };

--- a/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h
@@ -10,6 +10,7 @@
 #include "CesiumGeospatial/Projection.h"
 #include "CesiumGltf/GltfReader.h"
 #include "CesiumUtility/IntrusivePointer.h"
+#include <cassert>
 #include <optional>
 #include <spdlog/fwd.h>
 #include <unordered_map>
@@ -300,6 +301,7 @@ public:
    * @brief Returns the number of tiles that are currently loading.
    */
   uint32_t getNumberOfTilesLoading() const noexcept {
+    assert(this->_totalTilesCurrentlyLoading > -1);
     return this->_totalTilesCurrentlyLoading;
   }
 
@@ -427,8 +429,8 @@ private:
       _tiles;
   std::unique_ptr<RasterOverlayTile> _pPlaceholder;
   int64_t _tileDataBytes;
-  uint32_t _totalTilesCurrentlyLoading;
-  uint32_t _throttledTilesCurrentlyLoading;
+  int32_t _totalTilesCurrentlyLoading;
+  int32_t _throttledTilesCurrentlyLoading;
 
   static CesiumGltf::GltfReader _gltfReader;
 };


### PR DESCRIPTION
There are two small problems in `Cesium3DTiles/include/Cesium3DTiles/RasterOverlayTileProvider.h`:
1. `Cesium3DTiles::RasterOverlayTileProvider::_throttledTilesCurrentlyLoading` is int32_t but its get() function return uint32_t, so I change 3 associated variables.
2. `Function Cesium3DTiles::RasterOverlayTileProvider::getCredit()` return a `const std::optional<Credit>` and this cause clang-tidy reports ['const' at top level, which may reduce code readability without improving const correctness](https://stackoverflow.com/questions/63972019/understanding-const-at-top-level-which-may-reduce-code-readability-without-i). Just need to add '&'.