### PR TITLE
Add `AsyncSystem::all` and `Future<T>::catchImmediately`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 - Added `AsyncSystem::dispatchOneMainThreadTask` to dispatch a single task, rather than all the tasks that are waiting.
 - Added `AsyncSystem::createPromise` to create a Promise directly, rather than via a callback as in `AsyncSystem::createFuture`.
+- Added `AsyncSystem::catchImmediately` to catch a Future rejection immediately in any thread.
+- Added `AsyncSystem::all` to create a Future that resolves when a list of Futures resolve.
 
 ##### Fixes :wrench:
 

--- a/CesiumAsync/include/CesiumAsync/AsyncSystem.h
+++ b/CesiumAsync/include/CesiumAsync/AsyncSystem.h
@@ -171,37 +171,23 @@ public:
             Impl::WithTracing<void>::end(tracingName, std::forward<Func>(f))));
   }
 
-  // template <typename TIterator>
-  // Future<std::vector<T>> all(TIterator& begin, TIterator& end) const {
-  //   async::when_all(begin, end);
-  // }
-
-  // template <typename T, typename TIterator> struct FutureToTaskIterator {
-  //   using value_type = async::task<T>;
-
-  //   TIterator _iterator;
-
-  //   FutureToTaskIterator(const TIterator& iterator_) : _iterator(iterator) {}
-  //   TIterator& operator++() {
-  //     TIterator next = _iterator;
-  //     ++next;
-  //     return FutureToTaskIterator<TIterator>(next);
-  //   }
-
-  //   async::task<T>& operator*() const noexcept { return _iterator->_task; }
-  //   async::task<T>* operator->() const noexcept { return &_iterator->_task; }
-
-  //   bool operator==(const FutureToTaskIterator<T, TIterator>& rhs) const {
-  //     return _iterator == rhs._iterator;
-  //   }
-  // };
-
-  // template <typename T, typename TIterator>
-  // static FutureToTaskIterator<T, TIterator>
-  // unwrapIterator(const TIterator& iterator) {
-  //   return FutureToTaskIterator<T, TIterator>(iterator);
-  // }
-
+  /**
+   * @brief Creates a Future that resolves when every Future in a vector
+   * resolves, and rejects when any Future in the vector rejects.
+   *
+   * If any of the Futures rejects, the returned Future rejects as well. The
+   * exception included in the rejection will be from the first Future in the
+   * vector that rejects.
+   *
+   * To get detailed rejection information from each of the Futures,
+   * attach a `catchInMainThread` continuation prior to passing the
+   * list into `all`.
+   *
+   * @tparam T The type that each Future resolves to.
+   * @param futures The list of futures.
+   * @return A Future that resolves when all the given Futures resolve, and
+   * rejects when any Future in the vector rejects.
+   */
   template <typename T>
   Future<std::vector<T>> all(std::vector<Future<T>>&& futures) const {
     std::vector<async::task<T>> tasks;

--- a/CesiumAsync/include/CesiumAsync/Future.h
+++ b/CesiumAsync/include/CesiumAsync/Future.h
@@ -167,6 +167,31 @@ public:
   }
 
   /**
+   * @brief Registers a continuation function to be invoked immediately, and
+   * invalidates this Future.
+   *
+   * When this Future is rejected, the continuation function will be invoked
+   * in whatever thread does the rejection. Similarly, if the Future is already
+   * rejected when `catchImmediately` is called, the continuation function will
+   * be invoked immediately before this method returns.
+   *
+   * If the function itself returns a `Future`, the function will not be
+   * considered complete until that returned `Future` also resolves.
+   *
+   * Any `then` continuations chained after this one will be invoked with the
+   * return value of the catch callback.
+   *
+   * @tparam Func The type of the function.
+   * @param f The function.
+   * @return A future that resolves after the supplied function completes.
+   */
+  template <typename Func> Future<T> catchImmediately(Func&& f) && {
+    return std::move(*this).catchWithScheduler(
+        async::inline_scheduler(),
+        std::forward<Func>(f));
+  }
+
+  /**
    * @brief Waits for the future to resolve or reject and returns the result.
    *
    * This method must not be called from the main thread, the one that calls

--- a/CesiumAsync/test/TestAsyncSystem.cpp
+++ b/CesiumAsync/test/TestAsyncSystem.cpp
@@ -252,13 +252,14 @@ TEST_CASE("AsyncSystem") {
     auto all = asyncSystem.all(std::move(futures));
 
     bool resolved = false;
-    auto last = std::move(all).thenImmediately([&resolved](std::vector<int>&& result) {
-      CHECK(result.size() == 3);
-      CHECK(result[0] == 1);
-      CHECK(result[1] == 2);
-      CHECK(result[2] == 3);
-      resolved = true;
-    });
+    auto last =
+        std::move(all).thenImmediately([&resolved](std::vector<int>&& result) {
+          CHECK(result.size() == 3);
+          CHECK(result[0] == 1);
+          CHECK(result[1] == 2);
+          CHECK(result[2] == 3);
+          resolved = true;
+        });
 
     three.resolve(3);
     one.resolve(1);

--- a/CesiumAsync/test/TestAsyncSystem.cpp
+++ b/CesiumAsync/test/TestAsyncSystem.cpp
@@ -283,14 +283,15 @@ TEST_CASE("AsyncSystem") {
 
     bool rejected = false;
 
-    auto last =
-        std::move(all).thenImmediately([](std::vector<int>&& /*result*/) {
-          // Should not happen.
-          CHECK(false);
-        }).catchImmediately([&rejected](std::exception&& e) {
-          CHECK(std::string(e.what()) == "2");
-          rejected = true;
-        });
+    auto last = std::move(all)
+                    .thenImmediately([](std::vector<int>&& /*result*/) {
+                      // Should not happen.
+                      CHECK(false);
+                    })
+                    .catchImmediately([&rejected](std::exception&& e) {
+                      CHECK(std::string(e.what()) == "2");
+                      rejected = true;
+                    });
 
     three.resolve(3);
     one.resolve(1);
@@ -300,7 +301,8 @@ TEST_CASE("AsyncSystem") {
     CHECK(rejected);
   }
 
-  SECTION("When multiple futures in an 'all' reject, the data from the first rejection in the list is used") {
+  SECTION("When multiple futures in an 'all' reject, the data from the first "
+          "rejection in the list is used") {
     auto one = asyncSystem.createPromise<int>();
     auto two = asyncSystem.createPromise<int>();
     auto three = asyncSystem.createPromise<int>();
@@ -314,15 +316,16 @@ TEST_CASE("AsyncSystem") {
 
     bool rejected = false;
 
-    auto last =
-        std::move(all).thenImmediately([](std::vector<int>&& /*result*/) {
-          // Should not happen.
-          CHECK(false);
-        }).catchImmediately([&rejected](std::exception&& e) {
-          CHECK(std::string(e.what()) == "1");
-          CHECK(!rejected);
-          rejected = true;
-        });
+    auto last = std::move(all)
+                    .thenImmediately([](std::vector<int>&& /*result*/) {
+                      // Should not happen.
+                      CHECK(false);
+                    })
+                    .catchImmediately([&rejected](std::exception&& e) {
+                      CHECK(std::string(e.what()) == "1");
+                      CHECK(!rejected);
+                      rejected = true;
+                    });
 
     three.reject(std::runtime_error("3"));
     one.reject(std::runtime_error("1"));


### PR DESCRIPTION
Builds on #277 so merge that first.

`all` is needed for #252, and is also likely to be used for i3dm support. `catchImmediately` is useful for the tests.