### PR TITLE
Use angle brackets to #include catch2.

### DIFF
--- a/Cesium3DTiles/test/TestCreditSystem.cpp
+++ b/Cesium3DTiles/test/TestCreditSystem.cpp
@@ -1,5 +1,5 @@
 #include "Cesium3DTiles/CreditSystem.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 
 using namespace Cesium3DTiles;
 

--- a/Cesium3DTiles/test/TestQuantizedMeshContent.cpp
+++ b/Cesium3DTiles/test/TestQuantizedMeshContent.cpp
@@ -5,7 +5,7 @@
 #include "CesiumGltf/AccessorView.h"
 #include "CesiumUtility/Math.h"
 #include "QuantizedMeshContent.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 #include <glm/glm.hpp>
 
 using namespace Cesium3DTiles;

--- a/Cesium3DTiles/test/TestSkirtMeshMetadata.cpp
+++ b/Cesium3DTiles/test/TestSkirtMeshMetadata.cpp
@@ -1,6 +1,6 @@
 #include "CesiumUtility/Math.h"
 #include "SkirtMeshMetadata.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 
 using namespace Cesium3DTiles;
 using namespace CesiumUtility;

--- a/Cesium3DTiles/test/TestTilesetSelectionAlgorithm.cpp
+++ b/Cesium3DTiles/test/TestTilesetSelectionAlgorithm.cpp
@@ -8,11 +8,11 @@
 #include "SimpleAssetResponse.h"
 #include "SimplePrepareRendererResource.h"
 #include "SimpleTaskProcessor.h"
-#include "catch2/catch.hpp"
-#include "glm/mat4x4.hpp"
+#include <catch2/catch.hpp>
 #include <cstddef>
 #include <filesystem>
 #include <fstream>
+#include <glm/mat4x4.hpp>
 
 using namespace CesiumAsync;
 using namespace Cesium3DTiles;

--- a/Cesium3DTiles/test/TestUpsampleGltfForRasterOverlay.cpp
+++ b/Cesium3DTiles/test/TestUpsampleGltfForRasterOverlay.cpp
@@ -4,8 +4,8 @@
 #include "CesiumGltf/AccessorView.h"
 #include "CesiumUtility/Math.h"
 #include "SkirtMeshMetadata.h"
-#include "catch2/catch.hpp"
 #include "upsampleGltfForRasterOverlays.h"
+#include <catch2/catch.hpp>
 #include <cstring>
 #include <glm/trigonometric.hpp>
 #include <vector>

--- a/CesiumAsync/test/TestCacheAssetAccessor.cpp
+++ b/CesiumAsync/test/TestCacheAssetAccessor.cpp
@@ -5,7 +5,7 @@
 #include "MockAssetRequest.h"
 #include "MockAssetResponse.h"
 #include "ResponseCacheControl.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 #include <cstddef>
 #include <optional>
 #include <spdlog/spdlog.h>

--- a/CesiumAsync/test/TestDiskCache.cpp
+++ b/CesiumAsync/test/TestDiskCache.cpp
@@ -2,7 +2,7 @@
 #include "MockAssetRequest.h"
 #include "MockAssetResponse.h"
 #include "ResponseCacheControl.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 #include <cstddef>
 #include <spdlog/spdlog.h>
 

--- a/CesiumAsync/test/TestInternalTimegm.cpp
+++ b/CesiumAsync/test/TestInternalTimegm.cpp
@@ -1,5 +1,5 @@
 #include "InternalTimegm.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 
 using namespace CesiumAsync;
 

--- a/CesiumAsync/test/TestResponseCacheControl.cpp
+++ b/CesiumAsync/test/TestResponseCacheControl.cpp
@@ -1,5 +1,5 @@
 #include "ResponseCacheControl.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 
 using namespace CesiumAsync;
 

