### PR TITLE
Add SharedFutureResult

### DIFF
--- a/CesiumAsync/include/CesiumAsync/Future.h
+++ b/CesiumAsync/include/CesiumAsync/Future.h
@@ -281,6 +281,9 @@ private:
 
   template <typename R> friend struct Impl::ParameterizedTaskUnwrapper;
 
+  template <typename Func, typename T2>
+  friend auto Impl::futureFunctionToTaskFunction(Func&& f);
+
   friend struct Impl::TaskUnwrapper;
 
   template <typename R> friend class Future;

--- a/CesiumAsync/include/CesiumAsync/Impl/ContinuationReturnType.h
+++ b/CesiumAsync/include/CesiumAsync/Impl/ContinuationReturnType.h
@@ -3,11 +3,29 @@
 #include <type_traits>
 
 namespace CesiumAsync {
+
+template <typename T> class SharedFutureResult;
+
 namespace Impl {
 // Begin omitting doxgen warnings for Impl namespace
 //! @cond Doxygen_Suppress
 
-template <typename Func, typename T> struct ContinuationReturnType {
+template <typename Func, typename T, typename Enable = void>
+struct ContinuationReturnType {};
+
+template <typename Func, typename T>
+struct ContinuationReturnType<
+    Func,
+    T,
+    std::enable_if_t<std::is_invocable_v<Func, SharedFutureResult<T>>>> {
+  using type = typename std::invoke_result<Func, SharedFutureResult<T>>::type;
+};
+
+template <typename Func, typename T>
+struct ContinuationReturnType<
+    Func,
+    T,
+    std::enable_if_t<std::is_invocable_v<Func, T>>> {
   using type = typename std::invoke_result<Func, T>::type;
 };
 

--- a/CesiumAsync/include/CesiumAsync/Impl/unwrapFuture.h
+++ b/CesiumAsync/include/CesiumAsync/Impl/unwrapFuture.h
@@ -2,21 +2,58 @@
 
 #include "CesiumAsync/Impl/ContinuationFutureType.h"
 #include "CesiumAsync/Impl/ContinuationReturnType.h"
+#include "CesiumAsync/SharedFutureResult.h"
+#include <type_traits>
 
 namespace CesiumAsync {
 namespace Impl {
 // Begin omitting doxgen warnings for Impl namespace
 //! @cond Doxygen_Suppress
 
+template <typename T>
+inline constexpr bool isFuture =
+    !std::is_same_v<T, typename RemoveFuture<T>::type>;
+
+template <typename Func, typename T>
+auto futureFunctionToTaskFunction(Func&& f) {
+  if constexpr (std::is_invocable_v<Func>) {
+    // Function taking no parameters
+    if constexpr (isFuture<typename ContinuationReturnType<Func, void>::type>) {
+      // And returning a Future
+      return [f = std::forward<Func>(f)]() { return f()._task; };
+    } else {
+      // And returning a regular value
+      return std::forward<Func>(f);
+    }
+  } else if constexpr (std::is_invocable_v<Func, SharedFutureResult<T>>) {
+    // Function taking a SharedFuture<T>
+    if constexpr (isFuture<typename ContinuationReturnType<Func, T>::type>) {
+      // And returning a Future
+      return [f = std::forward<Func>(f)](const async::shared_task<T>& task) {
+        return f(SharedFutureResult<T>(task))._task;
+      };
+    } else {
+      // And returning a regular value
+      return [f = std::forward<Func>(f)](const async::shared_task<T>& task) {
+        return f(SharedFutureResult<T>(task));
+      };
+    }
+  } else {
+    // Function taking a normal value T
+    if constexpr (isFuture<typename ContinuationReturnType<Func, T>::type>) {
+      // And returning a Future
+      return
+          [f = std::forward<Func>(f)](T&& t) { return f(std::move(t))._task; };
+    } else {
+      // And returning a regular value
+      return std::forward<Func>(f);
+    }
+  }
+}
+
 struct IdentityUnwrapper {
   template <typename Func> static Func unwrap(Func&& f) {
     return std::forward<Func>(f);
-  }
-};
-
-template <typename T> struct ParameterizedTaskUnwrapper {
-  template <typename Func> static auto unwrap(Func&& f) {
-    return [f = std::forward<Func>(f)](T&& t) { return f(std::move(t))._task; };
   }
 };
 
@@ -27,13 +64,7 @@ struct TaskUnwrapper {
 };
 
 template <typename Func, typename T> auto unwrapFuture(Func&& f) {
-  return std::conditional<
-      std::is_same<
-          typename ContinuationReturnType<Func, T>::type,
-          typename RemoveFuture<
-              typename ContinuationFutureType<Func, T>::type>::type>::value,
-      IdentityUnwrapper,
-      ParameterizedTaskUnwrapper<T>>::type::unwrap(std::forward<Func>(f));
+  return futureFunctionToTaskFunction<Func, T>(std::forward<Func>(f));
 }
 
 template <typename Func> auto unwrapFuture(Func&& f) {

--- a/CesiumAsync/include/CesiumAsync/SharedFuture.h
+++ b/CesiumAsync/include/CesiumAsync/SharedFuture.h
@@ -259,6 +259,9 @@ private:
 
   template <typename R> friend struct Impl::ParameterizedTaskUnwrapper;
 
+  template <typename Func, typename T2>
+  friend auto Impl::futureFunctionToTaskFunction(Func&& f);
+
   friend struct Impl::TaskUnwrapper;
 
   template <typename R> friend class Future;

--- a/CesiumAsync/include/CesiumAsync/SharedFutureResult.h
+++ b/CesiumAsync/include/CesiumAsync/SharedFutureResult.h
@@ -1,0 +1,51 @@
+#pragma once
+
+namespace CesiumAsync {
+
+namespace Impl {
+template <typename Func, typename T>
+auto futureFunctionToTaskFunction(Func&& f);
+}
+
+/**
+ * @brief A reference to the result produced by a {@link SharedFuture<T>}.
+ *
+ * A {@link SharedFutureResult<T>} only exists for a {@link SharedFuture<T>}
+ * that is already resolved or rejected, and provides a means to access its
+ * value without the full {@link SharedFuture<T>} machinery.
+ *
+ * Shared future results are reference counted. They remain accessible as long
+ * as a {@link SharedFuture<T>} or {@link SharedFutureResult<T>} exists
+ * referencing them.
+ *
+ * {@link SharedFuture<T>::wait} and {@link SharedFutureResult<T>::get} are
+ * equivalent.
+ *
+ * @tparam T The type of value.
+ */
+template <typename T> class SharedFutureResult final {
+public:
+  /**
+   * @brief Gets the shared future's result value if the future resolved, or
+   * throws an exception if it rejected.
+   *
+   * This method is equivalent to {@link SharedFuture<T>::wait}, but it is
+   * guaranteed not to block because the Future is guaranteed to already be
+   * resolved or rejected.
+   *
+   * @return The resolved value.
+   */
+  const T& get() const { return this->_task.get(); }
+
+private:
+  SharedFutureResult(const async::shared_task<T>& task) : _task(task) {
+    assert(task.ready());
+  }
+
+  async::shared_task<T> _task;
+
+  template <typename Func, typename T2>
+  friend auto Impl::futureFunctionToTaskFunction(Func&& f);
+};
+
+} // namespace CesiumAsync


### PR DESCRIPTION
Async++ has a thing where your continuation function can take a `async::task` parameter (similar to our Future) instead of the actual resolved value. This lets you handle both resolve and reject from a single lambda. I thought something like this would be useful for #252 and so I implemented it. But it ended up not being very useful after all. This PR has those changes so we don't lose track of them in case we need them later, but I'm going to close it immediately because I don't think it's worth considering at this time.