### PR TITLE
Add Rectangle::computeUnion method and rename intersect to match

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,14 @@
 
 ### Next Release - ?
 
+##### Breaking Changes :mega:
+
+- Renamed `Rectangle::intersect` and `GlobeRectangle::intersect` to `computeIntersection`.
+
 ##### Additions :tada:
 
 - Added `Future<T>::share`, which returns a `SharedFuture<T>` and allows multiple continuations to be attached.
+- Added `Rectangle::computeUnion`.
 
 ### v0.6.0 - 2021-08-02
 

--- a/Cesium3DTilesSelection/src/BingMapsRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/BingMapsRasterOverlay.cpp
@@ -176,7 +176,8 @@ protected:
       for (CoverageArea coverageArea : creditAndCoverageAreas.coverageAreas) {
         if (coverageArea.zoomMin <= bingTileLevel &&
             bingTileLevel <= coverageArea.zoomMax &&
-            coverageArea.rectangle.intersect(tileRectangle).has_value()) {
+            coverageArea.rectangle.computeIntersection(tileRectangle)
+                .has_value()) {
           tileCredits.push_back(creditAndCoverageAreas.credit);
           break;
         }

--- a/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
@@ -173,12 +173,12 @@ void RasterOverlayTileProvider::mapRasterTilesToGeometryTile(
   // overlaps the geometry tile.  The RasterOverlayTileProvider and its tiling
   // scheme both have the opportunity to constrain the rectangle.
   CesiumGeometry::Rectangle imageryRectangle =
-      tilingSchemeRectangle.intersect(providerRectangle)
+      tilingSchemeRectangle.computeIntersection(providerRectangle)
           .value_or(tilingSchemeRectangle);
 
   CesiumGeometry::Rectangle intersection(0.0, 0.0, 0.0, 0.0);
   std::optional<CesiumGeometry::Rectangle> maybeIntersection =
-      geometryRectangle.intersect(imageryRectangle);
+      geometryRectangle.computeIntersection(imageryRectangle);
   if (maybeIntersection) {
     intersection = maybeIntersection.value();
   } else {
@@ -349,7 +349,8 @@ void RasterOverlayTileProvider::mapRasterTilesToGeometryTile(
 
     imageryRectangle = imageryTilingScheme.tileToRectangle(
         QuadtreeTileID(imageryLevel, i, southwestTileCoordinates.y));
-    clippedImageryRectangle = imageryRectangle.intersect(imageryBounds);
+    clippedImageryRectangle =
+        imageryRectangle.computeIntersection(imageryBounds);
 
     if (!clippedImageryRectangle) {
       continue;
@@ -382,7 +383,8 @@ void RasterOverlayTileProvider::mapRasterTilesToGeometryTile(
 
       imageryRectangle = imageryTilingScheme.tileToRectangle(
           QuadtreeTileID(imageryLevel, i, j));
-      clippedImageryRectangle = imageryRectangle.intersect(imageryBounds);
+      clippedImageryRectangle =
+          imageryRectangle.computeIntersection(imageryBounds);
 
       if (!clippedImageryRectangle) {
         continue;

--- a/CesiumGeometry/include/CesiumGeometry/Rectangle.h
+++ b/CesiumGeometry/include/CesiumGeometry/Rectangle.h
@@ -11,6 +11,17 @@ namespace CesiumGeometry {
  */
 struct CESIUMGEOMETRY_API Rectangle final {
   /**
+   * @brief Creates a new instance with all coordinate values set to 0.0.
+   *
+   * @param minimumX_ The minimum x-coordinate.
+   * @param minimumY_ The minimum y-coordinate.
+   * @param maximumX_ The maximum x-coordinate.
+   * @param maximumY_ The maximum y-coordinate.
+   */
+  constexpr Rectangle() noexcept
+      : minimumX(0.0), minimumY(0.0), maximumX(0.0), maximumY(0.0) {}
+
+  /**
    * @brief Creates a new instance.
    *
    * Creates a new rectangle from the given coordinates. This implicitly
@@ -180,6 +191,14 @@ struct CESIUMGEOMETRY_API Rectangle final {
    * intersection.
    */
   std::optional<Rectangle> intersect(const Rectangle& other) const noexcept;
+
+  /**
+   * @brief Computes the union of this rectangle with another.
+   *
+   * @param other The other rectangle to union with this one.
+   * @return The union rectangle, which fully contains both rectangles.
+   */
+  Rectangle computeUnion(const Rectangle& other) const noexcept;
 };
 
 } // namespace CesiumGeometry

--- a/CesiumGeometry/include/CesiumGeometry/Rectangle.h
+++ b/CesiumGeometry/include/CesiumGeometry/Rectangle.h
@@ -190,7 +190,8 @@ struct CESIUMGEOMETRY_API Rectangle final {
    * @returns The intersection rectangle, or `std::nullopt` if there is no
    * intersection.
    */
-  std::optional<Rectangle> intersect(const Rectangle& other) const noexcept;
+  std::optional<Rectangle>
+  computeIntersection(const Rectangle& other) const noexcept;
 
   /**
    * @brief Computes the union of this rectangle with another.

--- a/CesiumGeometry/src/Rectangle.cpp
+++ b/CesiumGeometry/src/Rectangle.cpp
@@ -55,4 +55,12 @@ Rectangle::intersect(const Rectangle& other) const noexcept {
   return Rectangle(left, bottom, right, top);
 }
 
+Rectangle Rectangle::computeUnion(const Rectangle& other) const noexcept {
+  return Rectangle(
+      glm::min(this->minimumX, other.minimumX),
+      glm::min(this->minimumY, other.minimumY),
+      glm::max(this->maximumX, other.maximumX),
+      glm::max(this->maximumY, other.maximumY));
+}
+
 } // namespace CesiumGeometry

--- a/CesiumGeometry/src/Rectangle.cpp
+++ b/CesiumGeometry/src/Rectangle.cpp
@@ -42,7 +42,7 @@ Rectangle::computeSignedDistance(const glm::dvec2& position) const noexcept {
 }
 
 std::optional<Rectangle>
-Rectangle::intersect(const Rectangle& other) const noexcept {
+Rectangle::computeIntersection(const Rectangle& other) const noexcept {
   double left = glm::max(this->minimumX, other.minimumX);
   double bottom = glm::max(this->minimumY, other.minimumY);
   double right = glm::min(this->maximumX, other.maximumX);

--- a/CesiumGeometry/test/TestRectangle.cpp
+++ b/CesiumGeometry/test/TestRectangle.cpp
@@ -2,6 +2,8 @@
 #include "CesiumUtility/Math.h"
 #include <catch2/catch.hpp>
 
+using namespace CesiumGeometry;
+
 TEST_CASE("Rectangle::computeSignedDistance") {
   struct TestCase {
     CesiumGeometry::Rectangle rectangle;
@@ -60,4 +62,64 @@ TEST_CASE("Rectangle::computeSignedDistance") {
       testCase.rectangle.computeSignedDistance(testCase.position),
       testCase.expectedResult,
       CesiumUtility::Math::EPSILON13));
+}
+
+TEST_CASE("Rectangle::computeUnion") {
+  Rectangle a(1.0, 2.0, 3.0, 4.0);
+  Rectangle b(0.0, 0.0, 10.0, 10.0);
+  Rectangle c(1.5, 2.5, 3.5, 4.5);
+  Rectangle d(0.5, 1.5, 2.5, 3.5);
+  Rectangle e(10.0, 11.0, 12.0, 13.0);
+
+  // One rectangle entirely inside another.
+  Rectangle intersectionAB = a.computeUnion(b);
+  CHECK(intersectionAB.minimumX == 0.0);
+  CHECK(intersectionAB.minimumY == 0.0);
+  CHECK(intersectionAB.maximumX == 10.0);
+  CHECK(intersectionAB.maximumY == 10.0);
+
+  Rectangle intersectionBA = b.computeUnion(a);
+  CHECK(intersectionBA.minimumX == 0.0);
+  CHECK(intersectionBA.minimumY == 0.0);
+  CHECK(intersectionBA.maximumX == 10.0);
+  CHECK(intersectionBA.maximumY == 10.0);
+
+  // One rectangle extends outside the other to the lower right
+  Rectangle intersectionAC = a.computeUnion(c);
+  CHECK(intersectionAC.minimumX == 1.0);
+  CHECK(intersectionAC.minimumY == 2.0);
+  CHECK(intersectionAC.maximumX == 3.5);
+  CHECK(intersectionAC.maximumY == 4.5);
+
+  Rectangle intersectionCA = c.computeUnion(a);
+  CHECK(intersectionCA.minimumX == 1.0);
+  CHECK(intersectionCA.minimumY == 2.0);
+  CHECK(intersectionCA.maximumX == 3.5);
+  CHECK(intersectionCA.maximumY == 4.5);
+
+  // One rectangle extends outside the other to the upper left
+  Rectangle intersectionAD = a.computeUnion(d);
+  CHECK(intersectionAD.minimumX == 0.5);
+  CHECK(intersectionAD.minimumY == 1.5);
+  CHECK(intersectionAD.maximumX == 3.0);
+  CHECK(intersectionAD.maximumY == 4.0);
+
+  Rectangle intersectionDA = d.computeUnion(a);
+  CHECK(intersectionDA.minimumX == 0.5);
+  CHECK(intersectionDA.minimumY == 1.5);
+  CHECK(intersectionDA.maximumX == 3.0);
+  CHECK(intersectionDA.maximumY == 4.0);
+
+  // Disjoint rectangles
+  Rectangle intersectionAE = a.computeUnion(e);
+  CHECK(intersectionAE.minimumX == 1.0);
+  CHECK(intersectionAE.minimumY == 2.0);
+  CHECK(intersectionAE.maximumX == 12.0);
+  CHECK(intersectionAE.maximumY == 13.0);
+
+  Rectangle intersectionEA = e.computeUnion(a);
+  CHECK(intersectionEA.minimumX == 1.0);
+  CHECK(intersectionEA.minimumY == 2.0);
+  CHECK(intersectionEA.maximumX == 12.0);
+  CHECK(intersectionEA.maximumY == 13.0);
 }

--- a/CesiumGeospatial/include/CesiumGeospatial/GlobeRectangle.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/GlobeRectangle.h
@@ -175,7 +175,7 @@ public:
    * intersection.
    */
   std::optional<GlobeRectangle>
-  intersect(const GlobeRectangle& other) const noexcept;
+  computeIntersection(const GlobeRectangle& other) const noexcept;
 
   /**
    * @brief Computes the union of this globe rectangle with another.

--- a/CesiumGeospatial/include/CesiumGeospatial/GlobeRectangle.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/GlobeRectangle.h
@@ -167,7 +167,8 @@ public:
    * account the fact that the same angle can be represented with multiple
    * values as well as the wrapping of longitude at the anti-meridian.  For a
    * simple intersection that ignores these factors and can be used with
-   * projected coordinates, see {@link CesiumGeometry::Rectangle::intersect}.
+   * projected coordinates, see
+   * {@link CesiumGeometry::Rectangle::computeIntersection}.
    *
    * @param other The other rectangle to intersect with this one.
    * @returns The intersection rectangle, or `std::nullopt` if there is no

--- a/CesiumGeospatial/src/GlobeRectangle.cpp
+++ b/CesiumGeospatial/src/GlobeRectangle.cpp
@@ -40,8 +40,8 @@ bool GlobeRectangle::contains(const Cartographic& cartographic) const noexcept {
       latitude >= this->_south && latitude <= this->_north);
 }
 
-std::optional<GlobeRectangle>
-GlobeRectangle::intersect(const GlobeRectangle& other) const noexcept {
+std::optional<GlobeRectangle> GlobeRectangle::computeIntersection(
+    const GlobeRectangle& other) const noexcept {
   double rectangleEast = this->_east;
   double rectangleWest = this->_west;
 


### PR DESCRIPTION
This is a small PR broken out of #252.

* Added `Rectangle::computeUnion` (we can't call it `union` because that's a C++ reserved word).
* Renamed `Rectangle::intersect` and `GlobeRectangle::intersect` to `computeIntersection` (to match).
