### PR TITLE
Fix build with _GLIBCXX_DEBUG

### DIFF
--- a/CesiumAsync/src/ResponseCacheControl.cpp
+++ b/CesiumAsync/src/ResponseCacheControl.cpp
@@ -27,8 +27,8 @@ ResponseCacheControl::ResponseCacheControl(
 
 /*static*/ std::optional<ResponseCacheControl>
 ResponseCacheControl::parseFromResponseHeaders(const HttpHeaders& headers) {
-  std::map<std::string, std::string, CaseInsensitiveCompare>::const_iterator cacheControlIter =
-      headers.find("Cache-Control");
+  std::map<std::string, std::string, CaseInsensitiveCompare>::const_iterator
+      cacheControlIter = headers.find("Cache-Control");
   if (cacheControlIter == headers.end()) {
     return std::nullopt;
   }

--- a/CesiumAsync/src/ResponseCacheControl.cpp
+++ b/CesiumAsync/src/ResponseCacheControl.cpp
@@ -27,7 +27,7 @@ ResponseCacheControl::ResponseCacheControl(
 
 /*static*/ std::optional<ResponseCacheControl>
 ResponseCacheControl::parseFromResponseHeaders(const HttpHeaders& headers) {
-  std::map<std::string, std::string>::const_iterator cacheControlIter =
+  std::map<std::string, std::string, CaseInsensitiveCompare>::const_iterator cacheControlIter =
       headers.find("Cache-Control");
   if (cacheControlIter == headers.end()) {
     return std::nullopt;


### PR DESCRIPTION
When building with `_GLIBCXX_DEBUG` the output is:
```
cmake -B build -D CMAKE_BUILD_TYPE=Debug -D CMAKE_CXX_FLAGS_DEBUG=-D_GLIBCXX_DEBUG && cmake --build build --parallel 8
```
 
```
Scanning dependencies of target CesiumAsync
[ 71%] Building CXX object CesiumAsync/CMakeFiles/CesiumAsync.dir/src/AsyncSystem.cpp.o
[ 71%] Building CXX object CesiumAsync/CMakeFiles/CesiumAsync.dir/src/CachingAssetAccessor.cpp.o
[ 71%] Building CXX object CesiumAsync/CMakeFiles/CesiumAsync.dir/src/HttpHeaders.cpp.o
[ 72%] Building CXX object CesiumAsync/CMakeFiles/CesiumAsync.dir/src/InternalTimegm.cpp.o
[ 72%] Building CXX object CesiumAsync/CMakeFiles/CesiumAsync.dir/src/QueuedScheduler.cpp.o
[ 72%] Building CXX object CesiumAsync/CMakeFiles/CesiumAsync.dir/src/ResponseCacheControl.cpp.o
/home/ian/Code/cesium-native/CesiumAsync/src/ResponseCacheControl.cpp: In static member function ‘static std::optional<CesiumAsync::ResponseCacheControl> CesiumAsync::ResponseCacheControl::parseFromResponseHeaders(const HttpHeaders&)’:
/home/ian/Code/cesium-native/CesiumAsync/src/ResponseCacheControl.cpp:31:19: error: conversion from ‘_Safe_iterator<[...],map<[...],[...],CesiumAsync::CaseInsensitiveCompare>,[...]>’ to non-scalar type ‘_Safe_iterator<[...],map<[...],[...],std::less<std::__cxx11::basic_string<char> >>,[...]>’ requested
   31 |       headers.find("Cache-Control");
      |       ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
/home/ian/Code/cesium-native/CesiumAsync/src/ResponseCacheControl.cpp:32:39: error: ‘std::_Rb_tree_const_iterator<std::pair<const std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > >’ is an inaccessible base of ‘__gnu_debug::_Safe_iterator<std::_Rb_tree_const_iterator<std::pair<const std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > >, std::__debug::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >, std::bidirectional_iterator_tag>’
   32 |   if (cacheControlIter == headers.end()) {
      |                                       ^
make[2]: *** [CesiumAsync/CMakeFiles/CesiumAsync.dir/build.make:128: CesiumAsync/CMakeFiles/CesiumAsync.dir/src/ResponseCacheControl.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2849: CesiumAsync/CMakeFiles/CesiumAsync.dir/all] Error 2
make: *** [Makefile:163: all] Error 2
```

Supplying the full map type fixed the problem. Not sure why this works, but it's consistent with the code below.
```
  std::map<std::string, std::string, CaseInsensitiveCompare>
parameterizedDirectives;
```