--- a/CesiumGeometry/test/TestAxisTransforms.cpp
+++ b/CesiumGeometry/test/TestAxisTransforms.cpp
@@ -1,6 +1,6 @@
 #include "CesiumGeometry/AxisTransforms.h"
 #include "CesiumUtility/Math.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 
 TEST_CASE("AxisTransforms convert the axes correctly") {
 

--- a/CesiumGeometry/test/TestBoundingSphere.cpp
+++ b/CesiumGeometry/test/TestBoundingSphere.cpp
@@ -1,6 +1,6 @@
 #include "CesiumGeometry/BoundingSphere.h"
 #include "CesiumGeometry/Plane.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 #include <glm/mat3x3.hpp>
 
 using namespace CesiumGeometry;

--- a/CesiumGeometry/test/TestClipTriangleAtAxisAlignedThreshold.cpp
+++ b/CesiumGeometry/test/TestClipTriangleAtAxisAlignedThreshold.cpp
@@ -1,5 +1,5 @@
 #include "CesiumGeometry/clipTriangleAtAxisAlignedThreshold.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 
 using namespace CesiumGeometry;
 

--- a/CesiumGeometry/test/TestIntersectionTests.cpp
+++ b/CesiumGeometry/test/TestIntersectionTests.cpp
@@ -1,7 +1,7 @@
 #include "CesiumGeometry/IntersectionTests.h"
 #include "CesiumGeometry/Plane.h"
 #include "CesiumGeometry/Ray.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 #include <glm/mat3x3.hpp>
 
 using namespace CesiumGeometry;

--- a/CesiumGeometry/test/TestOrientedBoundingBox.cpp
+++ b/CesiumGeometry/test/TestOrientedBoundingBox.cpp
@@ -1,6 +1,6 @@
 #include "Cesium3DTiles/ViewState.h"
 #include "CesiumGeometry/OrientedBoundingBox.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtx/string_cast.hpp>
 #include <optional>

--- a/CesiumGeometry/test/TestPlane.cpp
+++ b/CesiumGeometry/test/TestPlane.cpp
@@ -1,6 +1,6 @@
 #include "CesiumGeometry/Plane.h"
 #include "CesiumGeospatial/Ellipsoid.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 #include <glm/geometric.hpp>
 
 using namespace CesiumGeometry;

--- a/CesiumGeometry/test/TestRectangle.cpp
+++ b/CesiumGeometry/test/TestRectangle.cpp
@@ -1,6 +1,6 @@
 #include "CesiumGeometry/Rectangle.h"
 #include "CesiumUtility/Math.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 
 TEST_CASE("Rectangle::computeSignedDistance") {
   struct TestCase {

--- a/CesiumGeospatial/test/TestBoundingRegion.cpp
+++ b/CesiumGeospatial/test/TestBoundingRegion.cpp
@@ -3,7 +3,7 @@
 #include "CesiumGeospatial/Ellipsoid.h"
 #include "CesiumGeospatial/GlobeRectangle.h"
 #include "CesiumUtility/Math.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 
 using namespace CesiumUtility;
 using namespace CesiumGeometry;

--- a/CesiumGeospatial/test/TestGlobeRectangle.cpp
+++ b/CesiumGeospatial/test/TestGlobeRectangle.cpp
@@ -1,5 +1,5 @@
 #include "CesiumGeospatial/GlobeRectangle.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 
 TEST_CASE("GlobeRectangle::fromDegrees example") {
   //! [fromDegrees]

--- a/CesiumGltf/test/TestAccessorView.cpp
+++ b/CesiumGltf/test/TestAccessorView.cpp
@@ -1,6 +1,6 @@
 #include "CesiumGltf/AccessorView.h"
 #include "CesiumGltf/Model.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 #include <glm/vec3.hpp>
 
 TEST_CASE("AccessorView construct and read example") {

--- a/CesiumGltf/test/TestJsonValue.cpp
+++ b/CesiumGltf/test/TestJsonValue.cpp
@@ -1,5 +1,5 @@
-#include "catch2/catch.hpp"
 #include <CesiumUtility/JsonValue.h>
+#include <catch2/catch.hpp>
 #include <cstdint>
 #include <limits>
 

--- a/CesiumGltfReader/test/TestReader.cpp
+++ b/CesiumGltfReader/test/TestReader.cpp
@@ -1,7 +1,7 @@
 #include "CesiumGltf/AccessorView.h"
 #include "CesiumGltf/GltfReader.h"
 #include "CesiumGltf/KHR_draco_mesh_compression.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>

--- a/CesiumGltfWriter/test/TestWriter.cpp
+++ b/CesiumGltfWriter/test/TestWriter.cpp
@@ -5,11 +5,11 @@
 #include "CesiumGltf/Node.h"
 #include "CesiumGltf/Scene.h"
 #include "CesiumGltf/Writer.h"
-#include "catch2/catch.hpp"
 #include <CesiumGltf/GltfReader.h>
 #include <CesiumGltf/MeshPrimitive.h>
 #include <CesiumGltf/WriteModelOptions.h>
 #include <algorithm>
+#include <catch2/catch.hpp>
 #include <cstddef>
 #include <gsl/span>
 #include <string>

--- a/CesiumNativeTests/src/test-main.cpp
+++ b/CesiumNativeTests/src/test-main.cpp
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>

--- a/CesiumUtility/test/TestDoublyLinkedList.cpp
+++ b/CesiumUtility/test/TestDoublyLinkedList.cpp
@@ -1,5 +1,5 @@
 #include "CesiumUtility/DoublyLinkedList.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 
 using namespace CesiumUtility;
 

--- a/CesiumUtility/test/TestMath.cpp
+++ b/CesiumUtility/test/TestMath.cpp
@@ -1,5 +1,5 @@
 #include "CesiumUtility/Math.h"
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 
 using namespace CesiumUtility;
 


### PR DESCRIPTION
We were using quotes instead of angle brackets to #include catch2. So this trivial PR just changes it to angle brackets, consistent with all the other third party libraries.