### PR TITLE
CMake option for code coverage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### Next Release - ?
+
+##### Additions :tada:
+
+* Added `CESIUM_COVERAGE_ENABLED` option to the build system.
+
 ### v0.5.0 - 2021-07-01
 
 ##### Breaking Changes :mega:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(cesium-native
 
 option(PRIVATE_CESIUM_SQLITE "ON to rename SQLite symbols to cesium_sqlite3_* so they won't conflict with other SQLite implemenentations" OFF)
 option(CESIUM_TRACING_ENABLED "Whether to enable the Cesium performance tracing framework (CESIUM_TRACE_* macros)." OFF)
-option(CESIUM_COVERAGE_ENABLED "Whether to enable code coverage" ON)
+option(CESIUM_COVERAGE_ENABLED "Whether to enable code coverage" OFF)
 
 if (CESIUM_TRACING_ENABLED)
     add_compile_definitions(CESIUM_TRACING_ENABLED=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ project(cesium-native
 
 option(PRIVATE_CESIUM_SQLITE "ON to rename SQLite symbols to cesium_sqlite3_* so they won't conflict with other SQLite implemenentations" OFF)
 option(CESIUM_TRACING_ENABLED "Whether to enable the Cesium performance tracing framework (CESIUM_TRACE_* macros)." OFF)
+option(CESIUM_COVERAGE_ENABLED "Whether to enable code coverage" ON)
 
 if (CESIUM_TRACING_ENABLED)
     add_compile_definitions(CESIUM_TRACING_ENABLED=1)
@@ -16,23 +17,23 @@ endif()
 # Add Modules
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/extern/cmake-modules/")
 
-# Add a coverage target iff:
-# - gcovr is available
-# - cesium-native is not being used as a git submodule
-# - g++ is the active compiler.
-# This branch must occur before adding other targets, or gcovr
-# won't be able to inject the necessary coverage information.
-get_directory_property(_is_being_used_as_submodule PARENT_DIRECTORY)
-find_program(_gcovr "gcovr")
-if(CMAKE_COMPILER_IS_GNUCXX AND _gcovr AND NOT _is_being_used_as_submodule)
-    include(CodeCoverage)
-    append_coverage_compiler_flags()
-    setup_target_for_coverage_gcovr_html(
-        NAME cesium-native-tests-coverage
-        EXECUTABLE ctest -j ${PROCESSOR_COUNT}
-        EXCLUDE "${PROJECT_SOURCE_DIR}/extern/*" "${PROJECT_BINARY_DIR}"
-        DEPENDENCIES cesium-native-tests
-    )
+if (CESIUM_COVERAGE_ENABLED)
+    # Add a coverage target iff:
+    # - gcovr is available
+    # - g++ is the active compiler.
+    # This branch must occur before adding other targets, or gcovr
+    # won't be able to inject the necessary coverage information.
+    find_program(_gcovr "gcovr")
+    if(CMAKE_COMPILER_IS_GNUCXX AND _gcovr)
+        include(CodeCoverage)
+        append_coverage_compiler_flags()
+        setup_target_for_coverage_gcovr_html(
+            NAME cesium-native-tests-coverage
+            EXECUTABLE ctest -j ${PROCESSOR_COUNT}
+            EXCLUDE "${PROJECT_SOURCE_DIR}/extern/*" "${PROJECT_BINARY_DIR}"
+            DEPENDENCIES cesium-native-tests
+        )
+    endif()
 endif()
 
 if (NOT DEFINED GLOB_USE_CONFIGURE_DEPENDS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,23 +17,15 @@ endif()
 # Add Modules
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/extern/cmake-modules/")
 
-if (CESIUM_COVERAGE_ENABLED)
-    # Add a coverage target iff:
-    # - gcovr is available
-    # - g++ is the active compiler.
-    # This branch must occur before adding other targets, or gcovr
-    # won't be able to inject the necessary coverage information.
-    find_program(_gcovr "gcovr")
-    if(CMAKE_COMPILER_IS_GNUCXX AND _gcovr)
-        include(CodeCoverage)
-        append_coverage_compiler_flags()
-        setup_target_for_coverage_gcovr_html(
-            NAME cesium-native-tests-coverage
-            EXECUTABLE ctest -j ${PROCESSOR_COUNT}
-            EXCLUDE "${PROJECT_SOURCE_DIR}/extern/*" "${PROJECT_BINARY_DIR}"
-            DEPENDENCIES cesium-native-tests
-        )
-    endif()
+if (CESIUM_COVERAGE_ENABLED AND NOT MSVC)
+    include(CodeCoverage)
+    append_coverage_compiler_flags()
+    setup_target_for_coverage_gcovr_html(
+        NAME cesium-native-tests-coverage
+        EXECUTABLE ctest -j ${PROCESSOR_COUNT}
+        EXCLUDE "${PROJECT_SOURCE_DIR}/extern/*" "${PROJECT_BINARY_DIR}"
+        DEPENDENCIES cesium-native-tests
+    )
 endif()
 
 if (NOT DEFINED GLOB_USE_CONFIGURE_DEPENDS)


### PR DESCRIPTION
This PR adds a cmake option to enable or disable code coverage. I also removed the "cesium-native-is-submodule" check because it didn't seem to be working, plus there's no need for it now that you can enabled or disable manually
