### PR TITLE
Fix for "Forbid Holes" not working

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug introduced in v0.7.0 where Bing credits were not being collected.
+- Fixed the "forbidHoles" option not working when frustum culling was enabled and when external tilesets were used.
 
 ### v0.7.0 - 2021-09-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug introduced in v0.7.0 where Bing credits were not being collected.
-- Fixed the "forbidHoles" option not working when frustum culling was enabled and when external tilesets were used.
+- Fixed a bug where the "forbidHoles" option was not working with raster overlays and external tilesets.
 
 ### v0.7.0 - 2021-09-01
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
@@ -465,6 +465,11 @@ public:
   bool isRenderable() const noexcept;
 
   /**
+   * @brief Determines if this tile is has external tileset content.
+   */
+  bool isExternalTileset() const noexcept;
+
+  /**
    * @brief Trigger the process of loading the {@link Tile::getContent}.
    *
    * This function is not supposed to be called by clients.

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -110,7 +110,7 @@ bool Tile::isRenderable() const noexcept {
       return std::all_of(
           this->_rasterTiles.begin(),
           this->_rasterTiles.end(),
-          [](const RasterMappedTo3DTile& rasterTile) -> bool {
+          [](const RasterMappedTo3DTile& rasterTile) {
             return rasterTile.getReadyTile() != nullptr;
           });
     }

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -110,8 +110,11 @@ bool Tile::isRenderable() const noexcept {
       return std::all_of(
           this->_rasterTiles.begin(),
           this->_rasterTiles.end(),
-          [](const RasterMappedTo3DTile& rasterTile) {
-            return rasterTile.getReadyTile() != nullptr;
+          [](const RasterMappedTo3DTile& rasterTile) -> bool {
+            return rasterTile.getReadyTile() ||
+                   rasterTile.getLoadingTile() &&
+                       rasterTile.getLoadingTile()->getState() >=
+                           RasterOverlayTile::LoadState::Loaded;
           });
     }
   }

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -112,9 +112,9 @@ bool Tile::isRenderable() const noexcept {
           this->_rasterTiles.end(),
           [](const RasterMappedTo3DTile& rasterTile) -> bool {
             return rasterTile.getReadyTile() ||
-                   rasterTile.getLoadingTile() &&
-                       rasterTile.getLoadingTile()->getState() >=
-                           RasterOverlayTile::LoadState::Loaded;
+                   (rasterTile.getLoadingTile() &&
+                    rasterTile.getLoadingTile()->getState() >=
+                        RasterOverlayTile::LoadState::Loaded);
           });
     }
   }

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -111,10 +111,7 @@ bool Tile::isRenderable() const noexcept {
           this->_rasterTiles.begin(),
           this->_rasterTiles.end(),
           [](const RasterMappedTo3DTile& rasterTile) -> bool {
-            return rasterTile.getReadyTile() ||
-                   (rasterTile.getLoadingTile() &&
-                    rasterTile.getLoadingTile()->getState() >=
-                        RasterOverlayTile::LoadState::Loaded);
+            return rasterTile.getReadyTile() != nullptr;
           });
     }
   }

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -119,6 +119,11 @@ bool Tile::isRenderable() const noexcept {
   return false;
 }
 
+bool Tile::isExternalTileset() const noexcept {
+  return this->getState() >= LoadState::ContentLoaded && this->_pContent &&
+         !this->_pContent->model;
+}
+
 namespace {
 int32_t getTextureCoordinatesForProjection(
     std::vector<CesiumGeospatial::Projection>& projections,

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -1435,7 +1435,9 @@ bool Tileset::_queueLoadOfChildrenRequiredForRefinement(
       // While we are waiting for the child to load, we need to push along the
       // tile and raster loading by continuing to update it, as if we were
       // visiting it.
-      child.update(frameState.lastFrameNumber, frameState.currentFrameNumber);
+      if (child.getState() >= Tile::LoadState::ContentLoaded) {
+        child.update(frameState.lastFrameNumber, frameState.currentFrameNumber);
+      }
     }
   }
   return waitingForChildren;

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -1421,6 +1421,9 @@ bool Tileset::_queueLoadOfChildrenRequiredForRefinement(
     if (!child.isRenderable()) {
       waitingForChildren = true;
 
+      // While we are waiting for the child to load, we need to push along the
+      // tile and raster loading by continuing to update it.
+      child.update(frameState.lastFrameNumber, frameState.currentFrameNumber);
       this->_markTileVisited(child);
 
       // We're using the distance to the parent tile to compute the load
@@ -1431,13 +1434,6 @@ bool Tileset::_queueLoadOfChildrenRequiredForRefinement(
           frameState.frustums,
           child,
           distances);
-
-      // While we are waiting for the child to load, we need to push along the
-      // tile and raster loading by continuing to update it, as if we were
-      // visiting it.
-      if (child.getState() >= Tile::LoadState::ContentLoaded) {
-        child.update(frameState.lastFrameNumber, frameState.currentFrameNumber);
-      }
     }
   }
   return waitingForChildren;

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -1418,7 +1418,7 @@ bool Tileset::_queueLoadOfChildrenRequiredForRefinement(
   gsl::span<Tile> children = tile.getChildren();
   bool waitingForChildren = false;
   for (Tile& child : children) {
-    if (!child.isRenderable()) {
+    if (!child.isRenderable() && !child.isExternalTileset()) {
       waitingForChildren = true;
 
       // While we are waiting for the child to load, we need to push along the

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -1431,6 +1431,11 @@ bool Tileset::_queueLoadOfChildrenRequiredForRefinement(
           frameState.frustums,
           child,
           distances);
+
+      // While we are waiting for the child to load, we need to push along the
+      // tile and raster loading by continuing to update it, as if we were
+      // visiting it.
+      child.update(frameState.lastFrameNumber, frameState.currentFrameNumber);
     }
   }
   return waitingForChildren;

--- a/Cesium3DTilesSelection/test/TestTilesetSelectionAlgorithm.cpp
+++ b/Cesium3DTilesSelection/test/TestTilesetSelectionAlgorithm.cpp
@@ -281,7 +281,7 @@ TEST_CASE("Test replace refinement for render") {
       REQUIRE(root->getState() == Tile::LoadState::Done);
       REQUIRE(!doesTileMeetSSE(viewState, *root, tileset));
       for (const auto& child : root->getChildren()) {
-        REQUIRE(child.getState() == Tile::LoadState::FailedTemporarily);
+        REQUIRE(child.getState() == Tile::LoadState::Failed);
         REQUIRE(doesTileMeetSSE(viewState, child, tileset));
       }
 


### PR DESCRIPTION
There was an issue (may or may not be related to [this issue](https://github.com/CesiumGS/cesium-unreal/issues/440)) where enabling "Forbid Holes" completely broke the loading of CWT and probably any other tileset. To reproduce simply load up CWT, check "Forbid Holes", and refresh the tileset.

Why I think it was happening:
Children are initially not considered "renderable" so the parent tile refuses to refine.  I've seen the children have placeholder loading raster tiles (not mapped yet) and I've seen the children have loaded raster tiles that weren't yet put into the ready slot. In both cases they're considered not renderable so the parent does not refine. While the parent is waiting, `Tile::loadContent` gets called on the children, but there is never a `Tile::update` call and so sometimes the raster to geometry mapping is missed (when the tile provider was a placeholder during `Tile::loadContent`?) and `RasterMappedTo3DTile::update` is never called (so even loaded raster tiles are never set to ready).

So since the children were not being considered renderable and they were not making any progress towards being renderable, "Forbid Holes" forced the parents to wait indefinitely for the children.

I'm only describing the problem in this detail so someone can verify that this is a reasonable fix 🙂.

Edit: I also added a fix here for the issue of forbid holes not working with external tilesets.
