### PR TITLE
Fixed property name of normal texture info

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 - Added `Future<T>::share`, which returns a `SharedFuture<T>` and allows multiple continuations to be attached.
 
+##### Fixes :wrench:
+
+- Fixed a bug that caused CesiumGltfWriter to write a material's normal texture info into a property named `normalTextureInfo` rather than `normalTexture`.
+
 ### v0.6.0 - 2021-08-02
 
 ##### Breaking Changes :mega:

--- a/CesiumGltfWriter/src/MaterialWriter.cpp
+++ b/CesiumGltfWriter/src/MaterialWriter.cpp
@@ -67,7 +67,7 @@ void writeNormalTexture(
     const CesiumGltf::MaterialNormalTextureInfo& normalTexture,
     CesiumJsonWriter::JsonWriter& jsonWriter) {
   auto& j = jsonWriter;
-  j.Key("normalTextureInfo");
+  j.Key("normalTexture");
   j.StartObject();
 
   j.Key("index");


### PR DESCRIPTION
According to [the specification](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#reference-material), the property name for the normal texture should be `normalTexture` (its *type* is called `normalTextureInfo`, but not the property).

This caused a validation error 

    UNEXPECTED_PROPERTY | Unexpected property. | /materials/0/normalTextureInfo

for assets that contained a normal texture.

This PR just fixes that property name.



