### PR TITLE
Fix travis build failures on Linux caused by an expired PPA certificate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ jobs:
       # We're using Clang 10 instead of the default (Clang 7) because of std::variant related failures
       # on Clang 7, possibly related to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90397
       install:
+        - cat /etc/apt/sources.list.d
         - sudo apt-get update
         -  # Workaround for an apparent Ubuntu package problem.
         -  # See https://travis-ci.community/t/clang-10-was-recently-broken-on-linux-unmet-dependencies-for-clang-10-clang-tidy-10-valgrind/11527

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ jobs:
       os: linux
       dist: focal
       install:
+        - # As of 2021-08-23, the server listed in the rabbitmq PPA has an expired certificate
+        - # and breaks our ability to update. We don't need it, so remove it.
+        - sudo rm /etc/apt/sources.list.d/rabbitmq.list
         - sudo apt-get update
         - sudo apt-get install cmake doxygen
     - name: Linux + Clang
@@ -44,8 +47,8 @@ jobs:
       # We're using Clang 10 instead of the default (Clang 7) because of std::variant related failures
       # on Clang 7, possibly related to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90397
       install:
-        - ls /etc/apt/sources.list.d
-        - cat /etc/apt/sources.list.d/*
+        - # As of 2021-08-23, the server listed in the rabbitmq PPA has an expired certificate
+        - # and breaks our ability to update. We don't need it, so remove it.
         - sudo rm /etc/apt/sources.list.d/rabbitmq.list
         - sudo apt-get update
         -  # Workaround for an apparent Ubuntu package problem.

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ jobs:
       # We're using Clang 10 instead of the default (Clang 7) because of std::variant related failures
       # on Clang 7, possibly related to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90397
       install:
-        - cat /etc/apt/sources.list.d
+        - ls /etc/apt/sources.list.d
         - sudo apt-get update
         -  # Workaround for an apparent Ubuntu package problem.
         -  # See https://travis-ci.community/t/clang-10-was-recently-broken-on-linux-unmet-dependencies-for-clang-10-clang-tidy-10-valgrind/11527

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
       install:
         - ls /etc/apt/sources.list.d
         - cat /etc/apt/sources.list.d/*
-        - sudo add-apt-repository --remove ppa:rabbitmq/ppa
+        - sudo rm /etc/apt/sources.list.d/rabbitmq.list
         - sudo apt-get update
         -  # Workaround for an apparent Ubuntu package problem.
         -  # See https://travis-ci.community/t/clang-10-was-recently-broken-on-linux-unmet-dependencies-for-clang-10-clang-tidy-10-valgrind/11527

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ jobs:
       install:
         - ls /etc/apt/sources.list.d
         - cat /etc/apt/sources.list.d/*
+        - sudo add-apt-repository --remove ppa:rabbitmq/ppa
         - sudo apt-get update
         -  # Workaround for an apparent Ubuntu package problem.
         -  # See https://travis-ci.community/t/clang-10-was-recently-broken-on-linux-unmet-dependencies-for-clang-10-clang-tidy-10-valgrind/11527

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ jobs:
       # on Clang 7, possibly related to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90397
       install:
         - ls /etc/apt/sources.list.d
+        - cat /etc/apt/sources.list.d/*
         - sudo apt-get update
         -  # Workaround for an apparent Ubuntu package problem.
         -  # See https://travis-ci.community/t/clang-10-was-recently-broken-on-linux-unmet-dependencies-for-clang-10-clang-tidy-10-valgrind/11527


### PR DESCRIPTION
All Linux builds in all branches are currently failing. For example:
https://app.travis-ci.com/github/CesiumGS/cesium-native/jobs/532894339

The error is:
```
Err:5 https://packages.erlang-solutions.com/ubuntu focal Release
  Certificate verification failed: The certificate is NOT trusted. The certificate chain uses expired certificate.  Could not handshake: Error in the certificate verification. [IP: 13.32.214.118 443]
```

So some random third party package source used by Ubuntu Focal on Travis has an expired certificate and it's breaking all our builds. Nice. Turns out this is rabbitmq.list and we don't need it, so I've removed it.
