### PR TITLE
Detect missing overlay textures coordinates and add them.

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContentLoadResult.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContentLoadResult.h
@@ -60,12 +60,22 @@ struct TileContentLoadResult {
   std::vector<CesiumGeometry::QuadtreeTileRectangularRange>
       availableTileRectangles;
 
+  // TODO: other forms of tile availability, like a bitfield?
+
   /**
    * @brief The HTTP status code received when accessing this content.
    */
   uint16_t httpStatusCode;
 
-  // TODO: other forms of tile availability, like a bitfield?
+  /**
+   * @brief The raster overlay projections for which texture coordinates have
+   * been generated.
+   *
+   * For the projection at index `n`, there is a set of texture coordinates
+   * with the attribute name `_CESIUMOVERLAY_n` that corresponds to that
+   * projection.
+   */
+  std::vector<CesiumGeospatial::Projection> rasterOverlayProjections;
 };
 
 } // namespace Cesium3DTilesSelection


### PR DESCRIPTION
Fixes CesiumGS/cesium-unreal#612

It works like this:
- When generating overlay texture coordinates, also store the corresponding Projections in the `TileContentLoadResult`.
- When replacing a placeholder tile with real tiles, check if we have the right texture coordinates for the provider's projection. If not, force the tile to reload. We could definitely do a more surgical update here in the future.
