### PR TITLE
Default constructors for views, IsMetadataInteger/Floating.

### DIFF
--- a/CesiumGltf/include/CesiumGltf/MetadataArrayView.h
+++ b/CesiumGltf/include/CesiumGltf/MetadataArrayView.h
@@ -9,6 +9,8 @@
 namespace CesiumGltf {
 template <typename ElementType> class MetadataArrayView {
 public:
+  MetadataArrayView() : _valueBuffer{} {}
+
   MetadataArrayView(const gsl::span<const std::byte>& buffer)
       : _valueBuffer{
             CesiumUtility::reintepretCastSpan<const ElementType>(buffer)} {}
@@ -25,6 +27,8 @@ private:
 
 template <> class MetadataArrayView<bool> {
 public:
+  MetadataArrayView() : _valueBuffer{}, _bitOffset{0}, _instanceCount{0} {}
+
   MetadataArrayView(
       const gsl::span<const std::byte>& buffer,
       int64_t bitOffset,
@@ -51,6 +55,9 @@ private:
 
 template <> class MetadataArrayView<std::string_view> {
 public:
+  MetadataArrayView()
+      : _valueBuffer{}, _offsetBuffer{}, _offsetType{}, _size{0} {}
+
   MetadataArrayView(
       const gsl::span<const std::byte>& buffer,
       const gsl::span<const std::byte>& offsetBuffer,

--- a/CesiumGltf/include/CesiumGltf/MetadataPropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/MetadataPropertyView.h
@@ -135,6 +135,19 @@ enum class MetadataPropertyViewStatus {
 template <typename ElementType> class MetadataPropertyView {
 public:
   /**
+   * @brief Constructs a new instance viewing a non-existent property.
+   */
+  MetadataPropertyView()
+      : _status{MetadataPropertyViewStatus::InvalidPropertyNotExist},
+        _valueBuffer{},
+        _arrayOffsetBuffer{},
+        _stringOffsetBuffer{},
+        _offsetType{},
+        _offsetSize{},
+        _componentCount{},
+        _instanceCount{} {}
+
+  /**
    * @brief Construct a new instance pointing to the data specified by
    * FeatureTableProperty
    * @param valueBuffer The raw buffer specified by {@link FeatureTableProperty::bufferView}

--- a/CesiumGltf/include/CesiumGltf/PropertyType.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyType.h
@@ -6,21 +6,21 @@
 
 namespace CesiumGltf {
 enum class PropertyType {
-  None = 0,
-  Int8 = 1 << 0,
-  Uint8 = 1 << 1,
-  Int16 = 1 << 2,
-  Uint16 = 1 << 3,
-  Int32 = 1 << 4,
-  Uint32 = 1 << 5,
-  Int64 = 1 << 6,
-  Uint64 = 1 << 7,
-  Float32 = 1 << 8,
-  Float64 = 1 << 9,
-  Boolean = 1 << 10,
-  Enum = 1 << 11,
-  String = 1 << 12,
-  Array = 1 << 13,
+  None,
+  Int8,
+  Uint8,
+  Int16,
+  Uint16,
+  Int32,
+  Uint32,
+  Int64,
+  Uint64,
+  Float32,
+  Float64,
+  Boolean,
+  Enum,
+  String,
+  Array,
 };
 
 std::string convertPropertyTypeToString(CesiumGltf::PropertyType type);

--- a/CesiumGltf/include/CesiumGltf/PropertyTypeTraits.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTypeTraits.h
@@ -37,7 +37,8 @@ template <> struct IsMetadataInteger<uint64_t> : std::true_type {};
 template <> struct IsMetadataInteger<int64_t> : std::true_type {};
 
 /**
- * @brief Check if a C++ type can be represented as a floating-point property type
+ * @brief Check if a C++ type can be represented as a floating-point property
+ * type
  */
 template <typename... T> struct IsMetadataFloating;
 template <typename T> struct IsMetadataFloating<T> : std::false_type {};

--- a/CesiumGltf/include/CesiumGltf/PropertyTypeTraits.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTypeTraits.h
@@ -23,6 +23,28 @@ template <> struct IsMetadataNumeric<float> : std::true_type {};
 template <> struct IsMetadataNumeric<double> : std::true_type {};
 
 /**
+ * @brief Check if a C++ type can be represented as an integer property type
+ */
+template <typename... T> struct IsMetadataInteger;
+template <typename T> struct IsMetadataInteger<T> : std::false_type {};
+template <> struct IsMetadataInteger<uint8_t> : std::true_type {};
+template <> struct IsMetadataInteger<int8_t> : std::true_type {};
+template <> struct IsMetadataInteger<uint16_t> : std::true_type {};
+template <> struct IsMetadataInteger<int16_t> : std::true_type {};
+template <> struct IsMetadataInteger<uint32_t> : std::true_type {};
+template <> struct IsMetadataInteger<int32_t> : std::true_type {};
+template <> struct IsMetadataInteger<uint64_t> : std::true_type {};
+template <> struct IsMetadataInteger<int64_t> : std::true_type {};
+
+/**
+ * @brief Check if a C++ type can be represented as a floating-point property type
+ */
+template <typename... T> struct IsMetadataFloating;
+template <typename T> struct IsMetadataFloating<T> : std::false_type {};
+template <> struct IsMetadataFloating<float> : std::true_type {};
+template <> struct IsMetadataFloating<double> : std::true_type {};
+
+/**
  * @brief Check if a C++ type can be represented as a boolean property type
  */
 template <typename... T> struct IsMetadataBoolean;


### PR DESCRIPTION
Some small changes to the metadata system to support CesiumGS/cesium-unreal#545:

* Add default constructors for `MetadataPropertyView` and `MetadataArrayView`, to reduce the need for std::monostate. You can think of these as views on invalid properties and empty arrays, respectively.
* Added `IsMetadataInteger<T>` and `IsMetadataFloat<T>` to distinguish between the two types of numeric properties.
* Make the `PropertyType` enum not a bitmask, because it's not used as one and as a bitmask it won't fit into a uint8, which is required by Unreal Blueprints enums.