### PR TITLE
Fix tile URL "extra" in glTFs.

### DIFF
--- a/Cesium3DTilesSelection/src/GltfContent.cpp
+++ b/Cesium3DTilesSelection/src/GltfContent.cpp
@@ -42,7 +42,7 @@ GltfContent::load(const TileContentLoadInput& input) {
   }
 
   if (loadedModel.model) {
-    loadedModel.model.value().extras["Cesium3DTilesSelection_TileUrl"] = url;
+    loadedModel.model.value().extras["Cesium3DTiles_TileUrl"] = url;
   }
 
   pResult->model = std::move(loadedModel.model);

--- a/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
+++ b/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
@@ -1164,7 +1164,7 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
       BoundingRegion(rectangle, minimumHeight, maximumHeight);
 
   if (pResult->model) {
-    pResult->model.value().extras["Cesium3DTilesSelection_TileUrl"] = url;
+    pResult->model.value().extras["Cesium3DTiles_TileUrl"] = url;
   }
 
   return pResult;


### PR DESCRIPTION
We add an extra to loaded glTFs indicating the URL they were loaded from, `Cesium3DTiles_TileUrl`, which is really handy for debugging. But in #301 it was accidentally renamed to `Cesium3DTilesSelection_TileUrl`. This PR changes it back, so double-clicking tiles in Unreal Engine tells you their URL again.
