### PR TITLE
Metadata tweaks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 ##### Additions :tada:
 
+- Added support for the `EXT_feature_metadata` glTF extension.
+- Added automatic conversion of the B3DM batch table to the `EXT_feature_metadata` extension.
 - Added `CESIUM_COVERAGE_ENABLED` option to the build system.
 - Added `AsyncSystem::dispatchOneMainThreadTask` to dispatch a single task, rather than all the tasks that are waiting.
 - Added `AsyncSystem::createPromise` to create a Promise directly, rather than via a callback as in `AsyncSystem::createFuture`.

--- a/Cesium3DTiles/src/upgradeBatchTableToFeatureMetadata.cpp
+++ b/Cesium3DTiles/src/upgradeBatchTableToFeatureMetadata.cpp
@@ -5,6 +5,7 @@
 #include "CesiumGltf/ModelEXT_feature_metadata.h"
 #include "CesiumGltf/PropertyType.h"
 #include "CesiumGltf/PropertyTypeTraits.h"
+#include "CesiumUtility/Tracing.h"
 #include <glm/glm.hpp>
 #include <map>
 #include <rapidjson/document.h>
@@ -1241,6 +1242,8 @@ void upgradeBatchTableToFeatureMetadata(
     const rapidjson::Document& featureTableJson,
     const rapidjson::Document& batchTableJson,
     const gsl::span<const std::byte>& batchTableBinaryData) {
+
+  CESIUM_TRACE("upgradeBatchTableToFeatureMetadata");
 
   // Check to make sure a char of rapidjson is 1 byte
   static_assert(

--- a/Cesium3DTiles/src/upgradeBatchTableToFeatureMetadata.cpp
+++ b/Cesium3DTiles/src/upgradeBatchTableToFeatureMetadata.cpp
@@ -1296,6 +1296,12 @@ void upgradeBatchTableToFeatureMetadata(
        propertyIt != batchTableJson.MemberEnd();
        ++propertyIt) {
     std::string name = propertyIt->name.GetString();
+
+    // Don't interpret extensions or extras as a property.
+    if (name == "extensions" || name == "extras") {
+      continue;
+    }
+
     ClassProperty& classProperty =
         classDefinition.properties.emplace(name, ClassProperty()).first->second;
     classProperty.name = name;


### PR DESCRIPTION
After merging #281, I found some small things to fix:

* Don't interpret `extras` or `extensions` as property names, because they're special. Without this change, Cesium for Unreal was throwing assertion failures and log messages when loading Cesium OSM Buildings.
* Add performance tracing to `upgradeBatchTableToFeatureMetadata` (the time spent in there is very reasonable).
* Updated CHANGES.md.