### PR TITLE
Fix warnings detected by Visual Studio, Part 0

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/CreditSystem.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/CreditSystem.h
@@ -47,7 +47,7 @@ public:
   /**
    * @brief Get the HTML string for this credit
    */
-  const std::string& getHtml(Credit credit) const;
+  const std::string& getHtml(Credit credit) const noexcept;
 
   /**
    * @brief Adds the Credit to the set of credits to show this frame
@@ -58,7 +58,7 @@ public:
    * @brief Notifies this CreditSystem to start tracking the credits to show for
    * the next frame.
    */
-  void startNextFrame();
+  void startNextFrame() noexcept;
 
   /**
    * @brief Get the credits to show this frame.

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/CreditSystem.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/CreditSystem.h
@@ -17,12 +17,14 @@ public:
   /**
    * @brief Returns `true` if two credit objects have the same ID.
    */
-  bool operator==(const Credit& rhs) const { return this->id == rhs.id; }
+  bool operator==(const Credit& rhs) const noexcept {
+    return this->id == rhs.id;
+  }
 
 private:
   size_t id;
 
-  Credit(size_t id_) { id = id_; }
+  Credit(size_t id_) noexcept { id = id_; }
 
   friend class CreditSystem;
 };
@@ -61,7 +63,7 @@ public:
   /**
    * @brief Get the credits to show this frame.
    */
-  const std::vector<Credit>& getCreditsToShowThisFrame() const {
+  const std::vector<Credit>& getCreditsToShowThisFrame() const noexcept {
     return _creditsToShowThisFrame;
   }
 
@@ -69,7 +71,8 @@ public:
    * @brief Get the credits that were shown last frame but should no longer be
    * shown.
    */
-  const std::vector<Credit>& getCreditsToNoLongerShowThisFrame() const {
+  const std::vector<Credit>&
+  getCreditsToNoLongerShowThisFrame() const noexcept {
     return _creditsToNoLongerShowThisFrame;
   }
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ITileExcluder.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ITileExcluder.h
@@ -11,7 +11,7 @@ class Tile;
 class ITileExcluder {
 public:
   virtual ~ITileExcluder() = default;
-  virtual bool shouldExclude(const Tile& tile) const = 0;
+  virtual bool shouldExclude(const Tile& tile) const noexcept = 0;
 };
 
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterMappedTo3DTile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterMappedTo3DTile.h
@@ -157,7 +157,7 @@ public:
   void detachFromTile(Tile& tile) noexcept;
 
 private:
-  void computeTranslationAndScale(Tile& tile);
+  void computeTranslationAndScale(const Tile& tile);
 
   CesiumUtility::IntrusivePointer<RasterOverlayTile> _pLoadingTile;
   CesiumUtility::IntrusivePointer<RasterOverlayTile> _pReadyTile;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlay.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlay.h
@@ -64,15 +64,17 @@ public:
   /**
    * @brief Gets the name of this overlay.
    */
-  const std::string& getName() const { return this->_name; }
+  const std::string& getName() const noexcept { return this->_name; }
 
   /**
    * @brief Gets options for this overlay.
    */
-  RasterOverlayOptions& getOptions() { return this->_options; }
+  RasterOverlayOptions& getOptions() noexcept { return this->_options; }
 
   /** @copydoc getOptions */
-  const RasterOverlayOptions& getOptions() const { return this->_options; }
+  const RasterOverlayOptions& getOptions() const noexcept {
+    return this->_options;
+  }
 
   /**
    * @brief Gets the tile provider for this overlay.

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayTile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayTile.h
@@ -132,7 +132,7 @@ public:
    * @brief Returns the {@link CesiumGeometry::Rectangle} that defines the bounds
    * of this tile in the raster overlay's projected coordinates.
    */
-  const CesiumGeometry::Rectangle& getRectangle() const {
+  const CesiumGeometry::Rectangle& getRectangle() const noexcept {
     return this->_rectangle;
   }
 
@@ -143,7 +143,9 @@ public:
    * This is used to control which content (how highly detailed) the
    * {@link RasterOverlayTileProvider} uses within the bounds of this tile.
    */
-  double getTargetGeometricError() const { return this->_targetGeometricError; }
+  double getTargetGeometricError() const noexcept {
+    return this->_targetGeometricError;
+  }
 
   /**
    * @brief Returns the current {@link LoadState}.
@@ -183,14 +185,16 @@ public:
   /**
    * @brief Returns the renderer resources that have been created for this tile.
    */
-  void* getRendererResources() const { return this->_pRendererResources; }
+  void* getRendererResources() const noexcept {
+    return this->_pRendererResources;
+  }
 
   /**
    * @brief Set the renderer resources for this tile.
    *
    * This function is not supposed to be called by clients.
    */
-  void setRendererResources(void* pValue) {
+  void setRendererResources(void* pValue) noexcept {
     this->_pRendererResources = pValue;
   }
 
@@ -198,7 +202,7 @@ public:
    * @brief Determines if more detailed data is available for the spatial area
    * covered by this tile.
    */
-  MoreDetailAvailable isMoreDetailAvailable() const {
+  MoreDetailAvailable isMoreDetailAvailable() const noexcept {
     return this->_moreDetailAvailable;
   }
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayTile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayTile.h
@@ -113,7 +113,7 @@ public:
   RasterOverlayTile(
       RasterOverlay& overlay,
       double targetGeometricError,
-      const CesiumGeometry::Rectangle& imageryRectangle);
+      const CesiumGeometry::Rectangle& imageryRectangle) noexcept;
 
   /** @brief Default destructor. */
   ~RasterOverlayTile();
@@ -224,7 +224,7 @@ public:
 private:
   friend class RasterOverlayTileProvider;
 
-  void setState(LoadState newState);
+  void setState(LoadState newState) noexcept;
 
   RasterOverlay* _pOverlay;
   double _targetGeometricError;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayTileProvider.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayTileProvider.h
@@ -354,7 +354,7 @@ private:
    * @param tile The tile that is starting to load.
    * @param isThrottledLoad True if the load was originally throttled.
    */
-  void beginTileLoad(RasterOverlayTile& tile, bool isThrottledLoad);
+  void beginTileLoad(RasterOverlayTile& tile, bool isThrottledLoad) noexcept;
 
   /**
    * @brief Finalizes loading of a tile.
@@ -365,7 +365,7 @@ private:
    * @param tile The tile that finished loading.
    * @param isThrottledLoad True if the load was originally throttled.
    */
-  void finalizeTileLoad(RasterOverlayTile& tile, bool isThrottledLoad);
+  void finalizeTileLoad(RasterOverlayTile& tile, bool isThrottledLoad) noexcept;
 
 private:
   RasterOverlay* _pOwner;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayTileProvider.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayTileProvider.h
@@ -27,7 +27,7 @@ struct CESIUM3DTILESSELECTION_API LoadedRasterOverlayImage {
    * This will be an empty optional if the loading failed. In this case,
    * the `errors` vector will contain the corresponding error messages.
    */
-  std::optional<CesiumGltf::ImageCesium> image;
+  std::optional<CesiumGltf::ImageCesium> image{};
 
   /**
    * @brief The projected rectangle defining the bounds of this image.
@@ -35,20 +35,20 @@ struct CESIUM3DTILESSELECTION_API LoadedRasterOverlayImage {
    * The rectangle extends from the left side of the leftmost pixel to the
    * right side of the rightmost pixel, and similar for the vertical direction.
    */
-  CesiumGeometry::Rectangle rectangle;
+  CesiumGeometry::Rectangle rectangle{};
 
   /**
    * @brief The {@link Credit} objects that decribe the attributions that
    * are required when using the image.
    */
-  std::vector<Credit> credits;
+  std::vector<Credit> credits{};
 
   /**
    * @brief Error messages from loading the image.
    *
    * If the image was loaded successfully, this should be empty.
    */
-  std::vector<std::string> errors;
+  std::vector<std::string> errors{};
 
   /**
    * @brief Warnings from loading the image.
@@ -56,13 +56,13 @@ struct CESIUM3DTILESSELECTION_API LoadedRasterOverlayImage {
   // Implementation note: In the current implementation, this will
   // always be empty, but it might contain warnings in the future,
   // when other image types or loaders are used.
-  std::vector<std::string> warnings;
+  std::vector<std::string> warnings{};
 
   /**
    * @brief Whether more detailed data, beyond this image, is available within
    * the bounds of this image.
    */
-  bool moreDetailAvailable;
+  bool moreDetailAvailable = false;
 };
 
 /**
@@ -73,7 +73,7 @@ struct LoadTileImageFromUrlOptions {
    * @brief The rectangle definining the bounds of the image being loaded,
    * expressed in the {@link RasterOverlayTileProvider}'s projection.
    */
-  CesiumGeometry::Rectangle rectangle = {};
+  CesiumGeometry::Rectangle rectangle{};
 
   /**
    * @brief The credits to display with this tile.
@@ -81,7 +81,7 @@ struct LoadTileImageFromUrlOptions {
    * This property is copied verbatim to the
    * {@link LoadedRasterOverlayImage::credits} property.
    */
-  std::vector<Credit> credits = {};
+  std::vector<Credit> credits{};
 
   /**
    * @brief Whether more detailed data, beyond this image, is available within

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsOverlay.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsOverlay.h
@@ -36,7 +36,7 @@ public:
       RasterOverlay* pOwner) override;
 
   const std::vector<CesiumGeospatial::CartographicPolygon>&
-  getPolygons() const {
+  getPolygons() const noexcept {
     return this->_polygons;
   }
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsTileExcluder.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsTileExcluder.h
@@ -34,7 +34,7 @@ public:
    * @return true if the tile should be excluded because it is entirely inside a
    * polygon.
    */
-  virtual bool shouldExclude(const Tile& tile) const override;
+  virtual bool shouldExclude(const Tile& tile) const noexcept override;
 
   /**
    * @brief Gets the overlay defining the polygons.

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsTileExcluder.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsTileExcluder.h
@@ -23,7 +23,8 @@ public:
    * ensure that the lifetime of this overlay is longer than the lifetime of the
    * newly-constructed `RasterizedPolygonsOverlay`.
    */
-  RasterizedPolygonsTileExcluder(const RasterizedPolygonsOverlay& overlay);
+  RasterizedPolygonsTileExcluder(
+      const RasterizedPolygonsOverlay& overlay) noexcept;
 
   /**
    * @brief Determines whether a given tile is entirely inside a polygon and

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
@@ -586,8 +586,7 @@ private:
    * This method should only be called when this tile's parent is already
    * loaded.
    */
-  void
-  upsampleParent(const std::vector<CesiumGeospatial::Projection>&& projections);
+  void upsampleParent(std::vector<CesiumGeospatial::Projection>&& projections);
 
   /**
    * @brief Initiates loading of any overlays attached to this tile.

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
@@ -556,7 +556,8 @@ private:
    * This method should only be called when this tile's parent is already
    * loaded.
    */
-  void upsampleParent(const std::vector<CesiumGeospatial::Projection>&& projections);
+  void
+  upsampleParent(const std::vector<CesiumGeospatial::Projection>&& projections);
 
   /**
    * @brief Initiates loading of any overlays attached to this tile.

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
@@ -556,7 +556,7 @@ private:
    * This method should only be called when this tile's parent is already
    * loaded.
    */
-  void upsampleParent(std::vector<CesiumGeospatial::Projection>&& projections);
+  void upsampleParent(const std::vector<CesiumGeospatial::Projection>&& projections);
 
   /**
    * @brief Initiates loading of any overlays attached to this tile.

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContentLoadResult.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContentLoadResult.h
@@ -29,12 +29,12 @@ struct TileContentLoadResult {
    * If it has a value but the model is blank, the tile can
    * be "rendered", but it is rendered as nothing.
    */
-  std::optional<CesiumGltf::Model> model;
+  std::optional<CesiumGltf::Model> model{};
 
   /**
    * @brief A new context, if any, used by the `childTiles`.
    */
-  std::unique_ptr<TileContext> pNewTileContext;
+  std::unique_ptr<TileContext> pNewTileContext{};
 
   /**
    * @brief New child tiles discovered by loading this tile.
@@ -43,7 +43,7 @@ struct TileContentLoadResult {
    * contains the root tiles of the subtree. This is ignored if the
    * tile already has any child tiles.
    */
-  std::optional<std::vector<Tile>> childTiles;
+  std::optional<std::vector<Tile>> childTiles{};
 
   /**
    * @brief An improved bounding volume for this tile.
@@ -51,19 +51,19 @@ struct TileContentLoadResult {
    * If this is available, then it is more accurate than the one the tile used
    * originally.
    */
-  std::optional<BoundingVolume> updatedBoundingVolume;
+  std::optional<BoundingVolume> updatedBoundingVolume{};
 
   /**
    * @brief Available quadtree tiles discovered as a result of loading this
    * tile.
    */
   std::vector<CesiumGeometry::QuadtreeTileRectangularRange>
-      availableTileRectangles;
+      availableTileRectangles{};
 
   /**
    * @brief The HTTP status code received when accessing this content.
    */
-  uint16_t httpStatusCode;
+  uint16_t httpStatusCode = 0;
 
   // TODO: other forms of tile availability, like a bitfield?
 };

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileSelectionState.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileSelectionState.h
@@ -117,7 +117,7 @@ public:
    * @return `true` if the tile was kicked, and `false` otherwise
    */
   constexpr bool wasKicked(int32_t frameNumber) const noexcept {
-    Result result = this->getResult(frameNumber);
+    const Result result = this->getResult(frameNumber);
     return result == Result::RenderedAndKicked ||
            result == Result::RefinedAndKicked;
   }
@@ -131,7 +131,7 @@ public:
    * @return The {@link TileSelectionState::Result} prior to being kicked.
    */
   constexpr Result getOriginalResult(int32_t frameNumber) const noexcept {
-    Result result = this->getResult(frameNumber);
+    const Result result = this->getResult(frameNumber);
 
     switch (result) {
     case Result::RefinedAndKicked:

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -323,8 +323,8 @@ private:
    *
    * @param pRequest The request for which the response was received.
    */
-  CesiumAsync::Future<void> _handleAssetResponse(
-      const std::shared_ptr<CesiumAsync::IAssetRequest>&& pRequest);
+  CesiumAsync::Future<void>
+  _handleAssetResponse(std::shared_ptr<CesiumAsync::IAssetRequest>&& pRequest);
 
   struct LoadResult {
     std::unique_ptr<TileContext> pContext;
@@ -346,7 +346,7 @@ private:
    * @return The LoadResult structure
    */
   static LoadResult _handleTilesetResponse(
-      const std::shared_ptr<CesiumAsync::IAssetRequest>&& pRequest,
+      std::shared_ptr<CesiumAsync::IAssetRequest>&& pRequest,
       std::unique_ptr<TileContext>&& pContext,
       const std::shared_ptr<spdlog::logger>& pLogger,
       bool useWaterMask);
@@ -386,7 +386,7 @@ private:
    * @param pContext The context.
    */
   void _handleTokenRefreshResponse(
-      const std::shared_ptr<CesiumAsync::IAssetRequest>&& pIonRequest,
+      std::shared_ptr<CesiumAsync::IAssetRequest>&& pIonRequest,
       TileContext* pContext,
       const std::shared_ptr<spdlog::logger>& pLogger);
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -323,8 +323,8 @@ private:
    *
    * @param pRequest The request for which the response was received.
    */
-  CesiumAsync::Future<void>
-  _handleAssetResponse(const std::shared_ptr<CesiumAsync::IAssetRequest>&& pRequest);
+  CesiumAsync::Future<void> _handleAssetResponse(
+      const std::shared_ptr<CesiumAsync::IAssetRequest>&& pRequest);
 
   struct LoadResult {
     std::unique_ptr<TileContext> pContext;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -324,7 +324,7 @@ private:
    * @param pRequest The request for which the response was received.
    */
   CesiumAsync::Future<void>
-  _handleAssetResponse(std::shared_ptr<CesiumAsync::IAssetRequest>&& pRequest);
+  _handleAssetResponse(const std::shared_ptr<CesiumAsync::IAssetRequest>&& pRequest);
 
   struct LoadResult {
     std::unique_ptr<TileContext> pContext;
@@ -346,7 +346,7 @@ private:
    * @return The LoadResult structure
    */
   static LoadResult _handleTilesetResponse(
-      std::shared_ptr<CesiumAsync::IAssetRequest>&& pRequest,
+      const std::shared_ptr<CesiumAsync::IAssetRequest>&& pRequest,
       std::unique_ptr<TileContext>&& pContext,
       const std::shared_ptr<spdlog::logger>& pLogger,
       bool useWaterMask);
@@ -386,7 +386,7 @@ private:
    * @param pContext The context.
    */
   void _handleTokenRefreshResponse(
-      std::shared_ptr<CesiumAsync::IAssetRequest>&& pIonRequest,
+      const std::shared_ptr<CesiumAsync::IAssetRequest>&& pIonRequest,
       TileContext* pContext,
       const std::shared_ptr<spdlog::logger>& pLogger);
 
@@ -584,7 +584,7 @@ private:
       const std::vector<double>& distances);
   void processQueue(
       std::vector<Tileset::LoadRecord>& queue,
-      std::atomic<uint32_t>& loadsInProgress,
+      const std::atomic<uint32_t>& loadsInProgress,
       uint32_t maximumLoadsInProgress);
 
   Tileset(const Tileset& rhs) = delete;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -540,7 +540,7 @@ private:
      */
     double priority;
 
-    bool operator<(const LoadRecord& rhs) const {
+    bool operator<(const LoadRecord& rhs) const noexcept {
       return this->priority < rhs.priority;
     }
   };

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -500,11 +500,11 @@ private:
       const std::vector<ViewState>& frustums,
       const Tile& tile,
       const std::vector<double>& distances,
-      bool culled) const;
+      bool culled) const noexcept;
 
   void _processLoadQueue();
-  void _unloadCachedTiles();
-  void _markTileVisited(Tile& tile);
+  void _unloadCachedTiles() noexcept;
+  void _markTileVisited(Tile& tile) noexcept;
 
   std::string getResolvedContentUrl(const Tile& tile) const;
 

--- a/Cesium3DTilesSelection/src/Batched3DModelContent.cpp
+++ b/Cesium3DTilesSelection/src/Batched3DModelContent.cpp
@@ -159,9 +159,9 @@ std::unique_ptr<TileContentLoadResult> Batched3DModelContent::load(
   }
 
   const uint32_t glbStart = headerLength + header.featureTableJsonByteLength +
-                      header.featureTableBinaryByteLength +
-                      header.batchTableJsonByteLength +
-                      header.batchTableBinaryByteLength;
+                            header.featureTableBinaryByteLength +
+                            header.batchTableJsonByteLength +
+                            header.batchTableBinaryByteLength;
   const uint32_t glbEnd = header.byteLength;
 
   if (glbEnd <= glbStart) {
@@ -182,8 +182,9 @@ std::unique_ptr<TileContentLoadResult> Batched3DModelContent::load(
     rapidjson::Document featureTable =
         parseFeatureTableJsonData(pLogger, gltf, featureTableJsonData);
 
-    const int64_t batchTableStart = headerLength + header.featureTableJsonByteLength +
-                              header.featureTableBinaryByteLength;
+    const int64_t batchTableStart = headerLength +
+                                    header.featureTableJsonByteLength +
+                                    header.featureTableBinaryByteLength;
     const int64_t batchTableLength =
         header.batchTableBinaryByteLength + header.batchTableJsonByteLength;
 

--- a/Cesium3DTilesSelection/src/Batched3DModelContent.cpp
+++ b/Cesium3DTilesSelection/src/Batched3DModelContent.cpp
@@ -57,7 +57,7 @@ rapidjson::Document parseFeatureTableJsonData(
     return document;
   }
 
-  auto rtcIt = document.FindMember("RTC_CENTER");
+  const auto rtcIt = document.FindMember("RTC_CENTER");
   if (rtcIt != document.MemberEnd() && rtcIt->value.IsArray() &&
       rtcIt->value.Size() == 3 && rtcIt->value[0].IsDouble() &&
       rtcIt->value[1].IsDouble() && rtcIt->value[2].IsDouble()) {
@@ -158,18 +158,18 @@ std::unique_ptr<TileContentLoadResult> Batched3DModelContent::load(
         "size specified in its header.");
   }
 
-  uint32_t glbStart = headerLength + header.featureTableJsonByteLength +
+  const uint32_t glbStart = headerLength + header.featureTableJsonByteLength +
                       header.featureTableBinaryByteLength +
                       header.batchTableJsonByteLength +
                       header.batchTableBinaryByteLength;
-  uint32_t glbEnd = header.byteLength;
+  const uint32_t glbEnd = header.byteLength;
 
   if (glbEnd <= glbStart) {
     throw std::runtime_error("The B3DM is invalid because the start of the "
                              "glTF model is after the end of the entire B3DM.");
   }
 
-  gsl::span<const std::byte> glbData =
+  const gsl::span<const std::byte> glbData =
       data.subspan(glbStart, glbEnd - glbStart);
   std::unique_ptr<TileContentLoadResult> pResult =
       GltfContent::load(pLogger, url, glbData);
@@ -177,21 +177,21 @@ std::unique_ptr<TileContentLoadResult> Batched3DModelContent::load(
   if (pResult->model && header.featureTableJsonByteLength > 0) {
     CesiumGltf::Model& gltf = pResult->model.value();
 
-    gsl::span<const std::byte> featureTableJsonData =
+    const gsl::span<const std::byte> featureTableJsonData =
         data.subspan(headerLength, header.featureTableJsonByteLength);
     rapidjson::Document featureTable =
         parseFeatureTableJsonData(pLogger, gltf, featureTableJsonData);
 
-    int64_t batchTableStart = headerLength + header.featureTableJsonByteLength +
+    const int64_t batchTableStart = headerLength + header.featureTableJsonByteLength +
                               header.featureTableBinaryByteLength;
-    int64_t batchTableLength =
+    const int64_t batchTableLength =
         header.batchTableBinaryByteLength + header.batchTableJsonByteLength;
 
     if (batchTableLength > 0) {
-      gsl::span<const std::byte> batchTableJsonData = data.subspan(
+      const gsl::span<const std::byte> batchTableJsonData = data.subspan(
           static_cast<size_t>(batchTableStart),
           header.batchTableJsonByteLength);
-      gsl::span<const std::byte> batchTableBinaryData = data.subspan(
+      const gsl::span<const std::byte> batchTableBinaryData = data.subspan(
           static_cast<size_t>(
               batchTableStart + header.batchTableJsonByteLength),
           header.batchTableBinaryByteLength);

--- a/Cesium3DTilesSelection/src/BingMapsRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/BingMapsRasterOverlay.cpp
@@ -177,7 +177,7 @@ protected:
     const unsigned int bingTileLevel = tileID.level + 1;
 
     for (const CreditAndCoverageAreas& creditAndCoverageAreas : _credits) {
-      for (CoverageArea coverageArea : creditAndCoverageAreas.coverageAreas) {
+      for (const CoverageArea& coverageArea : creditAndCoverageAreas.coverageAreas) {
         if (coverageArea.zoomMin <= bingTileLevel &&
             bingTileLevel <= coverageArea.zoomMax &&
             coverageArea.rectangle.computeIntersection(tileRectangle)

--- a/Cesium3DTilesSelection/src/BingMapsRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/BingMapsRasterOverlay.cpp
@@ -177,7 +177,8 @@ protected:
     const unsigned int bingTileLevel = tileID.level + 1;
 
     for (const CreditAndCoverageAreas& creditAndCoverageAreas : _credits) {
-      for (const CoverageArea& coverageArea : creditAndCoverageAreas.coverageAreas) {
+      for (const CoverageArea& coverageArea :
+           creditAndCoverageAreas.coverageAreas) {
         if (coverageArea.zoomMin <= bingTileLevel &&
             bingTileLevel <= coverageArea.zoomMax &&
             coverageArea.rectangle.computeIntersection(tileRectangle)

--- a/Cesium3DTilesSelection/src/BingMapsRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/BingMapsRasterOverlay.cpp
@@ -155,7 +155,7 @@ protected:
                 tileID.computeInvertedY(this->getTilingScheme()));
           }
           if (key == "subdomain") {
-            size_t subdomainIndex =
+            const size_t subdomainIndex =
                 (tileID.level + tileID.x + tileID.y) % this->_subdomains.size();
             return this->_subdomains[subdomainIndex];
           }
@@ -168,13 +168,13 @@ protected:
     options.rectangle = this->getTilingScheme().tileToRectangle(tileID);
     std::vector<Credit>& tileCredits = options.credits;
 
-    CesiumGeospatial::GlobeRectangle tileRectangle =
+    const CesiumGeospatial::GlobeRectangle tileRectangle =
         CesiumGeospatial::unprojectRectangleSimple(
             this->getProjection(),
             options.rectangle);
 
     // Cesium levels start at 0, Bing levels start at 1
-    unsigned int bingTileLevel = tileID.level + 1;
+    const unsigned int bingTileLevel = tileID.level + 1;
 
     for (const CreditAndCoverageAreas& creditAndCoverageAreas : _credits) {
       for (CoverageArea coverageArea : creditAndCoverageAreas.coverageAreas) {
@@ -195,7 +195,7 @@ private:
   static std::string tileXYToQuadKey(uint32_t level, uint32_t x, uint32_t y) {
     std::string quadkey;
     for (int32_t i = static_cast<int32_t>(level); i >= 0; --i) {
-      uint32_t bitmask = static_cast<uint32_t>(1 << i);
+      const uint32_t bitmask = static_cast<uint32_t>(1 << i);
       uint32_t digit = 0;
 
       if ((x & bitmask) != 0) {
@@ -265,7 +265,7 @@ std::vector<CreditAndCoverageAreas> collectCredits(
     const rapidjson::Value* pResource,
     const std::shared_ptr<CreditSystem>& pCreditSystem) {
   std::vector<CreditAndCoverageAreas> credits;
-  auto attributionsIt = pResource->FindMember("imageryProviders");
+  const auto attributionsIt = pResource->FindMember("imageryProviders");
   if (attributionsIt != pResource->MemberEnd() &&
       attributionsIt->value.IsArray()) {
 
@@ -273,19 +273,19 @@ std::vector<CreditAndCoverageAreas> collectCredits(
          attributionsIt->value.GetArray()) {
 
       std::vector<CoverageArea> coverageAreas;
-      auto coverageAreasIt = attribution.FindMember("coverageAreas");
+      const auto coverageAreasIt = attribution.FindMember("coverageAreas");
       if (coverageAreasIt != attribution.MemberEnd() &&
           coverageAreasIt->value.IsArray()) {
 
         for (const rapidjson::Value& area : coverageAreasIt->value.GetArray()) {
 
-          auto bboxIt = area.FindMember("bbox");
+          const auto bboxIt = area.FindMember("bbox");
           if (bboxIt != area.MemberEnd() && bboxIt->value.IsArray() &&
               bboxIt->value.Size() == 4) {
 
-            auto zoomMinIt = area.FindMember("zoomMin");
-            auto zoomMaxIt = area.FindMember("zoomMax");
-            auto bboxArrayIt = bboxIt->value.GetArray();
+            const auto zoomMinIt = area.FindMember("zoomMin");
+            const auto zoomMaxIt = area.FindMember("zoomMax");
+            const auto bboxArrayIt = bboxIt->value.GetArray();
             if (zoomMinIt != area.MemberEnd() &&
                 zoomMaxIt != area.MemberEnd() && zoomMinIt->value.IsUint() &&
                 zoomMaxIt->value.IsUint() && bboxArrayIt[0].IsNumber() &&
@@ -307,7 +307,7 @@ std::vector<CreditAndCoverageAreas> collectCredits(
         }
       }
 
-      auto creditString = attribution.FindMember("attribution");
+      const auto creditString = attribution.FindMember("attribution");
       if (creditString != attribution.MemberEnd() &&
           creditString->value.IsString()) {
         credits.push_back(
@@ -437,7 +437,7 @@ BingMapsRasterOverlay::createTileProvider(
             }
 
             const std::byte* responseBuffer = pResponse->data().data();
-            size_t responseSize = pResponse->data().size();
+            const size_t responseSize = pResponse->data().size();
 
             sessionCache[metadataUrl] = std::vector<std::byte>(
                 pResponse->data().begin(),

--- a/Cesium3DTilesSelection/src/BoundingVolume.cpp
+++ b/Cesium3DTilesSelection/src/BoundingVolume.cpp
@@ -12,8 +12,10 @@ BoundingVolume transformBoundingVolume(
     const glm::dmat4x4& transform;
 
     BoundingVolume operator()(const OrientedBoundingBox& boundingBox) {
-      const glm::dvec3 center = transform * glm::dvec4(boundingBox.getCenter(), 1.0);
-      const glm::dmat3 halfAxes = glm::dmat3(transform) * boundingBox.getHalfAxes();
+      const glm::dvec3 center =
+          transform * glm::dvec4(boundingBox.getCenter(), 1.0);
+      const glm::dmat3 halfAxes =
+          glm::dmat3(transform) * boundingBox.getHalfAxes();
       return OrientedBoundingBox(center, halfAxes);
     }
 

--- a/Cesium3DTilesSelection/src/BoundingVolume.cpp
+++ b/Cesium3DTilesSelection/src/BoundingVolume.cpp
@@ -12,8 +12,8 @@ BoundingVolume transformBoundingVolume(
     const glm::dmat4x4& transform;
 
     BoundingVolume operator()(const OrientedBoundingBox& boundingBox) {
-      glm::dvec3 center = transform * glm::dvec4(boundingBox.getCenter(), 1.0);
-      glm::dmat3 halfAxes = glm::dmat3(transform) * boundingBox.getHalfAxes();
+      const glm::dvec3 center = transform * glm::dvec4(boundingBox.getCenter(), 1.0);
+      const glm::dmat3 halfAxes = glm::dmat3(transform) * boundingBox.getHalfAxes();
       return OrientedBoundingBox(center, halfAxes);
     }
 
@@ -23,10 +23,10 @@ BoundingVolume transformBoundingVolume(
     }
 
     BoundingVolume operator()(const BoundingSphere& boundingSphere) {
-      glm::dvec3 center =
+      const glm::dvec3 center =
           transform * glm::dvec4(boundingSphere.getCenter(), 1.0);
 
-      double uniformScale = glm::max(
+      const double uniformScale = glm::max(
           glm::max(
               glm::length(glm::dvec3(transform[0])),
               glm::length(glm::dvec3(transform[1]))),

--- a/Cesium3DTilesSelection/src/BoundingVolume.cpp
+++ b/Cesium3DTilesSelection/src/BoundingVolume.cpp
@@ -17,7 +17,7 @@ BoundingVolume transformBoundingVolume(
       return OrientedBoundingBox(center, halfAxes);
     }
 
-    BoundingVolume operator()(const BoundingRegion& boundingRegion) {
+    BoundingVolume operator()(const BoundingRegion& boundingRegion) noexcept {
       // Regions are not transformed.
       return boundingRegion;
     }
@@ -35,8 +35,8 @@ BoundingVolume transformBoundingVolume(
       return BoundingSphere(center, boundingSphere.getRadius() * uniformScale);
     }
 
-    BoundingVolume
-    operator()(const BoundingRegionWithLooseFittingHeights& boundingRegion) {
+    BoundingVolume operator()(
+        const BoundingRegionWithLooseFittingHeights& boundingRegion) noexcept {
       // Regions are not transformed.
       return boundingRegion;
     }
@@ -47,20 +47,20 @@ BoundingVolume transformBoundingVolume(
 
 glm::dvec3 getBoundingVolumeCenter(const BoundingVolume& boundingVolume) {
   struct Operation {
-    glm::dvec3 operator()(const OrientedBoundingBox& boundingBox) {
+    glm::dvec3 operator()(const OrientedBoundingBox& boundingBox) noexcept {
       return boundingBox.getCenter();
     }
 
-    glm::dvec3 operator()(const BoundingRegion& boundingRegion) {
+    glm::dvec3 operator()(const BoundingRegion& boundingRegion) noexcept {
       return boundingRegion.getBoundingBox().getCenter();
     }
 
-    glm::dvec3 operator()(const BoundingSphere& boundingSphere) {
+    glm::dvec3 operator()(const BoundingSphere& boundingSphere) noexcept {
       return boundingSphere.getCenter();
     }
 
-    glm::dvec3
-    operator()(const BoundingRegionWithLooseFittingHeights& boundingRegion) {
+    glm::dvec3 operator()(
+        const BoundingRegionWithLooseFittingHeights& boundingRegion) noexcept {
       return boundingRegion.getBoundingRegion().getBoundingBox().getCenter();
     }
   };

--- a/Cesium3DTilesSelection/src/CompositeContent.cpp
+++ b/Cesium3DTilesSelection/src/CompositeContent.cpp
@@ -121,7 +121,9 @@ CompositeContent::load(const TileContentLoadInput& input) {
       break;
     }
 
-    const gsl::span<const std::byte> innerData(data.data() + pos, pInner->byteLength);
+    const gsl::span<const std::byte> innerData(
+        data.data() + pos,
+        pInner->byteLength);
 
     std::unique_ptr<TileContentLoadResult> pInnerLoadResult =
         TileContentFactory::createContent(derive(input, innerData));

--- a/Cesium3DTilesSelection/src/CompositeContent.cpp
+++ b/Cesium3DTilesSelection/src/CompositeContent.cpp
@@ -121,7 +121,7 @@ CompositeContent::load(const TileContentLoadInput& input) {
       break;
     }
 
-    gsl::span<const std::byte> innerData(data.data() + pos, pInner->byteLength);
+    const gsl::span<const std::byte> innerData(data.data() + pos, pInner->byteLength);
 
     std::unique_ptr<TileContentLoadResult> pInnerLoadResult =
         TileContentFactory::createContent(derive(input, innerData));

--- a/Cesium3DTilesSelection/src/CreditSystem.cpp
+++ b/Cesium3DTilesSelection/src/CreditSystem.cpp
@@ -18,7 +18,7 @@ Credit CreditSystem::createCredit(const std::string& html) {
   return Credit(_credits.size() - 1);
 }
 
-const std::string& CreditSystem::getHtml(Credit credit) const {
+const std::string& CreditSystem::getHtml(Credit credit) const noexcept {
   if (credit.id < _credits.size()) {
     return _credits[credit.id].html;
   }
@@ -50,7 +50,7 @@ void CreditSystem::addCreditToFrame(Credit credit) {
   _credits[credit.id].lastFrameNumber = _currentFrameNumber;
 }
 
-void CreditSystem::startNextFrame() {
+void CreditSystem::startNextFrame() noexcept {
   _creditsToNoLongerShowThisFrame.swap(_creditsToShowThisFrame);
   _creditsToShowThisFrame.clear();
   _currentFrameNumber++;

--- a/Cesium3DTilesSelection/src/GltfContent.cpp
+++ b/Cesium3DTilesSelection/src/GltfContent.cpp
@@ -79,7 +79,9 @@ static int generateOverlayTextureCoordinates(
   const int uvAccessorId = static_cast<int>(accessors.size());
   accessors.emplace_back();
 
-  const CesiumGltf::AccessorView<glm::vec3> positionView(gltf, positionAccessorIndex);
+  const CesiumGltf::AccessorView<glm::vec3> positionView(
+      gltf,
+      positionAccessorIndex);
   if (positionView.status() != CesiumGltf::AccessorViewStatus::Valid) {
     return -1;
   }
@@ -146,8 +148,10 @@ static int generateOverlayTextureCoordinates(
       const glm::dvec3 projectedPosition2 =
           projectPosition(projection, cartographic.value());
 
-      const double distance1 = rectangle.computeSignedDistance(projectedPosition);
-      const double distance2 = rectangle.computeSignedDistance(projectedPosition2);
+      const double distance1 =
+          rectangle.computeSignedDistance(projectedPosition);
+      const double distance2 =
+          rectangle.computeSignedDistance(projectedPosition2);
 
       if (distance2 < distance1) {
         projectedPosition = projectedPosition2;

--- a/Cesium3DTilesSelection/src/GltfContent.cpp
+++ b/Cesium3DTilesSelection/src/GltfContent.cpp
@@ -70,16 +70,16 @@ static int generateOverlayTextureCoordinates(
   std::vector<CesiumGltf::BufferView>& bufferViews = gltf.bufferViews;
   std::vector<CesiumGltf::Accessor>& accessors = gltf.accessors;
 
-  int uvBufferId = static_cast<int>(buffers.size());
+  const int uvBufferId = static_cast<int>(buffers.size());
   CesiumGltf::Buffer& uvBuffer = buffers.emplace_back();
 
-  int uvBufferViewId = static_cast<int>(bufferViews.size());
+  const int uvBufferViewId = static_cast<int>(bufferViews.size());
   bufferViews.emplace_back();
 
-  int uvAccessorId = static_cast<int>(accessors.size());
+  const int uvAccessorId = static_cast<int>(accessors.size());
   accessors.emplace_back();
 
-  CesiumGltf::AccessorView<glm::vec3> positionView(gltf, positionAccessorIndex);
+  const CesiumGltf::AccessorView<glm::vec3> positionView(gltf, positionAccessorIndex);
   if (positionView.status() != CesiumGltf::AccessorViewStatus::Valid) {
     return -1;
   }
@@ -105,13 +105,13 @@ static int generateOverlayTextureCoordinates(
   CesiumGltf::AccessorWriter<glm::vec2> uvWriter(gltf, uvAccessorId);
   assert(uvWriter.status() == CesiumGltf::AccessorViewStatus::Valid);
 
-  double width = rectangle.computeWidth();
-  double height = rectangle.computeHeight();
+  const double width = rectangle.computeWidth();
+  const double height = rectangle.computeHeight();
 
   for (int64_t i = 0; i < positionView.size(); ++i) {
     // Get the ECEF position
-    glm::vec3 position = positionView[i];
-    glm::dvec3 positionEcef = transform * glm::dvec4(position, 1.0);
+    const glm::vec3 position = positionView[i];
+    const glm::dvec3 positionEcef = transform * glm::dvec4(position, 1.0);
 
     // Convert it to cartographic
     std::optional<CesiumGeospatial::Cartographic> cartographic =
@@ -127,8 +127,8 @@ static int generateOverlayTextureCoordinates(
         projectPosition(projection, cartographic.value());
 
     double longitude = cartographic.value().longitude;
-    double latitude = cartographic.value().latitude;
-    double ellipsoidHeight = cartographic.value().height;
+    const double latitude = cartographic.value().latitude;
+    const double ellipsoidHeight = cartographic.value().height;
 
     // If the position is near the anti-meridian and the projected position is
     // outside the expected range, try using the equivalent longitude on the
@@ -143,11 +143,11 @@ static int generateOverlayTextureCoordinates(
       cartographic.value().longitude += cartographic.value().longitude < 0.0
                                             ? CesiumUtility::Math::TWO_PI
                                             : -CesiumUtility::Math::TWO_PI;
-      glm::dvec3 projectedPosition2 =
+      const glm::dvec3 projectedPosition2 =
           projectPosition(projection, cartographic.value());
 
-      double distance1 = rectangle.computeSignedDistance(projectedPosition);
-      double distance2 = rectangle.computeSignedDistance(projectedPosition2);
+      const double distance1 = rectangle.computeSignedDistance(projectedPosition);
+      const double distance2 = rectangle.computeSignedDistance(projectedPosition2);
 
       if (distance2 < distance1) {
         projectedPosition = projectedPosition2;
@@ -232,13 +232,13 @@ GltfContent::createRasterOverlayTextureCoordinates(
           return;
         }
 
-        int positionAccessorIndex = positionIt->second;
+        const int positionAccessorIndex = positionIt->second;
         if (positionAccessorIndex < 0 ||
             positionAccessorIndex >= static_cast<int>(gltf_.accessors.size())) {
           return;
         }
 
-        int textureCoordinateAccessorIndex =
+        const int textureCoordinateAccessorIndex =
             positionAccessorsToTextureCoordinateAccessor[static_cast<size_t>(
                 positionAccessorIndex)];
         if (textureCoordinateAccessorIndex > 0) {
@@ -252,12 +252,12 @@ GltfContent::createRasterOverlayTextureCoordinates(
           return;
         }
 
-        glm::dmat4 fullTransform =
+        const glm::dmat4 fullTransform =
             transform * CesiumGeometry::AxisTransforms::Y_UP_TO_Z_UP *
             nodeTransform;
 
         // Generate new texture coordinates
-        int nextTextureCoordinateAccessorIndex =
+        const int nextTextureCoordinateAccessorIndex =
             generateOverlayTextureCoordinates(
                 gltf_,
                 positionAccessorIndex,

--- a/Cesium3DTilesSelection/src/IonRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/IonRasterOverlay.cpp
@@ -81,7 +81,7 @@ IonRasterOverlay::createTileProvider(
                 "externalType",
                 "unknown");
             if (externalType == "BING") {
-              auto optionsIt = response.FindMember("options");
+              const auto optionsIt = response.FindMember("options");
               if (optionsIt == response.MemberEnd() ||
                   !optionsIt->value.IsObject()) {
                 SPDLOG_LOGGER_ERROR(

--- a/Cesium3DTilesSelection/src/QuadtreeRasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/src/QuadtreeRasterOverlayTileProvider.cpp
@@ -248,9 +248,10 @@ uint32_t QuadtreeRasterOverlayTileProvider::computeLevelFromGeometricError(
   const CesiumGeometry::Rectangle& tilingSchemeRectangle =
       tilingScheme.getRectangle();
 
-  const double toMeters = computeApproximateConversionFactorToMetersNearPosition(
-      this->getProjection(),
-      position);
+  const double toMeters =
+      computeApproximateConversionFactorToMetersNearPosition(
+          this->getProjection(),
+          position);
 
   const double levelZeroMaximumTexelSpacingMeters =
       (tilingSchemeRectangle.computeWidth() * toMeters) /
@@ -287,7 +288,10 @@ QuadtreeRasterOverlayTileProvider::getQuadtreeTile(
   // subtle) race condition.
   auto loadParentTile = [tileID, this]() {
     const Rectangle rectangle = this->getTilingScheme().tileToRectangle(tileID);
-    const QuadtreeTileID parentID(tileID.level - 1, tileID.x >> 1, tileID.y >> 1);
+    const QuadtreeTileID parentID(
+        tileID.level - 1,
+        tileID.x >> 1,
+        tileID.y >> 1);
     return this->getQuadtreeTile(parentID).thenImmediately(
         [rectangle](const LoadedQuadtreeImage& loaded) {
           return LoadedQuadtreeImage{loaded.pLoaded, rectangle};
@@ -613,9 +617,9 @@ QuadtreeRasterOverlayTileProvider::combineImages(
           targetRectangle,
           images);
 
-  const int32_t targetImageBytes = measurements.widthPixels *
-                             measurements.heightPixels * measurements.channels *
-                             measurements.bytesPerChannel;
+  const int32_t targetImageBytes =
+      measurements.widthPixels * measurements.heightPixels *
+      measurements.channels * measurements.bytesPerChannel;
   if (targetImageBytes <= 0) {
     // Target image has no pixels, so our work here is done.
     return LoadedRasterOverlayImage{

--- a/Cesium3DTilesSelection/src/QuadtreeRasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/src/QuadtreeRasterOverlayTileProvider.cpp
@@ -131,12 +131,12 @@ QuadtreeRasterOverlayTileProvider::mapRasterTilesToGeometryTile(
       intersection.getCenter());
   imageryLevel = glm::max(0U, imageryLevel);
 
-  uint32_t maximumLevel = this->getMaximumLevel();
+  const uint32_t maximumLevel = this->getMaximumLevel();
   if (imageryLevel > maximumLevel) {
     imageryLevel = maximumLevel;
   }
 
-  uint32_t minimumLevel = this->getMinimumLevel();
+  const uint32_t minimumLevel = this->getMinimumLevel();
   if (imageryLevel < minimumLevel) {
     imageryLevel = minimumLevel;
   }
@@ -166,10 +166,10 @@ QuadtreeRasterOverlayTileProvider::mapRasterTilesToGeometryTile(
   // actually need the southernmost or westernmost tiles.
 
   // We define "very close" as being within 1/512 of the width of the tile.
-  double veryCloseX = geometryRectangle.computeWidth() / 512.0;
-  double veryCloseY = geometryRectangle.computeHeight() / 512.0;
+  const double veryCloseX = geometryRectangle.computeWidth() / 512.0;
+  const double veryCloseY = geometryRectangle.computeHeight() / 512.0;
 
-  CesiumGeometry::Rectangle southwestTileRectangle =
+  const CesiumGeometry::Rectangle southwestTileRectangle =
       imageryTilingScheme.tileToRectangle(southwestTileCoordinates);
 
   if (glm::abs(southwestTileRectangle.maximumY - geometryRectangle.minimumY) <
@@ -184,7 +184,7 @@ QuadtreeRasterOverlayTileProvider::mapRasterTilesToGeometryTile(
     ++southwestTileCoordinates.x;
   }
 
-  CesiumGeometry::Rectangle northeastTileRectangle =
+  const CesiumGeometry::Rectangle northeastTileRectangle =
       imageryTilingScheme.tileToRectangle(northeastTileCoordinates);
 
   if (glm::abs(northeastTileRectangle.maximumY - geometryRectangle.minimumY) <
@@ -202,7 +202,7 @@ QuadtreeRasterOverlayTileProvider::mapRasterTilesToGeometryTile(
   // Create TileImagery instances for each imagery tile overlapping this terrain
   // tile. We need to do all texture coordinate computations in the imagery
   // provider's projection.
-  CesiumGeometry::Rectangle imageryBounds = intersection;
+  const CesiumGeometry::Rectangle imageryBounds = intersection;
   std::optional<CesiumGeometry::Rectangle> clippedImageryRectangle =
       std::nullopt;
 
@@ -248,18 +248,18 @@ uint32_t QuadtreeRasterOverlayTileProvider::computeLevelFromGeometricError(
   const CesiumGeometry::Rectangle& tilingSchemeRectangle =
       tilingScheme.getRectangle();
 
-  double toMeters = computeApproximateConversionFactorToMetersNearPosition(
+  const double toMeters = computeApproximateConversionFactorToMetersNearPosition(
       this->getProjection(),
       position);
 
-  double levelZeroMaximumTexelSpacingMeters =
+  const double levelZeroMaximumTexelSpacingMeters =
       (tilingSchemeRectangle.computeWidth() * toMeters) /
       (this->_imageWidth * tilingScheme.getNumberOfXTilesAtLevel(0));
 
-  double twoToTheLevelPower =
+  const double twoToTheLevelPower =
       levelZeroMaximumTexelSpacingMeters / geometricError;
-  double level = glm::log2(twoToTheLevelPower);
-  double rounded = glm::max(glm::round(level), 0.0);
+  const double level = glm::log2(twoToTheLevelPower);
+  const double rounded = glm::max(glm::round(level), 0.0);
   return static_cast<uint32_t>(rounded);
 }
 
@@ -286,8 +286,8 @@ QuadtreeRasterOverlayTileProvider::getQuadtreeTile(
   // non-thread-safe object from another thread and creating a (potentially very
   // subtle) race condition.
   auto loadParentTile = [tileID, this]() {
-    Rectangle rectangle = this->getTilingScheme().tileToRectangle(tileID);
-    QuadtreeTileID parentID(tileID.level - 1, tileID.x >> 1, tileID.y >> 1);
+    const Rectangle rectangle = this->getTilingScheme().tileToRectangle(tileID);
+    const QuadtreeTileID parentID(tileID.level - 1, tileID.x >> 1, tileID.y >> 1);
     return this->getQuadtreeTile(parentID).thenImmediately(
         [rectangle](const LoadedQuadtreeImage& loaded) {
           return LoadedQuadtreeImage{loaded.pLoaded, rectangle};
@@ -384,7 +384,7 @@ void blitImage(
     const ImageCesium& source,
     const Rectangle& sourceRectangle,
     const std::optional<Rectangle>& sourceSubset) {
-  Rectangle sourceToCopy = sourceSubset.value_or(sourceRectangle);
+  const Rectangle sourceToCopy = sourceSubset.value_or(sourceRectangle);
   std::optional<Rectangle> overlap =
       targetRectangle.computeIntersection(sourceToCopy);
   if (!overlap) {
@@ -392,9 +392,9 @@ void blitImage(
     return;
   }
 
-  PixelRectangle targetPixels =
+  const PixelRectangle targetPixels =
       computePixelRectangle(target, targetRectangle, *overlap);
-  PixelRectangle sourcePixels =
+  const PixelRectangle sourcePixels =
       computePixelRectangle(source, sourceRectangle, *overlap);
 
   ImageManipulation::blitImage(target, targetPixels, source, sourcePixels);
@@ -420,7 +420,7 @@ QuadtreeRasterOverlayTileProvider::loadTileImage(
         // This set of images is only "useful" if at least one actually has
         // image data, and that image data is _not_ from an ancestor. We can
         // identify ancestor images because they have a `subset`.
-        bool haveAnyUsefulImageData = std::any_of(
+        const bool haveAnyUsefulImageData = std::any_of(
             images.begin(),
             images.end(),
             [](const LoadedQuadtreeImage& image) {
@@ -452,7 +452,7 @@ QuadtreeRasterOverlayTileProvider::loadTileImage(
 void QuadtreeRasterOverlayTileProvider::unloadCachedTiles() {
   CESIUM_TRACE("QuadtreeRasterOverlayTileProvider::unloadCachedTiles");
 
-  int64_t maxCacheBytes = this->getOwner().getOptions().subTileCacheBytes;
+  const int64_t maxCacheBytes = this->getOwner().getOptions().subTileCacheBytes;
   if (this->_cachedBytes <= maxCacheBytes) {
     return;
   }
@@ -461,7 +461,7 @@ void QuadtreeRasterOverlayTileProvider::unloadCachedTiles() {
 
   while (it != this->_tilesOldToRecent.end() &&
          this->_cachedBytes > maxCacheBytes) {
-    SharedFuture<LoadedQuadtreeImage>& future = it->future;
+    const SharedFuture<LoadedQuadtreeImage>& future = it->future;
     if (!future.isReady()) {
       // Don't unload tiles that are still loading.
       ++it;
@@ -532,7 +532,7 @@ QuadtreeRasterOverlayTileProvider::measureCombinedImage(
     }
 
     // The portion of the source that we actually need to copy.
-    Rectangle sourceSubset = image.subset.value_or(loaded.rectangle);
+    const Rectangle sourceSubset = image.subset.value_or(loaded.rectangle);
 
     // Find the bounds of the combined image.
     // Intersect the loaded image's rectangle with the target rectangle.
@@ -587,10 +587,10 @@ QuadtreeRasterOverlayTileProvider::measureCombinedImage(
   }
 
   // Compute the pixel dimensions needed for the combined image.
-  int32_t combinedWidthPixels = static_cast<int32_t>(Math::roundUp(
+  const int32_t combinedWidthPixels = static_cast<int32_t>(Math::roundUp(
       combinedRectangle->computeWidth() / projectedWidthPerPixel,
       pixelTolerance));
-  int32_t combinedHeightPixels = static_cast<int32_t>(Math::roundUp(
+  const int32_t combinedHeightPixels = static_cast<int32_t>(Math::roundUp(
       combinedRectangle->computeHeight() / projectedHeightPerPixel,
       pixelTolerance));
 
@@ -608,12 +608,12 @@ QuadtreeRasterOverlayTileProvider::combineImages(
     const Projection& /* projection */,
     std::vector<LoadedQuadtreeImage>&& images) {
 
-  CombinedImageMeasurements measurements =
+  const CombinedImageMeasurements measurements =
       QuadtreeRasterOverlayTileProvider::measureCombinedImage(
           targetRectangle,
           images);
 
-  int32_t targetImageBytes = measurements.widthPixels *
+  const int32_t targetImageBytes = measurements.widthPixels *
                              measurements.heightPixels * measurements.channels *
                              measurements.bytesPerChannel;
   if (targetImageBytes <= 0) {

--- a/Cesium3DTilesSelection/src/QuadtreeRasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/src/QuadtreeRasterOverlayTileProvider.cpp
@@ -15,7 +15,7 @@ namespace {
 
 // One hundredth of a pixel. If we compute a rectangle that goes less than "this
 // much" into the next pixel, we'll ignore the extra.
-const double pixelTolerance = 0.01;
+constexpr double pixelTolerance = 0.01;
 
 } // namespace
 

--- a/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
+++ b/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
@@ -158,7 +158,7 @@ static glm::dvec3 octDecode(uint8_t x, uint8_t y) {
   result.z = 1.0 - (glm::abs(result.x) + glm::abs(result.y));
 
   if (result.z < 0.0) {
-    double oldVX = result.x;
+    const double oldVX = result.x;
     result.x =
         (1.0 - glm::abs(result.y)) * CesiumUtility::Math::signNotZero(oldVX);
     result.y =
@@ -189,7 +189,7 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
   readIndex += headerLength;
 
   // parse u, v, and height buffers
-  uint32_t vertexCount = meshView.header->vertexCount;
+  const uint32_t vertexCount = meshView.header->vertexCount;
 
   meshView.uBuffer = gsl::span<const uint16_t>(
       reinterpret_cast<const uint16_t*>(data.data() + readIndex),
@@ -232,7 +232,7 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
       return std::nullopt;
     }
 
-    uint32_t indicesCount = meshView.triangleCount * 3;
+    const uint32_t indicesCount = meshView.triangleCount * 3;
     meshView.indicesBuffer = gsl::span<const std::byte>(
         data.data() + readIndex,
         indicesCount * sizeof(uint32_t));
@@ -251,7 +251,7 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
       return std::nullopt;
     }
 
-    uint32_t indicesCount = meshView.triangleCount * 3;
+    const uint32_t indicesCount = meshView.triangleCount * 3;
     meshView.indicesBuffer = gsl::span<const std::byte>(
         data.data() + readIndex,
         indicesCount * sizeof(uint16_t));
@@ -321,10 +321,10 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
       break;
     }
 
-    uint8_t extensionID =
+    const uint8_t extensionID =
         *reinterpret_cast<const uint8_t*>(data.data() + readIndex);
     readIndex += sizeof(uint8_t);
-    uint32_t extensionLength =
+    const uint32_t extensionLength =
         *reinterpret_cast<const uint32_t*>(data.data() + readIndex);
     readIndex += sizeof(uint32_t);
 
@@ -380,7 +380,7 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
 static double calculateSkirtHeight(
     const CesiumGeospatial::Ellipsoid& ellipsoid,
     const CesiumGeospatial::GlobeRectangle& rectangle) {
-  double levelMaximumGeometricError =
+  const double levelMaximumGeometricError =
       calcQuadtreeMaxGeometricError(ellipsoid) * rectangle.computeWidth();
   return levelMaximumGeometricError * 5.0;
 }
@@ -402,10 +402,10 @@ static void addSkirt(
     gsl::span<float>& positions,
     gsl::span<float>& normals,
     gsl::span<I>& indices) {
-  double west = rectangle.getWest();
-  double south = rectangle.getSouth();
-  double east = rectangle.getEast();
-  double north = rectangle.getNorth();
+  const double west = rectangle.getWest();
+  const double south = rectangle.getSouth();
+  const double east = rectangle.getEast();
+  const double north = rectangle.getNorth();
 
   size_t newEdgeIndex = currentVertexCount;
   size_t positionIdx = currentVertexCount * 3;
@@ -413,12 +413,12 @@ static void addSkirt(
   for (size_t i = 0; i < edgeIndices.size(); ++i) {
     E edgeIdx = edgeIndices[i];
 
-    double uRatio = uvsAndHeights[edgeIdx].x;
-    double vRatio = uvsAndHeights[edgeIdx].y;
-    double heightRatio = uvsAndHeights[edgeIdx].z;
-    double longitude = Math::lerp(west, east, uRatio) + longitudeOffset;
-    double latitude = Math::lerp(south, north, vRatio) + latitudeOffset;
-    double heightMeters =
+    const double uRatio = uvsAndHeights[edgeIdx].x;
+    const double vRatio = uvsAndHeights[edgeIdx].y;
+    const double heightRatio = uvsAndHeights[edgeIdx].z;
+    const double longitude = Math::lerp(west, east, uRatio) + longitudeOffset;
+    const double latitude = Math::lerp(south, north, vRatio) + latitudeOffset;
+    const double heightMeters =
         Math::lerp(minimumHeight, maximumHeight, heightRatio) - skirtHeight;
     glm::dvec3 position = ellipsoid.cartographicToCartesian(
         Cartographic(longitude, latitude, heightMeters));
@@ -429,7 +429,7 @@ static void addSkirt(
     positions[positionIdx + 2] = static_cast<float>(position.z);
 
     if (!normals.empty()) {
-      size_t componentIndex = static_cast<size_t>(3 * edgeIdx);
+      const size_t componentIndex = static_cast<size_t>(3 * edgeIdx);
       normals[positionIdx] = normals[componentIndex];
       normals[positionIdx + 1] = normals[componentIndex + 1];
       normals[positionIdx + 2] = normals[componentIndex + 2];
@@ -471,13 +471,13 @@ static void addSkirts(
     gsl::span<float>& outputPositions,
     gsl::span<float>& outputNormals,
     gsl::span<I>& outputIndices) {
-  uint32_t westVertexCount =
+  const uint32_t westVertexCount =
       static_cast<uint32_t>(westEdgeIndicesBuffer.size() / sizeof(E));
-  uint32_t southVertexCount =
+  const uint32_t southVertexCount =
       static_cast<uint32_t>(southEdgeIndicesBuffer.size() / sizeof(E));
-  uint32_t eastVertexCount =
+  const uint32_t eastVertexCount =
       static_cast<uint32_t>(eastEdgeIndicesBuffer.size() / sizeof(E));
-  uint32_t northVertexCount =
+  const uint32_t northVertexCount =
       static_cast<uint32_t>(northEdgeIndicesBuffer.size() / sizeof(E));
 
   // allocate edge indices to be sort later
@@ -635,22 +635,22 @@ static std::vector<std::byte> generateNormals(
     const gsl::span<T>& indices,
     size_t currentNumOfIndex) {
   std::vector<std::byte> normalsBuffer(positions.size() * sizeof(float));
-  gsl::span<float> normals(
+  const gsl::span<float> normals(
       reinterpret_cast<float*>(normalsBuffer.data()),
       positions.size());
   for (size_t i = 0; i < currentNumOfIndex; i += 3) {
     T id0 = indices[i];
     T id1 = indices[i + 1];
     T id2 = indices[i + 2];
-    size_t id0x3 = static_cast<size_t>(id0) * 3;
-    size_t id1x3 = static_cast<size_t>(id1) * 3;
-    size_t id2x3 = static_cast<size_t>(id2) * 3;
+    const size_t id0x3 = static_cast<size_t>(id0) * 3;
+    const size_t id1x3 = static_cast<size_t>(id1) * 3;
+    const size_t id2x3 = static_cast<size_t>(id2) * 3;
 
-    glm::vec3 p0 =
+    const glm::vec3 p0 =
         glm::vec3(positions[id0x3], positions[id0x3 + 1], positions[id0x3 + 2]);
-    glm::vec3 p1 =
+    const glm::vec3 p1 =
         glm::vec3(positions[id1x3], positions[id1x3 + 1], positions[id1x3 + 2]);
-    glm::vec3 p2 =
+    const glm::vec3 p2 =
         glm::vec3(positions[id2x3], positions[id2x3 + 1], positions[id2x3 + 2]);
 
     glm::vec3 normal = glm::cross(p1 - p0, p2 - p0);
@@ -736,12 +736,12 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
 
   // get vertex count for this mesh
   const QuantizedMeshHeader* pHeader = meshView->header;
-  uint32_t vertexCount = pHeader->vertexCount;
-  uint32_t indicesCount = meshView->triangleCount * 3;
-  uint32_t skirtVertexCount =
+  const uint32_t vertexCount = pHeader->vertexCount;
+  const uint32_t indicesCount = meshView->triangleCount * 3;
+  const uint32_t skirtVertexCount =
       meshView->westEdgeIndicesCount + meshView->southEdgeIndicesCount +
       meshView->eastEdgeIndicesCount + meshView->northEdgeIndicesCount;
-  uint32_t skirtIndicesCount = (skirtVertexCount - 4) * 6;
+  const uint32_t skirtIndicesCount = (skirtVertexCount - 4) * 6;
 
   // decode position without skirt, but preallocate position buffer to include
   // skirt as well
@@ -752,16 +752,16 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
       (vertexCount + skirtVertexCount) * 3);
   size_t positionOutputIndex = 0;
 
-  glm::dvec3 center(
+  const glm::dvec3 center(
       pHeader->BoundingSphereCenterX,
       pHeader->BoundingSphereCenterY,
       pHeader->BoundingSphereCenterZ);
-  glm::dvec3 horizonOcclusionPoint(
+  const glm::dvec3 horizonOcclusionPoint(
       pHeader->HorizonOcclusionPointX,
       pHeader->HorizonOcclusionPointY,
       pHeader->HorizonOcclusionPointZ);
-  double minimumHeight = pHeader->MinimumHeight;
-  double maximumHeight = pHeader->MaximumHeight;
+  const double minimumHeight = pHeader->MinimumHeight;
+  const double maximumHeight = pHeader->MaximumHeight;
 
   double minX = std::numeric_limits<double>::max();
   double minY = std::numeric_limits<double>::max();
@@ -772,10 +772,10 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
 
   const Ellipsoid& ellipsoid = Ellipsoid::WGS84;
   const CesiumGeospatial::GlobeRectangle& rectangle = pRegion->getRectangle();
-  double west = rectangle.getWest();
-  double south = rectangle.getSouth();
-  double east = rectangle.getEast();
-  double north = rectangle.getNorth();
+  const double west = rectangle.getWest();
+  const double south = rectangle.getSouth();
+  const double east = rectangle.getEast();
+  const double north = rectangle.getNorth();
 
   int32_t u = 0;
   int32_t v = 0;
@@ -791,9 +791,9 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
     double vRatio = static_cast<double>(v) / 32767.0;
     double heightRatio = static_cast<double>(height) / 32767.0;
 
-    double longitude = Math::lerp(west, east, uRatio);
-    double latitude = Math::lerp(south, north, vRatio);
-    double heightMeters = Math::lerp(minimumHeight, maximumHeight, heightRatio);
+    const double longitude = Math::lerp(west, east, uRatio);
+    const double latitude = Math::lerp(south, north, vRatio);
+    const double heightMeters = Math::lerp(minimumHeight, maximumHeight, heightRatio);
 
     glm::dvec3 position = ellipsoid.cartographicToCartesian(
         Cartographic(longitude, latitude, heightMeters));
@@ -817,7 +817,7 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
   std::vector<std::byte> outputNormalsBuffer;
   gsl::span<float> outputNormals;
   if (!meshView->octEncodedNormalBuffer.empty()) {
-    uint32_t totalNormalFloats = (vertexCount + skirtVertexCount) * 3;
+    const uint32_t totalNormalFloats = (vertexCount + skirtVertexCount) * 3;
     outputNormalsBuffer.resize(totalNormalFloats * sizeof(float));
     outputNormals = gsl::span<float>(
         reinterpret_cast<float*>(outputNormalsBuffer.data()),
@@ -842,14 +842,14 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
       meshView->indexType == QuantizedMeshIndexType::UnsignedInt
           ? sizeof(uint32_t)
           : sizeof(uint16_t);
-  double skirtHeight = calculateSkirtHeight(ellipsoid, rectangle);
-  double longitudeOffset = (east - west) * 0.0001;
-  double latitudeOffset = (north - south) * 0.0001;
+  const double skirtHeight = calculateSkirtHeight(ellipsoid, rectangle);
+  const double longitudeOffset = (east - west) * 0.0001;
+  const double latitudeOffset = (north - south) * 0.0001;
   if (meshView->indexType == QuantizedMeshIndexType::UnsignedInt) {
     // decode the tile indices without skirt.
-    size_t outputIndicesCount = indicesCount + skirtIndicesCount;
+    const size_t outputIndicesCount = indicesCount + skirtIndicesCount;
     outputIndicesBuffer.resize(outputIndicesCount * sizeof(uint32_t));
-    gsl::span<const uint32_t> indices(
+    const gsl::span<const uint32_t> indices(
         reinterpret_cast<const uint32_t*>(meshView->indicesBuffer.data()),
         indicesCount);
     gsl::span<uint32_t> outputIndices(
@@ -889,8 +889,8 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
 
     indexSizeBytes = sizeof(uint32_t);
   } else {
-    size_t outputIndicesCount = indicesCount + skirtIndicesCount;
-    gsl::span<const uint16_t> indices(
+    const size_t outputIndicesCount = indicesCount + skirtIndicesCount;
+    const gsl::span<const uint16_t> indices(
         reinterpret_cast<const uint16_t*>(meshView->indicesBuffer.data()),
         indicesCount);
     if (vertexCount + skirtVertexCount < std::numeric_limits<uint16_t>::max()) {
@@ -981,7 +981,7 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
   pbr.metallicFactor = 0.0;
   pbr.roughnessFactor = 1.0;
 
-  size_t meshId = model.meshes.size();
+  const size_t meshId = model.meshes.size();
   model.meshes.emplace_back();
   CesiumGltf::Mesh& mesh = model.meshes[meshId];
   mesh.primitives.emplace_back();
@@ -991,12 +991,12 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
   primitive.material = 0;
 
   // add position buffer to gltf
-  size_t positionBufferId = model.buffers.size();
+  const size_t positionBufferId = model.buffers.size();
   model.buffers.emplace_back();
   CesiumGltf::Buffer& positionBuffer = model.buffers[positionBufferId];
   positionBuffer.cesium.data = std::move(outputPositionsBuffer);
 
-  size_t positionBufferViewId = model.bufferViews.size();
+  const size_t positionBufferViewId = model.bufferViews.size();
   model.bufferViews.emplace_back();
   CesiumGltf::BufferView& positionBufferView =
       model.bufferViews[positionBufferViewId];
@@ -1006,7 +1006,7 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
   positionBufferView.byteLength = int64_t(positionBuffer.cesium.data.size());
   positionBufferView.target = CesiumGltf::BufferView::Target::ARRAY_BUFFER;
 
-  size_t positionAccessorId = model.accessors.size();
+  const size_t positionAccessorId = model.accessors.size();
   model.accessors.emplace_back();
   CesiumGltf::Accessor& positionAccessor = model.accessors[positionAccessorId];
   positionAccessor.bufferView = static_cast<int>(positionBufferViewId);
@@ -1021,12 +1021,12 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
 
   // add normal buffer to gltf if there are any
   if (!outputNormalsBuffer.empty()) {
-    size_t normalBufferId = model.buffers.size();
+    const size_t normalBufferId = model.buffers.size();
     model.buffers.emplace_back();
     CesiumGltf::Buffer& normalBuffer = model.buffers[normalBufferId];
     normalBuffer.cesium.data = std::move(outputNormalsBuffer);
 
-    size_t normalBufferViewId = model.bufferViews.size();
+    const size_t normalBufferViewId = model.bufferViews.size();
     model.bufferViews.emplace_back();
     CesiumGltf::BufferView& normalBufferView =
         model.bufferViews[normalBufferViewId];
@@ -1036,7 +1036,7 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
     normalBufferView.byteLength = int64_t(normalBuffer.cesium.data.size());
     normalBufferView.target = CesiumGltf::BufferView::Target::ARRAY_BUFFER;
 
-    size_t normalAccessorId = model.accessors.size();
+    const size_t normalAccessorId = model.accessors.size();
     model.accessors.emplace_back();
     CesiumGltf::Accessor& normalAccessor = model.accessors[normalAccessorId];
     normalAccessor.bufferView = int32_t(normalBufferViewId);
@@ -1049,12 +1049,12 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
   }
 
   // add indices buffer to gltf
-  size_t indicesBufferId = model.buffers.size();
+  const size_t indicesBufferId = model.buffers.size();
   model.buffers.emplace_back();
   CesiumGltf::Buffer& indicesBuffer = model.buffers[indicesBufferId];
   indicesBuffer.cesium.data = std::move(outputIndicesBuffer);
 
-  size_t indicesBufferViewId = model.bufferViews.size();
+  const size_t indicesBufferViewId = model.bufferViews.size();
   model.bufferViews.emplace_back();
   CesiumGltf::BufferView& indicesBufferView =
       model.bufferViews[indicesBufferViewId];
@@ -1064,7 +1064,7 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
   indicesBufferView.byteStride = indexSizeBytes;
   indicesBufferView.target = CesiumGltf::BufferView::Target::ARRAY_BUFFER;
 
-  size_t indicesAccessorId = model.accessors.size();
+  const size_t indicesAccessorId = model.accessors.size();
   model.accessors.emplace_back();
   CesiumGltf::Accessor& indicesAccessor = model.accessors[indicesAccessorId];
   indicesAccessor.bufferView = int32_t(indicesBufferViewId);
@@ -1103,7 +1103,7 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
   if (!meshView->onlyWater && !meshView->onlyLand) {
 
     // create source image
-    size_t waterMaskImageId = model.images.size();
+    const size_t waterMaskImageId = model.images.size();
     model.images.emplace_back();
     CesiumGltf::Image& waterMaskImage = model.images[waterMaskImageId];
     waterMaskImage.cesium.width = 256;
@@ -1117,7 +1117,7 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
         65536);
 
     // create sampler parameters
-    size_t waterMaskSamplerId = model.samplers.size();
+    const size_t waterMaskSamplerId = model.samplers.size();
     model.samplers.emplace_back();
     CesiumGltf::Sampler& waterMaskSampler = model.samplers[waterMaskSamplerId];
     waterMaskSampler.magFilter = CesiumGltf::Sampler::MagFilter::LINEAR;
@@ -1127,7 +1127,7 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
     waterMaskSampler.wrapT = CesiumGltf::Sampler::WrapT::CLAMP_TO_EDGE;
 
     // create texture
-    size_t waterMaskTextureId = model.textures.size();
+    const size_t waterMaskTextureId = model.textures.size();
     model.textures.emplace_back();
     CesiumGltf::Texture& waterMaskTexture = model.textures[waterMaskTextureId];
     waterMaskTexture.sampler = int32_t(waterMaskSamplerId);
@@ -1197,7 +1197,7 @@ static void processMetadata(
     return;
   }
 
-  auto availableIt = metadata.FindMember("available");
+  const auto availableIt = metadata.FindMember("available");
   if (availableIt == metadata.MemberEnd() || !availableIt->value.IsArray()) {
     return;
   }

--- a/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
+++ b/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
@@ -66,7 +66,7 @@ struct ExtensionHeader {
 enum class QuantizedMeshIndexType { UnsignedShort, UnsignedInt };
 
 struct QuantizedMeshView {
-  QuantizedMeshView()
+  QuantizedMeshView() noexcept
       : header{nullptr},
         indexType{QuantizedMeshIndexType::UnsignedShort},
         triangleCount{0},

--- a/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
+++ b/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
@@ -113,8 +113,8 @@ struct QuantizedMeshView {
 };
 
 // We can't use sizeof(QuantizedMeshHeader) because it may be padded.
-const size_t headerLength = 92;
-const size_t extensionHeaderLength = 5;
+constexpr size_t headerLength = 92;
+constexpr size_t extensionHeaderLength = 5;
 
 int32_t zigZagDecode(int32_t value) noexcept {
   return (value >> 1) ^ (-(value & 1));
@@ -149,7 +149,7 @@ static T readValue(
 }
 
 static glm::dvec3 octDecode(uint8_t x, uint8_t y) {
-  const uint8_t rangeMax = 255;
+  constexpr uint8_t rangeMax = 255;
 
   glm::dvec3 result;
 

--- a/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
+++ b/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
@@ -116,7 +116,9 @@ struct QuantizedMeshView {
 const size_t headerLength = 92;
 const size_t extensionHeaderLength = 5;
 
-int32_t zigZagDecode(int32_t value) { return (value >> 1) ^ (-(value & 1)); }
+int32_t zigZagDecode(int32_t value) noexcept {
+  return (value >> 1) ^ (-(value & 1));
+}
 
 template <class E, class D>
 void decodeIndices(const gsl::span<const E>& encoded, gsl::span<D>& decoded) {
@@ -139,7 +141,7 @@ template <class T>
 static T readValue(
     const gsl::span<const std::byte>& data,
     size_t offset,
-    T defaultValue) {
+    T defaultValue) noexcept {
   if (offset + sizeof(T) <= data.size()) {
     return *reinterpret_cast<const T*>(data.data() + offset);
   }
@@ -494,7 +496,7 @@ static void addSkirts(
       westEdgeIndices.end(),
       sortEdgeIndices.begin(),
       sortEdgeIndices.begin() + westVertexCount,
-      [&uvsAndHeights](auto lhs, auto rhs) {
+      [&uvsAndHeights](auto lhs, auto rhs) noexcept {
         return uvsAndHeights[lhs].y < uvsAndHeights[rhs].y;
       });
   westEdgeIndices = gsl::span(sortEdgeIndices.data(), westVertexCount);
@@ -525,7 +527,7 @@ static void addSkirts(
       southEdgeIndices.end(),
       sortEdgeIndices.begin(),
       sortEdgeIndices.begin() + southVertexCount,
-      [&uvsAndHeights](auto lhs, auto rhs) {
+      [&uvsAndHeights](auto lhs, auto rhs) noexcept {
         return uvsAndHeights[lhs].x > uvsAndHeights[rhs].x;
       });
   southEdgeIndices = gsl::span(sortEdgeIndices.data(), southVertexCount);
@@ -556,7 +558,7 @@ static void addSkirts(
       eastEdgeIndices.end(),
       sortEdgeIndices.begin(),
       sortEdgeIndices.begin() + eastVertexCount,
-      [&uvsAndHeights](auto lhs, auto rhs) {
+      [&uvsAndHeights](auto lhs, auto rhs) noexcept {
         return uvsAndHeights[lhs].y > uvsAndHeights[rhs].y;
       });
   eastEdgeIndices = gsl::span(sortEdgeIndices.data(), eastVertexCount);
@@ -587,7 +589,7 @@ static void addSkirts(
       northEdgeIndices.end(),
       sortEdgeIndices.begin(),
       sortEdgeIndices.begin() + northVertexCount,
-      [&uvsAndHeights](auto lhs, auto rhs) {
+      [&uvsAndHeights](auto lhs, auto rhs) noexcept {
         return uvsAndHeights[lhs].x < uvsAndHeights[rhs].x;
       });
   northEdgeIndices = gsl::span(sortEdgeIndices.data(), northVertexCount);

--- a/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
+++ b/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
@@ -379,7 +379,7 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
 
 static double calculateSkirtHeight(
     const CesiumGeospatial::Ellipsoid& ellipsoid,
-    const CesiumGeospatial::GlobeRectangle& rectangle) {
+    const CesiumGeospatial::GlobeRectangle& rectangle) noexcept {
   const double levelMaximumGeometricError =
       calcQuadtreeMaxGeometricError(ellipsoid) * rectangle.computeWidth();
   return levelMaximumGeometricError * 5.0;

--- a/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
+++ b/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
@@ -793,7 +793,8 @@ QuantizedMeshContent::load(const TileContentLoadInput& input) {
 
     const double longitude = Math::lerp(west, east, uRatio);
     const double latitude = Math::lerp(south, north, vRatio);
-    const double heightMeters = Math::lerp(minimumHeight, maximumHeight, heightRatio);
+    const double heightMeters =
+        Math::lerp(minimumHeight, maximumHeight, heightRatio);
 
     glm::dvec3 position = ellipsoid.cartographicToCartesian(
         Cartographic(longitude, latitude, heightMeters));

--- a/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
+++ b/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
@@ -121,7 +121,7 @@ int32_t zigZagDecode(int32_t value) noexcept {
 }
 
 template <class E, class D>
-void decodeIndices(const gsl::span<const E>& encoded, gsl::span<D>& decoded) {
+void decodeIndices(const gsl::span<const E>& encoded, const gsl::span<D>& decoded) {
   if (decoded.size() < encoded.size()) {
     throw std::runtime_error("decoded buffer is too small.");
   }
@@ -399,9 +399,9 @@ static void addSkirt(
     double latitudeOffset,
     const std::vector<glm::dvec3>& uvsAndHeights,
     const gsl::span<const E>& edgeIndices,
-    gsl::span<float>& positions,
-    gsl::span<float>& normals,
-    gsl::span<I>& indices) {
+    const gsl::span<float>& positions,
+    const gsl::span<float>& normals,
+    const gsl::span<I>& indices) {
   const double west = rectangle.getWest();
   const double south = rectangle.getSouth();
   const double east = rectangle.getEast();
@@ -468,9 +468,9 @@ static void addSkirts(
     const gsl::span<const std::byte>& southEdgeIndicesBuffer,
     const gsl::span<const std::byte>& eastEdgeIndicesBuffer,
     const gsl::span<const std::byte>& northEdgeIndicesBuffer,
-    gsl::span<float>& outputPositions,
-    gsl::span<float>& outputNormals,
-    gsl::span<I>& outputIndices) {
+    const gsl::span<float>& outputPositions,
+    const gsl::span<float>& outputNormals,
+    const gsl::span<I>& outputIndices) {
   const uint32_t westVertexCount =
       static_cast<uint32_t>(westEdgeIndicesBuffer.size() / sizeof(E));
   const uint32_t southVertexCount =
@@ -613,7 +613,7 @@ static void addSkirts(
 
 static void decodeNormals(
     const gsl::span<const std::byte>& encoded,
-    gsl::span<float>& decoded) {
+    const gsl::span<float>& decoded) {
   if (decoded.size() < encoded.size()) {
     throw std::runtime_error("decoded buffer is too small.");
   }

--- a/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
+++ b/Cesium3DTilesSelection/src/QuantizedMeshContent.cpp
@@ -121,7 +121,9 @@ int32_t zigZagDecode(int32_t value) noexcept {
 }
 
 template <class E, class D>
-void decodeIndices(const gsl::span<const E>& encoded, const gsl::span<D>& decoded) {
+void decodeIndices(
+    const gsl::span<const E>& encoded,
+    const gsl::span<D>& decoded) {
   if (decoded.size() < encoded.size()) {
     throw std::runtime_error("decoded buffer is too small.");
   }

--- a/Cesium3DTilesSelection/src/RasterMappedTo3DTile.cpp
+++ b/Cesium3DTilesSelection/src/RasterMappedTo3DTile.cpp
@@ -86,7 +86,7 @@ RasterMappedTo3DTile::update(Tile& tile) {
       this->_pLoadingTile->getState() >= RasterOverlayTile::LoadState::Loaded) {
     // Unattach the old tile
     if (this->_pReadyTile && this->getState() != AttachmentState::Unattached) {
-      TilesetExternals& externals = tile.getTileset()->getExternals();
+      const TilesetExternals& externals = tile.getTileset()->getExternals();
       externals.pPrepareRendererResources->detachRasterInMainThread(
           tile,
           this->getTextureCoordinateID(),
@@ -121,7 +121,7 @@ RasterMappedTo3DTile::update(Tile& tile) {
         pCandidate->getState() >= RasterOverlayTile::LoadState::Loaded &&
         this->_pReadyTile != pCandidate) {
       if (this->getState() != AttachmentState::Unattached) {
-        TilesetExternals& externals = tile.getTileset()->getExternals();
+        const TilesetExternals& externals = tile.getTileset()->getExternals();
         externals.pPrepareRendererResources->detachRasterInMainThread(
             tile,
             this->getTextureCoordinateID(),
@@ -142,7 +142,7 @@ RasterMappedTo3DTile::update(Tile& tile) {
       this->getState() == RasterMappedTo3DTile::AttachmentState::Unattached) {
     this->_pReadyTile->loadInMainThread();
 
-    TilesetExternals& externals = tile.getTileset()->getExternals();
+    const TilesetExternals& externals = tile.getTileset()->getExternals();
     externals.pPrepareRendererResources->attachRasterInMainThread(
         tile,
         this->getTextureCoordinateID(),
@@ -177,7 +177,7 @@ void RasterMappedTo3DTile::detachFromTile(Tile& tile) noexcept {
     return;
   }
 
-  TilesetExternals& externals = tile.getTileset()->getExternals();
+  const TilesetExternals& externals = tile.getTileset()->getExternals();
   externals.pPrepareRendererResources->detachRasterInMainThread(
       tile,
       this->getTextureCoordinateID(),
@@ -198,18 +198,18 @@ void RasterMappedTo3DTile::computeTranslationAndScale(Tile& tile) {
     return;
   }
 
-  RasterOverlayTileProvider& tileProvider =
+  const RasterOverlayTileProvider& tileProvider =
       *this->_pReadyTile->getOverlay().getTileProvider();
-  CesiumGeometry::Rectangle geometryRectangle =
+  const CesiumGeometry::Rectangle geometryRectangle =
       projectRectangleSimple(tileProvider.getProjection(), *pRectangle);
-  CesiumGeometry::Rectangle imageryRectangle =
+  const CesiumGeometry::Rectangle imageryRectangle =
       this->_pReadyTile->getRectangle();
 
-  double terrainWidth = geometryRectangle.computeWidth();
-  double terrainHeight = geometryRectangle.computeHeight();
+  const double terrainWidth = geometryRectangle.computeWidth();
+  const double terrainHeight = geometryRectangle.computeHeight();
 
-  double scaleX = terrainWidth / imageryRectangle.computeWidth();
-  double scaleY = terrainHeight / imageryRectangle.computeHeight();
+  const double scaleX = terrainWidth / imageryRectangle.computeWidth();
+  const double scaleY = terrainHeight / imageryRectangle.computeHeight();
   this->_translation = glm::dvec2(
       (scaleX * (geometryRectangle.minimumX - imageryRectangle.minimumX)) /
           terrainWidth,

--- a/Cesium3DTilesSelection/src/RasterMappedTo3DTile.cpp
+++ b/Cesium3DTilesSelection/src/RasterMappedTo3DTile.cpp
@@ -187,7 +187,7 @@ void RasterMappedTo3DTile::detachFromTile(Tile& tile) noexcept {
   this->_state = AttachmentState::Unattached;
 }
 
-void RasterMappedTo3DTile::computeTranslationAndScale(Tile& tile) {
+void RasterMappedTo3DTile::computeTranslationAndScale(const Tile& tile) {
   if (!this->_pReadyTile) {
     return;
   }

--- a/Cesium3DTilesSelection/src/RasterMappedTo3DTile.cpp
+++ b/Cesium3DTilesSelection/src/RasterMappedTo3DTile.cpp
@@ -18,7 +18,7 @@ RasterOverlayTile* findTileOverlay(Tile& tile, const RasterOverlay& overlay) {
   auto parentTileIt = std::find_if(
       tiles.begin(),
       tiles.end(),
-      [&overlay](RasterMappedTo3DTile& raster) {
+      [&overlay](RasterMappedTo3DTile& raster) noexcept {
         return raster.getReadyTile() &&
                &raster.getReadyTile()->getOverlay() == &overlay;
       });

--- a/Cesium3DTilesSelection/src/RasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlay.cpp
@@ -84,7 +84,7 @@ void RasterOverlay::loadTileProvider(
           this)
       .thenInMainThread(
           [this](
-              std::unique_ptr<RasterOverlayTileProvider> pProvider) noexcept {
+              std::unique_ptr<RasterOverlayTileProvider>&& pProvider) noexcept {
             this->_pTileProvider = std::move(pProvider);
             this->_isLoadingTileProvider = false;
             CESIUM_TRACE_END_IN_TRACK("createTileProvider");

--- a/Cesium3DTilesSelection/src/RasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlay.cpp
@@ -83,7 +83,8 @@ void RasterOverlay::loadTileProvider(
           pLogger,
           this)
       .thenInMainThread(
-          [this](std::unique_ptr<RasterOverlayTileProvider> pProvider) {
+          [this](
+              std::unique_ptr<RasterOverlayTileProvider> pProvider) noexcept {
             this->_pTileProvider = std::move(pProvider);
             this->_isLoadingTileProvider = false;
             CESIUM_TRACE_END_IN_TRACK("createTileProvider");

--- a/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
@@ -42,13 +42,14 @@ void RasterOverlayCollection::add(std::unique_ptr<RasterOverlay>&& pOverlay) {
 
 void RasterOverlayCollection::remove(RasterOverlay* pOverlay) noexcept {
   // Remove all mappings of this overlay to geometry tiles.
-  auto removeCondition = [pOverlay](const RasterMappedTo3DTile& mapped) {
-    return (
-        (mapped.getLoadingTile() &&
-         &mapped.getLoadingTile()->getOverlay() == pOverlay) ||
-        (mapped.getReadyTile() &&
-         &mapped.getReadyTile()->getOverlay() == pOverlay));
-  };
+  auto removeCondition =
+      [pOverlay](const RasterMappedTo3DTile& mapped) noexcept {
+        return (
+            (mapped.getLoadingTile() &&
+             &mapped.getLoadingTile()->getOverlay() == pOverlay) ||
+            (mapped.getReadyTile() &&
+             &mapped.getReadyTile()->getOverlay() == pOverlay));
+      };
 
   this->_pTileset->forEachLoadedTile([&removeCondition](Tile& tile) {
     std::vector<RasterMappedTo3DTile>& mapped = tile.getMappedRasterTiles();
@@ -67,7 +68,7 @@ void RasterOverlayCollection::remove(RasterOverlay* pOverlay) noexcept {
   auto it = std::find_if(
       this->_overlays.begin(),
       this->_overlays.end(),
-      [pOverlay](std::unique_ptr<RasterOverlay>& pCheck) {
+      [pOverlay](std::unique_ptr<RasterOverlay>& pCheck) noexcept {
         return pCheck.get() == pOverlay;
       });
   if (it == this->_overlays.end()) {

--- a/Cesium3DTilesSelection/src/RasterOverlayTile.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayTile.cpp
@@ -22,10 +22,10 @@ RasterOverlayTile::RasterOverlayTile(RasterOverlay& overlay) noexcept
       _references(0),
       _moreDetailAvailable(MoreDetailAvailable::Unknown) {}
 
-RasterOverlayTile::RasterOverlayTile(
+RasterOverlayTile::RasterOverlayTile (
     RasterOverlay& overlay,
     double targetGeometricError,
-    const CesiumGeometry::Rectangle& rectangle)
+    const CesiumGeometry::Rectangle& rectangle) noexcept
     : _pOverlay(&overlay),
       _targetGeometricError(targetGeometricError),
       _rectangle(rectangle),
@@ -88,7 +88,7 @@ void RasterOverlayTile::releaseReference() noexcept {
   }
 }
 
-void RasterOverlayTile::setState(LoadState newState) {
+void RasterOverlayTile::setState(LoadState newState) noexcept {
   this->_state = newState;
 }
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/RasterOverlayTile.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayTile.cpp
@@ -80,7 +80,7 @@ void RasterOverlayTile::addReference() noexcept { ++this->_references; }
 
 void RasterOverlayTile::releaseReference() noexcept {
   assert(this->_references > 0);
-  uint32_t references = --this->_references;
+  const uint32_t references = --this->_references;
   if (references == 0) {
     assert(this->_pOverlay != nullptr);
     assert(this->_pOverlay->getTileProvider() != nullptr);

--- a/Cesium3DTilesSelection/src/RasterOverlayTile.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayTile.cpp
@@ -22,7 +22,7 @@ RasterOverlayTile::RasterOverlayTile(RasterOverlay& overlay) noexcept
       _references(0),
       _moreDetailAvailable(MoreDetailAvailable::Unknown) {}
 
-RasterOverlayTile::RasterOverlayTile (
+RasterOverlayTile::RasterOverlayTile(
     RasterOverlay& overlay,
     double targetGeometricError,
     const CesiumGeometry::Rectangle& rectangle) noexcept

--- a/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
@@ -301,7 +301,7 @@ void RasterOverlayTileProvider::doLoad(
                 pLogger,
                 std::move(loadedImage));
           })
-      .thenInMainThread([this, &tile, isThrottledLoad](LoadResult&& result) {
+      .thenInMainThread([this, &tile, isThrottledLoad](LoadResult&& result) noexcept {
         tile._rectangle = result.rectangle;
         tile._pRendererResources = result.pRendererResources;
         tile._image = std::move(result.image);

--- a/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
@@ -301,21 +301,22 @@ void RasterOverlayTileProvider::doLoad(
                 pLogger,
                 std::move(loadedImage));
           })
-      .thenInMainThread([this, &tile, isThrottledLoad](LoadResult&& result) noexcept {
-        tile._rectangle = result.rectangle;
-        tile._pRendererResources = result.pRendererResources;
-        tile._image = std::move(result.image);
-        tile._tileCredits = std::move(result.credits);
-        tile._moreDetailAvailable =
-            result.moreDetailAvailable
-                ? RasterOverlayTile::MoreDetailAvailable::Yes
-                : RasterOverlayTile::MoreDetailAvailable::No;
-        tile.setState(result.state);
+      .thenInMainThread(
+          [this, &tile, isThrottledLoad](LoadResult&& result) noexcept {
+            tile._rectangle = result.rectangle;
+            tile._pRendererResources = result.pRendererResources;
+            tile._image = std::move(result.image);
+            tile._tileCredits = std::move(result.credits);
+            tile._moreDetailAvailable =
+                result.moreDetailAvailable
+                    ? RasterOverlayTile::MoreDetailAvailable::Yes
+                    : RasterOverlayTile::MoreDetailAvailable::No;
+            tile.setState(result.state);
 
-        this->_tileDataBytes += int64_t(tile.getImage().pixelData.size());
+            this->_tileDataBytes += int64_t(tile.getImage().pixelData.size());
 
-        this->finalizeTileLoad(tile, isThrottledLoad);
-      })
+            this->finalizeTileLoad(tile, isThrottledLoad);
+          })
       .catchInMainThread([this, &tile, isThrottledLoad](
                              const std::exception& /*e*/) {
         tile._pRendererResources = nullptr;

--- a/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
@@ -164,7 +164,7 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
                   options.moreDetailAvailable};
             }
 
-            gsl::span<const std::byte> data = pResponse->data();
+            const gsl::span<const std::byte> data = pResponse->data();
 
             CesiumGltf::ImageReaderResult loadedImage =
                 RasterOverlayTileProvider::_gltfReader.readImage(data);
@@ -244,8 +244,8 @@ static LoadResult createLoadResultFromLoadedImage(
 
   CesiumGltf::ImageCesium& image = loadedImage.image.value();
 
-  int32_t bytesPerPixel = image.channels * image.bytesPerChannel;
-  int64_t requiredBytes =
+  const int32_t bytesPerPixel = image.channels * image.bytesPerChannel;
+  const int64_t requiredBytes =
       static_cast<int64_t>(image.width) * image.height * bytesPerPixel;
   if (image.width > 0 && image.height > 0 &&
       image.pixelData.size() >= static_cast<size_t>(requiredBytes)) {

--- a/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
@@ -330,7 +330,7 @@ void RasterOverlayTileProvider::doLoad(
 
 void RasterOverlayTileProvider::beginTileLoad(
     RasterOverlayTile& tile,
-    bool isThrottledLoad) {
+    bool isThrottledLoad) noexcept {
   // Keep this tile from being destroyed while it's loading.
   tile.addReference();
 
@@ -342,7 +342,7 @@ void RasterOverlayTileProvider::beginTileLoad(
 
 void RasterOverlayTileProvider::finalizeTileLoad(
     RasterOverlayTile& tile,
-    bool isThrottledLoad) {
+    bool isThrottledLoad) noexcept {
   --this->_totalTilesCurrentlyLoading;
   if (isThrottledLoad) {
     --this->_throttledTilesCurrentlyLoading;

--- a/Cesium3DTilesSelection/src/RasterizedPolygonsOverlay.cpp
+++ b/Cesium3DTilesSelection/src/RasterizedPolygonsOverlay.cpp
@@ -86,7 +86,11 @@ void rasterizePolygons(
       const double maxX = glm::max(a.x, glm::max(b.x, c.x));
       const double maxY = glm::max(a.y, glm::max(b.y, c.y));
 
-      const CesiumGeospatial::GlobeRectangle triangleBounds(minX, minY, maxX, maxY);
+      const CesiumGeospatial::GlobeRectangle triangleBounds(
+          minX,
+          minY,
+          maxX,
+          maxY);
 
       // skip this triangle if it is entirely outside the tile bounds
       if (!rectangle.computeIntersection(triangleBounds)) {
@@ -101,8 +105,9 @@ void rasterizePolygons(
       const glm::dvec2 ca_perp(-ca.y, ca.x);
 
       for (size_t j = 0; j < 256; ++j) {
-        const double pixelY = rectangle.getSouth() +
-                        rectangleHeight * (1.0 - (double(j) + 0.5) / 256.0);
+        const double pixelY =
+            rectangle.getSouth() +
+            rectangleHeight * (1.0 - (double(j) + 0.5) / 256.0);
         for (size_t i = 0; i < 256; ++i) {
           const double pixelX =
               rectangle.getWest() + rectangleWidth * (double(i) + 0.5) / 256.0;

--- a/Cesium3DTilesSelection/src/RasterizedPolygonsOverlay.cpp
+++ b/Cesium3DTilesSelection/src/RasterizedPolygonsOverlay.cpp
@@ -58,8 +58,8 @@ void rasterizePolygons(
     return;
   }
 
-  double rectangleWidth = rectangle.computeWidth();
-  double rectangleHeight = rectangle.computeHeight();
+  const double rectangleWidth = rectangle.computeWidth();
+  const double rectangleHeight = rectangle.computeHeight();
 
   // create source image
   image.width = 256;
@@ -81,39 +81,39 @@ void rasterizePolygons(
       const glm::dvec2& c = vertices[indices[3 * triangle + 2]];
 
       // TODO: deal with the corner cases here
-      double minX = glm::min(a.x, glm::min(b.x, c.x));
-      double minY = glm::min(a.y, glm::min(b.y, c.y));
-      double maxX = glm::max(a.x, glm::max(b.x, c.x));
-      double maxY = glm::max(a.y, glm::max(b.y, c.y));
+      const double minX = glm::min(a.x, glm::min(b.x, c.x));
+      const double minY = glm::min(a.y, glm::min(b.y, c.y));
+      const double maxX = glm::max(a.x, glm::max(b.x, c.x));
+      const double maxY = glm::max(a.y, glm::max(b.y, c.y));
 
-      CesiumGeospatial::GlobeRectangle triangleBounds(minX, minY, maxX, maxY);
+      const CesiumGeospatial::GlobeRectangle triangleBounds(minX, minY, maxX, maxY);
 
       // skip this triangle if it is entirely outside the tile bounds
       if (!rectangle.computeIntersection(triangleBounds)) {
         continue;
       }
 
-      glm::dvec2 ab = b - a;
-      glm::dvec2 ab_perp(-ab.y, ab.x);
-      glm::dvec2 bc = c - b;
-      glm::dvec2 bc_perp(-bc.y, bc.x);
-      glm::dvec2 ca = a - c;
-      glm::dvec2 ca_perp(-ca.y, ca.x);
+      const glm::dvec2 ab = b - a;
+      const glm::dvec2 ab_perp(-ab.y, ab.x);
+      const glm::dvec2 bc = c - b;
+      const glm::dvec2 bc_perp(-bc.y, bc.x);
+      const glm::dvec2 ca = a - c;
+      const glm::dvec2 ca_perp(-ca.y, ca.x);
 
       for (size_t j = 0; j < 256; ++j) {
-        double pixelY = rectangle.getSouth() +
+        const double pixelY = rectangle.getSouth() +
                         rectangleHeight * (1.0 - (double(j) + 0.5) / 256.0);
         for (size_t i = 0; i < 256; ++i) {
-          double pixelX =
+          const double pixelX =
               rectangle.getWest() + rectangleWidth * (double(i) + 0.5) / 256.0;
-          glm::dvec2 v(pixelX, pixelY);
+          const glm::dvec2 v(pixelX, pixelY);
 
-          glm::dvec2 av = v - a;
-          glm::dvec2 cv = v - c;
+          const glm::dvec2 av = v - a;
+          const glm::dvec2 cv = v - c;
 
-          double v_proj_ab_perp = glm::dot(av, ab_perp);
-          double v_proj_bc_perp = glm::dot(cv, bc_perp);
-          double v_proj_ca_perp = glm::dot(cv, ca_perp);
+          const double v_proj_ab_perp = glm::dot(av, ab_perp);
+          const double v_proj_bc_perp = glm::dot(cv, bc_perp);
+          const double v_proj_ca_perp = glm::dot(cv, ca_perp);
 
           // will determine in or out, irrespective of winding
           if ((v_proj_ab_perp >= 0.0 && v_proj_ca_perp >= 0.0 &&
@@ -161,7 +161,7 @@ public:
         [&polygons = this->_polygons,
          projection = this->getProjection(),
          rectangle = overlayTile.getRectangle()]() -> LoadedRasterOverlayImage {
-          CesiumGeospatial::GlobeRectangle tileRectangle =
+          const CesiumGeospatial::GlobeRectangle tileRectangle =
               CesiumGeospatial::unprojectRectangleSimple(projection, rectangle);
 
           LoadedRasterOverlayImage resultImage;

--- a/Cesium3DTilesSelection/src/RasterizedPolygonsTileExcluder.cpp
+++ b/Cesium3DTilesSelection/src/RasterizedPolygonsTileExcluder.cpp
@@ -9,7 +9,8 @@ RasterizedPolygonsTileExcluder::RasterizedPolygonsTileExcluder(
     const RasterizedPolygonsOverlay& overlay) noexcept
     : _pOverlay(&overlay) {}
 
-bool RasterizedPolygonsTileExcluder::shouldExclude(const Tile& tile) const {
+bool RasterizedPolygonsTileExcluder::shouldExclude(
+    const Tile& tile) const noexcept {
   return Cesium3DTilesSelection::Impl::withinPolygons(
       tile.getBoundingVolume(),
       this->_pOverlay->getPolygons());

--- a/Cesium3DTilesSelection/src/RasterizedPolygonsTileExcluder.cpp
+++ b/Cesium3DTilesSelection/src/RasterizedPolygonsTileExcluder.cpp
@@ -6,7 +6,7 @@
 using namespace Cesium3DTilesSelection;
 
 RasterizedPolygonsTileExcluder::RasterizedPolygonsTileExcluder(
-    const RasterizedPolygonsOverlay& overlay)
+    const RasterizedPolygonsOverlay& overlay) noexcept
     : _pOverlay(&overlay) {}
 
 bool RasterizedPolygonsTileExcluder::shouldExclude(const Tile& tile) const {

--- a/Cesium3DTilesSelection/src/SkirtMeshMetadata.cpp
+++ b/Cesium3DTilesSelection/src/SkirtMeshMetadata.cpp
@@ -26,9 +26,9 @@ SkirtMeshMetadata::parseFromGltfExtras(const JsonValue::Object& extras) {
     return std::nullopt;
   }
 
-  double noSkirtIndicesBegin =
+  const double noSkirtIndicesBegin =
       (*pNoSkirtRange)[0].getSafeNumberOrDefault<double>(-1.0);
-  double noSkirtIndicesCount =
+  const double noSkirtIndicesCount =
       (*pNoSkirtRange)[1].getSafeNumberOrDefault<double>(-1.0);
 
   if (noSkirtIndicesBegin < 0.0 || noSkirtIndicesCount < 0.0) {

--- a/Cesium3DTilesSelection/src/SkirtMeshMetadata.h
+++ b/Cesium3DTilesSelection/src/SkirtMeshMetadata.h
@@ -4,7 +4,7 @@
 
 namespace Cesium3DTilesSelection {
 struct SkirtMeshMetadata {
-  SkirtMeshMetadata()
+  SkirtMeshMetadata() noexcept
       : noSkirtIndicesBegin{0},
         noSkirtIndicesCount{0},
         meshCenter{0.0, 0.0, 0.0},

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -110,7 +110,7 @@ bool Tile::isRenderable() const noexcept {
       return std::all_of(
           this->_rasterTiles.begin(),
           this->_rasterTiles.end(),
-          [](const RasterMappedTo3DTile& rasterTile) {
+          [](const RasterMappedTo3DTile& rasterTile) noexcept {
             return rasterTile.getReadyTile() != nullptr;
           });
     }
@@ -355,7 +355,7 @@ void Tile::loadContent() {
 
             return result;
           })
-      .thenInMainThread([this](LoadResult&& loadResult) {
+      .thenInMainThread([this](LoadResult&& loadResult) noexcept {
         this->_pContent = std::move(loadResult.pContent);
         this->_pRendererResources = loadResult.pRendererResources;
         this->getTileset()->notifyTileDoneLoading(this);
@@ -888,13 +888,13 @@ void Tile::upsampleParent(
             std::move(pContent),
             pRendererResources};
       })
-      .thenInMainThread([this](LoadResult&& loadResult) {
+      .thenInMainThread([this](LoadResult&& loadResult) noexcept {
         this->_pContent = std::move(loadResult.pContent);
         this->_pRendererResources = loadResult.pRendererResources;
         this->getTileset()->notifyTileDoneLoading(this);
         this->setState(loadResult.state);
       })
-      .catchInMainThread([this](const std::exception& /*e*/) {
+      .catchInMainThread([this](const std::exception& /*e*/) noexcept {
         this->_pContent.reset();
         this->_pRendererResources = nullptr;
         this->getTileset()->notifyTileDoneLoading(this);

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -321,7 +321,7 @@ void Tile::loadContent() {
                 // arbitrary information to the consumer, so the up-axis
                 // is stored here:
                 model.extras["gltfUpAxis"] =
-                    static_cast<std::underlying_type<Axis>::type>(gltfUpAxis);
+                    static_cast<std::underlying_type_t<Axis>>(gltfUpAxis);
 
                 const BoundingVolume& boundingVolume =
                     loadInput.tileBoundingVolume;

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -830,7 +830,7 @@ Tile::generateTextureCoordinates(
 }
 
 void Tile::upsampleParent(
-    std::vector<CesiumGeospatial::Projection>&& projections) {
+    const std::vector<CesiumGeospatial::Projection>&& projections) {
   Tile* pParent = this->getParent();
   const UpsampledQuadtreeNode* pSubdividedParentID =
       std::get_if<UpsampledQuadtreeNode>(&this->getTileID());

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -856,7 +856,7 @@ Tile::generateTextureCoordinates(
 }
 
 void Tile::upsampleParent(
-    const std::vector<CesiumGeospatial::Projection>&& projections) {
+    std::vector<CesiumGeospatial::Projection>&& projections) {
   Tile* pParent = this->getParent();
   const UpsampledQuadtreeNode* pSubdividedParentID =
       std::get_if<UpsampledQuadtreeNode>(&this->getTileID());

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -320,7 +320,7 @@ void Tile::loadContent() {
                 // TODO The `extras` are currently the only way to pass
                 // arbitrary information to the consumer, so the up-axis
                 // is stored here:
-                model.extras["gltfUpAxis"] = gltfUpAxis;
+                model.extras["gltfUpAxis"] = static_cast<std::underlying_type<Axis>::type>(gltfUpAxis);
 
                 const BoundingVolume& boundingVolume =
                     loadInput.tileBoundingVolume;

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -253,9 +253,9 @@ void Tile::loadContent() {
   this->loadOverlays(projections);
 
   struct LoadResult {
-    LoadState state;
-    std::unique_ptr<TileContentLoadResult> pContent;
-    void* pRendererResources;
+    LoadState state = LoadState::Unloaded;
+    std::unique_ptr<TileContentLoadResult> pContent = nullptr;
+    void* pRendererResources = nullptr;
   };
   TileContentLoadInput loadInput(tileset.getExternals().pLogger, *this);
 

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -573,7 +573,8 @@ void Tile::update(
   if (this->getState() == LoadState::FailedTemporarily) {
     // Check with the TileContext to see if we should retry.
     if (this->_pContext->failedTileCallback) {
-      const FailedTileAction action = this->_pContext->failedTileCallback(*this);
+      const FailedTileAction action =
+          this->_pContext->failedTileCallback(*this);
       switch (action) {
       case FailedTileAction::GiveUp:
         this->setState(LoadState::Failed);

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -320,7 +320,8 @@ void Tile::loadContent() {
                 // TODO The `extras` are currently the only way to pass
                 // arbitrary information to the consumer, so the up-axis
                 // is stored here:
-                model.extras["gltfUpAxis"] = static_cast<std::underlying_type<Axis>::type>(gltfUpAxis);
+                model.extras["gltfUpAxis"] =
+                    static_cast<std::underlying_type<Axis>::type>(gltfUpAxis);
 
                 const BoundingVolume& boundingVolume =
                     loadInput.tileBoundingVolume;

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -157,7 +157,7 @@ void mapRasterOverlaysToTile(
     // TODO: we can compute a much more precise projected rectangle by
     //       projecting each vertex, but that would require us to have
     //       geometry first.
-    Rectangle overlayRectangle =
+    const Rectangle overlayRectangle =
         projectRectangleSimple(pProvider->getProjection(), *pRectangle);
 
     IntrusivePointer<RasterOverlayTile> pRaster =
@@ -171,7 +171,7 @@ void mapRasterOverlaysToTile(
       const CesiumGeospatial::Projection& projection =
           pRaster->getOverlay().getTileProvider()->getProjection();
 
-      int32_t projectionID =
+      const int32_t projectionID =
           getTextureCoordinatesForProjection(projections, projection);
 
       mappedTile.setTextureCoordinateID(projectionID);
@@ -502,22 +502,22 @@ static void createQuadtreeSubdividedChildren(Tile& parent) {
     return;
   }
 
-  QuadtreeTileID swID(
+  const QuadtreeTileID swID(
       pParentTileID->level + 1,
       pParentTileID->x * 2,
       pParentTileID->y * 2);
-  QuadtreeTileID seID(swID.level, swID.x + 1, swID.y);
-  QuadtreeTileID nwID(swID.level, swID.x, swID.y + 1);
-  QuadtreeTileID neID(swID.level, swID.x + 1, swID.y + 1);
+  const QuadtreeTileID seID(swID.level, swID.x + 1, swID.y);
+  const QuadtreeTileID nwID(swID.level, swID.x, swID.y + 1);
+  const QuadtreeTileID neID(swID.level, swID.x + 1, swID.y + 1);
 
-  QuadtreeTilingScheme& tilingScheme =
+  const QuadtreeTilingScheme& tilingScheme =
       parent.getContext()->implicitContext.value().tilingScheme;
-  Projection& projection =
+  const Projection& projection =
       parent.getContext()->implicitContext.value().projection;
 
   parent.createChildTiles(4);
 
-  gsl::span<Tile> children = parent.getChildren();
+  const gsl::span<Tile> children = parent.getChildren();
   Tile& sw = children[0];
   Tile& se = children[1];
   Tile& nw = children[2];
@@ -528,7 +528,7 @@ static void createQuadtreeSubdividedChildren(Tile& parent) {
   nw.setContext(parent.getContext());
   ne.setContext(parent.getContext());
 
-  double geometricError = parent.getGeometricError() * 0.5;
+  const double geometricError = parent.getGeometricError() * 0.5;
   sw.setGeometricError(geometricError);
   se.setGeometricError(geometricError);
   nw.setGeometricError(geometricError);
@@ -544,8 +544,8 @@ static void createQuadtreeSubdividedChildren(Tile& parent) {
   nw.setTileID(UpsampledQuadtreeNode{nwID});
   ne.setTileID(UpsampledQuadtreeNode{neID});
 
-  double minimumHeight = pRegion->getMinimumHeight();
-  double maximumHeight = pRegion->getMaximumHeight();
+  const double minimumHeight = pRegion->getMinimumHeight();
+  const double maximumHeight = pRegion->getMaximumHeight();
 
   sw.setBoundingVolume(BoundingRegionWithLooseFittingHeights(BoundingRegion(
       unprojectRectangleSimple(projection, tilingScheme.tileToRectangle(swID)),
@@ -573,7 +573,7 @@ void Tile::update(
   if (this->getState() == LoadState::FailedTemporarily) {
     // Check with the TileContext to see if we should retry.
     if (this->_pContext->failedTileCallback) {
-      FailedTileAction action = this->_pContext->failedTileCallback(*this);
+      const FailedTileAction action = this->_pContext->failedTileCallback(*this);
       switch (action) {
       case FailedTileAction::GiveUp:
         this->setState(LoadState::Failed);
@@ -663,21 +663,21 @@ void Tile::update(
     const CesiumGeometry::QuadtreeTileAvailability& availability =
         implicitContext.availability;
 
-    QuadtreeTileID id = std::get<QuadtreeTileID>(this->_id);
+    const QuadtreeTileID id = std::get<QuadtreeTileID>(this->_id);
 
-    QuadtreeTileID swID(id.level + 1, id.x * 2, id.y * 2);
-    uint32_t sw = availability.isTileAvailable(swID) ? 1 : 0;
+    const QuadtreeTileID swID(id.level + 1, id.x * 2, id.y * 2);
+    const uint32_t sw = availability.isTileAvailable(swID) ? 1 : 0;
 
-    QuadtreeTileID seID(swID.level, swID.x + 1, swID.y);
-    uint32_t se = availability.isTileAvailable(seID) ? 1 : 0;
+    const QuadtreeTileID seID(swID.level, swID.x + 1, swID.y);
+    const uint32_t se = availability.isTileAvailable(seID) ? 1 : 0;
 
-    QuadtreeTileID nwID(swID.level, swID.x, swID.y + 1);
-    uint32_t nw = availability.isTileAvailable(nwID) ? 1 : 0;
+    const QuadtreeTileID nwID(swID.level, swID.x, swID.y + 1);
+    const uint32_t nw = availability.isTileAvailable(nwID) ? 1 : 0;
 
-    QuadtreeTileID neID(swID.level, swID.x + 1, swID.y + 1);
-    uint32_t ne = availability.isTileAvailable(neID) ? 1 : 0;
+    const QuadtreeTileID neID(swID.level, swID.x + 1, swID.y + 1);
+    const uint32_t ne = availability.isTileAvailable(neID) ? 1 : 0;
 
-    size_t childCount = sw + se + nw + ne;
+    const size_t childCount = sw + se + nw + ne;
     if (childCount > 0) {
       // If any children are available, we need to create all four in order to
       // avoid holes. But non-available tiles will be upsampled instead of
@@ -722,7 +722,7 @@ void Tile::update(
                   i));
           --i;
 
-          Rectangle projectedRectangle =
+          const Rectangle projectedRectangle =
               projectRectangleSimple(pProvider->getProjection(), *pRectangle);
           CesiumUtility::IntrusivePointer<RasterOverlayTile> pTile =
               pProvider->getTile(projectedRectangle, this->getGeometricError());
@@ -732,7 +732,7 @@ void Tile::update(
         continue;
       }
 
-      RasterOverlayTile::MoreDetailAvailable moreDetailAvailable =
+      const RasterOverlayTile::MoreDetailAvailable moreDetailAvailable =
           mappedRasterTile.update(*this);
       moreRasterDetailAvailable |=
           moreDetailAvailable == RasterOverlayTile::MoreDetailAvailable::Yes;
@@ -769,7 +769,7 @@ int64_t Tile::computeByteSize() const noexcept {
     // the decoded image size instead.
     const std::vector<CesiumGltf::BufferView>& bufferViews = model.bufferViews;
     for (const CesiumGltf::Image& image : model.images) {
-      int32_t bufferView = image.bufferView;
+      const int32_t bufferView = image.bufferView;
       if (bufferView < 0 ||
           bufferView >= static_cast<int32_t>(bufferViews.size())) {
         continue;
@@ -803,9 +803,9 @@ Tile::generateTextureCoordinates(
       for (size_t i = 0; i < projections.size(); ++i) {
         const Projection& projection = projections[i];
 
-        int textureCoordinateID = static_cast<int32_t>(i);
+        const int textureCoordinateID = static_cast<int32_t>(i);
 
-        CesiumGeometry::Rectangle rectangle =
+        const CesiumGeometry::Rectangle rectangle =
             projectRectangleSimple(projection, *pRectangle);
 
         CesiumGeospatial::BoundingRegion boundingRegion =
@@ -910,7 +910,7 @@ void Tile::loadOverlays(
   Tileset* pTileset = this->getTileset();
 
   if (pTileset->supportsRasterOverlays()) {
-    RasterOverlayCollection& overlays = pTileset->getOverlays();
+    const RasterOverlayCollection& overlays = pTileset->getOverlays();
     mapRasterOverlaysToTile(*this, overlays, projections);
   }
 }

--- a/Cesium3DTilesSelection/src/TileContentFactory.cpp
+++ b/Cesium3DTilesSelection/src/TileContentFactory.cpp
@@ -52,7 +52,7 @@ TileContentFactory::createContent(const TileContentLoadInput& input) {
   // Determine if this is plausibly a JSON external tileset.
   size_t i;
   for (i = 0; i < data.size(); ++i) {
-    if (!std::isspace(static_cast<char>(data[i]))) {
+    if (!std::isspace(static_cast<unsigned char>(data[i]))) {
       break;
     }
   }

--- a/Cesium3DTilesSelection/src/TileContentFactory.cpp
+++ b/Cesium3DTilesSelection/src/TileContentFactory.cpp
@@ -25,7 +25,7 @@ void TileContentFactory::registerContentType(
       contentType.begin(),
       contentType.end(),
       std::back_inserter(lowercaseContentType),
-      [](char c) { return static_cast<char>(::tolower(c)); });
+      [](char c) noexcept { return static_cast<char>(::tolower(c)); });
   TileContentFactory::_loadersByContentType[lowercaseContentType] = pLoader;
 }
 

--- a/Cesium3DTilesSelection/src/TileContentFactory.cpp
+++ b/Cesium3DTilesSelection/src/TileContentFactory.cpp
@@ -86,7 +86,7 @@ TileContentFactory::createContent(const TileContentLoadInput& input) {
 std::optional<std::string>
 TileContentFactory::getMagic(const gsl::span<const std::byte>& data) {
   if (data.size() >= 4) {
-    gsl::span<const std::byte> magicData = data.subspan(0, 4);
+    const gsl::span<const std::byte> magicData = data.subspan(0, 4);
     return std::string(reinterpret_cast<const char*>(magicData.data()), 4);
   }
 

--- a/Cesium3DTilesSelection/src/TileMapServiceRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/TileMapServiceRasterOverlay.cpp
@@ -135,7 +135,7 @@ TileMapServiceRasterOverlay::createTileProvider(
 
   pOwner = pOwner ? pOwner : this;
 
-  std::optional<Credit> credit =
+  const std::optional<Credit> credit =
       this->_options.credit ? std::make_optional(pCreditSystem->createCredit(
                                   this->_options.credit.value()))
                             : std::nullopt;
@@ -161,10 +161,10 @@ TileMapServiceRasterOverlay::createTileProvider(
               return nullptr;
             }
 
-            gsl::span<const std::byte> data = pResponse->data();
+            const gsl::span<const std::byte> data = pResponse->data();
 
             tinyxml2::XMLDocument doc;
-            tinyxml2::XMLError error = doc.Parse(
+            const tinyxml2::XMLError error = doc.Parse(
                 reinterpret_cast<const char*>(data.data()),
                 data.size_bytes());
             if (error != tinyxml2::XMLError::XML_SUCCESS) {
@@ -204,7 +204,7 @@ TileMapServiceRasterOverlay::createTileProvider(
               tinyxml2::XMLElement* pTileset =
                   pTilesets->FirstChildElement("TileSet");
               while (pTileset) {
-                uint32_t level =
+                const uint32_t level =
                     getAttributeUint32(pTileset, "order").value_or(0);
                 minimumLevel = glm::min(minimumLevel, level);
                 maximumLevel = glm::max(maximumLevel, level);

--- a/Cesium3DTilesSelection/src/TileUtilities.cpp
+++ b/Cesium3DTilesSelection/src/TileUtilities.cpp
@@ -78,19 +78,19 @@ bool withinPolygons(
       const glm::dvec2& b = vertices[indices[j - 1]];
       const glm::dvec2& c = vertices[indices[j]];
 
-      glm::dvec2 ab = b - a;
-      glm::dvec2 ab_perp(-ab.y, ab.x);
-      glm::dvec2 bc = c - b;
-      glm::dvec2 bc_perp(-bc.y, bc.x);
-      glm::dvec2 ca = a - c;
-      glm::dvec2 ca_perp(-ca.y, ca.x);
+      const glm::dvec2 ab = b - a;
+      const glm::dvec2 ab_perp(-ab.y, ab.x);
+      const glm::dvec2 bc = c - b;
+      const glm::dvec2 bc_perp(-bc.y, bc.x);
+      const glm::dvec2 ca = a - c;
+      const glm::dvec2 ca_perp(-ca.y, ca.x);
 
-      glm::dvec2 av = rectangleCorners[0] - a;
-      glm::dvec2 cv = rectangleCorners[0] - c;
+      const glm::dvec2 av = rectangleCorners[0] - a;
+      const glm::dvec2 cv = rectangleCorners[0] - c;
 
-      double v_proj_ab_perp = glm::dot(av, ab_perp);
-      double v_proj_bc_perp = glm::dot(cv, bc_perp);
-      double v_proj_ca_perp = glm::dot(cv, ca_perp);
+      const double v_proj_ab_perp = glm::dot(av, ab_perp);
+      const double v_proj_bc_perp = glm::dot(cv, bc_perp);
+      const double v_proj_ca_perp = glm::dot(cv, ca_perp);
 
       // This will determine in or out, irrespective of winding.
       if ((v_proj_ab_perp >= 0.0 && v_proj_ca_perp >= 0.0 &&
@@ -115,17 +115,17 @@ bool withinPolygons(
       const glm::dvec2& a = vertices[j];
       const glm::dvec2& b = vertices[(j + 1) % vertices.size()];
 
-      glm::dvec2 ba = a - b;
+      const glm::dvec2 ba = a - b;
 
       // Check each rectangle edge.
       for (size_t k = 0; k < 4; ++k) {
         const glm::dvec2& cd = rectangleEdges[k];
-        glm::dmat2 lineSegmentMatrix(cd, ba);
-        glm::dvec2 ca = a - rectangleCorners[k];
+        const glm::dmat2 lineSegmentMatrix(cd, ba);
+        const glm::dvec2 ca = a - rectangleCorners[k];
 
         // s and t are calculated such that:
         // line_intersection = a + t * ab = c + s * cd
-        glm::dvec2 st = glm::inverse(lineSegmentMatrix) * ca;
+        const glm::dvec2 st = glm::inverse(lineSegmentMatrix) * ca;
 
         // check that the intersection is within the line segments
         if (st.x <= 1.0 && st.x >= 0.0 && st.y <= 1.0 && st.y >= 0.0) {

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -140,7 +140,7 @@ Tileset::~Tileset() {
 }
 
 Future<void>
-Tileset::_handleAssetResponse(std::shared_ptr<IAssetRequest>&& pRequest) {
+Tileset::_handleAssetResponse(const std::shared_ptr<IAssetRequest>&& pRequest) {
   const IAssetResponse* pResponse = pRequest->response();
   if (!pResponse) {
     SPDLOG_LOGGER_ERROR(
@@ -593,7 +593,7 @@ CesiumGeometry::Axis obtainGltfUpAxis(const rapidjson::Document& tileset) {
 } // namespace
 
 /*static*/ Tileset::LoadResult Tileset::_handleTilesetResponse(
-    std::shared_ptr<IAssetRequest>&& pRequest,
+    const std::shared_ptr<IAssetRequest>&& pRequest,
     std::unique_ptr<TileContext>&& pContext,
     const std::shared_ptr<spdlog::logger>& pLogger,
     bool useWaterMask) {
@@ -1055,7 +1055,7 @@ static bool updateContextWithNewToken(
 }
 
 void Tileset::_handleTokenRefreshResponse(
-    std::shared_ptr<IAssetRequest>&& pIonRequest,
+    const std::shared_ptr<IAssetRequest>&& pIonRequest,
     TileContext* pContext,
     const std::shared_ptr<spdlog::logger>& pLogger) {
   const IAssetResponse* pIonResponse = pIonRequest->response();
@@ -2016,7 +2016,7 @@ static bool anyRasterOverlaysNeedLoading(const Tile& tile) noexcept {
 
 void Tileset::processQueue(
     std::vector<Tileset::LoadRecord>& queue,
-    std::atomic<uint32_t>& loadsInProgress,
+    const std::atomic<uint32_t>& loadsInProgress,
     uint32_t maximumLoadsInProgress) {
   if (loadsInProgress >= maximumLoadsInProgress) {
     return;

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -240,8 +240,8 @@ static double computeFogDensity(
     const std::vector<FogDensityAtHeight>& fogDensityTable,
     const ViewState& viewState) {
   const double height = viewState.getPositionCartographic()
-                      .value_or(Cartographic(0.0, 0.0, 0.0))
-                      .height;
+                            .value_or(Cartographic(0.0, 0.0, 0.0))
+                            .height;
 
   // Find the entry that is for >= this camera height.
   auto nextIt =
@@ -262,7 +262,8 @@ static double computeFogDensity(
   const double heightB = nextIt->cameraHeight;
   const double densityB = nextIt->fogDensity;
 
-  const double t = glm::clamp((height - heightA) / (heightB - heightA), 0.0, 1.0);
+  const double t =
+      glm::clamp((height - heightA) / (heightB - heightA), 0.0, 1.0);
 
   const double density = glm::mix(densityA, densityB, t);
 
@@ -794,7 +795,8 @@ static std::optional<BoundingVolume> getBoundingVolumeProperty(
       glm::length(transform[0]),
       glm::length(transform[1]),
       glm::length(transform[2]));
-  const double maxScaleComponent = glm::max(scale.x, glm::max(scale.y, scale.z));
+  const double maxScaleComponent =
+      glm::max(scale.x, glm::max(scale.y, scale.z));
   tile.setGeometricError(geometricError.value() * maxScaleComponent);
 
   std::optional<BoundingVolume> viewerRequestVolume =
@@ -1388,7 +1390,8 @@ Tileset::TraversalDetails Tileset::_renderLeaf(
     const std::vector<double>& distances,
     ViewUpdateResult& result) {
 
-  const TileSelectionState lastFrameSelectionState = tile.getLastSelectionState();
+  const TileSelectionState lastFrameSelectionState =
+      tile.getLastSelectionState();
 
   tile.setLastSelectionState(TileSelectionState(
       frameState.currentFrameNumber,
@@ -1500,7 +1503,8 @@ Tileset::TraversalDetails Tileset::_renderInnerTile(
     Tile& tile,
     ViewUpdateResult& result) {
 
-  const TileSelectionState lastFrameSelectionState = tile.getLastSelectionState();
+  const TileSelectionState lastFrameSelectionState =
+      tile.getLastSelectionState();
 
   markChildrenNonRendered(frameState.lastFrameNumber, tile, result);
   tile.setLastSelectionState(TileSelectionState(
@@ -1525,7 +1529,8 @@ Tileset::TraversalDetails Tileset::_refineToNothing(
     ViewUpdateResult& result,
     bool areChildrenRenderable) {
 
-  const TileSelectionState lastFrameSelectionState = tile.getLastSelectionState();
+  const TileSelectionState lastFrameSelectionState =
+      tile.getLastSelectionState();
 
   // Nothing else to do except mark this tile refined and return.
   TraversalDetails noChildrenTraversalDetails;
@@ -1579,7 +1584,8 @@ bool Tileset::_kickDescendantsAndRenderTile(
     size_t loadIndexHigh,
     bool queuedForLoad,
     const std::vector<double>& distances) {
-  const TileSelectionState lastFrameSelectionState = tile.getLastSelectionState();
+  const TileSelectionState lastFrameSelectionState =
+      tile.getLastSelectionState();
 
   std::vector<Tile*>& renderList = result.tilesToRenderThisFrame;
 
@@ -1618,7 +1624,8 @@ bool Tileset::_kickDescendantsAndRenderTile(
   const bool wasRenderedLastFrame =
       lastFrameSelectionState.getResult(frameState.lastFrameNumber) ==
       TileSelectionState::Result::Rendered;
-  const bool wasReallyRenderedLastFrame = wasRenderedLastFrame && tile.isRenderable();
+  const bool wasReallyRenderedLastFrame =
+      wasRenderedLastFrame && tile.isRenderable();
 
   if (!wasReallyRenderedLastFrame &&
       traversalDetails.notYetRenderableCount >
@@ -1702,7 +1709,8 @@ Tileset::TraversalDetails Tileset::_visitTile(
     //
     // Note that even if we decide to render a tile here, it may later get
     // "kicked" in favor of an ancestor.
-    const TileSelectionState lastFrameSelectionState = tile.getLastSelectionState();
+    const TileSelectionState lastFrameSelectionState =
+        tile.getLastSelectionState();
     const bool renderThisTile = shouldRenderThisTile(
         tile,
         lastFrameSelectionState,
@@ -1746,7 +1754,8 @@ Tileset::TraversalDetails Tileset::_visitTile(
   bool queuedForLoad =
       _loadAndRenderAdditiveRefinedTile(frameState, tile, result, distances);
 
-  const size_t firstRenderedDescendantIndex = result.tilesToRenderThisFrame.size();
+  const size_t firstRenderedDescendantIndex =
+      result.tilesToRenderThisFrame.size();
   const size_t loadIndexLow = this->_loadQueueLow.size();
   const size_t loadIndexMedium = this->_loadQueueMedium.size();
   const size_t loadIndexHigh = this->_loadQueueHigh.size();

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -140,7 +140,7 @@ Tileset::~Tileset() {
 }
 
 Future<void>
-Tileset::_handleAssetResponse(const std::shared_ptr<IAssetRequest>&& pRequest) {
+Tileset::_handleAssetResponse(std::shared_ptr<IAssetRequest>&& pRequest) {
   const IAssetResponse* pResponse = pRequest->response();
   if (!pResponse) {
     SPDLOG_LOGGER_ERROR(
@@ -593,7 +593,7 @@ CesiumGeometry::Axis obtainGltfUpAxis(const rapidjson::Document& tileset) {
 } // namespace
 
 /*static*/ Tileset::LoadResult Tileset::_handleTilesetResponse(
-    const std::shared_ptr<IAssetRequest>&& pRequest,
+    std::shared_ptr<IAssetRequest>&& pRequest,
     std::unique_ptr<TileContext>&& pContext,
     const std::shared_ptr<spdlog::logger>& pLogger,
     bool useWaterMask) {
@@ -1055,7 +1055,7 @@ static bool updateContextWithNewToken(
 }
 
 void Tileset::_handleTokenRefreshResponse(
-    const std::shared_ptr<IAssetRequest>&& pIonRequest,
+    std::shared_ptr<IAssetRequest>&& pIonRequest,
     TileContext* pContext,
     const std::shared_ptr<spdlog::logger>& pLogger) {
   const IAssetResponse* pIonResponse = pIonRequest->response();

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -1696,7 +1696,7 @@ Tileset::TraversalDetails Tileset::_visitTile(
     return _renderLeaf(frameState, tile, distances, result);
   }
 
-  bool unconditionallyRefine = tile.getUnconditionallyRefine();
+  const bool unconditionallyRefine = tile.getUnconditionallyRefine();
   const bool meetsSse = _meetsSse(frameState.frustums, tile, distances, culled);
   const bool waitingForChildren =
       _queueLoadOfChildrenRequiredForRefinement(frameState, tile, distances);

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -231,7 +231,8 @@ Tileset::_handleAssetResponse(std::shared_ptr<IAssetRequest>&& pRequest) {
       std::move(pContext));
 }
 
-static bool operator<(const FogDensityAtHeight& fogDensity, double height) {
+static bool
+operator<(const FogDensityAtHeight& fogDensity, double height) noexcept {
   return fogDensity.cameraHeight < height;
 }
 
@@ -853,7 +854,7 @@ static std::optional<BoundingVolume> getBoundingVolumeProperty(
  */
 static std::string createExtensionsQueryParameter(
     const std::vector<std::string>& knownExtensions,
-    const std::vector<std::string>& extensions) noexcept {
+    const std::vector<std::string>& extensions) {
 
   std::string extensionsToRequest;
   for (const std::string& extension : knownExtensions) {
@@ -1229,7 +1230,7 @@ static bool isVisibleFromCamera(
  * @param fogDensity The fog density
  * @return Whether the tile is visible in the fog
  */
-static bool isVisibleInFog(double distance, double fogDensity) {
+static bool isVisibleInFog(double distance, double fogDensity) noexcept {
   if (fogDensity <= 0.0) {
     return true;
   }
@@ -1377,7 +1378,9 @@ Tileset::TraversalDetails Tileset::_visitTileIfNeeded(
       result);
 }
 
-static bool isLeaf(const Tile& tile) { return tile.getChildren().empty(); }
+static bool isLeaf(const Tile& tile) noexcept {
+  return tile.getChildren().empty();
+}
 
 Tileset::TraversalDetails Tileset::_renderLeaf(
     const FrameState& frameState,
@@ -1440,7 +1443,7 @@ bool Tileset::_meetsSse(
     const std::vector<ViewState>& frustums,
     const Tile& tile,
     const std::vector<double>& distances,
-    bool culled) const {
+    bool culled) const noexcept {
 
   double largestSse = 0.0;
 
@@ -1473,7 +1476,7 @@ bool Tileset::_meetsSse(
 static bool shouldRenderThisTile(
     const Tile& tile,
     const TileSelectionState& lastFrameSelectionState,
-    int32_t lastFrameNumber) {
+    int32_t lastFrameNumber) noexcept {
   TileSelectionState::Result originalResult =
       lastFrameSelectionState.getOriginalResult(lastFrameNumber);
   if (originalResult == TileSelectionState::Result::Rendered) {
@@ -1849,7 +1852,7 @@ void Tileset::_processLoadQueue() {
       this->_options.maximumSimultaneousTileLoads);
 }
 
-void Tileset::_unloadCachedTiles() {
+void Tileset::_unloadCachedTiles() noexcept {
   const int64_t maxBytes = this->getOptions().maximumCachedBytes;
 
   Tile* pTile = this->_loadedTiles.head();
@@ -1873,7 +1876,7 @@ void Tileset::_unloadCachedTiles() {
   }
 }
 
-void Tileset::_markTileVisited(Tile& tile) {
+void Tileset::_markTileVisited(Tile& tile) noexcept {
   this->_loadedTiles.insertAtTail(tile);
 }
 
@@ -1936,7 +1939,8 @@ std::string Tileset::getResolvedContentUrl(const Tile& tile) const {
           });
     }
 
-    std::string operator()(UpsampledQuadtreeNode /*subdividedParent*/) {
+    std::string
+    operator()(UpsampledQuadtreeNode /*subdividedParent*/) noexcept {
       return std::string();
     }
   };
@@ -1949,7 +1953,7 @@ std::string Tileset::getResolvedContentUrl(const Tile& tile) const {
   return CesiumUtility::Uri::resolve(tile.getContext()->baseUrl, url, true);
 }
 
-static bool anyRasterOverlaysNeedLoading(const Tile& tile) {
+static bool anyRasterOverlaysNeedLoading(const Tile& tile) noexcept {
   for (const RasterMappedTo3DTile& mapped : tile.getMappedRasterTiles()) {
     const RasterOverlayTile* pLoading = mapped.getLoadingTile();
     if (pLoading &&

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -160,7 +160,7 @@ Tileset::_handleAssetResponse(std::shared_ptr<IAssetRequest>&& pRequest) {
     return this->getAsyncSystem().createResolvedFuture();
   }
 
-  gsl::span<const std::byte> data = pResponse->data();
+  const gsl::span<const std::byte> data = pResponse->data();
 
   rapidjson::Document ionResponse;
   ionResponse.Parse(reinterpret_cast<const char*>(data.data()), data.size());
@@ -177,14 +177,14 @@ Tileset::_handleAssetResponse(std::shared_ptr<IAssetRequest>&& pRequest) {
 
   if (this->_externals.pCreditSystem) {
 
-    auto attributionsIt = ionResponse.FindMember("attributions");
+    const auto attributionsIt = ionResponse.FindMember("attributions");
     if (attributionsIt != ionResponse.MemberEnd() &&
         attributionsIt->value.IsArray()) {
 
       for (const rapidjson::Value& attribution :
            attributionsIt->value.GetArray()) {
 
-        auto html = attribution.FindMember("html");
+        const auto html = attribution.FindMember("html");
         if (html != attribution.MemberEnd() && html->value.IsString()) {
           this->_tilesetCredits.push_back(
               this->_externals.pCreditSystem->createCredit(
@@ -239,7 +239,7 @@ operator<(const FogDensityAtHeight& fogDensity, double height) noexcept {
 static double computeFogDensity(
     const std::vector<FogDensityAtHeight>& fogDensityTable,
     const ViewState& viewState) {
-  double height = viewState.getPositionCartographic()
+  const double height = viewState.getPositionCartographic()
                       .value_or(Cartographic(0.0, 0.0, 0.0))
                       .height;
 
@@ -256,15 +256,15 @@ static double computeFogDensity(
 
   auto prevIt = nextIt - 1;
 
-  double heightA = prevIt->cameraHeight;
-  double densityA = prevIt->fogDensity;
+  const double heightA = prevIt->cameraHeight;
+  const double densityA = prevIt->fogDensity;
 
-  double heightB = nextIt->cameraHeight;
-  double densityB = nextIt->fogDensity;
+  const double heightB = nextIt->cameraHeight;
+  const double densityB = nextIt->fogDensity;
 
-  double t = glm::clamp((height - heightA) / (heightB - heightA), 0.0, 1.0);
+  const double t = glm::clamp((height - heightA) / (heightB - heightA), 0.0, 1.0);
 
-  double density = glm::mix(densityA, densityB, t);
+  const double density = glm::mix(densityA, densityB, t);
 
   // CesiumJS will also fade out the fog based on the camera angle,
   // so when we're looking straight down there's no fog. This is unfortunate
@@ -310,8 +310,8 @@ const ViewUpdateResult&
 Tileset::updateView(const std::vector<ViewState>& frustums) {
   this->_asyncSystem.dispatchMainThreadTasks();
 
-  int32_t previousFrameNumber = this->_previousFrameNumber;
-  int32_t currentFrameNumber = previousFrameNumber + 1;
+  const int32_t previousFrameNumber = this->_previousFrameNumber;
+  const int32_t currentFrameNumber = previousFrameNumber + 1;
 
   ViewUpdateResult& result = this->_updateResult;
   // result.tilesLoading = 0;
@@ -379,7 +379,7 @@ Tileset::updateView(const std::vector<ViewState>& frustums) {
     }
 
     // per-tileset ion-specified credit
-    for (Credit& credit : this->_tilesetCredits) {
+    for (const Credit& credit : this->_tilesetCredits) {
       pCreditSystem->addCreditToFrame(credit);
     }
 
@@ -400,7 +400,7 @@ Tileset::updateView(const std::vector<ViewState>& frustums) {
         const RasterOverlayTile* pRasterOverlayTile =
             mappedRasterTile.getReadyTile();
         if (pRasterOverlayTile != nullptr) {
-          for (Credit credit : pRasterOverlayTile->getCredits()) {
+          for (const Credit credit : pRasterOverlayTile->getCredits()) {
             pCreditSystem->addCreditToFrame(credit);
           }
         }
@@ -560,12 +560,12 @@ namespace {
  * @return The up-axis to use for glTF content
  */
 CesiumGeometry::Axis obtainGltfUpAxis(const rapidjson::Document& tileset) {
-  auto assetIt = tileset.FindMember("asset");
+  const auto assetIt = tileset.FindMember("asset");
   if (assetIt == tileset.MemberEnd()) {
     return CesiumGeometry::Axis::Y;
   }
   const rapidjson::Value& assetJson = assetIt->value;
-  auto gltfUpAxisIt = assetJson.FindMember("gltfUpAxis");
+  const auto gltfUpAxisIt = assetJson.FindMember("gltfUpAxis");
   if (gltfUpAxisIt == assetJson.MemberEnd()) {
     return CesiumGeometry::Axis::Y;
   }
@@ -616,7 +616,7 @@ CesiumGeometry::Axis obtainGltfUpAxis(const rapidjson::Document& tileset) {
 
   pContext->baseUrl = pRequest->url();
 
-  gsl::span<const std::byte> data = pResponse->data();
+  const gsl::span<const std::byte> data = pResponse->data();
 
   rapidjson::Document tileset;
   tileset.Parse(reinterpret_cast<const char*>(data.data()), data.size());
@@ -635,13 +635,13 @@ CesiumGeometry::Axis obtainGltfUpAxis(const rapidjson::Document& tileset) {
   std::unique_ptr<Tile> pRootTile = std::make_unique<Tile>();
   pRootTile->setContext(pContext.get());
 
-  auto rootIt = tileset.FindMember("root");
-  auto formatIt = tileset.FindMember("format");
+  const auto rootIt = tileset.FindMember("root");
+  const auto formatIt = tileset.FindMember("format");
 
   bool supportsRasterOverlays = false;
 
   if (rootIt != tileset.MemberEnd()) {
-    rapidjson::Value& rootJson = rootIt->value;
+    const rapidjson::Value& rootJson = rootIt->value;
     Tileset::_createTile(
         *pRootTile,
         rootJson,
@@ -670,12 +670,12 @@ CesiumGeometry::Axis obtainGltfUpAxis(const rapidjson::Document& tileset) {
 static std::optional<BoundingVolume> getBoundingVolumeProperty(
     const rapidjson::Value& tileJson,
     const std::string& key) {
-  auto bvIt = tileJson.FindMember(key.c_str());
+  const auto bvIt = tileJson.FindMember(key.c_str());
   if (bvIt == tileJson.MemberEnd() || !bvIt->value.IsObject()) {
     return std::nullopt;
   }
 
-  auto boxIt = bvIt->value.FindMember("box");
+  const auto boxIt = bvIt->value.FindMember("box");
   if (boxIt != bvIt->value.MemberEnd() && boxIt->value.IsArray() &&
       boxIt->value.Size() >= 12) {
     const auto& a = boxIt->value.GetArray();
@@ -698,7 +698,7 @@ static std::optional<BoundingVolume> getBoundingVolumeProperty(
             a[11].GetDouble()));
   }
 
-  auto regionIt = bvIt->value.FindMember("region");
+  const auto regionIt = bvIt->value.FindMember("region");
   if (regionIt != bvIt->value.MemberEnd() && regionIt->value.IsArray() &&
       regionIt->value.Size() >= 6) {
     const auto& a = regionIt->value;
@@ -717,7 +717,7 @@ static std::optional<BoundingVolume> getBoundingVolumeProperty(
         a[5].GetDouble());
   }
 
-  auto sphereIt = bvIt->value.FindMember("sphere");
+  const auto sphereIt = bvIt->value.FindMember("sphere");
   if (sphereIt != bvIt->value.MemberEnd() && sphereIt->value.IsArray() &&
       sphereIt->value.Size() >= 4) {
     const auto& a = sphereIt->value;
@@ -747,14 +747,14 @@ static std::optional<BoundingVolume> getBoundingVolumeProperty(
 
   tile.setContext(const_cast<TileContext*>(&context));
 
-  std::optional<glm::dmat4x4> tileTransform =
+  const std::optional<glm::dmat4x4> tileTransform =
       JsonHelpers::getTransformProperty(tileJson, "transform");
   glm::dmat4x4 transform =
       parentTransform * tileTransform.value_or(glm::dmat4x4(1.0));
   tile.setTransform(transform);
 
-  auto contentIt = tileJson.FindMember("content");
-  auto childrenIt = tileJson.FindMember("children");
+  const auto contentIt = tileJson.FindMember("content");
+  const auto childrenIt = tileJson.FindMember("children");
 
   if (contentIt != tileJson.MemberEnd() && contentIt->value.IsObject()) {
     auto uriIt = contentIt->value.FindMember("uri");
@@ -790,11 +790,11 @@ static std::optional<BoundingVolume> getBoundingVolumeProperty(
 
   tile.setBoundingVolume(
       transformBoundingVolume(transform, boundingVolume.value()));
-  glm::dvec3 scale = glm::dvec3(
+  const glm::dvec3 scale = glm::dvec3(
       glm::length(transform[0]),
       glm::length(transform[1]),
       glm::length(transform[2]));
-  double maxScaleComponent = glm::max(scale.x, glm::max(scale.y, scale.z));
+  const double maxScaleComponent = glm::max(scale.x, glm::max(scale.y, scale.z));
   tile.setGeometricError(geometricError.value() * maxScaleComponent);
 
   std::optional<BoundingVolume> viewerRequestVolume =
@@ -804,7 +804,7 @@ static std::optional<BoundingVolume> getBoundingVolumeProperty(
         transformBoundingVolume(transform, viewerRequestVolume.value()));
   }
 
-  auto refineIt = tileJson.FindMember("refine");
+  const auto refineIt = tileJson.FindMember("refine");
   if (refineIt != tileJson.MemberEnd() && refineIt->value.IsString()) {
     std::string refine = refineIt->value.GetString();
     if (refine == "REPLACE") {
@@ -824,7 +824,7 @@ static std::optional<BoundingVolume> getBoundingVolumeProperty(
   if (childrenIt != tileJson.MemberEnd() && childrenIt->value.IsArray()) {
     const auto& childrenJson = childrenIt->value;
     tile.createChildTiles(childrenJson.Size());
-    gsl::span<Tile> childTiles = tile.getChildren();
+    const gsl::span<Tile> childTiles = tile.getChildren();
 
     for (rapidjson::SizeType i = 0; i < childrenJson.Size(); ++i) {
       const auto& childJson = childrenJson[i];
@@ -896,7 +896,7 @@ static BoundingVolume createDefaultLooseEarthBoundingVolume(
       "application/vnd.quantized-mesh,application/octet-stream;q=0.9,*/"
       "*;q=0.01"));
 
-  auto tilesetVersionIt = layerJson.FindMember("version");
+  const auto tilesetVersionIt = layerJson.FindMember("version");
   if (tilesetVersionIt != layerJson.MemberEnd() &&
       tilesetVersionIt->value.IsString()) {
     context.version = tilesetVersionIt->value.GetString();
@@ -949,7 +949,7 @@ static BoundingVolume createDefaultLooseEarthBoundingVolume(
     return;
   }
 
-  CesiumGeometry::QuadtreeTilingScheme tilingScheme(
+  const CesiumGeometry::QuadtreeTilingScheme tilingScheme(
       quadtreeRectangleProjected,
       quadtreeXTiles,
       1);
@@ -996,7 +996,7 @@ static BoundingVolume createDefaultLooseEarthBoundingVolume(
     childTile.setContext(&context);
     childTile.setParent(&tile);
     childTile.setTileID(id);
-    CesiumGeospatial::GlobeRectangle childGlobeRectangle =
+    const CesiumGeospatial::GlobeRectangle childGlobeRectangle =
         unprojectRectangleSimple(projection, tilingScheme.tileToRectangle(id));
     childTile.setBoundingVolume(
         createDefaultLooseEarthBoundingVolume(childGlobeRectangle));
@@ -1022,7 +1022,7 @@ static bool updateContextWithNewToken(
     TileContext* pContext,
     const IAssetResponse* pIonResponse,
     const std::shared_ptr<spdlog::logger>& pLogger) {
-  gsl::span<const std::byte> data = pIonResponse->data();
+  const gsl::span<const std::byte> data = pIonResponse->data();
 
   rapidjson::Document ionResponse;
   ionResponse.Parse(reinterpret_cast<const char*>(data.data()), data.size());
@@ -1148,7 +1148,7 @@ static void markTileNonRendered(
     int32_t lastFrameNumber,
     Tile& tile,
     ViewUpdateResult& result) {
-  TileSelectionState::Result lastResult =
+  const TileSelectionState::Result lastResult =
       tile.getLastSelectionState().getResult(lastFrameNumber);
   markTileNonRendered(lastResult, tile, result);
 }
@@ -1160,7 +1160,7 @@ static void markChildrenNonRendered(
     ViewUpdateResult& result) {
   if (lastResult == TileSelectionState::Result::Refined) {
     for (Tile& child : tile.getChildren()) {
-      TileSelectionState::Result childLastResult =
+      const TileSelectionState::Result childLastResult =
           child.getLastSelectionState().getResult(lastFrameNumber);
       markTileNonRendered(childLastResult, child, result);
       markChildrenNonRendered(lastFrameNumber, childLastResult, child, result);
@@ -1172,7 +1172,7 @@ static void markChildrenNonRendered(
     int32_t lastFrameNumber,
     Tile& tile,
     ViewUpdateResult& result) {
-  TileSelectionState::Result lastResult =
+  const TileSelectionState::Result lastResult =
       tile.getLastSelectionState().getResult(lastFrameNumber);
   markChildrenNonRendered(lastFrameNumber, lastResult, tile, result);
 }
@@ -1181,7 +1181,7 @@ static void markTileAndChildrenNonRendered(
     int32_t lastFrameNumber,
     Tile& tile,
     ViewUpdateResult& result) {
-  TileSelectionState::Result lastResult =
+  const TileSelectionState::Result lastResult =
       tile.getLastSelectionState().getResult(lastFrameNumber);
   markTileNonRendered(lastResult, tile, result);
   markChildrenNonRendered(lastFrameNumber, lastResult, tile, result);
@@ -1235,7 +1235,7 @@ static bool isVisibleInFog(double distance, double fogDensity) noexcept {
     return true;
   }
 
-  double fogScalar = distance * fogDensity;
+  const double fogScalar = distance * fogDensity;
   return glm::exp(-(fogScalar * fogScalar)) > 0.0;
 }
 
@@ -1312,7 +1312,7 @@ Tileset::TraversalDetails Tileset::_visitTileIfNeeded(
 
   // Use a unique_ptr to ensure the _nextDistancesVector gets decrements when we
   // leave this scope.
-  auto decrementNextDistancesVector = [this](std::vector<double>*) {
+  const auto decrementNextDistancesVector = [this](std::vector<double>*) {
     --this->_nextDistancesVector;
   };
   std::unique_ptr<std::vector<double>, decltype(decrementNextDistancesVector)>
@@ -1333,8 +1333,8 @@ Tileset::TraversalDetails Tileset::_visitTileIfNeeded(
     bool isFogCulled = true;
 
     for (size_t i = 0; i < frustums.size(); ++i) {
-      double distance = distances[i];
-      double fogDensity = fogDensities[i];
+      const double distance = distances[i];
+      const double fogDensity = fogDensities[i];
 
       if (isVisibleInFog(distance, fogDensity)) {
         isFogCulled = false;
@@ -1388,7 +1388,7 @@ Tileset::TraversalDetails Tileset::_renderLeaf(
     const std::vector<double>& distances,
     ViewUpdateResult& result) {
 
-  TileSelectionState lastFrameSelectionState = tile.getLastSelectionState();
+  const TileSelectionState lastFrameSelectionState = tile.getLastSelectionState();
 
   tile.setLastSelectionState(TileSelectionState(
       frameState.currentFrameNumber,
@@ -1449,10 +1449,10 @@ bool Tileset::_meetsSse(
 
   for (size_t i = 0; i < frustums.size() && i < distances.size(); ++i) {
     const ViewState& frustum = frustums[i];
-    double distance = distances[i];
+    const double distance = distances[i];
 
     // Does this tile meet the screen-space error?
-    double sse =
+    const double sse =
         frustum.computeScreenSpaceError(tile.getGeometricError(), distance);
     if (sse > largestSse) {
       largestSse = sse;
@@ -1477,7 +1477,7 @@ static bool shouldRenderThisTile(
     const Tile& tile,
     const TileSelectionState& lastFrameSelectionState,
     int32_t lastFrameNumber) noexcept {
-  TileSelectionState::Result originalResult =
+  const TileSelectionState::Result originalResult =
       lastFrameSelectionState.getOriginalResult(lastFrameNumber);
   if (originalResult == TileSelectionState::Result::Rendered) {
     return true;
@@ -1500,7 +1500,7 @@ Tileset::TraversalDetails Tileset::_renderInnerTile(
     Tile& tile,
     ViewUpdateResult& result) {
 
-  TileSelectionState lastFrameSelectionState = tile.getLastSelectionState();
+  const TileSelectionState lastFrameSelectionState = tile.getLastSelectionState();
 
   markChildrenNonRendered(frameState.lastFrameNumber, tile, result);
   tile.setLastSelectionState(TileSelectionState(
@@ -1525,7 +1525,7 @@ Tileset::TraversalDetails Tileset::_refineToNothing(
     ViewUpdateResult& result,
     bool areChildrenRenderable) {
 
-  TileSelectionState lastFrameSelectionState = tile.getLastSelectionState();
+  const TileSelectionState lastFrameSelectionState = tile.getLastSelectionState();
 
   // Nothing else to do except mark this tile refined and return.
   TraversalDetails noChildrenTraversalDetails;
@@ -1579,7 +1579,7 @@ bool Tileset::_kickDescendantsAndRenderTile(
     size_t loadIndexHigh,
     bool queuedForLoad,
     const std::vector<double>& distances) {
-  TileSelectionState lastFrameSelectionState = tile.getLastSelectionState();
+  const TileSelectionState lastFrameSelectionState = tile.getLastSelectionState();
 
   std::vector<Tile*>& renderList = result.tilesToRenderThisFrame;
 
@@ -1615,10 +1615,10 @@ bool Tileset::_kickDescendantsAndRenderTile(
   // in that case, load this tile INSTEAD of loading any of the descendants, and
   // tell the up-level we're only waiting on this tile. Keep doing this until we
   // actually manage to render this tile.
-  bool wasRenderedLastFrame =
+  const bool wasRenderedLastFrame =
       lastFrameSelectionState.getResult(frameState.lastFrameNumber) ==
       TileSelectionState::Result::Rendered;
-  bool wasReallyRenderedLastFrame = wasRenderedLastFrame && tile.isRenderable();
+  const bool wasReallyRenderedLastFrame = wasRenderedLastFrame && tile.isRenderable();
 
   if (!wasReallyRenderedLastFrame &&
       traversalDetails.notYetRenderableCount >
@@ -1685,8 +1685,8 @@ Tileset::TraversalDetails Tileset::_visitTile(
     return _renderLeaf(frameState, tile, distances, result);
   }
 
-  bool meetsSse = _meetsSse(frameState.frustums, tile, distances, culled);
-  bool waitingForChildren =
+  const bool meetsSse = _meetsSse(frameState.frustums, tile, distances, culled);
+  const bool waitingForChildren =
       _queueLoadOfChildrenRequiredForRefinement(frameState, tile, distances);
 
   if (meetsSse || ancestorMeetsSse || waitingForChildren) {
@@ -1702,8 +1702,8 @@ Tileset::TraversalDetails Tileset::_visitTile(
     //
     // Note that even if we decide to render a tile here, it may later get
     // "kicked" in favor of an ancestor.
-    TileSelectionState lastFrameSelectionState = tile.getLastSelectionState();
-    bool renderThisTile = shouldRenderThisTile(
+    const TileSelectionState lastFrameSelectionState = tile.getLastSelectionState();
+    const bool renderThisTile = shouldRenderThisTile(
         tile,
         lastFrameSelectionState,
         frameState.lastFrameNumber);
@@ -1746,10 +1746,10 @@ Tileset::TraversalDetails Tileset::_visitTile(
   bool queuedForLoad =
       _loadAndRenderAdditiveRefinedTile(frameState, tile, result, distances);
 
-  size_t firstRenderedDescendantIndex = result.tilesToRenderThisFrame.size();
-  size_t loadIndexLow = this->_loadQueueLow.size();
-  size_t loadIndexMedium = this->_loadQueueMedium.size();
-  size_t loadIndexHigh = this->_loadQueueHigh.size();
+  const size_t firstRenderedDescendantIndex = result.tilesToRenderThisFrame.size();
+  const size_t loadIndexLow = this->_loadQueueLow.size();
+  const size_t loadIndexMedium = this->_loadQueueMedium.size();
+  const size_t loadIndexHigh = this->_loadQueueHigh.size();
 
   TraversalDetails traversalDetails = this->_visitVisibleChildrenNearToFar(
       frameState,
@@ -1758,7 +1758,7 @@ Tileset::TraversalDetails Tileset::_visitTile(
       tile,
       result);
 
-  bool descendantTilesAdded =
+  const bool descendantTilesAdded =
       firstRenderedDescendantIndex != result.tilesToRenderThisFrame.size();
   if (!descendantTilesAdded) {
     // No descendant tiles were added to the render list by the function above,
@@ -1820,7 +1820,7 @@ Tileset::TraversalDetails Tileset::_visitVisibleChildrenNearToFar(
   // TODO: actually visit near-to-far, rather than in order of occurrence.
   gsl::span<Tile> children = tile.getChildren();
   for (Tile& child : children) {
-    TraversalDetails childTraversal = this->_visitTileIfNeeded(
+    const TraversalDetails childTraversal = this->_visitTileIfNeeded(
         frameState,
         depth + 1,
         ancestorMeetsSse,
@@ -1867,7 +1867,7 @@ void Tileset::_unloadCachedTiles() noexcept {
 
     Tile* pNext = this->_loadedTiles.next(*pTile);
 
-    bool removed = pTile->unloadContent();
+    const bool removed = pTile->unloadContent();
     if (removed) {
       this->_loadedTiles.remove(*pTile);
     }
@@ -1979,20 +1979,20 @@ static bool anyRasterOverlaysNeedLoading(const Tile& tile) noexcept {
   if (tile.getState() == Tile::LoadState::Unloaded ||
       anyRasterOverlaysNeedLoading(tile)) {
 
-    glm::dvec3 boundingVolumeCenter =
+    const glm::dvec3 boundingVolumeCenter =
         getBoundingVolumeCenter(tile.getBoundingVolume());
 
     double highestLoadPriority = std::numeric_limits<double>::max();
     for (size_t i = 0; i < frustums.size() && i < distances.size(); ++i) {
       const ViewState& frustum = frustums[i];
-      double distance = distances[i];
+      const double distance = distances[i];
 
       glm::dvec3 tileDirection = boundingVolumeCenter - frustum.getPosition();
-      double magnitude = glm::length(tileDirection);
+      const double magnitude = glm::length(tileDirection);
 
       if (magnitude >= CesiumUtility::Math::EPSILON5) {
         tileDirection /= magnitude;
-        double loadPriority =
+        const double loadPriority =
             (1.0 - glm::dot(tileDirection, frustum.getDirection())) * distance;
         if (loadPriority < highestLoadPriority) {
           highestLoadPriority = loadPriority;

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -86,6 +86,7 @@ Tileset::Tileset(
       _overlays(*this),
       _tileDataBytes(0),
       _supportsRasterOverlays(false),
+      _gltfUpAxis(CesiumGeometry::Axis::Y),
       _distancesStack(),
       _nextDistancesVector(0) {
   CESIUM_TRACE_USE_TRACK_SET(this->_loadingSlots);

--- a/Cesium3DTilesSelection/src/ViewState.cpp
+++ b/Cesium3DTilesSelection/src/ViewState.cpp
@@ -54,22 +54,22 @@ template <class T>
 static bool isBoundingVolumeVisible(
     const T& boundingVolume,
     const CullingVolume& cullingVolume) noexcept {
-  CullingResult left = boundingVolume.intersectPlane(cullingVolume.leftPlane);
+  const CullingResult left = boundingVolume.intersectPlane(cullingVolume.leftPlane);
   if (left == CullingResult::Outside) {
     return false;
   }
 
-  CullingResult right = boundingVolume.intersectPlane(cullingVolume.rightPlane);
+  const CullingResult right = boundingVolume.intersectPlane(cullingVolume.rightPlane);
   if (right == CullingResult::Outside) {
     return false;
   }
 
-  CullingResult top = boundingVolume.intersectPlane(cullingVolume.topPlane);
+  const CullingResult top = boundingVolume.intersectPlane(cullingVolume.topPlane);
   if (top == CullingResult::Outside) {
     return false;
   }
 
-  CullingResult bottom =
+  const CullingResult bottom =
       boundingVolume.intersectPlane(cullingVolume.bottomPlane);
   if (bottom == CullingResult::Outside) {
     return false;
@@ -157,7 +157,7 @@ double ViewState::computeScreenSpaceError(
     double distance) const noexcept {
   // Avoid divide by zero when viewer is inside the tile
   distance = glm::max(distance, 1e-7);
-  double sseDenominator = this->_sseDenominator;
+  const double sseDenominator = this->_sseDenominator;
   return (geometricError * this->_viewportSize.y) / (distance * sseDenominator);
 }
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/ViewState.cpp
+++ b/Cesium3DTilesSelection/src/ViewState.cpp
@@ -34,7 +34,7 @@ ViewState::ViewState(
     const glm::dvec2& viewportSize,
     double horizontalFieldOfView,
     double verticalFieldOfView,
-    const std::optional<CesiumGeospatial::Cartographic>& positionCartographic)
+    const std::optional<CesiumGeospatial::Cartographic>& positionCartographic) 
     : _position(position),
       _direction(direction),
       _up(up),
@@ -87,26 +87,26 @@ bool ViewState::isBoundingVolumeVisible(
   struct Operation {
     const ViewState& viewState;
 
-    bool operator()(const OrientedBoundingBox& boundingBox) {
+    bool operator()(const OrientedBoundingBox& boundingBox) noexcept {
       return Cesium3DTilesSelection::isBoundingVolumeVisible(
           boundingBox,
           viewState._cullingVolume);
     }
 
-    bool operator()(const BoundingRegion& boundingRegion) {
+    bool operator()(const BoundingRegion& boundingRegion) noexcept {
       return Cesium3DTilesSelection::isBoundingVolumeVisible(
           boundingRegion,
           viewState._cullingVolume);
     }
 
-    bool operator()(const BoundingSphere& boundingSphere) {
+    bool operator()(const BoundingSphere& boundingSphere) noexcept {
       return Cesium3DTilesSelection::isBoundingVolumeVisible(
           boundingSphere,
           viewState._cullingVolume);
     }
 
     bool
-    operator()(const BoundingRegionWithLooseFittingHeights& boundingRegion) {
+    operator()(const BoundingRegionWithLooseFittingHeights& boundingRegion) noexcept {
       return Cesium3DTilesSelection::isBoundingVolumeVisible(
           boundingRegion.getBoundingRegion(),
           viewState._cullingVolume);
@@ -121,11 +121,11 @@ double ViewState::computeDistanceSquaredToBoundingVolume(
   struct Operation {
     const ViewState& viewState;
 
-    double operator()(const OrientedBoundingBox& boundingBox) {
+    double operator()(const OrientedBoundingBox& boundingBox) noexcept {
       return boundingBox.computeDistanceSquaredToPosition(viewState._position);
     }
 
-    double operator()(const BoundingRegion& boundingRegion) {
+    double operator()(const BoundingRegion& boundingRegion) noexcept {
       if (viewState._positionCartographic) {
         return boundingRegion.computeDistanceSquaredToPosition(
             viewState._positionCartographic.value(),
@@ -135,13 +135,13 @@ double ViewState::computeDistanceSquaredToBoundingVolume(
           viewState._position);
     }
 
-    double operator()(const BoundingSphere& boundingSphere) {
+    double operator()(const BoundingSphere& boundingSphere) noexcept {
       return boundingSphere.computeDistanceSquaredToPosition(
           viewState._position);
     }
 
     double
-    operator()(const BoundingRegionWithLooseFittingHeights& boundingRegion) {
+    operator()(const BoundingRegionWithLooseFittingHeights& boundingRegion) noexcept {
       if (viewState._positionCartographic) {
         return boundingRegion.computeConservativeDistanceSquaredToPosition(
             viewState._positionCartographic.value(),

--- a/Cesium3DTilesSelection/src/ViewState.cpp
+++ b/Cesium3DTilesSelection/src/ViewState.cpp
@@ -34,7 +34,7 @@ ViewState::ViewState(
     const glm::dvec2& viewportSize,
     double horizontalFieldOfView,
     double verticalFieldOfView,
-    const std::optional<CesiumGeospatial::Cartographic>& positionCartographic) 
+    const std::optional<CesiumGeospatial::Cartographic>& positionCartographic)
     : _position(position),
       _direction(direction),
       _up(up),
@@ -105,8 +105,8 @@ bool ViewState::isBoundingVolumeVisible(
           viewState._cullingVolume);
     }
 
-    bool
-    operator()(const BoundingRegionWithLooseFittingHeights& boundingRegion) noexcept {
+    bool operator()(
+        const BoundingRegionWithLooseFittingHeights& boundingRegion) noexcept {
       return Cesium3DTilesSelection::isBoundingVolumeVisible(
           boundingRegion.getBoundingRegion(),
           viewState._cullingVolume);
@@ -140,8 +140,8 @@ double ViewState::computeDistanceSquaredToBoundingVolume(
           viewState._position);
     }
 
-    double
-    operator()(const BoundingRegionWithLooseFittingHeights& boundingRegion) noexcept {
+    double operator()(
+        const BoundingRegionWithLooseFittingHeights& boundingRegion) noexcept {
       if (viewState._positionCartographic) {
         return boundingRegion.computeConservativeDistanceSquaredToPosition(
             viewState._positionCartographic.value(),

--- a/Cesium3DTilesSelection/src/ViewState.cpp
+++ b/Cesium3DTilesSelection/src/ViewState.cpp
@@ -54,17 +54,20 @@ template <class T>
 static bool isBoundingVolumeVisible(
     const T& boundingVolume,
     const CullingVolume& cullingVolume) noexcept {
-  const CullingResult left = boundingVolume.intersectPlane(cullingVolume.leftPlane);
+  const CullingResult left =
+      boundingVolume.intersectPlane(cullingVolume.leftPlane);
   if (left == CullingResult::Outside) {
     return false;
   }
 
-  const CullingResult right = boundingVolume.intersectPlane(cullingVolume.rightPlane);
+  const CullingResult right =
+      boundingVolume.intersectPlane(cullingVolume.rightPlane);
   if (right == CullingResult::Outside) {
     return false;
   }
 
-  const CullingResult top = boundingVolume.intersectPlane(cullingVolume.topPlane);
+  const CullingResult top =
+      boundingVolume.intersectPlane(cullingVolume.topPlane);
   if (top == CullingResult::Outside) {
     return false;
   }

--- a/Cesium3DTilesSelection/src/calcQuadtreeMaxGeometricError.cpp
+++ b/Cesium3DTilesSelection/src/calcQuadtreeMaxGeometricError.cpp
@@ -1,8 +1,8 @@
 #include "calcQuadtreeMaxGeometricError.h"
 
 namespace Cesium3DTilesSelection {
-double
-calcQuadtreeMaxGeometricError(const CesiumGeospatial::Ellipsoid& ellipsoid) noexcept {
+double calcQuadtreeMaxGeometricError(
+    const CesiumGeospatial::Ellipsoid& ellipsoid) noexcept {
   static const double mapQuality = 0.25;
   static const uint32_t mapWidth = 65;
   return ellipsoid.getMaximumRadius() * mapQuality / mapWidth;

--- a/Cesium3DTilesSelection/src/calcQuadtreeMaxGeometricError.cpp
+++ b/Cesium3DTilesSelection/src/calcQuadtreeMaxGeometricError.cpp
@@ -2,7 +2,7 @@
 
 namespace Cesium3DTilesSelection {
 double
-calcQuadtreeMaxGeometricError(const CesiumGeospatial::Ellipsoid& ellipsoid) {
+calcQuadtreeMaxGeometricError(const CesiumGeospatial::Ellipsoid& ellipsoid) noexcept {
   static const double mapQuality = 0.25;
   static const uint32_t mapWidth = 65;
   return ellipsoid.getMaximumRadius() * mapQuality / mapWidth;

--- a/Cesium3DTilesSelection/src/calcQuadtreeMaxGeometricError.h
+++ b/Cesium3DTilesSelection/src/calcQuadtreeMaxGeometricError.h
@@ -19,5 +19,5 @@ namespace Cesium3DTilesSelection {
  * @return The max geometric error.
  */
 double
-calcQuadtreeMaxGeometricError(const CesiumGeospatial::Ellipsoid& ellipsoid);
+calcQuadtreeMaxGeometricError(const CesiumGeospatial::Ellipsoid& ellipsoid) noexcept;
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/calcQuadtreeMaxGeometricError.h
+++ b/Cesium3DTilesSelection/src/calcQuadtreeMaxGeometricError.h
@@ -18,6 +18,6 @@ namespace Cesium3DTilesSelection {
  * @param ellipsoid The ellipsoid.
  * @return The max geometric error.
  */
-double
-calcQuadtreeMaxGeometricError(const CesiumGeospatial::Ellipsoid& ellipsoid) noexcept;
+double calcQuadtreeMaxGeometricError(
+    const CesiumGeospatial::Ellipsoid& ellipsoid) noexcept;
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/upgradeBatchTableToFeatureMetadata.cpp
+++ b/Cesium3DTilesSelection/src/upgradeBatchTableToFeatureMetadata.cpp
@@ -421,7 +421,7 @@ void updateNumericArrayProperty(
   // check if it's a fixed array
   if (compatibleTypes.minComponentCount == compatibleTypes.maxComponentCount) {
     const size_t numOfValues = static_cast<size_t>(featureTable.count) *
-                         *compatibleTypes.minComponentCount;
+                               *compatibleTypes.minComponentCount;
     std::vector<std::byte> valueBuffer(sizeof(ValueType) * numOfValues);
     ValueType* value = reinterpret_cast<ValueType*>(valueBuffer.data());
     for (int64_t i = 0; i < featureTable.count; ++i) {
@@ -509,7 +509,8 @@ void updateNumericArrayProperty(
   gltfValueBufferView.byteOffset = 0;
   gltfValueBufferView.byteLength =
       static_cast<int64_t>(gltfValueBuffer.cesium.data.size());
-  const int32_t valueBufferIdx = static_cast<int32_t>(gltf.bufferViews.size() - 1);
+  const int32_t valueBufferIdx =
+      static_cast<int32_t>(gltf.bufferViews.size() - 1);
 
   Buffer& gltfOffsetBuffer = gltf.buffers.emplace_back();
   gltfOffsetBuffer.byteLength = static_cast<int64_t>(offsetBuffer.size());
@@ -520,7 +521,8 @@ void updateNumericArrayProperty(
   gltfOffsetBufferView.byteOffset = 0;
   gltfOffsetBufferView.byteLength =
       static_cast<int64_t>(gltfOffsetBuffer.cesium.data.size());
-  const int32_t offsetBufferIdx = static_cast<int32_t>(gltf.bufferViews.size() - 1);
+  const int32_t offsetBufferIdx =
+      static_cast<int32_t>(gltf.bufferViews.size() - 1);
 
   classProperty.type = "ARRAY";
   classProperty.componentType = convertPropertyTypeToString(
@@ -883,7 +885,8 @@ void updateBooleanArrayProperty(
   gltfValueBufferView.byteOffset = 0;
   gltfValueBufferView.byteLength =
       static_cast<int64_t>(gltfValueBuffer.cesium.data.size());
-  const int32_t valueBufferIdx = static_cast<int32_t>(gltf.bufferViews.size() - 1);
+  const int32_t valueBufferIdx =
+      static_cast<int32_t>(gltf.bufferViews.size() - 1);
 
   Buffer& gltfOffsetBuffer = gltf.buffers.emplace_back();
   gltfOffsetBuffer.byteLength = static_cast<int64_t>(offsetBuffer.size());
@@ -894,7 +897,8 @@ void updateBooleanArrayProperty(
   gltfOffsetBufferView.byteOffset = 0;
   gltfOffsetBufferView.byteLength =
       static_cast<int64_t>(gltfOffsetBuffer.cesium.data.size());
-  const int32_t offsetBufferIdx = static_cast<int32_t>(gltf.bufferViews.size() - 1);
+  const int32_t offsetBufferIdx =
+      static_cast<int32_t>(gltf.bufferViews.size() - 1);
 
   classProperty.type = "ARRAY";
   classProperty.componentType = "BOOLEAN";

--- a/Cesium3DTilesSelection/src/upgradeBatchTableToFeatureMetadata.cpp
+++ b/Cesium3DTilesSelection/src/upgradeBatchTableToFeatureMetadata.cpp
@@ -60,11 +60,11 @@ const std::map<std::string, GltfFeatureTableType> b3dmComponentTypeToGltfType =
         {"DOUBLE", GltfFeatureTableType{"FLOAT64", sizeof(double)}},
 };
 
-int64_t roundUp(int64_t num, int64_t multiple) {
+int64_t roundUp(int64_t num, int64_t multiple) noexcept {
   return ((num + multiple - 1) / multiple) * multiple;
 }
 
-template <typename T> bool isInRangeForSignedInteger(int64_t value) {
+template <typename T> bool isInRangeForSignedInteger(int64_t value) noexcept {
   // this only work if sizeof(T) is smaller than int64_t
   static_assert(
       !std::is_same_v<T, uint64_t> && !std::is_same_v<T, float> &&
@@ -74,7 +74,8 @@ template <typename T> bool isInRangeForSignedInteger(int64_t value) {
          value <= static_cast<int64_t>(std::numeric_limits<T>::max());
 }
 
-template <typename T> bool isInRangeForUnsignedInteger(uint64_t value) {
+template <typename T>
+bool isInRangeForUnsignedInteger(uint64_t value) noexcept {
   static_assert(!std::is_signed_v<T>);
 
   return value >= static_cast<uint64_t>(std::numeric_limits<T>::lowest()) &&

--- a/Cesium3DTilesSelection/src/upgradeBatchTableToFeatureMetadata.cpp
+++ b/Cesium3DTilesSelection/src/upgradeBatchTableToFeatureMetadata.cpp
@@ -115,7 +115,7 @@ CompatibleTypes findCompatibleTypes(const rapidjson::Value& propertyValue) {
       type.isBool = true;
       type.isArray = false;
     } else if (it->IsInt64()) {
-      int64_t value = it->GetInt64();
+      const int64_t value = it->GetInt64();
       type.isInt8 &= isInRangeForSignedInteger<int8_t>(value);
       type.isUint8 &= isInRangeForSignedInteger<uint8_t>(value);
       type.isInt16 &= isInRangeForSignedInteger<int16_t>(value);
@@ -241,7 +241,7 @@ void updateExtensionWithJsonStringProperty(
     ++it;
   }
 
-  uint64_t totalSize = rapidjsonOffsets.back();
+  const uint64_t totalSize = rapidjsonOffsets.back();
   std::vector<std::byte> buffer;
   std::vector<std::byte> offsetBuffer;
   if (isInRangeForUnsignedInteger<uint8_t>(totalSize)) {
@@ -282,7 +282,7 @@ void updateExtensionWithJsonStringProperty(
   gltfBufferView.buffer = static_cast<int32_t>(gltf.buffers.size() - 1);
   gltfBufferView.byteOffset = 0;
   gltfBufferView.byteLength = static_cast<int64_t>(totalSize);
-  int32_t valueBufferViewIdx =
+  const int32_t valueBufferViewIdx =
       static_cast<int32_t>(gltf.bufferViews.size() - 1);
 
   Buffer& gltfOffsetBuffer = gltf.buffers.emplace_back();
@@ -294,7 +294,7 @@ void updateExtensionWithJsonStringProperty(
   gltfOffsetBufferView.byteOffset = 0;
   gltfOffsetBufferView.byteLength =
       static_cast<int64_t>(gltfOffsetBuffer.cesium.data.size());
-  int32_t offsetBufferViewIdx =
+  const int32_t offsetBufferViewIdx =
       static_cast<int32_t>(gltf.bufferViews.size() - 1);
 
   classProperty.type = "STRING";
@@ -316,13 +316,13 @@ void updateExtensionWithJsonNumericProperty(
   classProperty.type = typeName;
 
   // Create a new buffer for this property.
-  size_t bufferIndex = gltf.buffers.size();
+  const size_t bufferIndex = gltf.buffers.size();
   Buffer& buffer = gltf.buffers.emplace_back();
   buffer.byteLength =
       static_cast<int64_t>(sizeof(T) * static_cast<size_t>(featureTable.count));
   buffer.cesium.data.resize(static_cast<size_t>(buffer.byteLength));
 
-  size_t bufferViewIndex = gltf.bufferViews.size();
+  const size_t bufferViewIndex = gltf.bufferViews.size();
   BufferView& bufferView = gltf.bufferViews.emplace_back();
   bufferView.buffer = int32_t(bufferIndex);
   bufferView.byteOffset = 0;
@@ -353,14 +353,14 @@ void updateExtensionWithJsonBoolProperty(
   for (rapidjson::SizeType i = 0;
        i < static_cast<rapidjson::SizeType>(featureTable.count);
        ++i) {
-    bool value = jsonArray[i].GetBool();
-    size_t byteIndex = i / 8;
-    size_t bitIndex = i % 8;
+    const bool value = jsonArray[i].GetBool();
+    const size_t byteIndex = i / 8;
+    const size_t bitIndex = i % 8;
     data[byteIndex] =
         static_cast<std::byte>(value << bitIndex) | data[byteIndex];
   }
 
-  size_t bufferIndex = gltf.buffers.size();
+  const size_t bufferIndex = gltf.buffers.size();
   Buffer& buffer = gltf.buffers.emplace_back();
   buffer.byteLength = static_cast<int64_t>(data.size());
   buffer.cesium.data = std::move(data);
@@ -420,7 +420,7 @@ void updateNumericArrayProperty(
 
   // check if it's a fixed array
   if (compatibleTypes.minComponentCount == compatibleTypes.maxComponentCount) {
-    size_t numOfValues = static_cast<size_t>(featureTable.count) *
+    const size_t numOfValues = static_cast<size_t>(featureTable.count) *
                          *compatibleTypes.minComponentCount;
     std::vector<std::byte> valueBuffer(sizeof(ValueType) * numOfValues);
     ValueType* value = reinterpret_cast<ValueType*>(valueBuffer.data());
@@ -465,7 +465,7 @@ void updateNumericArrayProperty(
   PropertyType offsetType = PropertyType::None;
   std::vector<std::byte> valueBuffer;
   std::vector<std::byte> offsetBuffer;
-  uint64_t maxOffsetValue = numOfElements * sizeof(ValueType);
+  const uint64_t maxOffsetValue = numOfElements * sizeof(ValueType);
   if (isInRangeForUnsignedInteger<uint8_t>(maxOffsetValue)) {
     copyNumericDynamicArrayBuffers<TRapidjson, ValueType, uint8_t>(
         valueBuffer,
@@ -509,7 +509,7 @@ void updateNumericArrayProperty(
   gltfValueBufferView.byteOffset = 0;
   gltfValueBufferView.byteLength =
       static_cast<int64_t>(gltfValueBuffer.cesium.data.size());
-  int32_t valueBufferIdx = static_cast<int32_t>(gltf.bufferViews.size() - 1);
+  const int32_t valueBufferIdx = static_cast<int32_t>(gltf.bufferViews.size() - 1);
 
   Buffer& gltfOffsetBuffer = gltf.buffers.emplace_back();
   gltfOffsetBuffer.byteLength = static_cast<int64_t>(offsetBuffer.size());
@@ -520,7 +520,7 @@ void updateNumericArrayProperty(
   gltfOffsetBufferView.byteOffset = 0;
   gltfOffsetBufferView.byteLength =
       static_cast<int64_t>(gltfOffsetBuffer.cesium.data.size());
-  int32_t offsetBufferIdx = static_cast<int32_t>(gltf.bufferViews.size() - 1);
+  const int32_t offsetBufferIdx = static_cast<int32_t>(gltf.bufferViews.size() - 1);
 
   classProperty.type = "ARRAY";
   classProperty.componentType = convertPropertyTypeToString(
@@ -609,7 +609,7 @@ void updateStringArrayProperty(
     }
   }
 
-  uint64_t totalByteLength = totalChars * sizeof(rapidjson::Value::Ch);
+  const uint64_t totalByteLength = totalChars * sizeof(rapidjson::Value::Ch);
   std::vector<std::byte> valueBuffer;
   std::vector<std::byte> offsetBuffer;
   PropertyType offsetType = PropertyType::None;
@@ -661,7 +661,7 @@ void updateStringArrayProperty(
       static_cast<std::int32_t>(gltf.buffers.size() - 1);
   gltfValueBufferView.byteOffset = 0;
   gltfValueBufferView.byteLength = gltfValueBuffer.byteLength;
-  int32_t valueBufferViewIdx =
+  const int32_t valueBufferViewIdx =
       static_cast<int32_t>(gltf.bufferViews.size() - 1);
 
   // create gltf string offset buffer view
@@ -673,7 +673,7 @@ void updateStringArrayProperty(
   gltfOffsetBufferView.buffer = static_cast<int32_t>(gltf.buffers.size() - 1);
   gltfOffsetBufferView.byteOffset = 0;
   gltfOffsetBufferView.byteLength = gltfOffsetBuffer.byteLength;
-  int32_t offsetBufferViewIdx =
+  const int32_t offsetBufferViewIdx =
       static_cast<int32_t>(gltf.bufferViews.size() - 1);
 
   // fixed array of string
@@ -730,7 +730,7 @@ void updateStringArrayProperty(
       static_cast<int32_t>(gltf.buffers.size() - 1);
   gltfArrayOffsetBufferView.byteOffset = 0;
   gltfArrayOffsetBufferView.byteLength = gltfArrayOffsetBuffer.byteLength;
-  int32_t arrayOffsetBufferViewIdx =
+  const int32_t arrayOffsetBufferViewIdx =
       static_cast<int32_t>(gltf.bufferViews.size() - 1);
 
   classProperty.type = "ARRAY";
@@ -750,7 +750,7 @@ void copyBooleanArrayBuffers(
     const FeatureTable& featureTable,
     const rapidjson::Value& propertyValue) {
   size_t currentIndex = 0;
-  size_t totalByteLength =
+  const size_t totalByteLength =
       static_cast<size_t>(glm::ceil(static_cast<double>(numOfElements) / 8.0));
   valueBuffer.resize(totalByteLength);
   offsetBuffer.resize(
@@ -766,9 +766,9 @@ void copyBooleanArrayBuffers(
     ++offset;
     prevOffset = static_cast<OffsetType>(prevOffset + arrayMember.Size());
     for (const auto& data : arrayMember.GetArray()) {
-      bool value = data.GetBool();
-      size_t byteIndex = currentIndex / 8;
-      size_t bitIndex = currentIndex % 8;
+      const bool value = data.GetBool();
+      const size_t byteIndex = currentIndex / 8;
+      const size_t bitIndex = currentIndex % 8;
       valueBuffer[byteIndex] =
           static_cast<std::byte>(value << bitIndex) | valueBuffer[byteIndex];
       ++currentIndex;
@@ -789,9 +789,9 @@ void updateBooleanArrayProperty(
 
   // fixed array of boolean
   if (compatibleTypes.minComponentCount == compatibleTypes.maxComponentCount) {
-    size_t numOfElements = static_cast<size_t>(
+    const size_t numOfElements = static_cast<size_t>(
         featureTable.count * compatibleTypes.minComponentCount.value());
-    size_t totalByteLength = static_cast<size_t>(
+    const size_t totalByteLength = static_cast<size_t>(
         glm::ceil(static_cast<double>(numOfElements) / 8.0));
     std::vector<std::byte> valueBuffer(totalByteLength);
     size_t currentIndex = 0;
@@ -800,9 +800,9 @@ void updateBooleanArrayProperty(
       const auto& arrayMember =
           jsonOuterArray[static_cast<rapidjson::SizeType>(i)];
       for (const auto& data : arrayMember.GetArray()) {
-        bool value = data.GetBool();
-        size_t byteIndex = currentIndex / 8;
-        size_t bitIndex = currentIndex % 8;
+        const bool value = data.GetBool();
+        const size_t byteIndex = currentIndex / 8;
+        const size_t bitIndex = currentIndex % 8;
         valueBuffer[byteIndex] =
             static_cast<std::byte>(value << bitIndex) | valueBuffer[byteIndex];
         ++currentIndex;
@@ -883,7 +883,7 @@ void updateBooleanArrayProperty(
   gltfValueBufferView.byteOffset = 0;
   gltfValueBufferView.byteLength =
       static_cast<int64_t>(gltfValueBuffer.cesium.data.size());
-  int32_t valueBufferIdx = static_cast<int32_t>(gltf.bufferViews.size() - 1);
+  const int32_t valueBufferIdx = static_cast<int32_t>(gltf.bufferViews.size() - 1);
 
   Buffer& gltfOffsetBuffer = gltf.buffers.emplace_back();
   gltfOffsetBuffer.byteLength = static_cast<int64_t>(offsetBuffer.size());
@@ -894,7 +894,7 @@ void updateBooleanArrayProperty(
   gltfOffsetBufferView.byteOffset = 0;
   gltfOffsetBufferView.byteLength =
       static_cast<int64_t>(gltfOffsetBuffer.cesium.data.size());
-  int32_t offsetBufferIdx = static_cast<int32_t>(gltf.bufferViews.size() - 1);
+  const int32_t offsetBufferIdx = static_cast<int32_t>(gltf.bufferViews.size() - 1);
 
   classProperty.type = "ARRAY";
   classProperty.componentType = "BOOLEAN";
@@ -1032,7 +1032,7 @@ void updateExtensionWithJsonProperty(
 
   // Figure out which types we can use for this data.
   // Use the smallest type we can, and prefer signed to unsigned.
-  CompatibleTypes compatibleTypes = findCompatibleTypes(propertyValue);
+  const CompatibleTypes compatibleTypes = findCompatibleTypes(propertyValue);
   if (compatibleTypes.type.isBool) {
     updateExtensionWithJsonBoolProperty(
         gltf,
@@ -1186,7 +1186,7 @@ void updateExtensionWithBinaryProperty(
   }
 
   // convert class property
-  int64_t byteOffset = byteOffsetIt->value.GetInt64();
+  const int64_t byteOffset = byteOffsetIt->value.GetInt64();
   const std::string& componentType = componentTypeIt->value.GetString();
   const std::string& type = typeIt->value.GetString();
 
@@ -1219,7 +1219,7 @@ void updateExtensionWithBinaryProperty(
   }
 
   // convert feature table
-  size_t typeSize = gltfType.typeSize;
+  const size_t typeSize = gltfType.typeSize;
   auto& bufferView = gltf.bufferViews.emplace_back();
   bufferView.buffer = gltfBufferIndex;
   bufferView.byteOffset = gltfBufferOffset;
@@ -1256,7 +1256,7 @@ void upgradeBatchTableToFeatureMetadata(
 
   // If the feature table is missing the BATCH_LENGTH semantic, ignore the batch
   // table completely.
-  auto batchLengthIt = featureTableJson.FindMember("BATCH_LENGTH");
+  const auto batchLengthIt = featureTableJson.FindMember("BATCH_LENGTH");
   if (batchLengthIt == featureTableJson.MemberEnd() ||
       !batchLengthIt->value.IsInt64()) {
     SPDLOG_LOGGER_WARN(
@@ -1267,7 +1267,7 @@ void upgradeBatchTableToFeatureMetadata(
     return;
   }
 
-  int64_t batchLength = batchLengthIt->value.GetInt64();
+  const int64_t batchLength = batchLengthIt->value.GetInt64();
 
   // Add the binary part of the batch table - if any - to the glTF as a buffer.
   // We will reallign this buffer later on

--- a/Cesium3DTilesSelection/src/upgradeBatchTableToFeatureMetadata.cpp
+++ b/Cesium3DTilesSelection/src/upgradeBatchTableToFeatureMetadata.cpp
@@ -210,7 +210,7 @@ CompatibleTypes findCompatibleTypes(const rapidjson::Value& propertyValue) {
 void updateExtensionWithJsonStringProperty(
     Model& gltf,
     ClassProperty& classProperty,
-    FeatureTable& featureTable,
+    const FeatureTable& featureTable,
     FeatureTableProperty& featureTableProperty,
     const rapidjson::Value& propertyValue) {
   assert(propertyValue.Size() >= featureTable.count);
@@ -307,7 +307,7 @@ template <typename T, typename TRapidJson = T>
 void updateExtensionWithJsonNumericProperty(
     Model& gltf,
     ClassProperty& classProperty,
-    FeatureTable& featureTable,
+    const FeatureTable& featureTable,
     FeatureTableProperty& featureTableProperty,
     const rapidjson::Value& propertyValue,
     const std::string& typeName) {
@@ -342,7 +342,7 @@ void updateExtensionWithJsonNumericProperty(
 void updateExtensionWithJsonBoolProperty(
     Model& gltf,
     ClassProperty& classProperty,
-    FeatureTable& featureTable,
+    const FeatureTable& featureTable,
     FeatureTableProperty& featureTableProperty,
     const rapidjson::Value& propertyValue) {
   assert(propertyValue.Size() >= featureTable.count);
@@ -911,7 +911,7 @@ void updateBooleanArrayProperty(
 void updateExtensionWithArrayProperty(
     Model& gltf,
     ClassProperty& classProperty,
-    FeatureTable& featureTable,
+    const FeatureTable& featureTable,
     FeatureTableProperty& featureTableProperty,
     const CompatibleTypes& compatibleTypes,
     const rapidjson::Value& propertyValue) {
@@ -1019,7 +1019,7 @@ void updateExtensionWithArrayProperty(
 void updateExtensionWithJsonProperty(
     Model& gltf,
     ClassProperty& classProperty,
-    FeatureTable& featureTable,
+    const FeatureTable& featureTable,
     FeatureTableProperty& featureTableProperty,
     const rapidjson::Value& propertyValue) {
 
@@ -1148,7 +1148,7 @@ void updateExtensionWithBinaryProperty(
     int64_t gltfBufferOffset,
     BinaryProperty& binaryProperty,
     ClassProperty& classProperty,
-    FeatureTable& featureTable,
+    const FeatureTable& featureTable,
     FeatureTableProperty& featureTableProperty,
     const std::string& propertyName,
     const rapidjson::Value& propertyValue,

--- a/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.cpp
+++ b/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.cpp
@@ -82,11 +82,11 @@ static void addSkirts(
     int64_t vertexSizeFloats,
     int32_t positionAttributeIndex);
 
-static bool isWestChild(CesiumGeometry::UpsampledQuadtreeNode childID) {
+static bool isWestChild(CesiumGeometry::UpsampledQuadtreeNode childID) noexcept {
   return (childID.tileID.x % 2) == 0;
 }
 
-static bool isSouthChild(CesiumGeometry::UpsampledQuadtreeNode childID) {
+static bool isSouthChild(CesiumGeometry::UpsampledQuadtreeNode childID) noexcept {
   return (childID.tileID.y % 2) == 0;
 }
 

--- a/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.cpp
+++ b/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.cpp
@@ -82,11 +82,13 @@ static void addSkirts(
     int64_t vertexSizeFloats,
     int32_t positionAttributeIndex);
 
-static bool isWestChild(CesiumGeometry::UpsampledQuadtreeNode childID) noexcept {
+static bool
+isWestChild(CesiumGeometry::UpsampledQuadtreeNode childID) noexcept {
   return (childID.tileID.x % 2) == 0;
 }
 
-static bool isSouthChild(CesiumGeometry::UpsampledQuadtreeNode childID) noexcept {
+static bool
+isSouthChild(CesiumGeometry::UpsampledQuadtreeNode childID) noexcept {
   return (childID.tileID.y % 2) == 0;
 }
 

--- a/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.cpp
+++ b/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.cpp
@@ -121,7 +121,7 @@ Model upsampleGltfForRasterOverlays(
   auto nameIt = result.extras.find("Cesium3DTiles_TileUrl");
   if (nameIt != result.extras.end()) {
     std::string name = nameIt->second.getStringOrDefault("");
-    std::string::size_type upsampledIndex = name.find(" upsampled");
+    const std::string::size_type upsampledIndex = name.find(" upsampled");
     if (upsampledIndex != std::string::npos) {
       name = name.substr(0, upsampledIndex);
     }
@@ -161,7 +161,7 @@ static void copyVertexAttributes(
             attribute.buffer.data() + attribute.offset +
             attribute.stride * vertexIndex);
         for (int32_t i = 0; i < attribute.numberOfFloatsPerVertex; ++i) {
-          float value = *pInput;
+          const float value = *pInput;
           output.push_back(value);
           if (!skipMinMaxUpdate) {
             attribute.minimums[static_cast<size_t>(i)] = glm::min(
@@ -185,7 +185,7 @@ static void copyVertexAttributes(
             attribute.buffer.data() + attribute.offset +
             attribute.stride * vertex.second);
         for (int32_t i = 0; i < attribute.numberOfFloatsPerVertex; ++i) {
-          float value = glm::mix(*pInput0, *pInput1, vertex.t);
+          const float value = glm::mix(*pInput0, *pInput1, vertex.t);
           output.push_back(value);
           if (!skipMinMaxUpdate) {
             attribute.minimums[static_cast<size_t>(i)] = glm::min(
@@ -368,16 +368,16 @@ static void upsamplePrimitiveForRasterOverlays(
   std::vector<FloatVertexAttribute> attributes;
   attributes.reserve(primitive.attributes.size());
 
-  size_t vertexBufferIndex = model.buffers.size();
+  const size_t vertexBufferIndex = model.buffers.size();
   model.buffers.emplace_back();
 
-  size_t indexBufferIndex = model.buffers.size();
+  const size_t indexBufferIndex = model.buffers.size();
   model.buffers.emplace_back();
 
-  size_t vertexBufferViewIndex = model.bufferViews.size();
+  const size_t vertexBufferViewIndex = model.bufferViews.size();
   model.bufferViews.emplace_back();
 
-  size_t indexBufferViewIndex = model.bufferViews.size();
+  const size_t indexBufferViewIndex = model.bufferViews.size();
   model.bufferViews.emplace_back();
 
   BufferView& vertexBufferView = model.bufferViews[vertexBufferViewIndex];
@@ -431,8 +431,8 @@ static void upsamplePrimitiveForRasterOverlays(
     const Buffer& buffer =
         parentModel.buffers[static_cast<size_t>(bufferView.buffer)];
 
-    int64_t accessorByteStride = accessor.computeByteStride(parentModel);
-    int64_t accessorComponentElements = accessor.computeNumberOfComponents();
+    const int64_t accessorByteStride = accessor.computeByteStride(parentModel);
+    const int64_t accessorComponentElements = accessor.computeNumberOfComponents();
     if (accessor.componentType != Accessor::ComponentType::FLOAT) {
       // Can only interpolate floating point vertex attributes
       return;
@@ -474,15 +474,15 @@ static void upsamplePrimitiveForRasterOverlays(
     return;
   }
 
-  for (std::string& attribute : toRemove) {
+  for (const std::string& attribute : toRemove) {
     primitive.attributes.erase(attribute);
   }
 
-  bool keepAboveU = !isWestChild(childID);
-  bool keepAboveV = !isSouthChild(childID);
+  const bool keepAboveU = !isWestChild(childID);
+  const bool keepAboveV = !isSouthChild(childID);
 
-  AccessorView<glm::vec2> uvView(parentModel, uvAccessorIndex);
-  AccessorView<TIndex> indicesView(parentModel, primitive.indices);
+  const AccessorView<glm::vec2> uvView(parentModel, uvAccessorIndex);
+  const AccessorView<TIndex> indicesView(parentModel, primitive.indices);
 
   if (uvView.status() != AccessorViewStatus::Valid ||
       indicesView.status() != AccessorViewStatus::Valid) {
@@ -494,7 +494,7 @@ static void upsamplePrimitiveForRasterOverlays(
   int64_t indicesCount = indicesView.size();
   std::optional<SkirtMeshMetadata> parentSkirtMeshMetadata =
       SkirtMeshMetadata::parseFromGltfExtras(primitive.extras);
-  bool hasSkirt = (parentSkirtMeshMetadata != std::nullopt) &&
+  const bool hasSkirt = (parentSkirtMeshMetadata != std::nullopt) &&
                   (positionAttributeIndex != -1);
   if (hasSkirt) {
     indicesBegin = parentSkirtMeshMetadata->noSkirtIndicesBegin;
@@ -523,9 +523,9 @@ static void upsamplePrimitiveForRasterOverlays(
     TIndex i1 = indicesView[i + 1];
     TIndex i2 = indicesView[i + 2];
 
-    glm::vec2 uv0 = uvView[i0];
-    glm::vec2 uv1 = uvView[i1];
-    glm::vec2 uv2 = uvView[i2];
+    const glm::vec2 uv0 = uvView[i0];
+    const glm::vec2 uv1 = uvView[i1];
+    const glm::vec2 uv2 = uvView[i2];
 
     // Clip this triangle against the East-West boundary
     clippedA.clear();
@@ -642,7 +642,7 @@ static void upsamplePrimitiveForRasterOverlays(
   }
 
   // Update the accessor vertex counts and min/max values
-  int64_t numberOfVertices = int64_t(newVertexFloats.size()) / vertexSizeFloats;
+  const int64_t numberOfVertices = int64_t(newVertexFloats.size()) / vertexSizeFloats;
   for (const FloatVertexAttribute& attribute : attributes) {
     Accessor& accessor =
         model.accessors[static_cast<size_t>(attribute.accessorIndex)];
@@ -652,7 +652,7 @@ static void upsamplePrimitiveForRasterOverlays(
   }
 
   // Add an accessor for the indices
-  size_t indexAccessorIndex = model.accessors.size();
+  const size_t indexAccessorIndex = model.accessors.size();
   model.accessors.emplace_back();
   Accessor& newIndicesAccessor = model.accessors.back();
   newIndicesAccessor.bufferView = static_cast<int>(indexBufferViewIndex);
@@ -756,13 +756,13 @@ static uint32_t getOrCreateVertex(
           complements[static_cast<size_t>(~(*pIndex))]);
     }
 
-    uint32_t existingIndex = vertexMap[static_cast<size_t>(*pIndex)];
+    const uint32_t existingIndex = vertexMap[static_cast<size_t>(*pIndex)];
     if (existingIndex != std::numeric_limits<uint32_t>::max()) {
       return existingIndex;
     }
   }
 
-  uint32_t beforeOutput = static_cast<uint32_t>(output.size());
+  const uint32_t beforeOutput = static_cast<uint32_t>(output.size());
   copyVertexAttributes(attributes, complements, clipVertex, output);
   uint32_t newIndex =
       beforeOutput / (static_cast<uint32_t>(output.size()) - beforeOutput);
@@ -786,19 +786,19 @@ static void addClippedPolygon(
     return;
   }
 
-  uint32_t i0 = getOrCreateVertex(
+  const uint32_t i0 = getOrCreateVertex(
       output,
       attributes,
       vertexMap,
       complements,
       clipResult[0]);
-  uint32_t i1 = getOrCreateVertex(
+  const uint32_t i1 = getOrCreateVertex(
       output,
       attributes,
       vertexMap,
       complements,
       clipResult[1]);
-  uint32_t i2 = getOrCreateVertex(
+  const uint32_t i2 = getOrCreateVertex(
       output,
       attributes,
       vertexMap,
@@ -814,7 +814,7 @@ static void addClippedPolygon(
   clipVertexToIndices.push_back(i2);
 
   if (clipResult.size() > 3) {
-    uint32_t i3 = getOrCreateVertex(
+    const uint32_t i3 = getOrCreateVertex(
         output,
         attributes,
         vertexMap,
@@ -840,7 +840,7 @@ static void addEdge(
     const std::vector<CesiumGeometry::TriangleClipVertex>& complements,
     const std::vector<CesiumGeometry::TriangleClipVertex>& clipResult) {
   for (uint32_t i = 0; i < clipVertexToIndices.size(); ++i) {
-    glm::vec2 uv = getVertexValue(uvs, complements, clipResult[i]);
+    const glm::vec2 uv = getVertexValue(uvs, complements, clipResult[i]);
 
     if (CesiumUtility::Math::equalsEpsilon(
             uv.x,
@@ -908,11 +908,11 @@ static void addSkirt(
 
   uint32_t newEdgeIndex = uint32_t(output.size() / size_t(vertexSizeFloats));
   for (size_t i = 0; i < edgeIndices.size(); ++i) {
-    uint32_t edgeIdx = edgeIndices[i];
+    const uint32_t edgeIdx = edgeIndices[i];
     uint32_t offset = 0;
     for (size_t j = 0; j < attributes.size(); ++j) {
       FloatVertexAttribute& attribute = attributes[j];
-      uint32_t valueIndex = offset + uint32_t(vertexSizeFloats) * edgeIdx;
+      const uint32_t valueIndex = offset + uint32_t(vertexSizeFloats) * edgeIdx;
 
       if (int32_t(j) == positionAttributeIndex) {
         glm::dvec3 position{
@@ -952,7 +952,7 @@ static void addSkirt(
     }
 
     if (i < edgeIndices.size() - 1) {
-      uint32_t nextEdgeIdx = edgeIndices[i + 1];
+      const uint32_t nextEdgeIdx = edgeIndices[i + 1];
       indices.push_back(edgeIdx);
       indices.push_back(nextEdgeIdx);
       indices.push_back(newEdgeIndex);
@@ -978,7 +978,7 @@ static void addSkirts(
     int32_t positionAttributeIndex) {
   CESIUM_TRACE("addSkirts");
 
-  glm::dvec3 center = currentSkirt.meshCenter;
+  const glm::dvec3 center = currentSkirt.meshCenter;
   double shortestSkirtHeight =
       glm::min(parentSkirt.skirtWestHeight, parentSkirt.skirtEastHeight);
   shortestSkirtHeight =

--- a/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.cpp
+++ b/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.cpp
@@ -432,7 +432,8 @@ static void upsamplePrimitiveForRasterOverlays(
         parentModel.buffers[static_cast<size_t>(bufferView.buffer)];
 
     const int64_t accessorByteStride = accessor.computeByteStride(parentModel);
-    const int64_t accessorComponentElements = accessor.computeNumberOfComponents();
+    const int64_t accessorComponentElements =
+        accessor.computeNumberOfComponents();
     if (accessor.componentType != Accessor::ComponentType::FLOAT) {
       // Can only interpolate floating point vertex attributes
       return;
@@ -495,7 +496,7 @@ static void upsamplePrimitiveForRasterOverlays(
   std::optional<SkirtMeshMetadata> parentSkirtMeshMetadata =
       SkirtMeshMetadata::parseFromGltfExtras(primitive.extras);
   const bool hasSkirt = (parentSkirtMeshMetadata != std::nullopt) &&
-                  (positionAttributeIndex != -1);
+                        (positionAttributeIndex != -1);
   if (hasSkirt) {
     indicesBegin = parentSkirtMeshMetadata->noSkirtIndicesBegin;
     indicesCount = parentSkirtMeshMetadata->noSkirtIndicesCount;
@@ -642,7 +643,8 @@ static void upsamplePrimitiveForRasterOverlays(
   }
 
   // Update the accessor vertex counts and min/max values
-  const int64_t numberOfVertices = int64_t(newVertexFloats.size()) / vertexSizeFloats;
+  const int64_t numberOfVertices =
+      int64_t(newVertexFloats.size()) / vertexSizeFloats;
   for (const FloatVertexAttribute& attribute : attributes) {
     Accessor& accessor =
         model.accessors[static_cast<size_t>(attribute.accessorIndex)];

--- a/CesiumAsync/include/CesiumAsync/Impl/ImmediateScheduler.h
+++ b/CesiumAsync/include/CesiumAsync/Impl/ImmediateScheduler.h
@@ -9,7 +9,7 @@ namespace Impl {
 template <typename TScheduler> class ImmediateScheduler {
 public:
   explicit ImmediateScheduler(TScheduler* pScheduler)
-      : _pScheduler(pScheduler) {}
+      : _pScheduler(pScheduler) noexcept {}
 
   void schedule(async::task_run_handle t) {
     // Are we already in a suitable thread?
@@ -47,7 +47,7 @@ public:
       return *this;
     }
 
-    void reset() {
+    void reset() noexcept {
       if (this->_pScheduler) {
         std::vector<TScheduler*>& inSuitable =
             ImmediateScheduler<TScheduler>::getSchedulersCurrentlyDispatching();
@@ -74,7 +74,8 @@ private:
   // If a TScheduler instance is found in this thread-local vector, then the
   // current thread has been dispatched by this scheduler and therefore we can
   // dispatch immediately.
-  static std::vector<TScheduler*>& getSchedulersCurrentlyDispatching() {
+  static std::vector<TScheduler*>&
+  getSchedulersCurrentlyDispatching() noexcept {
     // We're using a static local here rather than a static field because, on
     // at least some Linux systems (mine), with Clang 12, in a Debug build, a
     // thread_local static field causes a SEGFAULT on access.

--- a/CesiumAsync/include/CesiumAsync/Impl/ImmediateScheduler.h
+++ b/CesiumAsync/include/CesiumAsync/Impl/ImmediateScheduler.h
@@ -27,8 +27,7 @@ public:
 
   class SchedulerScope {
   public:
-    SchedulerScope(TScheduler* pScheduler = nullptr) noexcept
-        : _pScheduler(pScheduler) {
+    SchedulerScope(TScheduler* pScheduler = nullptr) : _pScheduler(pScheduler) {
       if (this->_pScheduler) {
         std::vector<TScheduler*>& inSuitable =
             ImmediateScheduler<TScheduler>::getSchedulersCurrentlyDispatching();

--- a/CesiumAsync/include/CesiumAsync/Impl/ImmediateScheduler.h
+++ b/CesiumAsync/include/CesiumAsync/Impl/ImmediateScheduler.h
@@ -27,7 +27,8 @@ public:
 
   class SchedulerScope {
   public:
-    SchedulerScope(TScheduler* pScheduler = nullptr) : _pScheduler(pScheduler) {
+    SchedulerScope(TScheduler* pScheduler = nullptr) noexcept
+        : _pScheduler(pScheduler) {
       if (this->_pScheduler) {
         std::vector<TScheduler*>& inSuitable =
             ImmediateScheduler<TScheduler>::getSchedulersCurrentlyDispatching();

--- a/CesiumAsync/include/CesiumAsync/Impl/ImmediateScheduler.h
+++ b/CesiumAsync/include/CesiumAsync/Impl/ImmediateScheduler.h
@@ -8,8 +8,8 @@ namespace Impl {
 
 template <typename TScheduler> class ImmediateScheduler {
 public:
-  explicit ImmediateScheduler(TScheduler* pScheduler)
-      : _pScheduler(pScheduler) noexcept {}
+  explicit ImmediateScheduler(TScheduler* pScheduler) noexcept
+      : _pScheduler(pScheduler) {}
 
   void schedule(async::task_run_handle t) {
     // Are we already in a suitable thread?

--- a/CesiumAsync/include/CesiumAsync/Promise.h
+++ b/CesiumAsync/include/CesiumAsync/Promise.h
@@ -58,7 +58,7 @@ private:
   Promise(
       const std::shared_ptr<Impl::AsyncSystemSchedulers>& pSchedulers,
       const std::shared_ptr<async::event_task<T>>& pEvent)
-      : _pSchedulers(pSchedulers), _pEvent(pEvent) {}
+      : _pSchedulers(pSchedulers), _pEvent(pEvent) noexcept {}
 
   std::shared_ptr<Impl::AsyncSystemSchedulers> _pSchedulers;
   std::shared_ptr<async::event_task<T>> _pEvent;
@@ -84,7 +84,7 @@ private:
   Promise(
       const std::shared_ptr<Impl::AsyncSystemSchedulers>& pSchedulers,
       const std::shared_ptr<async::event_task<void>>& pEvent)
-      : _pSchedulers(pSchedulers), _pEvent(pEvent) {}
+      : _pSchedulers(pSchedulers), _pEvent(pEvent) noexcept {}
 
   std::shared_ptr<Impl::AsyncSystemSchedulers> _pSchedulers;
   std::shared_ptr<async::event_task<void>> _pEvent;

--- a/CesiumAsync/include/CesiumAsync/Promise.h
+++ b/CesiumAsync/include/CesiumAsync/Promise.h
@@ -57,8 +57,8 @@ public:
 private:
   Promise(
       const std::shared_ptr<Impl::AsyncSystemSchedulers>& pSchedulers,
-      const std::shared_ptr<async::event_task<T>>& pEvent)
-      : _pSchedulers(pSchedulers), _pEvent(pEvent) noexcept {}
+      const std::shared_ptr<async::event_task<T>>& pEvent) noexcept
+      : _pSchedulers(pSchedulers), _pEvent(pEvent) {}
 
   std::shared_ptr<Impl::AsyncSystemSchedulers> _pSchedulers;
   std::shared_ptr<async::event_task<T>> _pEvent;
@@ -83,8 +83,8 @@ public:
 private:
   Promise(
       const std::shared_ptr<Impl::AsyncSystemSchedulers>& pSchedulers,
-      const std::shared_ptr<async::event_task<void>>& pEvent)
-      : _pSchedulers(pSchedulers), _pEvent(pEvent) noexcept {}
+      const std::shared_ptr<async::event_task<void>>& pEvent) noexcept
+      : _pSchedulers(pSchedulers), _pEvent(pEvent) {}
 
   std::shared_ptr<Impl::AsyncSystemSchedulers> _pSchedulers;
   std::shared_ptr<async::event_task<void>> _pEvent;

--- a/CesiumAsync/include/CesiumAsync/ThreadPool.h
+++ b/CesiumAsync/include/CesiumAsync/ThreadPool.h
@@ -34,7 +34,7 @@ private:
   }
 
   static auto createPostRun() noexcept {
-    return []() { ThreadPool::_scope.reset(); };
+    return []() noexcept { ThreadPool::_scope.reset(); };
   }
 
   static thread_local Impl::ImmediateScheduler<Scheduler>::SchedulerScope

--- a/CesiumAsync/include/CesiumAsync/ThreadPool.h
+++ b/CesiumAsync/include/CesiumAsync/ThreadPool.h
@@ -33,7 +33,7 @@ private:
         [pScheduler]() { ThreadPool::_scope = pScheduler->immediate.scope(); };
   }
 
-  static auto createPostRun() {
+  static auto createPostRun() noexcept {
     return []() { ThreadPool::_scope.reset(); };
   }
 

--- a/CesiumAsync/src/CachingAssetAccessor.cpp
+++ b/CesiumAsync/src/CachingAssetAccessor.cpp
@@ -105,7 +105,7 @@ Future<std::shared_ptr<IAssetRequest>> CachingAssetAccessor::requestAsset(
     const AsyncSystem& asyncSystem,
     const std::string& url,
     const std::vector<THeader>& headers) {
-  int32_t requestSinceLastPrune = ++this->_requestSinceLastPrune;
+  const int32_t requestSinceLastPrune = ++this->_requestSinceLastPrune;
   if (requestSinceLastPrune == this->_requestsPerCachePrune) {
     // More requests may have started and incremented _requestSinceLastPrune
     // beyond _requestsPerCachePrune before this next line. That's ok.
@@ -119,7 +119,7 @@ Future<std::shared_ptr<IAssetRequest>> CachingAssetAccessor::requestAsset(
 
   CESIUM_TRACE_BEGIN_IN_TRACK("requestAsset (cached)");
 
-  ThreadPool& threadPool = this->_cacheThreadPool;
+  const ThreadPool& threadPool = this->_cacheThreadPool;
 
   return asyncSystem
       .runInThreadPool(
@@ -146,7 +146,7 @@ Future<std::shared_ptr<IAssetRequest>> CachingAssetAccessor::requestAsset(
                           return std::move(pCompletedRequest);
                         }
 
-                        std::optional<ResponseCacheControl> cacheControl =
+                        const std::optional<ResponseCacheControl> cacheControl =
                             ResponseCacheControl::parseFromResponseHeaders(
                                 pResponse->headers());
 
@@ -212,7 +212,7 @@ Future<std::shared_ptr<IAssetRequest>> CachingAssetAccessor::requestAsset(
 
                         const IAssetResponse* pResponseToStore =
                             pRequestToStore->response();
-                        std::optional<ResponseCacheControl> cacheControl =
+                        const std::optional<ResponseCacheControl> cacheControl =
                             ResponseCacheControl::parseFromResponseHeaders(
                                 pResponseToStore->headers());
 
@@ -273,7 +273,7 @@ bool shouldRevalidateCache(const CacheItem& cacheItem) {
 }
 
 bool isCacheStale(const CacheItem& cacheItem) noexcept {
-  std::time_t currentTime = std::time(nullptr);
+  const std::time_t currentTime = std::time(nullptr);
   return std::difftime(cacheItem.expiryTime, currentTime) < 0.0;
 }
 
@@ -292,7 +292,7 @@ bool shouldCacheRequest(
   }
 
   // check if response status code is cacheable
-  uint16_t statusCode = pResponse->statusCode();
+  const uint16_t statusCode = pResponse->statusCode();
   if (statusCode != 200 && // status OK
       statusCode != 201 && // status Created
       statusCode != 202 && // status Accepted

--- a/CesiumAsync/src/CachingAssetAccessor.cpp
+++ b/CesiumAsync/src/CachingAssetAccessor.cpp
@@ -13,9 +13,10 @@
 namespace CesiumAsync {
 class CacheAssetResponse : public IAssetResponse {
 public:
-  CacheAssetResponse(const CacheItem* pCacheItem) : _pCacheItem{pCacheItem} {}
+  CacheAssetResponse(const CacheItem* pCacheItem) noexcept
+      : _pCacheItem{pCacheItem} {}
 
-  virtual uint16_t statusCode() const override {
+  virtual uint16_t statusCode() const noexcept override {
     return this->_pCacheItem->cacheResponse.statusCode;
   }
 
@@ -27,11 +28,11 @@ public:
     return it->second;
   }
 
-  virtual const HttpHeaders& headers() const override {
+  virtual const HttpHeaders& headers() const noexcept override {
     return this->_pCacheItem->cacheResponse.headers;
   }
 
-  virtual gsl::span<const std::byte> data() const override {
+  virtual gsl::span<const std::byte> data() const noexcept override {
     return gsl::span<const std::byte>(
         this->_pCacheItem->cacheResponse.data.data(),
         this->_pCacheItem->cacheResponse.data.size());
@@ -46,19 +47,19 @@ public:
   CacheAssetRequest(CacheItem&& cacheItem)
       : _cacheItem(std::move(cacheItem)), _response(&this->_cacheItem) {}
 
-  virtual const std::string& method() const override {
+  virtual const std::string& method() const noexcept override {
     return this->_cacheItem.cacheRequest.method;
   }
 
-  virtual const std::string& url() const override {
+  virtual const std::string& url() const noexcept override {
     return this->_cacheItem.cacheRequest.url;
   }
 
-  virtual const HttpHeaders& headers() const override {
+  virtual const HttpHeaders& headers() const noexcept override {
     return this->_cacheItem.cacheRequest.headers;
   }
 
-  virtual const IAssetResponse* response() const override {
+  virtual const IAssetResponse* response() const noexcept override {
     return &this->_response;
   }
 
@@ -71,7 +72,7 @@ static std::time_t convertHttpDateToTime(const std::string& httpDate);
 
 static bool shouldRevalidateCache(const CacheItem& cacheItem);
 
-static bool isCacheStale(const CacheItem& cacheItem);
+static bool isCacheStale(const CacheItem& cacheItem) noexcept;
 
 static bool shouldCacheRequest(
     const IAssetRequest& request,
@@ -242,7 +243,7 @@ Future<std::shared_ptr<IAssetRequest>> CachingAssetAccessor::requestAsset(
                 std::make_shared<CacheAssetRequest>(std::move(cacheItem));
             return asyncSystem.createResolvedFuture(std::move(pRequest));
           })
-      .thenImmediately([](std::shared_ptr<IAssetRequest>&& pRequest) {
+      .thenImmediately([](std::shared_ptr<IAssetRequest>&& pRequest) noexcept {
         CESIUM_TRACE_END_IN_TRACK("requestAsset (cached)");
         return std::move(pRequest);
       });
@@ -271,7 +272,7 @@ bool shouldRevalidateCache(const CacheItem& cacheItem) {
   return isCacheStale(cacheItem);
 }
 
-bool isCacheStale(const CacheItem& cacheItem) {
+bool isCacheStale(const CacheItem& cacheItem) noexcept {
   std::time_t currentTime = std::time(nullptr);
   return std::difftime(cacheItem.expiryTime, currentTime) < 0.0;
 }

--- a/CesiumAsync/src/InternalTimegm.cpp
+++ b/CesiumAsync/src/InternalTimegm.cpp
@@ -33,7 +33,7 @@ time_t internalTimegm(std::tm const* t) {
 
   const time_t seconds_in_day = 3600 * 24;
   const time_t result = seconds_in_day * days_since_epoch + 3600 * t->tm_hour +
-                  60 * t->tm_min + t->tm_sec;
+                        60 * t->tm_min + t->tm_sec;
 
   return result;
 }

--- a/CesiumAsync/src/InternalTimegm.cpp
+++ b/CesiumAsync/src/InternalTimegm.cpp
@@ -22,17 +22,17 @@ time_t internalTimegm(std::tm const* t) {
     year += month / 12;
     month %= 12;
   } else if (month < 0) {
-    int years_diff = (-month + 11) / 12;
+    const int years_diff = (-month + 11) / 12;
     year -= years_diff;
     month += 12 * years_diff;
   }
   month++;
-  int day = t->tm_mday;
-  int day_of_year = daysFrom1jan(year, month, day);
-  int days_since_epoch = daysFrom1970(year) + day_of_year;
+  const int day = t->tm_mday;
+  const int day_of_year = daysFrom1jan(year, month, day);
+  const int days_since_epoch = daysFrom1970(year) + day_of_year;
 
-  time_t seconds_in_day = 3600 * 24;
-  time_t result = seconds_in_day * days_since_epoch + 3600 * t->tm_hour +
+  const time_t seconds_in_day = 3600 * 24;
+  const time_t result = seconds_in_day * days_since_epoch + 3600 * t->tm_hour +
                   60 * t->tm_min + t->tm_sec;
 
   return result;

--- a/CesiumAsync/src/ResponseCacheControl.cpp
+++ b/CesiumAsync/src/ResponseCacheControl.cpp
@@ -41,7 +41,7 @@ ResponseCacheControl::parseFromResponseHeaders(const HttpHeaders& headers) {
   size_t next = 0;
   while ((next = headerValue.find(',', last)) != std::string::npos) {
     std::string directive = trimSpace(headerValue.substr(last, next - last));
-    size_t equalSize = directive.find('=');
+    const size_t equalSize = directive.find('=');
     if (equalSize != std::string::npos) {
       parameterizedDirectives.insert(
           {trimSpace(directive.substr(0, equalSize)),
@@ -54,7 +54,7 @@ ResponseCacheControl::parseFromResponseHeaders(const HttpHeaders& headers) {
   }
 
   std::string directive = trimSpace(headerValue.substr(last));
-  size_t equalSize = directive.find('=');
+  const size_t equalSize = directive.find('=');
   if (equalSize != std::string::npos) {
     parameterizedDirectives.insert(
         {trimSpace(directive.substr(0, equalSize)),

--- a/CesiumAsync/src/ResponseCacheControl.h
+++ b/CesiumAsync/src/ResponseCacheControl.h
@@ -44,47 +44,51 @@ public:
   /**
    * @brief Must-Revalidate directive that appears in the Cache-Control header.
    */
-  inline bool mustRevalidate() const { return _mustRevalidate; }
+  inline bool mustRevalidate() const noexcept { return _mustRevalidate; }
 
   /**
    * @brief No-Cache directive that appears in the Cache-Control header.
    */
-  inline bool noCache() const { return _noCache; }
+  inline bool noCache() const noexcept { return _noCache; }
 
   /**
    * @brief No-Store directive that appears in the Cache-Control header.
    */
-  inline bool noStore() const { return _noStore; }
+  inline bool noStore() const noexcept { return _noStore; }
 
   /**
    * @brief No-Transform directive that appears in the Cache-Control header.
    */
-  inline bool noTransform() const { return _noTransform; }
+  inline bool noTransform() const noexcept { return _noTransform; }
 
   /**
    * @brief Public directive that appears in the Cache-Control header.
    */
-  inline bool accessControlPublic() const { return _accessControlPublic; }
+  inline bool accessControlPublic() const noexcept {
+    return _accessControlPublic;
+  }
 
   /**
    * @brief Private directive that appears in the Cache-Control header.
    */
-  inline bool accessControlPrivate() const { return _accessControlPrivate; }
+  inline bool accessControlPrivate() const noexcept {
+    return _accessControlPrivate;
+  }
 
   /**
    * @brief Proxy-Revalidate directive that appears in the Cache-Control header.
    */
-  inline bool proxyRevalidate() const { return _proxyRevalidate; }
+  inline bool proxyRevalidate() const noexcept { return _proxyRevalidate; }
 
   /**
    * @brief Max-Age directive that appears in the Cache-Control header.
    */
-  int maxAge() const { return _maxAge; }
+  int maxAge() const noexcept { return _maxAge; }
 
   /**
    * @brief S-Maxage directive that appears in the Cache-Control header.
    */
-  int sharedMaxAge() const { return _sharedMaxAge; }
+  int sharedMaxAge() const noexcept { return _sharedMaxAge; }
 
   /**
    * @brief Parse response cache control from the response's headers.

--- a/CesiumAsync/src/SqliteCache.cpp
+++ b/CesiumAsync/src/SqliteCache.cpp
@@ -141,7 +141,7 @@ SqliteStatementPtr prepareStatement(
     const SqliteConnectionPtr& pConnection,
     const std::string& sql) {
   CESIUM_SQLITE(sqlite3_stmt*) pStmt;
-  int status = CESIUM_SQLITE(sqlite3_prepare_v2)(
+  const int status = CESIUM_SQLITE(sqlite3_prepare_v2)(
       pConnection.get(),
       sql.c_str(),
       int(sql.size()),
@@ -340,11 +340,11 @@ std::optional<CacheItem> SqliteCache::getEntry(const std::string& key) const {
   }
 
   // Cache hit - unpack and return it.
-  int64_t itemIndex = CESIUM_SQLITE(
+  const int64_t itemIndex = CESIUM_SQLITE(
       sqlite3_column_int64)(this->_pImpl->_getEntryStmtWrapper.get(), 0);
 
   // parse cache item metadata
-  std::time_t expiryTime = CESIUM_SQLITE(
+  const std::time_t expiryTime = CESIUM_SQLITE(
       sqlite3_column_int64)(this->_pImpl->_getEntryStmtWrapper.get(), 1);
 
   // parse response cache
@@ -354,13 +354,13 @@ std::optional<CacheItem> SqliteCache::getEntry(const std::string& key) const {
   HttpHeaders responseHeaders =
       convertStringToHeaders(serializedResponseHeaders);
 
-  uint16_t statusCode = static_cast<uint16_t>(CESIUM_SQLITE(
+  const uint16_t statusCode = static_cast<uint16_t>(CESIUM_SQLITE(
       sqlite3_column_int)(this->_pImpl->_getEntryStmtWrapper.get(), 3));
 
   const std::byte* rawResponseData =
       reinterpret_cast<const std::byte*>(CESIUM_SQLITE(
           sqlite3_column_blob)(this->_pImpl->_getEntryStmtWrapper.get(), 4));
-  int responseDataSize = CESIUM_SQLITE(
+  const int responseDataSize = CESIUM_SQLITE(
       sqlite3_column_bytes)(this->_pImpl->_getEntryStmtWrapper.get(), 4);
   std::vector<std::byte> responseData(
       rawResponseData,
@@ -666,7 +666,7 @@ bool SqliteCache::prune() {
   }
 
   // check if we should delete more
-  int deletedRows =
+  const int deletedRows =
       CESIUM_SQLITE(sqlite3_changes)(this->_pImpl->_pConnection.get());
   if (totalItems - deletedRows < static_cast<int>(this->_pImpl->_maxItems)) {
     return true;

--- a/CesiumGeometry/include/CesiumGeometry/Axis.h
+++ b/CesiumGeometry/include/CesiumGeometry/Axis.h
@@ -7,7 +7,7 @@ namespace CesiumGeometry {
 /**
  * @brief An enum describing the x, y, and z axes
  */
-enum CESIUMGEOMETRY_API Axis {
+enum class CESIUMGEOMETRY_API Axis {
   /**
    * @brief The x-axis
    */

--- a/CesiumGeometry/src/BoundingSphere.cpp
+++ b/CesiumGeometry/src/BoundingSphere.cpp
@@ -6,10 +6,10 @@ namespace CesiumGeometry {
 
 CullingResult
 BoundingSphere::intersectPlane(const Plane& plane) const noexcept {
-  double distanceToPlane =
+  const double distanceToPlane =
       glm::dot(plane.getNormal(), this->_center) + plane.getDistance();
 
-  double radius = this->_radius;
+  const double radius = this->_radius;
   if (distanceToPlane < -radius) {
     // The center point is negative side of the plane normal
     return CullingResult::Outside;
@@ -24,7 +24,7 @@ BoundingSphere::intersectPlane(const Plane& plane) const noexcept {
 
 double BoundingSphere::computeDistanceSquaredToPosition(
     const glm::dvec3& position) const noexcept {
-  glm::dvec3 diff = position - this->_center;
+  const glm::dvec3 diff = position - this->_center;
   return glm::dot(diff, diff) - this->_radius * this->_radius;
 }
 

--- a/CesiumGeometry/src/CullingVolume.cpp
+++ b/CesiumGeometry/src/CullingVolume.cpp
@@ -12,17 +12,17 @@ CullingVolume createCullingVolume(
     const glm::dvec3& up,
     const double fovx,
     const double fovy) noexcept {
-  double t = glm::tan(0.5 * fovy);
-  double b = -t;
-  double r = glm::tan(0.5 * fovx);
-  double l = -r;
+  const double t = glm::tan(0.5 * fovy);
+  const double b = -t;
+  const double r = glm::tan(0.5 * fovx);
+  const double l = -r;
 
-  double n = 1.0;
+  const double n = 1.0;
 
   // TODO: this is all ported directly from CesiumJS, can probably be refactored
   // to be more efficient with GLM.
 
-  glm::dvec3 right = glm::cross(direction, up);
+  const glm::dvec3 right = glm::cross(direction, up);
 
   glm::dvec3 nearCenter = direction * n;
   nearCenter = position + nearCenter;
@@ -35,7 +35,7 @@ CullingVolume createCullingVolume(
   normal = glm::cross(normal, up);
   normal = glm::normalize(normal);
 
-  CesiumGeometry::Plane leftPlane(normal, -glm::dot(normal, position));
+  const CesiumGeometry::Plane leftPlane(normal, -glm::dot(normal, position));
 
   // Right plane computation
   normal = right * r;
@@ -44,7 +44,7 @@ CullingVolume createCullingVolume(
   normal = glm::cross(up, normal);
   normal = glm::normalize(normal);
 
-  CesiumGeometry::Plane rightPlane(normal, -glm::dot(normal, position));
+  const CesiumGeometry::Plane rightPlane(normal, -glm::dot(normal, position));
 
   // Bottom plane computation
   normal = up * b;
@@ -53,7 +53,7 @@ CullingVolume createCullingVolume(
   normal = glm::cross(right, normal);
   normal = glm::normalize(normal);
 
-  CesiumGeometry::Plane bottomPlane(normal, -glm::dot(normal, position));
+  const CesiumGeometry::Plane bottomPlane(normal, -glm::dot(normal, position));
 
   // Top plane computation
   normal = up * t;
@@ -62,7 +62,7 @@ CullingVolume createCullingVolume(
   normal = glm::cross(normal, right);
   normal = glm::normalize(normal);
 
-  CesiumGeometry::Plane topPlane(normal, -glm::dot(normal, position));
+  const CesiumGeometry::Plane topPlane(normal, -glm::dot(normal, position));
 
   return {leftPlane, rightPlane, topPlane, bottomPlane};
 }

--- a/CesiumGeometry/src/IntersectionTests.cpp
+++ b/CesiumGeometry/src/IntersectionTests.cpp
@@ -10,14 +10,14 @@ namespace CesiumGeometry {
 
 /*static*/ std::optional<glm::dvec3>
 IntersectionTests::rayPlane(const Ray& ray, const Plane& plane) noexcept {
-  double denominator = glm::dot(plane.getNormal(), ray.getDirection());
+  const double denominator = glm::dot(plane.getNormal(), ray.getDirection());
 
   if (glm::abs(denominator) < Math::EPSILON15) {
     // Ray is parallel to plane.  The ray may be in the polygon's plane.
     return std::optional<glm::dvec3>();
   }
 
-  double t =
+  const double t =
       (-plane.getDistance() - glm::dot(plane.getNormal(), ray.getOrigin())) /
       denominator;
 

--- a/CesiumGeometry/src/OrientedBoundingBox.cpp
+++ b/CesiumGeometry/src/OrientedBoundingBox.cpp
@@ -18,17 +18,17 @@ OrientedBoundingBox::intersectPlane(const Plane& plane) const noexcept {
   // plane is used as if it is its normal; the first three components are
   // assumed to be normalized
   const double radEffective = glm::abs(
-                            normal.x * xAxisDirectionAndHalfLength.x +
-                            normal.y * xAxisDirectionAndHalfLength.y +
-                            normal.z * xAxisDirectionAndHalfLength.z) +
-                        glm::abs(
-                            normal.x * yAxisDirectionAndHalfLength.x +
-                            normal.y * yAxisDirectionAndHalfLength.y +
-                            normal.z * yAxisDirectionAndHalfLength.z) +
-                        glm::abs(
-                            normal.x * zAxisDirectionAndHalfLength.x +
-                            normal.y * zAxisDirectionAndHalfLength.y +
-                            normal.z * zAxisDirectionAndHalfLength.z);
+                                  normal.x * xAxisDirectionAndHalfLength.x +
+                                  normal.y * xAxisDirectionAndHalfLength.y +
+                                  normal.z * xAxisDirectionAndHalfLength.z) +
+                              glm::abs(
+                                  normal.x * yAxisDirectionAndHalfLength.x +
+                                  normal.y * yAxisDirectionAndHalfLength.y +
+                                  normal.z * yAxisDirectionAndHalfLength.z) +
+                              glm::abs(
+                                  normal.x * zAxisDirectionAndHalfLength.x +
+                                  normal.y * zAxisDirectionAndHalfLength.y +
+                                  normal.z * zAxisDirectionAndHalfLength.z);
 
   const double distanceToPlane =
       ::glm::dot(normal, this->getCenter()) + plane.getDistance();

--- a/CesiumGeometry/src/OrientedBoundingBox.cpp
+++ b/CesiumGeometry/src/OrientedBoundingBox.cpp
@@ -8,7 +8,7 @@
 namespace CesiumGeometry {
 CullingResult
 OrientedBoundingBox::intersectPlane(const Plane& plane) const noexcept {
-  glm::dvec3 normal = plane.getNormal();
+  const glm::dvec3 normal = plane.getNormal();
 
   const glm::dmat3& halfAxes = this->getHalfAxes();
   const glm::dvec3& xAxisDirectionAndHalfLength = halfAxes[0];
@@ -17,7 +17,7 @@ OrientedBoundingBox::intersectPlane(const Plane& plane) const noexcept {
 
   // plane is used as if it is its normal; the first three components are
   // assumed to be normalized
-  double radEffective = glm::abs(
+  const double radEffective = glm::abs(
                             normal.x * xAxisDirectionAndHalfLength.x +
                             normal.y * xAxisDirectionAndHalfLength.y +
                             normal.z * xAxisDirectionAndHalfLength.z) +
@@ -30,7 +30,7 @@ OrientedBoundingBox::intersectPlane(const Plane& plane) const noexcept {
                             normal.y * zAxisDirectionAndHalfLength.y +
                             normal.z * zAxisDirectionAndHalfLength.z);
 
-  double distanceToPlane =
+  const double distanceToPlane =
       ::glm::dot(normal, this->getCenter()) + plane.getDistance();
 
   if (distanceToPlane <= -radEffective) {
@@ -46,22 +46,22 @@ OrientedBoundingBox::intersectPlane(const Plane& plane) const noexcept {
 
 double OrientedBoundingBox::computeDistanceSquaredToPosition(
     const glm::dvec3& position) const noexcept {
-  glm::dvec3 offset = position - this->getCenter();
+  const glm::dvec3 offset = position - this->getCenter();
 
   const glm::dmat3& halfAxes = this->getHalfAxes();
   glm::dvec3 u = halfAxes[0];
   glm::dvec3 v = halfAxes[1];
   glm::dvec3 w = halfAxes[2];
 
-  double uHalf = glm::length(u);
-  double vHalf = glm::length(v);
-  double wHalf = glm::length(w);
+  const double uHalf = glm::length(u);
+  const double vHalf = glm::length(v);
+  const double wHalf = glm::length(w);
 
   u /= uHalf;
   v /= vHalf;
   w /= wHalf;
 
-  glm::dvec3 pPrime(
+  const glm::dvec3 pPrime(
       glm::dot(offset, u),
       glm::dot(offset, v),
       glm::dot(offset, w));

--- a/CesiumGeometry/src/Plane.cpp
+++ b/CesiumGeometry/src/Plane.cpp
@@ -26,8 +26,8 @@ double Plane::getPointDistance(const glm::dvec3& point) const noexcept {
 glm::dvec3
 Plane::projectPointOntoPlane(const glm::dvec3& point) const noexcept {
   // projectedPoint = point - (normal.point + scale) * normal
-  double pointDistance = this->getPointDistance(point);
-  glm::dvec3 scaledNormal = this->_normal * pointDistance;
+  const double pointDistance = this->getPointDistance(point);
+  const glm::dvec3 scaledNormal = this->_normal * pointDistance;
   return point - scaledNormal;
 }
 

--- a/CesiumGeometry/src/QuadtreeTileAvailability.cpp
+++ b/CesiumGeometry/src/QuadtreeTileAvailability.cpp
@@ -13,7 +13,7 @@ QuadtreeTileAvailability::QuadtreeTileAvailability(
           this->_tilingScheme.getRootTilesX() *
           this->_tilingScheme.getRootTilesY()) {
   for (uint32_t j = 0; j < this->_tilingScheme.getRootTilesY(); ++j) {
-    uint32_t rowStart = j * this->_tilingScheme.getRootTilesX();
+    const uint32_t rowStart = j * this->_tilingScheme.getRootTilesX();
     for (uint32_t i = 0; i < this->_tilingScheme.getRootTilesX(); ++i) {
       QuadtreeTileID id(0, i, j);
       Rectangle extent = tilingScheme.tileToRectangle(id);
@@ -25,16 +25,16 @@ QuadtreeTileAvailability::QuadtreeTileAvailability(
 
 void QuadtreeTileAvailability::addAvailableTileRange(
     const QuadtreeTileRectangularRange& range) noexcept {
-  Rectangle ll = this->_tilingScheme.tileToRectangle(
+  const Rectangle ll = this->_tilingScheme.tileToRectangle(
       QuadtreeTileID(range.level, range.minimumX, range.minimumY));
-  Rectangle ur = this->_tilingScheme.tileToRectangle(
+  const Rectangle ur = this->_tilingScheme.tileToRectangle(
       QuadtreeTileID(range.level, range.maximumX, range.maximumY));
 
   RectangleWithLevel rectangleWithLevel{
       range.level,
       Rectangle(ll.minimumX, ll.minimumY, ur.maximumX, ur.maximumY)};
 
-  for (std::unique_ptr<QuadtreeNode>& pNode : this->_rootNodes) {
+  for (const std::unique_ptr<QuadtreeNode>& pNode : this->_rootNodes) {
     if (pNode->extent.overlaps(rectangleWithLevel.rectangle)) {
       putRectangleInQuadtree(
           this->_tilingScheme,
@@ -65,8 +65,8 @@ bool QuadtreeTileAvailability::isTileAvailable(
   // level n exists, then all its parent tiles back to level 0 exist too.  This
   // isn't really enforced anywhere, but Cesium would never load a tile for
   // which this is not true.
-  CesiumGeometry::Rectangle rectangle = this->_tilingScheme.tileToRectangle(id);
-  glm::dvec2 center = rectangle.getCenter();
+  const CesiumGeometry::Rectangle rectangle = this->_tilingScheme.tileToRectangle(id);
+  const glm::dvec2 center = rectangle.getCenter();
   return this->computeMaximumLevelAtPosition(center) >= id.level;
 }
 
@@ -123,10 +123,10 @@ bool QuadtreeTileAvailability::isTileAvailable(
   // Find the deepest quadtree node containing this point.
   bool found = false;
   while (!found) {
-    uint32_t ll = pNode->ll && pNode->ll->extent.contains(position) ? 1 : 0;
-    uint32_t lr = pNode->lr && pNode->lr->extent.contains(position) ? 1 : 0;
-    uint32_t ul = pNode->ul && pNode->ul->extent.contains(position) ? 1 : 0;
-    uint32_t ur = pNode->ur && pNode->ur->extent.contains(position) ? 1 : 0;
+    const uint32_t ll = pNode->ll && pNode->ll->extent.contains(position) ? 1 : 0;
+    const uint32_t lr = pNode->lr && pNode->lr->extent.contains(position) ? 1 : 0;
+    const uint32_t ul = pNode->ul && pNode->ul->extent.contains(position) ? 1 : 0;
+    const uint32_t ur = pNode->ur && pNode->ur->extent.contains(position) ? 1 : 0;
 
     // The common scenario is that the point is in only one quadrant and we can
     // simply iterate down the tree.  But if the point is on a boundary between

--- a/CesiumGeometry/src/QuadtreeTileAvailability.cpp
+++ b/CesiumGeometry/src/QuadtreeTileAvailability.cpp
@@ -65,7 +65,8 @@ bool QuadtreeTileAvailability::isTileAvailable(
   // level n exists, then all its parent tiles back to level 0 exist too.  This
   // isn't really enforced anywhere, but Cesium would never load a tile for
   // which this is not true.
-  const CesiumGeometry::Rectangle rectangle = this->_tilingScheme.tileToRectangle(id);
+  const CesiumGeometry::Rectangle rectangle =
+      this->_tilingScheme.tileToRectangle(id);
   const glm::dvec2 center = rectangle.getCenter();
   return this->computeMaximumLevelAtPosition(center) >= id.level;
 }
@@ -123,10 +124,14 @@ bool QuadtreeTileAvailability::isTileAvailable(
   // Find the deepest quadtree node containing this point.
   bool found = false;
   while (!found) {
-    const uint32_t ll = pNode->ll && pNode->ll->extent.contains(position) ? 1 : 0;
-    const uint32_t lr = pNode->lr && pNode->lr->extent.contains(position) ? 1 : 0;
-    const uint32_t ul = pNode->ul && pNode->ul->extent.contains(position) ? 1 : 0;
-    const uint32_t ur = pNode->ur && pNode->ur->extent.contains(position) ? 1 : 0;
+    const uint32_t ll =
+        pNode->ll && pNode->ll->extent.contains(position) ? 1 : 0;
+    const uint32_t lr =
+        pNode->lr && pNode->lr->extent.contains(position) ? 1 : 0;
+    const uint32_t ul =
+        pNode->ul && pNode->ul->extent.contains(position) ? 1 : 0;
+    const uint32_t ur =
+        pNode->ur && pNode->ur->extent.contains(position) ? 1 : 0;
 
     // The common scenario is that the point is in only one quadrant and we can
     // simply iterate down the tree.  But if the point is on a boundary between

--- a/CesiumGeometry/src/QuadtreeTileID.cpp
+++ b/CesiumGeometry/src/QuadtreeTileID.cpp
@@ -4,7 +4,7 @@ namespace CesiumGeometry {
 
 uint32_t QuadtreeTileID::computeInvertedY(
     const QuadtreeTilingScheme& tilingScheme) const noexcept {
-  uint32_t yTiles = tilingScheme.getNumberOfYTilesAtLevel(this->level);
+  const uint32_t yTiles = tilingScheme.getNumberOfYTilesAtLevel(this->level);
   return yTiles - this->y - 1;
 }
 

--- a/CesiumGeometry/src/QuadtreeTilingScheme.cpp
+++ b/CesiumGeometry/src/QuadtreeTilingScheme.cpp
@@ -26,16 +26,16 @@ QuadtreeTilingScheme::positionToTile(const glm::dvec2& position, uint32_t level)
     return std::nullopt;
   }
 
-  uint32_t xTiles = this->getNumberOfXTilesAtLevel(level);
-  uint32_t yTiles = this->getNumberOfYTilesAtLevel(level);
+  const uint32_t xTiles = this->getNumberOfXTilesAtLevel(level);
+  const uint32_t yTiles = this->getNumberOfYTilesAtLevel(level);
 
-  double overallWidth = this->getRectangle().computeWidth();
-  double xTileWidth = overallWidth / xTiles;
-  double overallHeight = this->getRectangle().computeHeight();
-  double yTileHeight = overallHeight / yTiles;
+  const double overallWidth = this->getRectangle().computeWidth();
+  const double xTileWidth = overallWidth / xTiles;
+  const double overallHeight = this->getRectangle().computeHeight();
+  const double yTileHeight = overallHeight / yTiles;
 
-  double distanceFromWest = position.x - this->getRectangle().minimumX;
-  double distanceFromSouth = position.y - this->getRectangle().minimumY;
+  const double distanceFromWest = position.x - this->getRectangle().minimumX;
+  const double distanceFromSouth = position.y - this->getRectangle().minimumY;
 
   uint32_t xTileCoordinate =
       static_cast<uint32_t>(distanceFromWest / xTileWidth);
@@ -56,16 +56,16 @@ QuadtreeTilingScheme::positionToTile(const glm::dvec2& position, uint32_t level)
 
 CesiumGeometry::Rectangle QuadtreeTilingScheme::tileToRectangle(
     const CesiumGeometry::QuadtreeTileID& tileID) const noexcept {
-  uint32_t xTiles = this->getNumberOfXTilesAtLevel(tileID.level);
-  uint32_t yTiles = this->getNumberOfYTilesAtLevel(tileID.level);
+  const uint32_t xTiles = this->getNumberOfXTilesAtLevel(tileID.level);
+  const uint32_t yTiles = this->getNumberOfYTilesAtLevel(tileID.level);
 
-  double xTileWidth = this->_rectangle.computeWidth() / xTiles;
-  double left = this->_rectangle.minimumX + tileID.x * xTileWidth;
-  double right = this->_rectangle.minimumX + (tileID.x + 1) * xTileWidth;
+  const double xTileWidth = this->_rectangle.computeWidth() / xTiles;
+  const double left = this->_rectangle.minimumX + tileID.x * xTileWidth;
+  const double right = this->_rectangle.minimumX + (tileID.x + 1) * xTileWidth;
 
-  double yTileHeight = this->_rectangle.computeHeight() / yTiles;
-  double bottom = this->_rectangle.minimumY + tileID.y * yTileHeight;
-  double top = this->_rectangle.minimumY + (tileID.y + 1) * yTileHeight;
+  const double yTileHeight = this->_rectangle.computeHeight() / yTiles;
+  const double bottom = this->_rectangle.minimumY + tileID.y * yTileHeight;
+  const double top = this->_rectangle.minimumY + (tileID.y + 1) * yTileHeight;
 
   return Rectangle(left, bottom, right, top);
 }

--- a/CesiumGeometry/src/Rectangle.cpp
+++ b/CesiumGeometry/src/Rectangle.cpp
@@ -25,7 +25,8 @@ bool Rectangle::fullyContains(const Rectangle& other) const noexcept {
 
 double
 Rectangle::computeSignedDistance(const glm::dvec2& position) const noexcept {
-  const glm::dvec2 bottomLeftDistance = glm::dvec2(minimumX, minimumY) - position;
+  const glm::dvec2 bottomLeftDistance =
+      glm::dvec2(minimumX, minimumY) - position;
   const glm::dvec2 topRightDistance = position - glm::dvec2(maximumX, maximumY);
   const glm::dvec2 maxDistance = glm::max(bottomLeftDistance, topRightDistance);
 

--- a/CesiumGeometry/src/Rectangle.cpp
+++ b/CesiumGeometry/src/Rectangle.cpp
@@ -10,10 +10,10 @@ bool Rectangle::contains(const glm::dvec2& position) const noexcept {
 }
 
 bool Rectangle::overlaps(const Rectangle& other) const noexcept {
-  double left = glm::max(this->minimumX, other.minimumX);
-  double bottom = glm::max(this->minimumY, other.minimumY);
-  double right = glm::min(this->maximumX, other.maximumX);
-  double top = glm::min(this->maximumY, other.maximumY);
+  const double left = glm::max(this->minimumX, other.minimumX);
+  const double bottom = glm::max(this->minimumY, other.minimumY);
+  const double right = glm::min(this->maximumX, other.maximumX);
+  const double top = glm::min(this->maximumY, other.maximumY);
   return bottom < top && left < right;
 }
 
@@ -25,9 +25,9 @@ bool Rectangle::fullyContains(const Rectangle& other) const noexcept {
 
 double
 Rectangle::computeSignedDistance(const glm::dvec2& position) const noexcept {
-  glm::dvec2 bottomLeftDistance = glm::dvec2(minimumX, minimumY) - position;
-  glm::dvec2 topRightDistance = position - glm::dvec2(maximumX, maximumY);
-  glm::dvec2 maxDistance = glm::max(bottomLeftDistance, topRightDistance);
+  const glm::dvec2 bottomLeftDistance = glm::dvec2(minimumX, minimumY) - position;
+  const glm::dvec2 topRightDistance = position - glm::dvec2(maximumX, maximumY);
+  const glm::dvec2 maxDistance = glm::max(bottomLeftDistance, topRightDistance);
 
   if (maxDistance.x <= 0.0 && maxDistance.y <= 0.0) {
     // Inside, report closest edge.
@@ -43,10 +43,10 @@ Rectangle::computeSignedDistance(const glm::dvec2& position) const noexcept {
 
 std::optional<Rectangle>
 Rectangle::computeIntersection(const Rectangle& other) const noexcept {
-  double left = glm::max(this->minimumX, other.minimumX);
-  double bottom = glm::max(this->minimumY, other.minimumY);
-  double right = glm::min(this->maximumX, other.maximumX);
-  double top = glm::min(this->maximumY, other.maximumY);
+  const double left = glm::max(this->minimumX, other.minimumX);
+  const double bottom = glm::max(this->minimumY, other.minimumY);
+  const double right = glm::min(this->maximumX, other.maximumX);
+  const double top = glm::min(this->maximumY, other.maximumY);
 
   if (bottom >= top || left >= right) {
     return std::nullopt;

--- a/CesiumGeospatial/include/CesiumGeospatial/BoundingRegionWithLooseFittingHeights.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/BoundingRegionWithLooseFittingHeights.h
@@ -22,7 +22,8 @@ public:
    *
    * @param boundingRegion The bounding region that has imprecise heights.
    */
-  BoundingRegionWithLooseFittingHeights(const BoundingRegion& boundingRegion);
+  BoundingRegionWithLooseFittingHeights(
+      const BoundingRegion& boundingRegion) noexcept;
 
   /**
    * @brief Gets the bounding region that has imprecise heights.

--- a/CesiumGeospatial/include/CesiumGeospatial/GeographicProjection.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/GeographicProjection.h
@@ -45,9 +45,9 @@ public:
    */
   static constexpr CesiumGeometry::Rectangle computeMaximumProjectedRectangle(
       const Ellipsoid& ellipsoid = Ellipsoid::WGS84) noexcept {
-    double longitudeValue =
+    const double longitudeValue =
         ellipsoid.getMaximumRadius() * CesiumUtility::Math::ONE_PI;
-    double latitudeValue =
+    const double latitudeValue =
         ellipsoid.getMaximumRadius() * CesiumUtility::Math::PI_OVER_TWO;
     return CesiumGeometry::Rectangle(
         -longitudeValue,

--- a/CesiumGeospatial/include/CesiumGeospatial/GlobeRectangle.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/GlobeRectangle.h
@@ -129,7 +129,7 @@ public:
    */
   constexpr double computeWidth() const noexcept {
     double east = this->_east;
-    double west = this->_west;
+    const double west = this->_west;
     if (east < west) {
       east += CesiumUtility::Math::TWO_PI;
     }

--- a/CesiumGeospatial/include/CesiumGeospatial/WebMercatorProjection.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/WebMercatorProjection.h
@@ -55,7 +55,8 @@ public:
    */
   static constexpr CesiumGeometry::Rectangle computeMaximumProjectedRectangle(
       const Ellipsoid& ellipsoid = Ellipsoid::WGS84) noexcept {
-    const double value = ellipsoid.getMaximumRadius() * CesiumUtility::Math::ONE_PI;
+    const double value =
+        ellipsoid.getMaximumRadius() * CesiumUtility::Math::ONE_PI;
     return CesiumGeometry::Rectangle(-value, -value, value, value);
   }
 

--- a/CesiumGeospatial/include/CesiumGeospatial/WebMercatorProjection.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/WebMercatorProjection.h
@@ -55,7 +55,7 @@ public:
    */
   static constexpr CesiumGeometry::Rectangle computeMaximumProjectedRectangle(
       const Ellipsoid& ellipsoid = Ellipsoid::WGS84) noexcept {
-    double value = ellipsoid.getMaximumRadius() * CesiumUtility::Math::ONE_PI;
+    const double value = ellipsoid.getMaximumRadius() * CesiumUtility::Math::ONE_PI;
     return CesiumGeometry::Rectangle(-value, -value, value, value);
   }
 

--- a/CesiumGeospatial/src/BoundingRegion.cpp
+++ b/CesiumGeospatial/src/BoundingRegion.cpp
@@ -55,7 +55,8 @@ BoundingRegion::BoundingRegion(
       glm::cross(glm::dvec3(0.0, 0.0, 1.0), easternMidpointCartesian));
 
   // Compute the normal of the plane bounding the southern edge of the tile.
-  const glm::dvec3 westVector = westernMidpointCartesian - easternMidpointCartesian;
+  const glm::dvec3 westVector =
+      westernMidpointCartesian - easternMidpointCartesian;
   const glm::dvec3 eastWestNormal = glm::normalize(westVector);
 
   if (!Math::equalsEpsilon(glm::length(eastWestNormal), 1.0, Math::EPSILON6)) {
@@ -285,9 +286,10 @@ static OrientedBoundingBox fromPlaneExtents(
     // If the rectangle spans the equator, CW is instead aligned with the
     // equator (because it sticks out the farthest at the equator).
     const double lonCenter = tangentPointCartographic.longitude;
-    const double latCenter = rectangle.getSouth() < 0.0 && rectangle.getNorth() > 0.0
-                           ? 0.0
-                           : tangentPointCartographic.latitude;
+    const double latCenter =
+        rectangle.getSouth() < 0.0 && rectangle.getNorth() > 0.0
+            ? 0.0
+            : tangentPointCartographic.latitude;
 
     // Compute XY extents using the rectangle at maximum height
     const Cartographic perimeterCartographicNC(
@@ -388,7 +390,7 @@ static OrientedBoundingBox fromPlaneExtents(
   planeOrigin.z = 0.0; // center the plane on the equator to simpify plane
                        // normal calculation
   const bool isPole = glm::abs(planeOrigin.x) < Math::EPSILON10 &&
-                glm::abs(planeOrigin.y) < Math::EPSILON10;
+                      glm::abs(planeOrigin.y) < Math::EPSILON10;
   const glm::dvec3 planeNormal =
       !isPole ? glm::normalize(planeOrigin) : glm::dvec3(1.0, 0.0, 0.0);
   const glm::dvec3 planeYAxis(0.0, 0.0, 1.0);
@@ -397,10 +399,11 @@ static OrientedBoundingBox fromPlaneExtents(
 
   // Get the horizon point relative to the center. This will be the farthest
   // extent in the plane's X dimension.
-  const glm::dvec3 horizonCartesian = ellipsoid.cartographicToCartesian(Cartographic(
-      centerLongitude + Math::PI_OVER_TWO,
-      latitudeNearestToEquator,
-      maximumHeight));
+  const glm::dvec3 horizonCartesian =
+      ellipsoid.cartographicToCartesian(Cartographic(
+          centerLongitude + Math::PI_OVER_TWO,
+          latitudeNearestToEquator,
+          maximumHeight));
   maxX = glm::dot(plane.projectPointOntoPlane(horizonCartesian), planeXAxis);
   minX = -maxX; // symmetrical
 

--- a/CesiumGeospatial/src/BoundingRegion.cpp
+++ b/CesiumGeospatial/src/BoundingRegion.cpp
@@ -33,7 +33,7 @@ BoundingRegion::BoundingRegion(
       _northNormal(),
       _planesAreInvalid(false) {
   // The middle latitude on the western edge.
-  glm::dvec3 westernMidpointCartesian =
+  const glm::dvec3 westernMidpointCartesian =
       ellipsoid.cartographicToCartesian(Cartographic(
           rectangle.getWest(),
           (rectangle.getSouth() + rectangle.getNorth()) * 0.5,
@@ -44,7 +44,7 @@ BoundingRegion::BoundingRegion(
       glm::cross(westernMidpointCartesian, glm::dvec3(0.0, 0.0, 1.0)));
 
   // The middle latitude on the eastern edge.
-  glm::dvec3 easternMidpointCartesian =
+  const glm::dvec3 easternMidpointCartesian =
       ellipsoid.cartographicToCartesian(Cartographic(
           rectangle.getEast(),
           (rectangle.getSouth() + rectangle.getNorth()) * 0.5,
@@ -55,25 +55,25 @@ BoundingRegion::BoundingRegion(
       glm::cross(glm::dvec3(0.0, 0.0, 1.0), easternMidpointCartesian));
 
   // Compute the normal of the plane bounding the southern edge of the tile.
-  glm::dvec3 westVector = westernMidpointCartesian - easternMidpointCartesian;
-  glm::dvec3 eastWestNormal = glm::normalize(westVector);
+  const glm::dvec3 westVector = westernMidpointCartesian - easternMidpointCartesian;
+  const glm::dvec3 eastWestNormal = glm::normalize(westVector);
 
   if (!Math::equalsEpsilon(glm::length(eastWestNormal), 1.0, Math::EPSILON6)) {
     this->_planesAreInvalid = true;
     return;
   }
 
-  double south = rectangle.getSouth();
+  const double south = rectangle.getSouth();
   glm::dvec3 southSurfaceNormal;
 
   if (south > 0.0) {
     // Compute a plane that doesn't cut through the tile.
-    glm::dvec3 southCenterCartesian =
+    const glm::dvec3 southCenterCartesian =
         ellipsoid.cartographicToCartesian(Cartographic(
             (rectangle.getWest() + rectangle.getEast()) * 0.5,
             south,
             0.0));
-    Plane westPlane(this->_southwestCornerCartesian, this->_westNormal);
+    const Plane westPlane(this->_southwestCornerCartesian, this->_westNormal);
 
     // Find a point that is on the west and the south planes
     std::optional<glm::dvec3> intersection = IntersectionTests::rayPlane(
@@ -95,17 +95,17 @@ BoundingRegion::BoundingRegion(
       glm::normalize(glm::cross(southSurfaceNormal, westVector));
 
   // Compute the normal of the plane bounding the northern edge of the tile.
-  double north = rectangle.getNorth();
+  const double north = rectangle.getNorth();
   glm::dvec3 northSurfaceNormal;
   if (north < 0.0) {
     // Compute a plane that doesn't cut through the tile.
-    glm::dvec3 northCenterCartesian =
+    const glm::dvec3 northCenterCartesian =
         ellipsoid.cartographicToCartesian(Cartographic(
             (rectangle.getWest() + rectangle.getEast()) * 0.5,
             north,
             0.0));
 
-    Plane eastPlane(this->_northeastCornerCartesian, this->_eastNormal);
+    const Plane eastPlane(this->_northeastCornerCartesian, this->_eastNormal);
 
     // Find a point that is on the east and the north planes
     std::optional<glm::dvec3> intersection = IntersectionTests::rayPlane(
@@ -168,18 +168,18 @@ double BoundingRegion::computeDistanceSquaredToPosition(
       const glm::dvec3& eastNormal = this->_eastNormal;
       const glm::dvec3& northNormal = this->_northNormal;
 
-      glm::dvec3 vectorFromSouthwestCorner =
+      const glm::dvec3 vectorFromSouthwestCorner =
           cartesianPosition - southwestCornerCartesian;
-      double distanceToWestPlane =
+      const double distanceToWestPlane =
           glm::dot(vectorFromSouthwestCorner, westNormal);
-      double distanceToSouthPlane =
+      const double distanceToSouthPlane =
           glm::dot(vectorFromSouthwestCorner, southNormal);
 
-      glm::dvec3 vectorFromNortheastCorner =
+      const glm::dvec3 vectorFromNortheastCorner =
           cartesianPosition - northeastCornerCartesian;
-      double distanceToEastPlane =
+      const double distanceToEastPlane =
           glm::dot(vectorFromNortheastCorner, eastNormal);
-      double distanceToNorthPlane =
+      const double distanceToNorthPlane =
           glm::dot(vectorFromNortheastCorner, northNormal);
 
       if (distanceToWestPlane > 0.0) {
@@ -195,20 +195,20 @@ double BoundingRegion::computeDistanceSquaredToPosition(
       }
     }
 
-    double cameraHeight = cartographicPosition.height;
-    double minimumHeight = this->_minimumHeight;
-    double maximumHeight = this->_maximumHeight;
+    const double cameraHeight = cartographicPosition.height;
+    const double minimumHeight = this->_minimumHeight;
+    const double maximumHeight = this->_maximumHeight;
 
     if (cameraHeight > maximumHeight) {
-      double distanceAboveTop = cameraHeight - maximumHeight;
+      const double distanceAboveTop = cameraHeight - maximumHeight;
       result += distanceAboveTop * distanceAboveTop;
     } else if (cameraHeight < minimumHeight) {
-      double distanceBelowBottom = minimumHeight - cameraHeight;
+      const double distanceBelowBottom = minimumHeight - cameraHeight;
       result += distanceBelowBottom * distanceBelowBottom;
     }
   }
 
-  double bboxDistanceSquared =
+  const double bboxDistanceSquared =
       this->getBoundingBox().computeDistanceSquaredToPosition(
           cartesianPosition);
   return glm::max(bboxDistanceSquared, result);
@@ -235,17 +235,17 @@ static OrientedBoundingBox fromPlaneExtents(
     double maximumZ) noexcept {
   glm::dmat3 halfAxes(planeXAxis, planeYAxis, planeZAxis);
 
-  glm::dvec3 centerOffset(
+  const glm::dvec3 centerOffset(
       (minimumX + maximumX) / 2.0,
       (minimumY + maximumY) / 2.0,
       (minimumZ + maximumZ) / 2.0);
 
-  glm::dvec3 scale(
+  const glm::dvec3 scale(
       (maximumX - minimumX) / 2.0,
       (maximumY - minimumY) / 2.0,
       (maximumZ - minimumZ) / 2.0);
 
-  glm::dmat3 scaledHalfAxes(
+  const glm::dmat3 scaledHalfAxes(
       halfAxes[0] * scale.x,
       halfAxes[1] * scale.y,
       halfAxes[2] * scale.z);
@@ -276,21 +276,21 @@ static OrientedBoundingBox fromPlaneExtents(
   if (rectangle.computeWidth() <= Math::ONE_PI) {
     // The bounding box will be aligned with the tangent plane at the center of
     // the rectangle.
-    Cartographic tangentPointCartographic = rectangle.computeCenter();
-    glm::dvec3 tangentPoint =
+    const Cartographic tangentPointCartographic = rectangle.computeCenter();
+    const glm::dvec3 tangentPoint =
         ellipsoid.cartographicToCartesian(tangentPointCartographic);
-    EllipsoidTangentPlane tangentPlane(tangentPoint, ellipsoid);
+    const EllipsoidTangentPlane tangentPlane(tangentPoint, ellipsoid);
     plane = tangentPlane.getPlane();
 
     // If the rectangle spans the equator, CW is instead aligned with the
     // equator (because it sticks out the farthest at the equator).
-    double lonCenter = tangentPointCartographic.longitude;
-    double latCenter = rectangle.getSouth() < 0.0 && rectangle.getNorth() > 0.0
+    const double lonCenter = tangentPointCartographic.longitude;
+    const double latCenter = rectangle.getSouth() < 0.0 && rectangle.getNorth() > 0.0
                            ? 0.0
                            : tangentPointCartographic.latitude;
 
     // Compute XY extents using the rectangle at maximum height
-    Cartographic perimeterCartographicNC(
+    const Cartographic perimeterCartographicNC(
         lonCenter,
         rectangle.getNorth(),
         maximumHeight);
@@ -298,7 +298,7 @@ static OrientedBoundingBox fromPlaneExtents(
         rectangle.getWest(),
         rectangle.getNorth(),
         maximumHeight);
-    Cartographic perimeterCartographicCW(
+    const Cartographic perimeterCartographicCW(
         rectangle.getWest(),
         latCenter,
         maximumHeight);
@@ -306,31 +306,31 @@ static OrientedBoundingBox fromPlaneExtents(
         rectangle.getWest(),
         rectangle.getSouth(),
         maximumHeight);
-    Cartographic perimeterCartographicSC(
+    const Cartographic perimeterCartographicSC(
         lonCenter,
         rectangle.getSouth(),
         maximumHeight);
 
-    glm::dvec3 perimeterCartesianNC =
+    const glm::dvec3 perimeterCartesianNC =
         ellipsoid.cartographicToCartesian(perimeterCartographicNC);
     glm::dvec3 perimeterCartesianNW =
         ellipsoid.cartographicToCartesian(perimeterCartographicNW);
-    glm::dvec3 perimeterCartesianCW =
+    const glm::dvec3 perimeterCartesianCW =
         ellipsoid.cartographicToCartesian(perimeterCartographicCW);
     glm::dvec3 perimeterCartesianSW =
         ellipsoid.cartographicToCartesian(perimeterCartographicSW);
-    glm::dvec3 perimeterCartesianSC =
+    const glm::dvec3 perimeterCartesianSC =
         ellipsoid.cartographicToCartesian(perimeterCartographicSC);
 
-    glm::dvec2 perimeterProjectedNC =
+    const glm::dvec2 perimeterProjectedNC =
         tangentPlane.projectPointToNearestOnPlane(perimeterCartesianNC);
-    glm::dvec2 perimeterProjectedNW =
+    const glm::dvec2 perimeterProjectedNW =
         tangentPlane.projectPointToNearestOnPlane(perimeterCartesianNW);
-    glm::dvec2 perimeterProjectedCW =
+    const glm::dvec2 perimeterProjectedCW =
         tangentPlane.projectPointToNearestOnPlane(perimeterCartesianCW);
-    glm::dvec2 perimeterProjectedSW =
+    const glm::dvec2 perimeterProjectedSW =
         tangentPlane.projectPointToNearestOnPlane(perimeterCartesianSW);
-    glm::dvec2 perimeterProjectedSC =
+    const glm::dvec2 perimeterProjectedSC =
         tangentPlane.projectPointToNearestOnPlane(perimeterCartesianSC);
 
     minX = glm::min(
@@ -372,12 +372,12 @@ static OrientedBoundingBox fromPlaneExtents(
 
   // Handle the case where rectangle width is greater than PI (wraps around more
   // than half the ellipsoid).
-  bool fullyAboveEquator = rectangle.getSouth() > 0.0;
-  bool fullyBelowEquator = rectangle.getNorth() < 0.0;
-  double latitudeNearestToEquator =
+  const bool fullyAboveEquator = rectangle.getSouth() > 0.0;
+  const bool fullyBelowEquator = rectangle.getNorth() < 0.0;
+  const double latitudeNearestToEquator =
       fullyAboveEquator ? rectangle.getSouth()
                         : fullyBelowEquator ? rectangle.getNorth() : 0.0;
-  double centerLongitude = rectangle.computeCenter().longitude;
+  const double centerLongitude = rectangle.computeCenter().longitude;
 
   // Plane is located at the rectangle's center longitude and the rectangle's
   // latitude that is closest to the equator. It rotates around the Z axis. This
@@ -387,17 +387,17 @@ static OrientedBoundingBox fromPlaneExtents(
       Cartographic(centerLongitude, latitudeNearestToEquator, maximumHeight));
   planeOrigin.z = 0.0; // center the plane on the equator to simpify plane
                        // normal calculation
-  bool isPole = glm::abs(planeOrigin.x) < Math::EPSILON10 &&
+  const bool isPole = glm::abs(planeOrigin.x) < Math::EPSILON10 &&
                 glm::abs(planeOrigin.y) < Math::EPSILON10;
-  glm::dvec3 planeNormal =
+  const glm::dvec3 planeNormal =
       !isPole ? glm::normalize(planeOrigin) : glm::dvec3(1.0, 0.0, 0.0);
-  glm::dvec3 planeYAxis(0.0, 0.0, 1.0);
-  glm::dvec3 planeXAxis = glm::cross(planeNormal, planeYAxis);
+  const glm::dvec3 planeYAxis(0.0, 0.0, 1.0);
+  const glm::dvec3 planeXAxis = glm::cross(planeNormal, planeYAxis);
   plane = Plane(planeOrigin, planeNormal);
 
   // Get the horizon point relative to the center. This will be the farthest
   // extent in the plane's X dimension.
-  glm::dvec3 horizonCartesian = ellipsoid.cartographicToCartesian(Cartographic(
+  const glm::dvec3 horizonCartesian = ellipsoid.cartographicToCartesian(Cartographic(
       centerLongitude + Math::PI_OVER_TWO,
       latitudeNearestToEquator,
       maximumHeight));
@@ -417,7 +417,7 @@ static OrientedBoundingBox fromPlaneExtents(
                  rectangle.getSouth(),
                  fullyAboveEquator ? minimumHeight : maximumHeight))
              .z;
-  glm::dvec3 farZ = ellipsoid.cartographicToCartesian(Cartographic(
+  const glm::dvec3 farZ = ellipsoid.cartographicToCartesian(Cartographic(
       rectangle.getEast(),
       latitudeNearestToEquator,
       maximumHeight));

--- a/CesiumGeospatial/src/BoundingRegionWithLooseFittingHeights.cpp
+++ b/CesiumGeospatial/src/BoundingRegionWithLooseFittingHeights.cpp
@@ -3,7 +3,7 @@
 namespace CesiumGeospatial {
 
 BoundingRegionWithLooseFittingHeights::BoundingRegionWithLooseFittingHeights(
-    const BoundingRegion& boundingRegion)
+    const BoundingRegion& boundingRegion) noexcept
     : _region(boundingRegion) {}
 
 double BoundingRegionWithLooseFittingHeights::

--- a/CesiumGeospatial/src/CartographicPolygon.cpp
+++ b/CesiumGeospatial/src/CartographicPolygon.cpp
@@ -8,7 +8,7 @@ namespace CesiumGeospatial {
 static std::vector<uint32_t>
 triangulatePolygon(const std::vector<glm::dvec2>& polygon) {
   std::vector<uint32_t> indices;
-  size_t vertexCount = polygon.size();
+  const size_t vertexCount = polygon.size();
 
   if (vertexCount < 3) {
     return indices;
@@ -47,7 +47,7 @@ triangulatePolygon(const std::vector<glm::dvec2>& polygon) {
 
 static std::optional<GlobeRectangle>
 computeBoundingRectangle(const std::vector<glm::dvec2>& polygon) {
-  size_t vertexCount = polygon.size();
+  const size_t vertexCount = polygon.size();
 
   if (vertexCount < 3) {
     return std::nullopt;
@@ -70,7 +70,7 @@ computeBoundingRectangle(const std::vector<glm::dvec2>& polygon) {
       south = point1.y;
     }
 
-    double dif_west = point1.x - west;
+    const double dif_west = point1.x - west;
     // check if the difference crosses the antipole
     if (glm::abs(dif_west) > CesiumUtility::Math::ONE_PI) {
       // east wrapping past the antipole to the west
@@ -83,7 +83,7 @@ computeBoundingRectangle(const std::vector<glm::dvec2>& polygon) {
       }
     }
 
-    double dif_east = point1.x - east;
+    const double dif_east = point1.x - east;
     // check if the difference crosses the antipole
     if (glm::abs(dif_east) > CesiumUtility::Math::ONE_PI) {
       // west wrapping past the antipole to the east

--- a/CesiumGeospatial/src/Ellipsoid.cpp
+++ b/CesiumGeospatial/src/Ellipsoid.cpp
@@ -16,9 +16,9 @@ Ellipsoid::geodeticSurfaceNormal(const glm::dvec3& position) const noexcept {
 
 glm::dvec3 Ellipsoid::geodeticSurfaceNormal(
     const Cartographic& cartographic) const noexcept {
-  double longitude = cartographic.longitude;
-  double latitude = cartographic.latitude;
-  double cosLatitude = glm::cos(latitude);
+  const double longitude = cartographic.longitude;
+  const double latitude = cartographic.latitude;
+  const double cosLatitude = glm::cos(latitude);
 
   return glm::normalize(glm::dvec3(
       cosLatitude * glm::cos(longitude),
@@ -30,7 +30,7 @@ glm::dvec3 Ellipsoid::cartographicToCartesian(
     const Cartographic& cartographic) const noexcept {
   glm::dvec3 n = this->geodeticSurfaceNormal(cartographic);
   glm::dvec3 k = this->_radiiSquared * n;
-  double gamma = sqrt(glm::dot(n, k));
+  const double gamma = sqrt(glm::dot(n, k));
   k /= gamma;
   n *= cartographic.height;
   return k + n;
@@ -44,33 +44,33 @@ Ellipsoid::cartesianToCartographic(const glm::dvec3& cartesian) const noexcept {
     return std::optional<Cartographic>();
   }
 
-  glm::dvec3 n = this->geodeticSurfaceNormal(p.value());
-  glm::dvec3 h = cartesian - p.value();
+  const glm::dvec3 n = this->geodeticSurfaceNormal(p.value());
+  const glm::dvec3 h = cartesian - p.value();
 
-  double longitude = glm::atan(n.y, n.x);
-  double latitude = glm::asin(n.z);
-  double height = Math::sign(glm::dot(h, cartesian)) * glm::length(h);
+  const double longitude = glm::atan(n.y, n.x);
+  const double latitude = glm::asin(n.z);
+  const double height = Math::sign(glm::dot(h, cartesian)) * glm::length(h);
 
   return Cartographic(longitude, latitude, height);
 }
 
 std::optional<glm::dvec3>
 Ellipsoid::scaleToGeodeticSurface(const glm::dvec3& cartesian) const noexcept {
-  double positionX = cartesian.x;
-  double positionY = cartesian.y;
-  double positionZ = cartesian.z;
+  const double positionX = cartesian.x;
+  const double positionY = cartesian.y;
+  const double positionZ = cartesian.z;
 
-  double oneOverRadiiX = this->_oneOverRadii.x;
-  double oneOverRadiiY = this->_oneOverRadii.y;
-  double oneOverRadiiZ = this->_oneOverRadii.z;
+  const double oneOverRadiiX = this->_oneOverRadii.x;
+  const double oneOverRadiiY = this->_oneOverRadii.y;
+  const double oneOverRadiiZ = this->_oneOverRadii.z;
 
-  double x2 = positionX * positionX * oneOverRadiiX * oneOverRadiiX;
-  double y2 = positionY * positionY * oneOverRadiiY * oneOverRadiiY;
-  double z2 = positionZ * positionZ * oneOverRadiiZ * oneOverRadiiZ;
+  const double x2 = positionX * positionX * oneOverRadiiX * oneOverRadiiX;
+  const double y2 = positionY * positionY * oneOverRadiiY * oneOverRadiiY;
+  const double z2 = positionZ * positionZ * oneOverRadiiZ * oneOverRadiiZ;
 
   // Compute the squared ellipsoid norm.
-  double squaredNorm = x2 + y2 + z2;
-  double ratio = sqrt(1.0 / squaredNorm);
+  const double squaredNorm = x2 + y2 + z2;
+  const double ratio = sqrt(1.0 / squaredNorm);
 
   // As an initial approximation, assume that the radial intersection is the
   // projection point.
@@ -81,13 +81,13 @@ Ellipsoid::scaleToGeodeticSurface(const glm::dvec3& cartesian) const noexcept {
     return !std::isfinite(ratio) ? std::optional<glm::dvec3>() : intersection;
   }
 
-  double oneOverRadiiSquaredX = this->_oneOverRadiiSquared.x;
-  double oneOverRadiiSquaredY = this->_oneOverRadiiSquared.y;
-  double oneOverRadiiSquaredZ = this->_oneOverRadiiSquared.z;
+  const double oneOverRadiiSquaredX = this->_oneOverRadiiSquared.x;
+  const double oneOverRadiiSquaredY = this->_oneOverRadiiSquared.y;
+  const double oneOverRadiiSquaredZ = this->_oneOverRadiiSquared.z;
 
   // Use the gradient at the intersection point in place of the true unit
   // normal. The difference in magnitude will be absorbed in the multiplier.
-  glm::dvec3 gradient(
+  const glm::dvec3 gradient(
       intersection.x * oneOverRadiiSquaredX * 2.0,
       intersection.y * oneOverRadiiSquaredY * 2.0,
       intersection.z * oneOverRadiiSquaredZ * 2.0);
@@ -132,7 +132,7 @@ Ellipsoid::scaleToGeodeticSurface(const glm::dvec3& cartesian) const noexcept {
                   y2 * yMultiplier3 * oneOverRadiiSquaredY +
                   z2 * zMultiplier3 * oneOverRadiiSquaredZ;
 
-    double derivative = -2.0 * denominator;
+    const double derivative = -2.0 * denominator;
 
     correction = func / derivative;
   } while (glm::abs(func) > Math::EPSILON12);

--- a/CesiumGeospatial/src/EllipsoidTangentPlane.cpp
+++ b/CesiumGeospatial/src/EllipsoidTangentPlane.cpp
@@ -28,7 +28,7 @@ EllipsoidTangentPlane::EllipsoidTangentPlane(
 
 glm::dvec2 EllipsoidTangentPlane::projectPointToNearestOnPlane(
     const glm::dvec3& cartesian) const noexcept {
-  Ray ray(cartesian, this->_plane.getNormal());
+  const Ray ray(cartesian, this->_plane.getNormal());
 
   std::optional<glm::dvec3> intersectionPoint =
       IntersectionTests::rayPlane(ray, this->_plane);
@@ -39,7 +39,7 @@ glm::dvec2 EllipsoidTangentPlane::projectPointToNearestOnPlane(
     }
   }
 
-  glm::dvec3 v = intersectionPoint.value() - this->_origin;
+  const glm::dvec3 v = intersectionPoint.value() - this->_origin;
   return glm::dvec2(glm::dot(this->_xAxis, v), glm::dot(this->_yAxis, v));
 }
 

--- a/CesiumGeospatial/src/GeographicProjection.cpp
+++ b/CesiumGeospatial/src/GeographicProjection.cpp
@@ -11,7 +11,7 @@ GeographicProjection::GeographicProjection(const Ellipsoid& ellipsoid) noexcept
 
 glm::dvec3
 GeographicProjection::project(const Cartographic& cartographic) const noexcept {
-  double semimajorAxis = this->_semimajorAxis;
+  const double semimajorAxis = this->_semimajorAxis;
   return glm::dvec3(
       cartographic.longitude * semimajorAxis,
       cartographic.latitude * semimajorAxis,
@@ -20,14 +20,14 @@ GeographicProjection::project(const Cartographic& cartographic) const noexcept {
 
 CesiumGeometry::Rectangle GeographicProjection::project(
     const CesiumGeospatial::GlobeRectangle& rectangle) const noexcept {
-  glm::dvec3 sw = this->project(rectangle.getSouthwest());
-  glm::dvec3 ne = this->project(rectangle.getNortheast());
+  const glm::dvec3 sw = this->project(rectangle.getSouthwest());
+  const glm::dvec3 ne = this->project(rectangle.getNortheast());
   return CesiumGeometry::Rectangle(sw.x, sw.y, ne.x, ne.y);
 }
 
 Cartographic GeographicProjection::unproject(
     const glm::dvec2& projectedCoordinates) const noexcept {
-  double oneOverEarthSemimajorAxis = this->_oneOverSemimajorAxis;
+  const double oneOverEarthSemimajorAxis = this->_oneOverSemimajorAxis;
 
   return Cartographic(
       projectedCoordinates.x * oneOverEarthSemimajorAxis,
@@ -44,8 +44,8 @@ Cartographic GeographicProjection::unproject(
 
 CesiumGeospatial::GlobeRectangle GeographicProjection::unproject(
     const CesiumGeometry::Rectangle& rectangle) const noexcept {
-  Cartographic sw = this->unproject(rectangle.getLowerLeft());
-  Cartographic ne = this->unproject(rectangle.getUpperRight());
+  const Cartographic sw = this->unproject(rectangle.getLowerLeft());
+  const Cartographic ne = this->unproject(rectangle.getUpperRight());
   return GlobeRectangle(sw.longitude, sw.latitude, ne.longitude, ne.latitude);
 }
 

--- a/CesiumGeospatial/src/GlobeRectangle.cpp
+++ b/CesiumGeospatial/src/GlobeRectangle.cpp
@@ -7,23 +7,23 @@ namespace CesiumGeospatial {
 
 Cartographic GlobeRectangle::computeCenter() const noexcept {
   double east = this->_east;
-  double west = this->_west;
+  const double west = this->_west;
 
   if (east < west) {
     east += Math::TWO_PI;
   }
 
-  double longitude = Math::negativePiToPi((west + east) * 0.5);
-  double latitude = (this->_south + this->_north) * 0.5;
+  const double longitude = Math::negativePiToPi((west + east) * 0.5);
+  const double latitude = (this->_south + this->_north) * 0.5;
 
   return Cartographic(longitude, latitude, 0.0);
 }
 
 bool GlobeRectangle::contains(const Cartographic& cartographic) const noexcept {
   double longitude = cartographic.longitude;
-  double latitude = cartographic.latitude;
+  const double latitude = cartographic.latitude;
 
-  double west = this->_west;
+  const double west = this->_west;
   double east = this->_east;
 
   if (east < west) {
@@ -60,9 +60,9 @@ std::optional<GlobeRectangle> GlobeRectangle::computeIntersection(
     rectangleWest += CesiumUtility::Math::TWO_PI;
   }
 
-  double west = CesiumUtility::Math::negativePiToPi(
+  const double west = CesiumUtility::Math::negativePiToPi(
       glm::max(rectangleWest, otherRectangleWest));
-  double east = CesiumUtility::Math::negativePiToPi(
+  const double east = CesiumUtility::Math::negativePiToPi(
       glm::min(rectangleEast, otherRectangleEast));
 
   if ((this->_west < this->_east || other._west < other._east) &&
@@ -70,8 +70,8 @@ std::optional<GlobeRectangle> GlobeRectangle::computeIntersection(
     return std::nullopt;
   }
 
-  double south = glm::max(this->_south, other._south);
-  double north = glm::min(this->_north, other._north);
+  const double south = glm::max(this->_south, other._south);
+  const double north = glm::min(this->_north, other._north);
 
   if (south >= north) {
     return std::nullopt;
@@ -100,9 +100,9 @@ GlobeRectangle::computeUnion(const GlobeRectangle& other) const noexcept {
     rectangleWest += CesiumUtility::Math::TWO_PI;
   }
 
-  double west = CesiumUtility::Math::convertLongitudeRange(
+  const double west = CesiumUtility::Math::convertLongitudeRange(
       glm::min(rectangleWest, otherRectangleWest));
-  double east = CesiumUtility::Math::convertLongitudeRange(
+  const double east = CesiumUtility::Math::convertLongitudeRange(
       glm::max(rectangleEast, otherRectangleEast));
 
   return GlobeRectangle(

--- a/CesiumGeospatial/src/Projection.cpp
+++ b/CesiumGeospatial/src/Projection.cpp
@@ -8,11 +8,11 @@ projectPosition(const Projection& projection, const Cartographic& position) {
   struct Operation {
     const Cartographic& position;
 
-    glm::dvec3 operator()(const GeographicProjection& geographic) {
+    glm::dvec3 operator()(const GeographicProjection& geographic) noexcept {
       return geographic.project(position);
     }
 
-    glm::dvec3 operator()(const WebMercatorProjection& webMercator) {
+    glm::dvec3 operator()(const WebMercatorProjection& webMercator) noexcept {
       return webMercator.project(position);
     }
   };
@@ -25,11 +25,11 @@ unprojectPosition(const Projection& projection, const glm::dvec3& position) {
   struct Operation {
     const glm::dvec3& position;
 
-    Cartographic operator()(const GeographicProjection& geographic) {
+    Cartographic operator()(const GeographicProjection& geographic) noexcept {
       return geographic.unproject(position);
     }
 
-    Cartographic operator()(const WebMercatorProjection& webMercator) {
+    Cartographic operator()(const WebMercatorProjection& webMercator) noexcept {
       return webMercator.unproject(position);
     }
   };
@@ -44,12 +44,12 @@ CesiumGeometry::Rectangle projectRectangleSimple(
     const GlobeRectangle& rectangle;
 
     CesiumGeometry::Rectangle
-    operator()(const GeographicProjection& geographic) {
+    operator()(const GeographicProjection& geographic) noexcept {
       return geographic.project(rectangle);
     }
 
     CesiumGeometry::Rectangle
-    operator()(const WebMercatorProjection& webMercator) {
+    operator()(const WebMercatorProjection& webMercator) noexcept {
       return webMercator.project(rectangle);
     }
   };
@@ -63,11 +63,12 @@ GlobeRectangle unprojectRectangleSimple(
   struct Operation {
     const CesiumGeometry::Rectangle& rectangle;
 
-    GlobeRectangle operator()(const GeographicProjection& geographic) {
+    GlobeRectangle operator()(const GeographicProjection& geographic) noexcept {
       return geographic.unproject(rectangle);
     }
 
-    GlobeRectangle operator()(const WebMercatorProjection& webMercator) {
+    GlobeRectangle
+    operator()(const WebMercatorProjection& webMercator) noexcept {
       return webMercator.unproject(rectangle);
     }
   };
@@ -81,11 +82,11 @@ double computeApproximateConversionFactorToMetersNearPosition(
   struct Operation {
     const glm::dvec2& position;
 
-    double operator()(const GeographicProjection& /*geographic*/) {
+    double operator()(const GeographicProjection& /*geographic*/) noexcept {
       return 1.0;
     }
 
-    double operator()(const WebMercatorProjection& webMercator) {
+    double operator()(const WebMercatorProjection& webMercator) noexcept {
       // TODO: is there a better estimate?
       return glm::cos(webMercator.unproject(position).latitude);
     }

--- a/CesiumGeospatial/src/Transforms.cpp
+++ b/CesiumGeospatial/src/Transforms.cpp
@@ -21,7 +21,7 @@ namespace CesiumGeospatial {
   if (Math::equalsEpsilon(origin.x, 0.0, Math::EPSILON14) &&
       Math::equalsEpsilon(origin.y, 0.0, Math::EPSILON14)) {
     // If x and y are zero, assume origin is at a pole, which is a special case.
-    double sign = Math::sign(origin.z);
+    const double sign = Math::sign(origin.z);
     return glm::dmat4x4(
         glm::dvec4(0.0, 1.0, 0.0, 0.0),
         glm::dvec4(-1.0 * sign, 0.0, 0.0, 0.0),
@@ -29,9 +29,9 @@ namespace CesiumGeospatial {
         glm::dvec4(origin, 1.0));
   }
 
-  glm::dvec3 up = ellipsoid.geodeticSurfaceNormal(origin);
-  glm::dvec3 east = glm::normalize(glm::dvec3(-origin.y, origin.x, 0.0));
-  glm::dvec3 north = glm::cross(up, east);
+  const glm::dvec3 up = ellipsoid.geodeticSurfaceNormal(origin);
+  const glm::dvec3 east = glm::normalize(glm::dvec3(-origin.y, origin.x, 0.0));
+  const glm::dvec3 north = glm::cross(up, east);
 
   return glm::dmat4x4(
       glm::dvec4(east, 0.0),

--- a/CesiumGeospatial/src/WebMercatorProjection.cpp
+++ b/CesiumGeospatial/src/WebMercatorProjection.cpp
@@ -25,7 +25,7 @@ WebMercatorProjection::WebMercatorProjection(
 
 glm::dvec3 WebMercatorProjection::project(
     const Cartographic& cartographic) const noexcept {
-  double semimajorAxis = this->_semimajorAxis;
+  const double semimajorAxis = this->_semimajorAxis;
   return glm::dvec3(
       cartographic.longitude * semimajorAxis,
       WebMercatorProjection::geodeticLatitudeToMercatorAngle(
@@ -36,14 +36,14 @@ glm::dvec3 WebMercatorProjection::project(
 
 CesiumGeometry::Rectangle WebMercatorProjection::project(
     const CesiumGeospatial::GlobeRectangle& rectangle) const noexcept {
-  glm::dvec3 sw = this->project(rectangle.getSouthwest());
-  glm::dvec3 ne = this->project(rectangle.getNortheast());
+  const glm::dvec3 sw = this->project(rectangle.getSouthwest());
+  const glm::dvec3 ne = this->project(rectangle.getNortheast());
   return CesiumGeometry::Rectangle(sw.x, sw.y, ne.x, ne.y);
 }
 
 Cartographic WebMercatorProjection::unproject(
     const glm::dvec2& projectedCoordinates) const noexcept {
-  double oneOverEarthSemimajorAxis = this->_oneOverSemimajorAxis;
+  const double oneOverEarthSemimajorAxis = this->_oneOverSemimajorAxis;
 
   return Cartographic(
       projectedCoordinates.x * oneOverEarthSemimajorAxis,
@@ -61,8 +61,8 @@ Cartographic WebMercatorProjection::unproject(
 
 CesiumGeospatial::GlobeRectangle WebMercatorProjection::unproject(
     const CesiumGeometry::Rectangle& rectangle) const noexcept {
-  Cartographic sw = this->unproject(rectangle.getLowerLeft());
-  Cartographic ne = this->unproject(rectangle.getUpperRight());
+  const Cartographic sw = this->unproject(rectangle.getLowerLeft());
+  const Cartographic ne = this->unproject(rectangle.getUpperRight());
   return GlobeRectangle(sw.longitude, sw.latitude, ne.longitude, ne.latitude);
 }
 
@@ -80,7 +80,7 @@ CesiumGeospatial::GlobeRectangle WebMercatorProjection::unproject(
       -WebMercatorProjection::MAXIMUM_LATITUDE,
       WebMercatorProjection::MAXIMUM_LATITUDE);
 
-  double sinLatitude = glm::sin(latitude);
+  const double sinLatitude = glm::sin(latitude);
   return 0.5 * glm::log((1.0 + sinLatitude) / (1.0 - sinLatitude));
 }
 

--- a/CesiumGltf/include/CesiumGltf/Accessor.h
+++ b/CesiumGltf/include/CesiumGltf/Accessor.h
@@ -19,7 +19,8 @@ struct CESIUMGLTF_API Accessor final : public AccessorSpec {
    * @return The number of components. Returns 0 if {@link Accessor::type} is
    * not a valid enumeration value.
    */
-  static int8_t computeNumberOfComponents(CesiumGltf::Accessor::Type type);
+  static int8_t
+  computeNumberOfComponents(CesiumGltf::Accessor::Type type) noexcept;
 
   /**
    * @brief Computes the number of bytes for a given accessor component type.
@@ -31,8 +32,8 @@ struct CESIUMGLTF_API Accessor final : public AccessorSpec {
    * @return The number of bytes for the component type. Returns 0 if
    * {@link Accessor::componentType} is not a valid enumeration value.
    */
-  static int8_t
-  computeByteSizeOfComponent(CesiumGltf::Accessor::ComponentType componentType);
+  static int8_t computeByteSizeOfComponent(
+      CesiumGltf::Accessor::ComponentType componentType) noexcept;
 
   /**
    * @brief Computes the number of components for this accessor.
@@ -44,7 +45,7 @@ struct CESIUMGLTF_API Accessor final : public AccessorSpec {
    * @return The number of components in this accessor. Returns 0 if this
    * accessor's {@link Accessor::type} does not have a valid enumeration value.
    */
-  int8_t computeNumberOfComponents() const;
+  int8_t computeNumberOfComponents() const noexcept;
 
   /**
    * @brief Computes the number of bytes for this accessor's component type.
@@ -58,7 +59,7 @@ struct CESIUMGLTF_API Accessor final : public AccessorSpec {
    * if this accessor's {@link Accessor::componentType} does not have a valid
    * enumeration value.
    */
-  int8_t computeByteSizeOfComponent() const;
+  int8_t computeByteSizeOfComponent() const noexcept;
 
   /**
    * @brief Computes the total number of bytes for this accessor in each vertex.
@@ -72,7 +73,7 @@ struct CESIUMGLTF_API Accessor final : public AccessorSpec {
    * {@link Accessor::componentType} does not have a valid enumeration
    * value.
    */
-  int64_t computeBytesPerVertex() const;
+  int64_t computeBytesPerVertex() const noexcept;
 
   /**
    * @brief Computes this accessor's stride.
@@ -90,6 +91,6 @@ struct CESIUMGLTF_API Accessor final : public AccessorSpec {
    * a valid enumeration value, or if {@link Accessor::bufferView} does not
    * refer to a valid {@link BufferView}.
    */
-  int64_t computeByteStride(const CesiumGltf::Model& model) const;
+  int64_t computeByteStride(const CesiumGltf::Model& model) const noexcept;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/include/CesiumGltf/AccessorView.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorView.h
@@ -222,8 +222,10 @@ private:
     }
 
     const int64_t accessorByteStride = accessor.computeByteStride(model);
-    const int64_t accessorComponentElements = accessor.computeNumberOfComponents();
-    const int64_t accessorComponentBytes = accessor.computeByteSizeOfComponent();
+    const int64_t accessorComponentElements =
+        accessor.computeNumberOfComponents();
+    const int64_t accessorComponentBytes =
+        accessor.computeByteSizeOfComponent();
     const int64_t accessorBytesPerStride =
         accessorComponentElements * accessorComponentBytes;
 

--- a/CesiumGltf/include/CesiumGltf/AccessorView.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorView.h
@@ -199,7 +199,7 @@ public:
   AccessorViewStatus status() const noexcept { return this->_status; }
 
 private:
-  void create(const Model& model, const Accessor& accessor) {
+  void create(const Model& model, const Accessor& accessor) noexcept {
     const CesiumGltf::BufferView* pBufferView =
         Model::getSafe(&model.bufferViews, accessor.bufferView);
     if (!pBufferView) {

--- a/CesiumGltf/include/CesiumGltf/AccessorView.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorView.h
@@ -215,16 +215,16 @@ private:
     }
 
     const std::vector<std::byte>& data = pBuffer->cesium.data;
-    int64_t bufferBytes = int64_t(data.size());
+    const int64_t bufferBytes = int64_t(data.size());
     if (pBufferView->byteOffset + pBufferView->byteLength > bufferBytes) {
       this->_status = AccessorViewStatus::BufferTooSmall;
       return;
     }
 
-    int64_t accessorByteStride = accessor.computeByteStride(model);
-    int64_t accessorComponentElements = accessor.computeNumberOfComponents();
-    int64_t accessorComponentBytes = accessor.computeByteSizeOfComponent();
-    int64_t accessorBytesPerStride =
+    const int64_t accessorByteStride = accessor.computeByteStride(model);
+    const int64_t accessorComponentElements = accessor.computeNumberOfComponents();
+    const int64_t accessorComponentBytes = accessor.computeByteSizeOfComponent();
+    const int64_t accessorBytesPerStride =
         accessorComponentElements * accessorComponentBytes;
 
     if (sizeof(T) != accessorBytesPerStride) {
@@ -232,8 +232,8 @@ private:
       return;
     }
 
-    int64_t accessorBytes = accessorByteStride * accessor.count;
-    int64_t bytesRemainingInBufferView =
+    const int64_t accessorBytes = accessorByteStride * accessor.count;
+    const int64_t bytesRemainingInBufferView =
         pBufferView->byteLength -
         (accessor.byteOffset + accessorByteStride * (accessor.count - 1) +
          accessorBytesPerStride);

--- a/CesiumGltf/include/CesiumGltf/AccessorWriter.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorWriter.h
@@ -24,7 +24,7 @@ public:
       : _accessor(model, accessor) {}
 
   /** @copydoc AccessorView::AccessorView(const Model&,int32_t) */
-  AccessorWriter(Model& model, int32_t accessorIndex)
+  AccessorWriter(Model& model, int32_t accessorIndex) noexcept
       : _accessor(model, accessorIndex) {}
 
   /** @copydoc AccessorView::operator[]() */

--- a/CesiumGltf/include/CesiumGltf/MetadataArrayView.h
+++ b/CesiumGltf/include/CesiumGltf/MetadataArrayView.h
@@ -39,9 +39,9 @@ public:
 
   bool operator[](int64_t index) const {
     index += _bitOffset;
-    int64_t byteIndex = index / 8;
-    int64_t bitIndex = index % 8;
-    int bitValue = static_cast<int>(_valueBuffer[byteIndex] >> bitIndex) & 1;
+    const int64_t byteIndex = index / 8;
+    const int64_t bitIndex = index % 8;
+    const int bitValue = static_cast<int>(_valueBuffer[byteIndex] >> bitIndex) & 1;
     return bitValue == 1;
   }
 
@@ -69,9 +69,9 @@ public:
         _size{size} {}
 
   std::string_view operator[](int64_t index) const {
-    size_t currentOffset =
+    const size_t currentOffset =
         getOffsetFromOffsetBuffer(index, _offsetBuffer, _offsetType);
-    size_t nextOffset =
+    const size_t nextOffset =
         getOffsetFromOffsetBuffer(index + 1, _offsetBuffer, _offsetType);
     return std::string_view(
         reinterpret_cast<const char*>(_valueBuffer.data() + currentOffset),
@@ -88,25 +88,25 @@ private:
     switch (offsetType) {
     case PropertyType::Uint8: {
       assert(instance < offsetBuffer.size() / sizeof(uint8_t));
-      uint8_t offset = *reinterpret_cast<const uint8_t*>(
+      const uint8_t offset = *reinterpret_cast<const uint8_t*>(
           offsetBuffer.data() + instance * sizeof(uint8_t));
       return static_cast<size_t>(offset);
     }
     case PropertyType::Uint16: {
       assert(instance < offsetBuffer.size() / sizeof(uint16_t));
-      uint16_t offset = *reinterpret_cast<const uint16_t*>(
+      const uint16_t offset = *reinterpret_cast<const uint16_t*>(
           offsetBuffer.data() + instance * sizeof(uint16_t));
       return static_cast<size_t>(offset);
     }
     case PropertyType::Uint32: {
       assert(instance < offsetBuffer.size() / sizeof(uint32_t));
-      uint32_t offset = *reinterpret_cast<const uint32_t*>(
+      const uint32_t offset = *reinterpret_cast<const uint32_t*>(
           offsetBuffer.data() + instance * sizeof(uint32_t));
       return static_cast<size_t>(offset);
     }
     case PropertyType::Uint64: {
       assert(instance < offsetBuffer.size() / sizeof(uint64_t));
-      uint64_t offset = *reinterpret_cast<const uint64_t*>(
+      const uint64_t offset = *reinterpret_cast<const uint64_t*>(
           offsetBuffer.data() + instance * sizeof(uint64_t));
       return static_cast<size_t>(offset);
     }

--- a/CesiumGltf/include/CesiumGltf/MetadataArrayView.h
+++ b/CesiumGltf/include/CesiumGltf/MetadataArrayView.h
@@ -19,7 +19,9 @@ public:
     return _valueBuffer[index];
   }
 
-  int64_t size() const noexcept { return static_cast<int64_t>(_valueBuffer.size()); }
+  int64_t size() const noexcept {
+    return static_cast<int64_t>(_valueBuffer.size());
+  }
 
 private:
   gsl::span<const ElementType> _valueBuffer;

--- a/CesiumGltf/include/CesiumGltf/MetadataArrayView.h
+++ b/CesiumGltf/include/CesiumGltf/MetadataArrayView.h
@@ -11,15 +11,15 @@ template <typename ElementType> class MetadataArrayView {
 public:
   MetadataArrayView() : _valueBuffer{} {}
 
-  MetadataArrayView(const gsl::span<const std::byte>& buffer)
+  MetadataArrayView(const gsl::span<const std::byte>& buffer) noexcept
       : _valueBuffer{
             CesiumUtility::reintepretCastSpan<const ElementType>(buffer)} {}
 
-  const ElementType& operator[](int64_t index) const {
+  const ElementType& operator[](int64_t index) const noexcept {
     return _valueBuffer[index];
   }
 
-  int64_t size() const { return static_cast<int64_t>(_valueBuffer.size()); }
+  int64_t size() const noexcept { return static_cast<int64_t>(_valueBuffer.size()); }
 
 private:
   gsl::span<const ElementType> _valueBuffer;
@@ -32,12 +32,12 @@ public:
   MetadataArrayView(
       const gsl::span<const std::byte>& buffer,
       int64_t bitOffset,
-      int64_t instanceCount)
+      int64_t instanceCount) noexcept
       : _valueBuffer{buffer},
         _bitOffset{bitOffset},
         _instanceCount{instanceCount} {}
 
-  bool operator[](int64_t index) const {
+  bool operator[](int64_t index) const noexcept {
     index += _bitOffset;
     const int64_t byteIndex = index / 8;
     const int64_t bitIndex = index % 8;
@@ -46,7 +46,7 @@ public:
     return bitValue == 1;
   }
 
-  int64_t size() const { return _instanceCount; }
+  int64_t size() const noexcept { return _instanceCount; }
 
 private:
   gsl::span<const std::byte> _valueBuffer;
@@ -63,13 +63,13 @@ public:
       const gsl::span<const std::byte>& buffer,
       const gsl::span<const std::byte>& offsetBuffer,
       PropertyType offsetType,
-      int64_t size)
+      int64_t size) noexcept
       : _valueBuffer{buffer},
         _offsetBuffer{offsetBuffer},
         _offsetType{offsetType},
         _size{size} {}
 
-  std::string_view operator[](int64_t index) const {
+  std::string_view operator[](int64_t index) const noexcept {
     const size_t currentOffset =
         getOffsetFromOffsetBuffer(index, _offsetBuffer, _offsetType);
     const size_t nextOffset =
@@ -79,13 +79,13 @@ public:
         (nextOffset - currentOffset));
   }
 
-  int64_t size() const { return _size; }
+  int64_t size() const noexcept { return _size; }
 
 private:
   static size_t getOffsetFromOffsetBuffer(
       size_t instance,
       const gsl::span<const std::byte>& offsetBuffer,
-      PropertyType offsetType) {
+      PropertyType offsetType) noexcept {
     switch (offsetType) {
     case PropertyType::Uint8: {
       assert(instance < offsetBuffer.size() / sizeof(uint8_t));

--- a/CesiumGltf/include/CesiumGltf/MetadataArrayView.h
+++ b/CesiumGltf/include/CesiumGltf/MetadataArrayView.h
@@ -41,7 +41,8 @@ public:
     index += _bitOffset;
     const int64_t byteIndex = index / 8;
     const int64_t bitIndex = index % 8;
-    const int bitValue = static_cast<int>(_valueBuffer[byteIndex] >> bitIndex) & 1;
+    const int bitValue =
+        static_cast<int>(_valueBuffer[byteIndex] >> bitIndex) & 1;
     return bitValue == 1;
   }
 

--- a/CesiumGltf/include/CesiumGltf/MetadataFeatureTableView.h
+++ b/CesiumGltf/include/CesiumGltf/MetadataFeatureTableView.h
@@ -350,7 +350,8 @@ private:
     }
 
     gsl::span<const std::byte> valueBuffer;
-    const auto status = getBufferSafe(featureTableProperty.bufferView, valueBuffer);
+    const auto status =
+        getBufferSafe(featureTableProperty.bufferView, valueBuffer);
     if (status != MetadataPropertyViewStatus::Valid) {
       return createInvalidPropertyView<T>(status);
     }

--- a/CesiumGltf/include/CesiumGltf/MetadataFeatureTableView.h
+++ b/CesiumGltf/include/CesiumGltf/MetadataFeatureTableView.h
@@ -499,7 +499,7 @@ private:
 
   MetadataPropertyViewStatus getBufferSafe(
       int32_t bufferViewIdx,
-      gsl::span<const std::byte>& buffer) const;
+      gsl::span<const std::byte>& buffer) const noexcept;
 
   MetadataPropertyViewStatus getOffsetBufferSafe(
       int32_t bufferViewIdx,
@@ -507,7 +507,7 @@ private:
       size_t valueBufferSize,
       size_t instanceCount,
       bool checkBitsSize,
-      gsl::span<const std::byte>& offsetBuffer) const;
+      gsl::span<const std::byte>& offsetBuffer) const noexcept;
 
   template <typename T>
   static MetadataPropertyView<T>

--- a/CesiumGltf/include/CesiumGltf/MetadataFeatureTableView.h
+++ b/CesiumGltf/include/CesiumGltf/MetadataFeatureTableView.h
@@ -512,7 +512,7 @@ private:
 
   template <typename T>
   static MetadataPropertyView<T>
-  createInvalidPropertyView(MetadataPropertyViewStatus invalidStatus) {
+  createInvalidPropertyView(MetadataPropertyViewStatus invalidStatus) noexcept {
     return MetadataPropertyView<T>(
         invalidStatus,
         gsl::span<const std::byte>(),

--- a/CesiumGltf/include/CesiumGltf/MetadataFeatureTableView.h
+++ b/CesiumGltf/include/CesiumGltf/MetadataFeatureTableView.h
@@ -343,14 +343,14 @@ private:
   MetadataPropertyView<T> getPrimitivePropertyValues(
       const ClassProperty& classProperty,
       const FeatureTableProperty& featureTableProperty) const {
-    PropertyType type = convertStringToPropertyType(classProperty.type);
+    const PropertyType type = convertStringToPropertyType(classProperty.type);
     if (TypeToPropertyType<T>::value != type) {
       return createInvalidPropertyView<T>(
           MetadataPropertyViewStatus::InvalidTypeMismatch);
     }
 
     gsl::span<const std::byte> valueBuffer;
-    auto status = getBufferSafe(featureTableProperty.bufferView, valueBuffer);
+    const auto status = getBufferSafe(featureTableProperty.bufferView, valueBuffer);
     if (status != MetadataPropertyViewStatus::Valid) {
       return createInvalidPropertyView<T>(status);
     }
@@ -402,7 +402,7 @@ private:
           MetadataPropertyViewStatus::InvalidTypeMismatch);
     }
 
-    PropertyType componentType =
+    const PropertyType componentType =
         convertStringToPropertyType(classProperty.componentType.getString());
     if (TypeToPropertyType<T>::value != componentType) {
       return createInvalidPropertyView<MetadataArrayView<T>>(
@@ -421,7 +421,7 @@ private:
               InvalidBufferViewSizeNotDivisibleByTypeSize);
     }
 
-    int64_t componentCount = classProperty.componentCount.value_or(0);
+    const int64_t componentCount = classProperty.componentCount.value_or(0);
     if (componentCount > 0 && featureTableProperty.arrayOffsetBufferView >= 0) {
       return createInvalidPropertyView<MetadataArrayView<T>>(
           MetadataPropertyViewStatus::
@@ -462,7 +462,7 @@ private:
     }
 
     // dynamic array
-    PropertyType offsetType =
+    const PropertyType offsetType =
         convertOffsetStringToPropertyType(featureTableProperty.offsetType);
     if (offsetType == PropertyType::None) {
       return createInvalidPropertyView<MetadataArrayView<T>>(

--- a/CesiumGltf/include/CesiumGltf/MetadataPropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/MetadataPropertyView.h
@@ -236,7 +236,8 @@ private:
   bool getBoolean(int64_t instance) const {
     const int64_t byteIndex = instance / 8;
     const int64_t bitIndex = instance % 8;
-    const int bitValue = static_cast<int>(_valueBuffer[byteIndex] >> bitIndex) & 1;
+    const int bitValue =
+        static_cast<int>(_valueBuffer[byteIndex] >> bitIndex) & 1;
     return bitValue == 1;
   }
 

--- a/CesiumGltf/include/CesiumGltf/MetadataPropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/MetadataPropertyView.h
@@ -164,7 +164,7 @@ public:
       gsl::span<const std::byte> stringOffsetBuffer,
       PropertyType offsetType,
       int64_t componentCount,
-      int64_t instanceCount) noexcept 
+      int64_t instanceCount) noexcept
       : _status{status},
         _valueBuffer{valueBuffer},
         _arrayOffsetBuffer{arrayOffsetBuffer},
@@ -274,7 +274,8 @@ private:
     return MetadataArrayView<T>{vals};
   }
 
-  MetadataArrayView<std::string_view> getStringArray(int64_t instance) const noexcept {
+  MetadataArrayView<std::string_view>
+  getStringArray(int64_t instance) const noexcept {
     if (_componentCount > 0) {
       const gsl::span<const std::byte> offsetVals(
           _stringOffsetBuffer.data() + instance * _componentCount * _offsetSize,

--- a/CesiumGltf/include/CesiumGltf/MetadataPropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/MetadataPropertyView.h
@@ -164,7 +164,7 @@ public:
       gsl::span<const std::byte> stringOffsetBuffer,
       PropertyType offsetType,
       int64_t componentCount,
-      int64_t instanceCount)
+      int64_t instanceCount) noexcept 
       : _status{status},
         _valueBuffer{valueBuffer},
         _arrayOffsetBuffer{arrayOffsetBuffer},
@@ -187,7 +187,7 @@ public:
    * @param instance The instance index
    * @return The value of the instance
    */
-  ElementType get(int64_t instance) const {
+  ElementType get(int64_t instance) const noexcept {
     assert(
         _status == MetadataPropertyViewStatus::Valid &&
         "Check the status() first to make sure view is valid");
@@ -226,14 +226,14 @@ public:
    * @brief Get the number of instances in the FeatureTable
    * @return The number of instances in the FeatureTable
    */
-  int64_t size() const { return _instanceCount; }
+  int64_t size() const noexcept { return _instanceCount; }
 
 private:
-  ElementType getNumeric(int64_t instance) const {
+  ElementType getNumeric(int64_t instance) const noexcept {
     return reinterpret_cast<const ElementType*>(_valueBuffer.data())[instance];
   }
 
-  bool getBoolean(int64_t instance) const {
+  bool getBoolean(int64_t instance) const noexcept {
     const int64_t byteIndex = instance / 8;
     const int64_t bitIndex = instance % 8;
     const int bitValue =
@@ -241,7 +241,7 @@ private:
     return bitValue == 1;
   }
 
-  std::string_view getString(int64_t instance) const {
+  std::string_view getString(int64_t instance) const noexcept {
     const size_t currentOffset =
         getOffsetFromOffsetBuffer(instance, _stringOffsetBuffer, _offsetType);
     const size_t nextOffset = getOffsetFromOffsetBuffer(
@@ -254,7 +254,7 @@ private:
   }
 
   template <typename T>
-  MetadataArrayView<T> getNumericArray(int64_t instance) const {
+  MetadataArrayView<T> getNumericArray(int64_t instance) const noexcept {
     if (_componentCount > 0) {
       const gsl::span<const std::byte> vals(
           _valueBuffer.data() + instance * _componentCount * sizeof(T),
@@ -274,7 +274,7 @@ private:
     return MetadataArrayView<T>{vals};
   }
 
-  MetadataArrayView<std::string_view> getStringArray(int64_t instance) const {
+  MetadataArrayView<std::string_view> getStringArray(int64_t instance) const noexcept {
     if (_componentCount > 0) {
       const gsl::span<const std::byte> offsetVals(
           _stringOffsetBuffer.data() + instance * _componentCount * _offsetSize,
@@ -302,7 +302,7 @@ private:
         (nextOffset - currentOffset) / _offsetSize);
   }
 
-  MetadataArrayView<bool> getBooleanArray(int64_t instance) const {
+  MetadataArrayView<bool> getBooleanArray(int64_t instance) const noexcept {
     if (_componentCount > 0) {
       const size_t offsetBits = _componentCount * instance;
       const size_t nextOffsetBits = _componentCount * (instance + 1);
@@ -326,7 +326,7 @@ private:
     return MetadataArrayView<bool>(buffer, currentOffset % 8, totalBits);
   }
 
-  static int64_t getOffsetSize(PropertyType offsetType) {
+  static int64_t getOffsetSize(PropertyType offsetType) noexcept {
     switch (offsetType) {
     case CesiumGltf::PropertyType::Uint8:
       return sizeof(uint8_t);
@@ -344,7 +344,7 @@ private:
   static size_t getOffsetFromOffsetBuffer(
       size_t instance,
       const gsl::span<const std::byte>& offsetBuffer,
-      PropertyType offsetType) {
+      PropertyType offsetType) noexcept {
     switch (offsetType) {
     case PropertyType::Uint8: {
       assert(instance < offsetBuffer.size() / sizeof(uint8_t));

--- a/CesiumGltf/include/CesiumGltf/MetadataPropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/MetadataPropertyView.h
@@ -234,16 +234,16 @@ private:
   }
 
   bool getBoolean(int64_t instance) const {
-    int64_t byteIndex = instance / 8;
-    int64_t bitIndex = instance % 8;
-    int bitValue = static_cast<int>(_valueBuffer[byteIndex] >> bitIndex) & 1;
+    const int64_t byteIndex = instance / 8;
+    const int64_t bitIndex = instance % 8;
+    const int bitValue = static_cast<int>(_valueBuffer[byteIndex] >> bitIndex) & 1;
     return bitValue == 1;
   }
 
   std::string_view getString(int64_t instance) const {
-    size_t currentOffset =
+    const size_t currentOffset =
         getOffsetFromOffsetBuffer(instance, _stringOffsetBuffer, _offsetType);
-    size_t nextOffset = getOffsetFromOffsetBuffer(
+    const size_t nextOffset = getOffsetFromOffsetBuffer(
         instance + 1,
         _stringOffsetBuffer,
         _offsetType);
@@ -255,19 +255,19 @@ private:
   template <typename T>
   MetadataArrayView<T> getNumericArray(int64_t instance) const {
     if (_componentCount > 0) {
-      gsl::span<const std::byte> vals(
+      const gsl::span<const std::byte> vals(
           _valueBuffer.data() + instance * _componentCount * sizeof(T),
           _componentCount * sizeof(T));
       return MetadataArrayView<T>{vals};
     }
 
-    size_t currentOffset =
+    const size_t currentOffset =
         getOffsetFromOffsetBuffer(instance, _arrayOffsetBuffer, _offsetType);
-    size_t nextOffset = getOffsetFromOffsetBuffer(
+    const size_t nextOffset = getOffsetFromOffsetBuffer(
         instance + 1,
         _arrayOffsetBuffer,
         _offsetType);
-    gsl::span<const std::byte> vals(
+    const gsl::span<const std::byte> vals(
         _valueBuffer.data() + currentOffset,
         (nextOffset - currentOffset));
     return MetadataArrayView<T>{vals};
@@ -275,7 +275,7 @@ private:
 
   MetadataArrayView<std::string_view> getStringArray(int64_t instance) const {
     if (_componentCount > 0) {
-      gsl::span<const std::byte> offsetVals(
+      const gsl::span<const std::byte> offsetVals(
           _stringOffsetBuffer.data() + instance * _componentCount * _offsetSize,
           (_componentCount + 1) * _offsetSize);
       return MetadataArrayView<std::string_view>(
@@ -285,13 +285,13 @@ private:
           _componentCount);
     }
 
-    size_t currentOffset =
+    const size_t currentOffset =
         getOffsetFromOffsetBuffer(instance, _arrayOffsetBuffer, _offsetType);
-    size_t nextOffset = getOffsetFromOffsetBuffer(
+    const size_t nextOffset = getOffsetFromOffsetBuffer(
         instance + 1,
         _arrayOffsetBuffer,
         _offsetType);
-    gsl::span<const std::byte> offsetVals(
+    const gsl::span<const std::byte> offsetVals(
         _stringOffsetBuffer.data() + currentOffset,
         (nextOffset - currentOffset + _offsetSize));
     return MetadataArrayView<std::string_view>(
@@ -303,23 +303,23 @@ private:
 
   MetadataArrayView<bool> getBooleanArray(int64_t instance) const {
     if (_componentCount > 0) {
-      size_t offsetBits = _componentCount * instance;
-      size_t nextOffsetBits = _componentCount * (instance + 1);
-      gsl::span<const std::byte> buffer(
+      const size_t offsetBits = _componentCount * instance;
+      const size_t nextOffsetBits = _componentCount * (instance + 1);
+      const gsl::span<const std::byte> buffer(
           _valueBuffer.data() + offsetBits / 8,
           (nextOffsetBits / 8 - offsetBits / 8 + 1));
       return MetadataArrayView<bool>(buffer, offsetBits % 8, _componentCount);
     }
 
-    size_t currentOffset =
+    const size_t currentOffset =
         getOffsetFromOffsetBuffer(instance, _arrayOffsetBuffer, _offsetType);
-    size_t nextOffset = getOffsetFromOffsetBuffer(
+    const size_t nextOffset = getOffsetFromOffsetBuffer(
         instance + 1,
         _arrayOffsetBuffer,
         _offsetType);
 
-    size_t totalBits = nextOffset - currentOffset;
-    gsl::span<const std::byte> buffer(
+    const size_t totalBits = nextOffset - currentOffset;
+    const gsl::span<const std::byte> buffer(
         _valueBuffer.data() + currentOffset / 8,
         (nextOffset / 8 - currentOffset / 8 + 1));
     return MetadataArrayView<bool>(buffer, currentOffset % 8, totalBits);
@@ -347,25 +347,25 @@ private:
     switch (offsetType) {
     case PropertyType::Uint8: {
       assert(instance < offsetBuffer.size() / sizeof(uint8_t));
-      uint8_t offset = *reinterpret_cast<const uint8_t*>(
+      const uint8_t offset = *reinterpret_cast<const uint8_t*>(
           offsetBuffer.data() + instance * sizeof(uint8_t));
       return static_cast<size_t>(offset);
     }
     case PropertyType::Uint16: {
       assert(instance < offsetBuffer.size() / sizeof(uint16_t));
-      uint16_t offset = *reinterpret_cast<const uint16_t*>(
+      const uint16_t offset = *reinterpret_cast<const uint16_t*>(
           offsetBuffer.data() + instance * sizeof(uint16_t));
       return static_cast<size_t>(offset);
     }
     case PropertyType::Uint32: {
       assert(instance < offsetBuffer.size() / sizeof(uint32_t));
-      uint32_t offset = *reinterpret_cast<const uint32_t*>(
+      const uint32_t offset = *reinterpret_cast<const uint32_t*>(
           offsetBuffer.data() + instance * sizeof(uint32_t));
       return static_cast<size_t>(offset);
     }
     case PropertyType::Uint64: {
       assert(instance < offsetBuffer.size() / sizeof(uint64_t));
-      uint64_t offset = *reinterpret_cast<const uint64_t*>(
+      const uint64_t offset = *reinterpret_cast<const uint64_t*>(
           offsetBuffer.data() + instance * sizeof(uint64_t));
       return static_cast<size_t>(offset);
     }

--- a/CesiumGltf/include/CesiumGltf/Model.h
+++ b/CesiumGltf/include/CesiumGltf/Model.h
@@ -108,7 +108,8 @@ struct CESIUMGLTF_API Model : public ModelSpec {
    * invalid.
    */
   template <typename T>
-  static const T* getSafe(const std::vector<T>* pItems, int32_t index) {
+  static const T*
+  getSafe(const std::vector<T>* pItems, int32_t index) noexcept {
     if (index < 0 || static_cast<size_t>(index) >= pItems->size()) {
       return nullptr;
     } else {
@@ -127,7 +128,7 @@ struct CESIUMGLTF_API Model : public ModelSpec {
    * invalid.
    */
   template <typename T>
-  static T* getSafe(std::vector<T>* pItems, int32_t index) {
+  static T* getSafe(std::vector<T>* pItems, int32_t index) noexcept {
     if (index < 0 || static_cast<size_t>(index) >= pItems->size()) {
       return nullptr;
     } else {

--- a/CesiumGltf/src/Accessor.cpp
+++ b/CesiumGltf/src/Accessor.cpp
@@ -4,7 +4,7 @@
 using namespace CesiumGltf;
 
 /*static*/ int8_t
-Accessor::computeNumberOfComponents(CesiumGltf::Accessor::Type type) {
+Accessor::computeNumberOfComponents(CesiumGltf::Accessor::Type type) noexcept {
   switch (type) {
   case CesiumGltf::Accessor::Type::SCALAR:
     return 1;
@@ -25,7 +25,7 @@ Accessor::computeNumberOfComponents(CesiumGltf::Accessor::Type type) {
 }
 
 /*static*/ int8_t Accessor::computeByteSizeOfComponent(
-    CesiumGltf::Accessor::ComponentType componentType) {
+    CesiumGltf::Accessor::ComponentType componentType) noexcept {
   switch (componentType) {
   case CesiumGltf::Accessor::ComponentType::BYTE:
   case CesiumGltf::Accessor::ComponentType::UNSIGNED_BYTE:
@@ -41,19 +41,20 @@ Accessor::computeNumberOfComponents(CesiumGltf::Accessor::Type type) {
   }
 }
 
-int8_t Accessor::computeNumberOfComponents() const {
+int8_t Accessor::computeNumberOfComponents() const noexcept {
   return Accessor::computeNumberOfComponents(this->type);
 }
 
-int8_t Accessor::computeByteSizeOfComponent() const {
+int8_t Accessor::computeByteSizeOfComponent() const noexcept {
   return Accessor::computeByteSizeOfComponent(this->componentType);
 }
 
-int64_t Accessor::computeBytesPerVertex() const {
+int64_t Accessor::computeBytesPerVertex() const noexcept {
   return this->computeByteSizeOfComponent() * this->computeNumberOfComponents();
 }
 
-int64_t Accessor::computeByteStride(const CesiumGltf::Model& model) const {
+int64_t
+Accessor::computeByteStride(const CesiumGltf::Model& model) const noexcept {
   const BufferView* pBufferView =
       Model::getSafe(&model.bufferViews, this->bufferView);
   if (!pBufferView) {

--- a/CesiumGltf/src/MetadataFeatureTableView.cpp
+++ b/CesiumGltf/src/MetadataFeatureTableView.cpp
@@ -6,7 +6,7 @@ static MetadataPropertyViewStatus checkOffsetBuffer(
     const gsl::span<const std::byte>& offsetBuffer,
     size_t valueBufferSize,
     size_t instanceCount,
-    bool checkBitSize) {
+    bool checkBitSize) noexcept {
   if (offsetBuffer.size() % sizeof(T) != 0) {
     return MetadataPropertyViewStatus::
         InvalidBufferViewSizeNotDivisibleByTypeSize;
@@ -49,7 +49,7 @@ static MetadataPropertyViewStatus checkStringArrayOffsetBuffer(
     const gsl::span<const std::byte>& arrayOffsetBuffer,
     const gsl::span<const std::byte>& stringOffsetBuffer,
     size_t valueBufferSize,
-    size_t instanceCount) {
+    size_t instanceCount) noexcept {
   auto status = checkOffsetBuffer<T>(
       arrayOffsetBuffer,
       stringOffsetBuffer.size(),
@@ -108,7 +108,7 @@ const ClassProperty* MetadataFeatureTableView::getClassProperty(
 
 MetadataPropertyViewStatus MetadataFeatureTableView::getBufferSafe(
     int32_t bufferViewIdx,
-    gsl::span<const std::byte>& buffer) const {
+    gsl::span<const std::byte>& buffer) const noexcept {
   buffer = {};
 
   const BufferView* pBufferView =
@@ -144,7 +144,7 @@ MetadataPropertyViewStatus MetadataFeatureTableView::getOffsetBufferSafe(
     size_t valueBufferSize,
     size_t instanceCount,
     bool checkBitsSize,
-    gsl::span<const std::byte>& offsetBuffer) const {
+    gsl::span<const std::byte>& offsetBuffer) const noexcept {
   auto status = getBufferSafe(bufferViewIdx, offsetBuffer);
   if (status != MetadataPropertyViewStatus::Valid) {
     return status;

--- a/CesiumGltf/src/MetadataFeatureTableView.cpp
+++ b/CesiumGltf/src/MetadataFeatureTableView.cpp
@@ -12,12 +12,12 @@ static MetadataPropertyViewStatus checkOffsetBuffer(
         InvalidBufferViewSizeNotDivisibleByTypeSize;
   }
 
-  size_t size = offsetBuffer.size() / sizeof(T);
+  const size_t size = offsetBuffer.size() / sizeof(T);
   if (size != instanceCount + 1) {
     return MetadataPropertyViewStatus::InvalidBufferViewSizeNotFitInstanceCount;
   }
 
-  gsl::span<const T> offsetValues(
+  const gsl::span<const T> offsetValues(
       reinterpret_cast<const T*>(offsetBuffer.data()),
       size);
 
@@ -50,7 +50,7 @@ static MetadataPropertyViewStatus checkStringArrayOffsetBuffer(
     const gsl::span<const std::byte>& stringOffsetBuffer,
     size_t valueBufferSize,
     size_t instanceCount) noexcept {
-  auto status = checkOffsetBuffer<T>(
+  const auto status = checkOffsetBuffer<T>(
       arrayOffsetBuffer,
       stringOffsetBuffer.size(),
       instanceCount,
@@ -202,7 +202,7 @@ MetadataFeatureTableView::getStringPropertyValues(
     return createInvalidPropertyView<std::string_view>(status);
   }
 
-  PropertyType offsetType =
+  const PropertyType offsetType =
       convertOffsetStringToPropertyType(featureTableProperty.offsetType);
   if (offsetType == PropertyType::None) {
     return createInvalidPropertyView<std::string_view>(
@@ -255,7 +255,7 @@ MetadataFeatureTableView::getStringArrayPropertyValues(
   }
 
   // check fixed or dynamic array
-  int64_t componentCount = classProperty.componentCount.value_or(0);
+  const int64_t componentCount = classProperty.componentCount.value_or(0);
   if (componentCount > 0 && featureTableProperty.arrayOffsetBufferView >= 0) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
         MetadataPropertyViewStatus::
@@ -269,7 +269,7 @@ MetadataFeatureTableView::getStringArrayPropertyValues(
   }
 
   // get offset type
-  PropertyType offsetType =
+  const PropertyType offsetType =
       convertOffsetStringToPropertyType(featureTableProperty.offsetType);
   if (offsetType == PropertyType::None) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(

--- a/CesiumGltf/src/Model.cpp
+++ b/CesiumGltf/src/Model.cpp
@@ -12,7 +12,7 @@ using namespace CesiumGltf;
 namespace {
 template <typename T>
 size_t copyElements(std::vector<T>& to, std::vector<T>& from) {
-  size_t out = to.size();
+  const size_t out = to.size();
   to.resize(out + from.size());
   for (size_t i = 0; i < from.size(); ++i) {
     to[out + i] = std::move(from[i]);
@@ -48,19 +48,19 @@ void Model::merge(Model&& rhs) {
           this->extensionsRequired.end()),
       this->extensionsRequired.end());
 
-  size_t firstAccessor = copyElements(this->accessors, rhs.accessors);
-  size_t firstAnimation = copyElements(this->animations, rhs.animations);
-  size_t firstBuffer = copyElements(this->buffers, rhs.buffers);
-  size_t firstBufferView = copyElements(this->bufferViews, rhs.bufferViews);
-  size_t firstCamera = copyElements(this->cameras, rhs.cameras);
-  size_t firstImage = copyElements(this->images, rhs.images);
-  size_t firstMaterial = copyElements(this->materials, rhs.materials);
-  size_t firstMesh = copyElements(this->meshes, rhs.meshes);
-  size_t firstNode = copyElements(this->nodes, rhs.nodes);
-  size_t firstSampler = copyElements(this->samplers, rhs.samplers);
-  size_t firstScene = copyElements(this->scenes, rhs.scenes);
-  size_t firstSkin = copyElements(this->skins, rhs.skins);
-  size_t firstTexture = copyElements(this->textures, rhs.textures);
+  const size_t firstAccessor = copyElements(this->accessors, rhs.accessors);
+  const size_t firstAnimation = copyElements(this->animations, rhs.animations);
+  const size_t firstBuffer = copyElements(this->buffers, rhs.buffers);
+  const size_t firstBufferView = copyElements(this->bufferViews, rhs.bufferViews);
+  const size_t firstCamera = copyElements(this->cameras, rhs.cameras);
+  const size_t firstImage = copyElements(this->images, rhs.images);
+  const size_t firstMaterial = copyElements(this->materials, rhs.materials);
+  const size_t firstMesh = copyElements(this->meshes, rhs.meshes);
+  const size_t firstNode = copyElements(this->nodes, rhs.nodes);
+  const size_t firstSampler = copyElements(this->samplers, rhs.samplers);
+  const size_t firstScene = copyElements(this->scenes, rhs.scenes);
+  const size_t firstSkin = copyElements(this->skins, rhs.skins);
+  const size_t firstTexture = copyElements(this->textures, rhs.textures);
 
   // Update the copied indices
   for (size_t i = firstAccessor; i < this->accessors.size(); ++i) {
@@ -200,7 +200,7 @@ void Model::merge(Model&& rhs) {
         Model::getSafe(&this->scenes, rhs.scene + int32_t(firstScene));
 
     newScene.nodes = pThisDefaultScene->nodes;
-    size_t originalNodeCount = newScene.nodes.size();
+    const size_t originalNodeCount = newScene.nodes.size();
     newScene.nodes.resize(originalNodeCount + pRhsDefaultScene->nodes.size());
     std::copy(
         pRhsDefaultScene->nodes.begin(),
@@ -293,13 +293,13 @@ void forEachPrimitiveInNodeObject(
         nodeTransform * translation * glm::dmat4(rotationQuat) * scale;
   }
 
-  int meshId = node.mesh;
+  const int meshId = node.mesh;
   if (meshId >= 0 && meshId < static_cast<int>(model.meshes.size())) {
     const Mesh& mesh = model.meshes[static_cast<size_t>(meshId)];
     forEachPrimitiveInMeshObject(nodeTransform, model, node, mesh, callback);
   }
 
-  for (int childNodeId : node.children) {
+  for (const int childNodeId : node.children) {
     if (childNodeId >= 0 &&
         childNodeId < static_cast<int>(model.nodes.size())) {
       forEachPrimitiveInNodeObject(
@@ -317,7 +317,7 @@ void forEachPrimitiveInSceneObject(
     const Model& model,
     const Scene& scene,
     TCallback& callback) {
-  for (int nodeID : scene.nodes) {
+  for (const int nodeID : scene.nodes) {
     if (nodeID >= 0 && nodeID < static_cast<int>(model.nodes.size())) {
       forEachPrimitiveInNodeObject(
           transform,
@@ -352,7 +352,7 @@ void Model::forEachPrimitiveInScene(
 void Model::forEachPrimitiveInScene(
     int sceneID,
     std::function<ForEachPrimitiveInSceneConstCallback>&& callback) const {
-  glm::dmat4x4 rootTransform(1.0);
+  const glm::dmat4x4 rootTransform(1.0);
 
   if (sceneID >= 0) {
     // Use the user-specified scene if it exists.
@@ -407,15 +407,15 @@ void addTriangleNormalToVertexNormals(
 
   // Add the triangle's normal to each vertex's accumulated normal.
 
-  uint32_t index0 = static_cast<uint32_t>(tIndex0);
-  uint32_t index1 = static_cast<uint32_t>(tIndex1);
-  uint32_t index2 = static_cast<uint32_t>(tIndex2);
+  const uint32_t index0 = static_cast<uint32_t>(tIndex0);
+  const uint32_t index1 = static_cast<uint32_t>(tIndex1);
+  const uint32_t index2 = static_cast<uint32_t>(tIndex2);
 
   const glm::vec3& vertex0 = positionView[index0];
   const glm::vec3& vertex1 = positionView[index1];
   const glm::vec3& vertex2 = positionView[index2];
 
-  glm::vec3 triangleNormal = glm::cross(vertex1 - vertex0, vertex2 - vertex0);
+  const glm::vec3 triangleNormal = glm::cross(vertex1 - vertex0, vertex2 - vertex0);
 
   // Add the triangle normal to each vertex's accumulated normal. At the end
   // we will normalize the accumulated vertex normals to average.
@@ -508,9 +508,9 @@ void generateSmoothNormals(
     const AccessorView<glm::vec3>& positionView,
     const std::optional<Accessor>& indexAccessor) {
 
-  size_t count = static_cast<size_t>(positionView.size());
-  size_t normalBufferStride = sizeof(glm::vec3);
-  size_t normalBufferSize = count * normalBufferStride;
+  const size_t count = static_cast<size_t>(positionView.size());
+  const size_t normalBufferStride = sizeof(glm::vec3);
+  const size_t normalBufferSize = count * normalBufferStride;
 
   std::vector<std::byte> normalByteBuffer(normalBufferSize);
   gsl::span<glm::vec3> normals(
@@ -549,7 +549,7 @@ void generateSmoothNormals(
 
   // normalizes the accumulated vertex normals
   for (size_t i = 0; i < count; ++i) {
-    float lengthSquared = glm::length2(normals[i]);
+    const float lengthSquared = glm::length2(normals[i]);
     if (lengthSquared < 1e-8f) {
       normals[i] = glm::vec3(0.0f);
     } else {
@@ -557,12 +557,12 @@ void generateSmoothNormals(
     }
   }
 
-  size_t normalBufferId = gltf.buffers.size();
+  const size_t normalBufferId = gltf.buffers.size();
   Buffer& normalBuffer = gltf.buffers.emplace_back();
   normalBuffer.byteLength = static_cast<int64_t>(normalBufferSize);
   normalBuffer.cesium.data = std::move(normalByteBuffer);
 
-  size_t normalBufferViewId = gltf.bufferViews.size();
+  const size_t normalBufferViewId = gltf.bufferViews.size();
   BufferView& normalBufferView = gltf.bufferViews.emplace_back();
   normalBufferView.buffer = static_cast<int32_t>(normalBufferId);
   normalBufferView.byteLength = static_cast<int64_t>(normalBufferSize);
@@ -570,7 +570,7 @@ void generateSmoothNormals(
   normalBufferView.byteStride = static_cast<int64_t>(normalBufferStride);
   normalBufferView.target = BufferView::Target::ARRAY_BUFFER;
 
-  size_t normalAccessorId = gltf.accessors.size();
+  const size_t normalAccessorId = gltf.accessors.size();
   Accessor& normalAccessor = gltf.accessors.emplace_back();
   normalAccessor.byteOffset = 0;
   normalAccessor.bufferView = static_cast<int32_t>(normalBufferViewId);
@@ -644,8 +644,8 @@ void Model::generateMissingNormalsSmooth() {
           return;
         }
 
-        int positionAccessorId = positionIt->second;
-        AccessorView<glm::vec3> positionView(gltf_, positionAccessorId);
+        const int positionAccessorId = positionIt->second;
+        const AccessorView<glm::vec3> positionView(gltf_, positionAccessorId);
         if (positionView.status() != AccessorViewStatus::Valid) {
           return;
         }

--- a/CesiumGltf/src/Model.cpp
+++ b/CesiumGltf/src/Model.cpp
@@ -21,7 +21,7 @@ size_t copyElements(std::vector<T>& to, std::vector<T>& from) {
   return out;
 }
 
-void updateIndex(int32_t& index, size_t offset) {
+void updateIndex(int32_t& index, size_t offset) noexcept {
   if (index == -1) {
     return;
   }

--- a/CesiumGltf/src/Model.cpp
+++ b/CesiumGltf/src/Model.cpp
@@ -51,7 +51,8 @@ void Model::merge(Model&& rhs) {
   const size_t firstAccessor = copyElements(this->accessors, rhs.accessors);
   const size_t firstAnimation = copyElements(this->animations, rhs.animations);
   const size_t firstBuffer = copyElements(this->buffers, rhs.buffers);
-  const size_t firstBufferView = copyElements(this->bufferViews, rhs.bufferViews);
+  const size_t firstBufferView =
+      copyElements(this->bufferViews, rhs.bufferViews);
   const size_t firstCamera = copyElements(this->cameras, rhs.cameras);
   const size_t firstImage = copyElements(this->images, rhs.images);
   const size_t firstMaterial = copyElements(this->materials, rhs.materials);
@@ -415,7 +416,8 @@ void addTriangleNormalToVertexNormals(
   const glm::vec3& vertex1 = positionView[index1];
   const glm::vec3& vertex2 = positionView[index2];
 
-  const glm::vec3 triangleNormal = glm::cross(vertex1 - vertex0, vertex2 - vertex0);
+  const glm::vec3 triangleNormal =
+      glm::cross(vertex1 - vertex0, vertex2 - vertex0);
 
   // Add the triangle normal to each vertex's accumulated normal. At the end
   // we will normalize the accumulated vertex normals to average.

--- a/CesiumGltf/src/Model.cpp
+++ b/CesiumGltf/src/Model.cpp
@@ -400,7 +400,7 @@ void Model::forEachPrimitiveInScene(
 namespace {
 template <typename TIndex>
 void addTriangleNormalToVertexNormals(
-    gsl::span<glm::vec3>& normals,
+    const gsl::span<glm::vec3>& normals,
     const AccessorView<glm::vec3>& positionView,
     TIndex tIndex0,
     TIndex tIndex1,
@@ -429,7 +429,7 @@ void addTriangleNormalToVertexNormals(
 template <typename TIndex, typename GetIndex>
 bool accumulateNormals(
     MeshPrimitive::Mode mode,
-    gsl::span<glm::vec3>& normals,
+    const gsl::span<glm::vec3>& normals,
     const AccessorView<glm::vec3>& positionView,
     int64_t numIndices,
     GetIndex getIndex) {

--- a/CesiumGltfReader/include/CesiumGltf/GltfReader.h
+++ b/CesiumGltfReader/include/CesiumGltf/GltfReader.h
@@ -134,7 +134,7 @@ public:
   /**
    * @brief Constructs a new instance.
    */
-  GltfReader() noexcept;
+  GltfReader();
 
   /**
    * @brief Registers an extension for a glTF object.

--- a/CesiumGltfReader/include/CesiumGltf/GltfReader.h
+++ b/CesiumGltfReader/include/CesiumGltf/GltfReader.h
@@ -134,7 +134,7 @@ public:
   /**
    * @brief Constructs a new instance.
    */
-  GltfReader();
+  GltfReader() noexcept;
 
   /**
    * @brief Registers an extension for a glTF object.

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -322,7 +322,7 @@ public:
 
 } // namespace
 
-GltfReader::GltfReader() {
+GltfReader::GltfReader() noexcept {
   this->registerExtension<
       MeshPrimitive,
       KHR_draco_mesh_compressionJsonHandler>();

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -75,10 +75,10 @@ namespace {
  * @return The string
  */
 std::string toMagicString(uint32_t i) {
-  unsigned char c0 = static_cast<unsigned char>(i & 0xFF);
-  unsigned char c1 = static_cast<unsigned char>((i >> 8) & 0xFF);
-  unsigned char c2 = static_cast<unsigned char>((i >> 16) & 0xFF);
-  unsigned char c3 = static_cast<unsigned char>((i >> 24) & 0xFF);
+  const unsigned char c0 = static_cast<unsigned char>(i & 0xFF);
+  const unsigned char c1 = static_cast<unsigned char>((i >> 8) & 0xFF);
+  const unsigned char c2 = static_cast<unsigned char>((i >> 16) & 0xFF);
+  const unsigned char c3 = static_cast<unsigned char>((i >> 24) & 0xFF);
   std::stringstream stream;
   stream << c0 << c1 << c2 << c3 << " (0x" << std::hex << i << ")";
   return stream.str();
@@ -120,7 +120,7 @@ ModelReaderResult readBinaryModel(
         {}};
   }
 
-  gsl::span<const std::byte> glbData = data.subspan(0, pHeader->length);
+  const gsl::span<const std::byte> glbData = data.subspan(0, pHeader->length);
 
   const ChunkHeader* pJsonChunkHeader =
       reinterpret_cast<const ChunkHeader*>(glbData.data() + sizeof(GlbHeader));
@@ -132,8 +132,8 @@ ModelReaderResult readBinaryModel(
         {}};
   }
 
-  size_t jsonStart = sizeof(GlbHeader) + sizeof(ChunkHeader);
-  size_t jsonEnd = jsonStart + pJsonChunkHeader->chunkLength;
+  const size_t jsonStart = sizeof(GlbHeader) + sizeof(ChunkHeader);
+  const size_t jsonEnd = jsonStart + pJsonChunkHeader->chunkLength;
 
   if (jsonEnd > glbData.size()) {
     return {
@@ -144,7 +144,7 @@ ModelReaderResult readBinaryModel(
         {}};
   }
 
-  gsl::span<const std::byte> jsonChunk =
+  const gsl::span<const std::byte> jsonChunk =
       glbData.subspan(jsonStart, pJsonChunkHeader->chunkLength);
   gsl::span<const std::byte> binaryChunk;
 
@@ -159,8 +159,8 @@ ModelReaderResult readBinaryModel(
           {}};
     }
 
-    size_t binaryStart = jsonEnd + sizeof(ChunkHeader);
-    size_t binaryEnd = binaryStart + pBinaryChunkHeader->chunkLength;
+    const size_t binaryStart = jsonEnd + sizeof(ChunkHeader);
+    const size_t binaryEnd = binaryStart + pBinaryChunkHeader->chunkLength;
 
     if (binaryEnd > glbData.size()) {
       return {
@@ -193,7 +193,7 @@ ModelReaderResult readBinaryModel(
       return result;
     }
 
-    int64_t binaryChunkSize = static_cast<int64_t>(binaryChunk.size());
+    const int64_t binaryChunkSize = static_cast<int64_t>(binaryChunk.size());
     if (buffer.byteLength > binaryChunkSize ||
         buffer.byteLength + 3 < binaryChunkSize) {
       result.errors.emplace_back("GLB binary chunk size does not match the "
@@ -238,8 +238,8 @@ void postprocess(
         continue;
       }
 
-      gsl::span<const std::byte> bufferSpan(buffer.cesium.data);
-      gsl::span<const std::byte> bufferViewSpan = bufferSpan.subspan(
+      const gsl::span<const std::byte> bufferSpan(buffer.cesium.data);
+      const gsl::span<const std::byte> bufferViewSpan = bufferSpan.subspan(
           static_cast<size_t>(bufferView.byteOffset),
           static_cast<size_t>(bufferView.byteLength));
       ImageReaderResult imageResult = context.reader.readImage(bufferViewSpan);

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -40,7 +40,7 @@ struct ChunkHeader {
 };
 #pragma pack(pop)
 
-bool isBinaryGltf(const gsl::span<const std::byte>& data) {
+bool isBinaryGltf(const gsl::span<const std::byte>& data) noexcept {
   if (data.size() < sizeof(GlbHeader)) {
     return false;
   }
@@ -257,7 +257,7 @@ void postprocess(
 class AnyExtensionJsonHandler : public JsonObjectJsonHandler,
                                 public IExtensionJsonHandler {
 public:
-  AnyExtensionJsonHandler(const ReaderContext& /* context */)
+  AnyExtensionJsonHandler(const ReaderContext& /* context */) noexcept
       : JsonObjectJsonHandler() {}
 
   virtual void reset(

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -210,7 +210,7 @@ ModelReaderResult readBinaryModel(
 }
 
 void postprocess(
-    ReaderContext& context,
+    const ReaderContext& context,
     ModelReaderResult& readModel,
     const ReadModelOptions& options) {
   Model& model = readModel.model.value();

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -322,7 +322,7 @@ public:
 
 } // namespace
 
-GltfReader::GltfReader() noexcept {
+GltfReader::GltfReader() {
   this->registerExtension<
       MeshPrimitive,
       KHR_draco_mesh_compressionJsonHandler>();

--- a/CesiumGltfReader/src/ImageManipulation.cpp
+++ b/CesiumGltfReader/src/ImageManipulation.cpp
@@ -16,7 +16,7 @@ void ImageManipulation::unsafeBlitImage(
     size_t sourceWidth,
     size_t sourceHeight,
     size_t bytesPerPixel) {
-  size_t bytesToCopyPerRow = bytesPerPixel * sourceWidth;
+  const size_t bytesToCopyPerRow = bytesPerPixel * sourceWidth;
 
   if (bytesToCopyPerRow == targetRowStride &&
       targetRowStride == sourceRowStride) {
@@ -60,11 +60,11 @@ bool ImageManipulation::blitImage(
   }
 
   size_t bytesPerPixel = size_t(target.bytesPerChannel * target.channels);
-  size_t bytesPerSourceRow = bytesPerPixel * size_t(source.width);
+  const size_t bytesPerSourceRow = bytesPerPixel * size_t(source.width);
   size_t bytesPerTargetRow = bytesPerPixel * size_t(target.width);
 
-  size_t requiredTargetSize = size_t(targetPixels.height) * bytesPerTargetRow;
-  size_t requiredSourceSize = size_t(sourcePixels.height) * bytesPerSourceRow;
+  const size_t requiredTargetSize = size_t(targetPixels.height) * bytesPerTargetRow;
+  const size_t requiredSourceSize = size_t(sourcePixels.height) * bytesPerSourceRow;
   if (target.pixelData.size() < requiredTargetSize ||
       source.pixelData.size() < requiredSourceSize) {
     return false;

--- a/CesiumGltfReader/src/ImageManipulation.cpp
+++ b/CesiumGltfReader/src/ImageManipulation.cpp
@@ -63,8 +63,10 @@ bool ImageManipulation::blitImage(
   const size_t bytesPerSourceRow = bytesPerPixel * size_t(source.width);
   size_t bytesPerTargetRow = bytesPerPixel * size_t(target.width);
 
-  const size_t requiredTargetSize = size_t(targetPixels.height) * bytesPerTargetRow;
-  const size_t requiredSourceSize = size_t(sourcePixels.height) * bytesPerSourceRow;
+  const size_t requiredTargetSize =
+      size_t(targetPixels.height) * bytesPerTargetRow;
+  const size_t requiredSourceSize =
+      size_t(sourcePixels.height) * bytesPerSourceRow;
   if (target.pixelData.size() < requiredTargetSize ||
       source.pixelData.size() < requiredSourceSize) {
     return false;

--- a/CesiumGltfReader/src/decodeDataUrls.cpp
+++ b/CesiumGltfReader/src/decodeDataUrls.cpp
@@ -12,7 +12,7 @@ std::vector<std::byte> decodeBase64(gsl::span<const std::byte> data) {
   CESIUM_TRACE("CesiumGltf::decodeBase64");
   std::vector<std::byte> result(modp_b64_decode_len(data.size()));
 
-  size_t resultLength = modp_b64_decode(
+  const size_t resultLength = modp_b64_decode(
       reinterpret_cast<char*>(result.data()),
       reinterpret_cast<const char*>(data.data()),
       data.size());
@@ -42,7 +42,7 @@ std::optional<DecodeResult> tryDecode(const std::string& uri) {
     return std::nullopt;
   }
 
-  size_t dataDelimeter = uri.find(',', dataPrefixLength);
+  const size_t dataDelimeter = uri.find(',', dataPrefixLength);
   if (dataDelimeter == std::string::npos) {
     return std::nullopt;
   }
@@ -63,7 +63,7 @@ std::optional<DecodeResult> tryDecode(const std::string& uri) {
         result.mimeType.size() - base64IndicatorLength);
   }
 
-  gsl::span<const std::byte> data(
+  const gsl::span<const std::byte> data(
       reinterpret_cast<const std::byte*>(uri.data()) + dataDelimeter + 1,
       uri.size() - dataDelimeter - 1);
 

--- a/CesiumGltfReader/src/decodeDraco.cpp
+++ b/CesiumGltfReader/src/decodeDraco.cpp
@@ -35,7 +35,7 @@ std::unique_ptr<draco::Mesh> decodeBufferViewToDracoMesh(
     return nullptr;
   }
 
-  BufferView& bufferView = *pBufferView;
+  const BufferView& bufferView = *pBufferView;
 
   Buffer* pBuffer = Model::getSafe(&model.buffers, bufferView.buffer);
   if (!pBuffer) {
@@ -54,7 +54,7 @@ std::unique_ptr<draco::Mesh> decodeBufferViewToDracoMesh(
     return nullptr;
   }
 
-  gsl::span<const std::byte> data(
+  const gsl::span<const std::byte> data(
       buffer.cesium.data.data() + bufferView.byteOffset,
       static_cast<uint64_t>(bufferView.byteLength));
 
@@ -141,7 +141,7 @@ void copyDecodedIndices(
   Buffer& indicesBuffer = model.buffers.emplace_back();
 
   int64_t indexBytes = pIndicesAccessor->computeByteSizeOfComponent();
-  int64_t indicesBytes = pIndicesAccessor->count * indexBytes;
+  const int64_t indicesBytes = pIndicesAccessor->count * indexBytes;
 
   indicesBuffer.cesium.data.resize(static_cast<size_t>(indicesBytes));
   indicesBuffer.byteLength = indicesBytes;
@@ -218,9 +218,9 @@ void copyDecodedAttribute(
   bufferView.buffer = static_cast<int32_t>(model.buffers.size());
   Buffer& buffer = model.buffers.emplace_back();
 
-  int8_t numberOfComponents = pAccessor->computeNumberOfComponents();
-  int64_t stride = numberOfComponents * pAccessor->computeByteSizeOfComponent();
-  int64_t sizeBytes = pAccessor->count * stride;
+  const int8_t numberOfComponents = pAccessor->computeNumberOfComponents();
+  const int64_t stride = numberOfComponents * pAccessor->computeByteSizeOfComponent();
+  const int64_t sizeBytes = pAccessor->count * stride;
 
   buffer.cesium.data.resize(static_cast<size_t>(sizeBytes));
   buffer.byteLength = sizeBytes;
@@ -229,9 +229,9 @@ void copyDecodedAttribute(
   bufferView.byteOffset = 0;
   pAccessor->byteOffset = 0;
 
-  auto doCopy = [pMesh, pAttribute, numberOfComponents](auto pOut) {
+  const auto doCopy = [pMesh, pAttribute, numberOfComponents](auto pOut) {
     for (draco::PointIndex i(0); i < pMesh->num_points(); ++i) {
-      draco::AttributeValueIndex valueIndex = pAttribute->mapped_index(i);
+      const draco::AttributeValueIndex valueIndex = pAttribute->mapped_index(i);
       pAttribute->ConvertValue(valueIndex, numberOfComponents, pOut);
       pOut += pAttribute->num_components();
     }
@@ -291,7 +291,7 @@ void decodePrimitive(
       continue;
     }
 
-    int32_t primitiveAttrIndex = primitiveAttrIt->second;
+    const int32_t primitiveAttrIndex = primitiveAttrIt->second;
     Accessor* pAccessor = Model::getSafe(&model.accessors, primitiveAttrIndex);
     if (!pAccessor) {
       readModel.warnings.emplace_back(
@@ -299,7 +299,7 @@ void decodePrimitive(
       continue;
     }
 
-    int32_t dracoAttrIndex = attribute.second;
+    const int32_t dracoAttrIndex = attribute.second;
     const draco::PointAttribute* pAttribute =
         pMesh->GetAttributeByUniqueId(static_cast<uint32_t>(dracoAttrIndex));
     if (pAttribute == nullptr) {

--- a/CesiumGltfReader/src/decodeDraco.cpp
+++ b/CesiumGltfReader/src/decodeDraco.cpp
@@ -219,7 +219,8 @@ void copyDecodedAttribute(
   Buffer& buffer = model.buffers.emplace_back();
 
   const int8_t numberOfComponents = pAccessor->computeNumberOfComponents();
-  const int64_t stride = numberOfComponents * pAccessor->computeByteSizeOfComponent();
+  const int64_t stride =
+      numberOfComponents * pAccessor->computeByteSizeOfComponent();
   const int64_t sizeBytes = pAccessor->count * stride;
 
   buffer.cesium.data.resize(static_cast<size_t>(sizeBytes));

--- a/CesiumGltfReader/src/decodeDraco.cpp
+++ b/CesiumGltfReader/src/decodeDraco.cpp
@@ -24,7 +24,7 @@ using namespace CesiumGltf;
 std::unique_ptr<draco::Mesh> decodeBufferViewToDracoMesh(
     ModelReaderResult& readModel,
     MeshPrimitive& /* primitive */,
-    KHR_draco_mesh_compression& draco) {
+    const KHR_draco_mesh_compression& draco) {
   CESIUM_TRACE("CesiumGltf::decodeBufferViewToDracoMesh");
   Model& model = readModel.model.value();
 
@@ -92,7 +92,7 @@ void copyData(const T* pSource, T* pDestination, int64_t length) {
 
 void copyDecodedIndices(
     ModelReaderResult& readModel,
-    MeshPrimitive& primitive,
+    const MeshPrimitive& primitive,
     draco::Mesh* pMesh) {
   CESIUM_TRACE("CesiumGltf::copyDecodedIndices");
   Model& model = readModel.model.value();

--- a/CesiumGltfWriter/include/CesiumGltf/WriteGLTFCallback.h
+++ b/CesiumGltfWriter/include/CesiumGltf/WriteGLTFCallback.h
@@ -10,5 +10,6 @@ using WriteGLTFCallback =
     const std::function<void(std::string_view, const std::vector<std::byte>&)>;
 
 /** Default no-op callback for glTF / GLB writing */
-inline void noopGltfWriter(std::string_view, const std::vector<std::byte>&) {}
+inline void
+noopGltfWriter(std::string_view, const std::vector<std::byte>&) noexcept {}
 } // namespace CesiumGltf

--- a/CesiumIonClient/include/CesiumIonClient/Assets.h
+++ b/CesiumIonClient/include/CesiumIonClient/Assets.h
@@ -12,7 +12,7 @@ struct Asset {
   /**
    * @brief The unique identifier for this asset.
    */
-  int64_t id;
+  int64_t id = -1;
 
   /**
    * @brief The name of this asset.
@@ -40,7 +40,7 @@ struct Asset {
   /**
    * @brief The number of bytes this asset occupies in the user's account.
    */
-  int64_t bytes;
+  int64_t bytes = 0;
 
   /**
    * @brief The date and time that this asset was created in [RFC
@@ -67,7 +67,7 @@ struct Asset {
   /**
    * @brief The percentage progress of the tiling pipeline preparing this asset.
    */
-  int8_t percentComplete;
+  int8_t percentComplete = 0;
 };
 
 struct Assets {

--- a/CesiumIonClient/include/CesiumIonClient/Connection.h
+++ b/CesiumIonClient/include/CesiumIonClient/Connection.h
@@ -53,7 +53,7 @@ public:
       int64_t clientID,
       const std::string& redirectPath,
       const std::vector<std::string>& scopes,
-      std::function<void(const std::string&)>&& openUrlCallback,
+      const std::function<void(const std::string&)>&& openUrlCallback,
       const std::string& ionApiUrl = "https://api.cesium.com/",
       const std::string& ionAuthorizeUrl = "https://cesium.com/ion/oauth");
 

--- a/CesiumIonClient/include/CesiumIonClient/Connection.h
+++ b/CesiumIonClient/include/CesiumIonClient/Connection.h
@@ -75,7 +75,7 @@ public:
   /**
    * @brief Gets the async system used by this connection to do work in threads.
    */
-  const CesiumAsync::AsyncSystem& getAsyncSystem() const {
+  const CesiumAsync::AsyncSystem& getAsyncSystem() const noexcept {
     return this->_asyncSystem;
   }
 
@@ -83,19 +83,22 @@ public:
    * @brief Gets the interface used by this connection to interact with the
    * Cesium ion REST API.
    */
-  const std::shared_ptr<CesiumAsync::IAssetAccessor>& getAssetAccessor() const {
+  const std::shared_ptr<CesiumAsync::IAssetAccessor>&
+  getAssetAccessor() const noexcept {
     return this->_pAssetAccessor;
   }
 
   /**
    * @brief Gets the access token used by this connection.
    */
-  const std::string& getAccessToken() const { return this->_accessToken; }
+  const std::string& getAccessToken() const noexcept {
+    return this->_accessToken;
+  }
 
   /**
    * @brief Gets the Cesium ion API base URL.
    */
-  const std::string& getApiUrl() const { return this->_apiUrl; }
+  const std::string& getApiUrl() const noexcept { return this->_apiUrl; }
 
   /**
    * @brief Retrieves profile information for the access token currently being

--- a/CesiumIonClient/include/CesiumIonClient/Connection.h
+++ b/CesiumIonClient/include/CesiumIonClient/Connection.h
@@ -53,7 +53,7 @@ public:
       int64_t clientID,
       const std::string& redirectPath,
       const std::vector<std::string>& scopes,
-      const std::function<void(const std::string&)>&& openUrlCallback,
+      std::function<void(const std::string&)>&& openUrlCallback,
       const std::string& ionApiUrl = "https://api.cesium.com/",
       const std::string& ionAuthorizeUrl = "https://cesium.com/ion/oauth");
 

--- a/CesiumIonClient/include/CesiumIonClient/Profile.h
+++ b/CesiumIonClient/include/CesiumIonClient/Profile.h
@@ -13,19 +13,19 @@ struct ProfileStorage final {
   /**
    * @brief The number of bytes currently being used by this account.
    */
-  int64_t used;
+  int64_t used = 0;
 
   /**
    * @brief The number of bytes available for additional asset uploads to this
    * account.
    */
-  int64_t available;
+  int64_t available = 0;
 
   /**
    * @brief The total number of bytes currently allowed to be used by this
    * account.
    */
-  int64_t total;
+  int64_t total = 0;
 };
 
 /**
@@ -37,38 +37,38 @@ struct Profile final {
   /**
    * @brief The unique identifier for this account.
    */
-  int64_t id;
+  int64_t id = -1;
 
   /**
    * @brief The array of scopes available with this token.
    */
-  std::vector<std::string> scopes;
+  std::vector<std::string> scopes{};
 
   /**
    * @brief The account username.
    */
-  std::string username;
+  std::string username{};
 
   /**
    * @brief The primary email address associated with this account.
    */
-  std::string email;
+  std::string email{};
 
   /**
    * @brief If true, the email address has been verified for this account.
    */
-  bool emailVerified;
+  bool emailVerified = false;
 
   /**
    * @brief A url to the profile image associated with this account.
    */
-  std::string avatar;
+  std::string avatar{};
 
   /**
    * @brief Information about the amount of storage available in the user's
    * account.
    */
-  ProfileStorage storage;
+  ProfileStorage storage{ 0, 0, 0 };
 };
 
 } // namespace CesiumIonClient

--- a/CesiumIonClient/include/CesiumIonClient/Profile.h
+++ b/CesiumIonClient/include/CesiumIonClient/Profile.h
@@ -68,7 +68,7 @@ struct Profile final {
    * @brief Information about the amount of storage available in the user's
    * account.
    */
-  ProfileStorage storage{ 0, 0, 0 };
+  ProfileStorage storage{0, 0, 0};
 };
 
 } // namespace CesiumIonClient

--- a/CesiumIonClient/include/CesiumIonClient/Token.h
+++ b/CesiumIonClient/include/CesiumIonClient/Token.h
@@ -12,38 +12,38 @@ struct Token {
   /**
    * @brief The identifier of the token.
    */
-  std::string jti;
+  std::string jti{};
 
   /**
    * @brief The name of the token.
    */
-  std::string name;
+  std::string name{};
 
   /**
    * @brief The token value.
    */
-  std::string token;
+  std::string token{};
 
   /**
    * @brief True if this is the default token.
    */
-  bool isDefault;
+  bool isDefault{};
 
   /**
    * @brief The date when this token was last used.
    */
-  std::string lastUsed;
+  std::string lastUsed{};
 
   /**
    * @brief The scopes granted by this token.
    */
-  std::vector<std::string> scopes;
+  std::vector<std::string> scopes{};
 
   /**
    * @brief The assets that this token my access.
    *
    * If `std::nullopt`, the token allows access to all assets.
    */
-  std::optional<std::vector<int64_t>> assets;
+  std::optional<std::vector<int64_t>> assets{};
 };
 } // namespace CesiumIonClient

--- a/CesiumIonClient/src/Connection.cpp
+++ b/CesiumIonClient/src/Connection.cpp
@@ -95,7 +95,7 @@ static std::string createAuthorizationErrorHtml(
     int64_t clientID,
     const std::string& redirectPath,
     const std::vector<std::string>& scopes,
-    std::function<void(const std::string&)>&& openUrlCallback,
+    const std::function<void(const std::string&)>&& openUrlCallback,
     const std::string& ionApiUrl,
     const std::string& ionAuthorizeUrl) {
 
@@ -259,7 +259,7 @@ static Response<T> createErrorResponse(const IAssetResponse* pResponse) {
 template <typename T>
 static Response<T> createJsonErrorResponse(
     const IAssetResponse* pResponse,
-    rapidjson::Document& d) {
+    const rapidjson::Document& d) {
   return Response<T>{
       std::nullopt,
       pResponse->statusCode(),

--- a/CesiumIonClient/src/Connection.cpp
+++ b/CesiumIonClient/src/Connection.cpp
@@ -95,7 +95,7 @@ static std::string createAuthorizationErrorHtml(
     int64_t clientID,
     const std::string& redirectPath,
     const std::vector<std::string>& scopes,
-    const std::function<void(const std::string&)>&& openUrlCallback,
+    std::function<void(const std::string&)>&& openUrlCallback,
     const std::string& ionApiUrl,
     const std::string& ionAuthorizeUrl) {
 

--- a/CesiumIonClient/src/Connection.cpp
+++ b/CesiumIonClient/src/Connection.cpp
@@ -29,9 +29,9 @@ using namespace CesiumUtility;
 
 namespace {
 std::string encodeBase64(const std::vector<uint8_t>& bytes) {
-  size_t count = modp_b64_encode_len(bytes.size());
+  const size_t count = modp_b64_encode_len(bytes.size());
   std::string result(count, 0);
-  size_t actualLength = modp_b64_encode(
+  const size_t actualLength = modp_b64_encode(
       result.data(),
       reinterpret_cast<const char*>(bytes.data()),
       bytes.size());
@@ -39,7 +39,7 @@ std::string encodeBase64(const std::vector<uint8_t>& bytes) {
 
   // Convert to a URL-friendly form of Base64 according to the algorithm
   // in [RFC7636 Appendix A](https://tools.ietf.org/html/rfc7636#appendix-A)
-  size_t firstPaddingIndex = result.find('=');
+  const size_t firstPaddingIndex = result.find('=');
   if (firstPaddingIndex != std::string::npos) {
     result.erase(result.begin() + int64_t(firstPaddingIndex), result.end());
   }
@@ -103,7 +103,7 @@ static std::string createAuthorizationErrorHtml(
 
   std::shared_ptr<httplib::Server> pServer =
       std::make_shared<httplib::Server>();
-  int port = pServer->bind_to_any_port("127.0.0.1");
+  const int port = pServer->bind_to_any_port("127.0.0.1");
 
   std::string redirectUrl =
       Uri::resolve("http://127.0.0.1:" + std::to_string(port), redirectPath);
@@ -203,7 +203,7 @@ static std::string createAuthorizationErrorHtml(
               createSuccessHtml(friendlyApplicationName),
               "text/html");
           promise.resolve(std::move(connection));
-        } catch (std::exception& exception) {
+        } catch (const std::exception& exception) {
           response.set_content(
               createAuthorizationErrorHtml(friendlyApplicationName, exception),
               "text/html");
@@ -325,7 +325,7 @@ CesiumAsync::Future<Response<Profile>> Connection::me() const {
                 JsonHelpers::getBoolOrDefault(d, "emailVerified", false);
             result.avatar = JsonHelpers::getStringOrDefault(d, "avatar", "");
 
-            auto storageIt = d.FindMember("storage");
+            const auto storageIt = d.FindMember("storage");
             if (storageIt == d.MemberEnd()) {
               result.storage.available = 0;
               result.storage.total = 0;
@@ -394,7 +394,7 @@ CesiumAsync::Future<Response<Assets>> Connection::assets() const {
 
             result.link = JsonHelpers::getStringOrDefault(d, "link", "");
 
-            auto itemsIt = d.FindMember("items");
+            const auto itemsIt = d.FindMember("items");
             if (itemsIt != d.MemberEnd() && itemsIt->value.IsArray()) {
               const rapidjson::Value& items = itemsIt->value;
               result.items.resize(items.Size());
@@ -423,7 +423,7 @@ static Token tokenFromJson(const rapidjson::Value& json) {
   token.lastUsed = JsonHelpers::getStringOrDefault(json, "lastUsed", "");
   token.scopes = JsonHelpers::getStrings(json, "scopes");
 
-  auto assetsIt = json.FindMember("assets");
+  const auto assetsIt = json.FindMember("assets");
   if (assetsIt != json.MemberEnd()) {
     token.assets = JsonHelpers::getInt64s(json, "assets");
   } else {
@@ -546,7 +546,7 @@ CesiumAsync::Future<Response<Token>> Connection::createToken(
   }
   writer.EndObject();
 
-  gsl::span<const std::byte> tokenBytes(
+  const gsl::span<const std::byte> tokenBytes(
       reinterpret_cast<const std::byte*>(tokenBuffer.GetString()),
       tokenBuffer.GetSize());
   return this->_pAssetAccessor
@@ -610,7 +610,7 @@ CesiumAsync::Future<Response<Token>> Connection::createToken(
   writer.String(codeVerifier.c_str(), rapidjson::SizeType(codeVerifier.size()));
   writer.EndObject();
 
-  gsl::span<const std::byte> payload(
+  const gsl::span<const std::byte> payload(
       reinterpret_cast<const std::byte*>(postBuffer.GetString()),
       postBuffer.GetSize());
 

--- a/CesiumJsonReader/include/CesiumJsonReader/ArrayJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/ArrayJsonHandler.h
@@ -116,7 +116,7 @@ template <>
 class CESIUMJSONREADER_API ArrayJsonHandler<double, DoubleJsonHandler>
     : public JsonHandler {
 public:
-  ArrayJsonHandler() : JsonHandler() {}
+  ArrayJsonHandler() noexcept : JsonHandler() {}
 
   void reset(IJsonHandler* pParent, std::vector<double>* pArray) {
     JsonHandler::reset(pParent);
@@ -233,7 +233,7 @@ template <typename T>
 class CESIUMJSONREADER_API ArrayJsonHandler<T, IntegerJsonHandler<T>>
     : public JsonHandler {
 public:
-  ArrayJsonHandler() : JsonHandler() {}
+  ArrayJsonHandler() noexcept : JsonHandler() {}
 
   void reset(IJsonHandler* pParent, std::vector<T>* pArray) {
     JsonHandler::reset(pParent);
@@ -344,7 +344,7 @@ template <>
 class CESIUMJSONREADER_API ArrayJsonHandler<std::string, StringJsonHandler>
     : public JsonHandler {
 public:
-  ArrayJsonHandler() : JsonHandler() {}
+  ArrayJsonHandler() noexcept : JsonHandler() {}
 
   void reset(IJsonHandler* pParent, std::vector<std::string>* pArray) {
     JsonHandler::reset(pParent);

--- a/CesiumJsonReader/include/CesiumJsonReader/ArrayJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/ArrayJsonHandler.h
@@ -66,11 +66,11 @@ public:
   }
 
   virtual IJsonHandler*
-  readObjectKey(const std::string_view& /*str*/) override {
+  readObjectKey(const std::string_view& /*str*/) noexcept override {
     return nullptr;
   }
 
-  virtual IJsonHandler* readObjectEnd() override { return nullptr; }
+  virtual IJsonHandler* readObjectEnd() noexcept override { return nullptr; }
 
   virtual IJsonHandler* readArrayStart() override {
     if (this->_arrayIsOpen) {

--- a/CesiumJsonReader/include/CesiumJsonReader/IgnoreValueJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/IgnoreValueJsonHandler.h
@@ -7,7 +7,7 @@
 namespace CesiumJsonReader {
 class CESIUMJSONREADER_API IgnoreValueJsonHandler : public IJsonHandler {
 public:
-  void reset(IJsonHandler* pParent);
+  void reset(IJsonHandler* pParent) noexcept;
 
   virtual IJsonHandler* readNull() override;
   virtual IJsonHandler* readBool(bool b) override;
@@ -27,7 +27,7 @@ public:
       const std::string& warning,
       std::vector<std::string>&& context = std::vector<std::string>()) override;
 
-  IJsonHandler* parent();
+  IJsonHandler* parent() noexcept;
 
 private:
   IJsonHandler* _pParent = nullptr;

--- a/CesiumJsonReader/include/CesiumJsonReader/JsonReader.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/JsonReader.h
@@ -77,7 +77,7 @@ private:
     virtual void reportWarning(
         const std::string& warning,
         std::vector<std::string>&& context) override;
-    void setInputStream(rapidjson::MemoryStream* pInputStream);
+    void setInputStream(rapidjson::MemoryStream* pInputStream) noexcept;
 
   private:
     std::vector<std::string>& _warnings;

--- a/CesiumJsonReader/include/CesiumJsonReader/ObjectJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/ObjectJsonHandler.h
@@ -13,8 +13,8 @@ public:
   virtual IJsonHandler* readObjectEnd() override /* final */;
 
 protected:
-  virtual IJsonHandler* StartSubObject();
-  virtual IJsonHandler* EndSubObject();
+  virtual IJsonHandler* StartSubObject() noexcept;
+  virtual IJsonHandler* EndSubObject() noexcept;
 
   template <typename TAccessor, typename TProperty>
   IJsonHandler*
@@ -31,14 +31,14 @@ protected:
     return &accessor;
   }
 
-  const char* getCurrentKey() const;
+  const char* getCurrentKey() const noexcept;
 
   virtual void reportWarning(
       const std::string& warning,
       std::vector<std::string>&& context = std::vector<std::string>()) override;
 
 protected:
-  void setCurrentKey(const char* key);
+  void setCurrentKey(const char* key) noexcept;
 
 private:
   template <typename T> struct isOptional {

--- a/CesiumJsonReader/include/CesiumJsonReader/ObjectJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/ObjectJsonHandler.h
@@ -7,7 +7,7 @@
 namespace CesiumJsonReader {
 class CESIUMJSONREADER_API ObjectJsonHandler : public JsonHandler {
 public:
-  ObjectJsonHandler() : JsonHandler() {}
+  ObjectJsonHandler() noexcept : JsonHandler() {}
 
   virtual IJsonHandler* readObjectStart() override /* final */;
   virtual IJsonHandler* readObjectEnd() override /* final */;

--- a/CesiumJsonReader/include/CesiumJsonReader/ObjectJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/ObjectJsonHandler.h
@@ -50,6 +50,6 @@ private:
   };
 
   int32_t _depth = 0;
-  const char* _currentKey;
+  const char* _currentKey = nullptr;
 };
 } // namespace CesiumJsonReader

--- a/CesiumJsonReader/include/CesiumJsonReader/StringJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/StringJsonHandler.h
@@ -9,7 +9,7 @@ class CESIUMJSONREADER_API StringJsonHandler : public JsonHandler {
 public:
   StringJsonHandler() noexcept;
   void reset(IJsonHandler* pParent, std::string* pString);
-  std::string* getObject();
+  std::string* getObject() noexcept;
   virtual IJsonHandler* readString(const std::string_view& str) override;
 
 private:

--- a/CesiumJsonReader/src/ExtensionReaderContext.cpp
+++ b/CesiumJsonReader/src/ExtensionReaderContext.cpp
@@ -9,7 +9,7 @@ using namespace CesiumUtility;
 class AnyExtensionJsonHandler : public JsonObjectJsonHandler,
                                 public IExtensionJsonHandler {
 public:
-  AnyExtensionJsonHandler() : JsonObjectJsonHandler() {}
+  AnyExtensionJsonHandler() noexcept : JsonObjectJsonHandler() {}
 
   virtual void reset(
       IJsonHandler* pParentHandler,

--- a/CesiumJsonReader/src/IgnoreValueJsonHandler.cpp
+++ b/CesiumJsonReader/src/IgnoreValueJsonHandler.cpp
@@ -3,7 +3,7 @@
 
 using namespace CesiumJsonReader;
 
-void IgnoreValueJsonHandler::reset(IJsonHandler* pParent) {
+void IgnoreValueJsonHandler::reset(IJsonHandler* pParent) noexcept {
   this->_pParent = pParent;
   this->_depth = 0;
 }
@@ -41,13 +41,13 @@ IgnoreValueJsonHandler::readString(const std::string_view& /*str*/) {
   return this->_depth == 0 ? this->parent() : this;
 }
 
-IJsonHandler* IgnoreValueJsonHandler::readObjectStart() {
+IJsonHandler* IgnoreValueJsonHandler::readObjectStart() noexcept {
   ++this->_depth;
   return this;
 }
 
-IJsonHandler*
-IgnoreValueJsonHandler::readObjectKey(const std::string_view& /*str*/) {
+IJsonHandler* IgnoreValueJsonHandler::readObjectKey(
+    const std::string_view& /*str*/) noexcept {
   return this;
 }
 
@@ -56,7 +56,7 @@ IJsonHandler* IgnoreValueJsonHandler::readObjectEnd() {
   return this->_depth == 0 ? this->parent() : this;
 }
 
-IJsonHandler* IgnoreValueJsonHandler::readArrayStart() {
+IJsonHandler* IgnoreValueJsonHandler::readArrayStart() noexcept {
   ++this->_depth;
   return this;
 }
@@ -73,4 +73,6 @@ void IgnoreValueJsonHandler::reportWarning(
   this->parent()->reportWarning(warning, std::move(context));
 }
 
-IJsonHandler* IgnoreValueJsonHandler::parent() { return this->_pParent; }
+IJsonHandler* IgnoreValueJsonHandler::parent() noexcept {
+  return this->_pParent;
+}

--- a/CesiumJsonReader/src/IgnoreValueJsonHandler.cpp
+++ b/CesiumJsonReader/src/IgnoreValueJsonHandler.cpp
@@ -41,13 +41,13 @@ IgnoreValueJsonHandler::readString(const std::string_view& /*str*/) {
   return this->_depth == 0 ? this->parent() : this;
 }
 
-IJsonHandler* IgnoreValueJsonHandler::readObjectStart() noexcept {
+IJsonHandler* IgnoreValueJsonHandler::readObjectStart() {
   ++this->_depth;
   return this;
 }
 
-IJsonHandler* IgnoreValueJsonHandler::readObjectKey(
-    const std::string_view& /*str*/) noexcept {
+IJsonHandler*
+IgnoreValueJsonHandler::readObjectKey(const std::string_view& /*str*/) {
   return this;
 }
 
@@ -56,7 +56,7 @@ IJsonHandler* IgnoreValueJsonHandler::readObjectEnd() {
   return this->_depth == 0 ? this->parent() : this;
 }
 
-IJsonHandler* IgnoreValueJsonHandler::readArrayStart() noexcept {
+IJsonHandler* IgnoreValueJsonHandler::readArrayStart() {
   ++this->_depth;
   return this;
 }

--- a/CesiumJsonReader/src/JsonReader.cpp
+++ b/CesiumJsonReader/src/JsonReader.cpp
@@ -9,7 +9,7 @@ namespace {
 struct Dispatcher {
   IJsonHandler* pCurrent;
 
-  bool update(IJsonHandler* pNext) {
+  bool update(IJsonHandler* pNext) noexcept {
     if (pNext == nullptr) {
       return false;
     }
@@ -25,7 +25,10 @@ struct Dispatcher {
   bool Int64(int64_t i) { return update(pCurrent->readInt64(i)); }
   bool Uint64(uint64_t i) { return update(pCurrent->readUint64(i)); }
   bool Double(double d) { return update(pCurrent->readDouble(d)); }
-  bool RawNumber(const char* /* str */, size_t /* length */, bool /* copy */) {
+  bool RawNumber(
+      const char* /* str */,
+      size_t /* length */,
+      bool /* copy */) noexcept {
     // This should not be called.
     assert(false);
     return false;
@@ -112,7 +115,7 @@ void JsonReader::FinalJsonHandler::reportWarning(
 }
 
 void JsonReader::FinalJsonHandler::setInputStream(
-    rapidjson::MemoryStream* pInputStream) {
+    rapidjson::MemoryStream* pInputStream) noexcept {
   this->_pInputStream = pInputStream;
 }
 

--- a/CesiumJsonReader/src/ObjectJsonHandler.cpp
+++ b/CesiumJsonReader/src/ObjectJsonHandler.cpp
@@ -21,9 +21,9 @@ IJsonHandler* ObjectJsonHandler::readObjectEnd() {
   return this->parent();
 }
 
-IJsonHandler* ObjectJsonHandler::StartSubObject() { return nullptr; }
+IJsonHandler* ObjectJsonHandler::StartSubObject() noexcept { return nullptr; }
 
-IJsonHandler* ObjectJsonHandler::EndSubObject() { return nullptr; }
+IJsonHandler* ObjectJsonHandler::EndSubObject() noexcept { return nullptr; }
 
 void ObjectJsonHandler::reportWarning(
     const std::string& warning,
@@ -34,10 +34,10 @@ void ObjectJsonHandler::reportWarning(
   this->parent()->reportWarning(warning, std::move(context));
 }
 
-const char* ObjectJsonHandler::getCurrentKey() const {
+const char* ObjectJsonHandler::getCurrentKey() const noexcept {
   return this->_currentKey;
 }
 
-void ObjectJsonHandler::setCurrentKey(const char* key) {
+void ObjectJsonHandler::setCurrentKey(const char* key) noexcept {
   this->_currentKey = key;
 }

--- a/CesiumJsonReader/src/StringJsonHandler.cpp
+++ b/CesiumJsonReader/src/StringJsonHandler.cpp
@@ -10,7 +10,7 @@ void StringJsonHandler::reset(IJsonHandler* pParent, std::string* pString) {
   this->_pString = pString;
 }
 
-std::string* StringJsonHandler::getObject() { return this->_pString; }
+std::string* StringJsonHandler::getObject() noexcept { return this->_pString; }
 
 IJsonHandler* StringJsonHandler::readString(const std::string_view& str) {
   *this->_pString = str;

--- a/CesiumJsonWriter/include/CesiumJsonWriter/PrettyJsonWriter.h
+++ b/CesiumJsonWriter/include/CesiumJsonWriter/PrettyJsonWriter.h
@@ -15,7 +15,7 @@ class PrettyJsonWriter : public JsonWriter {
   std::unique_ptr<rapidjson::PrettyWriter<rapidjson::StringBuffer>> pretty;
 
 public:
-  PrettyJsonWriter();
+  PrettyJsonWriter() noexcept;
   ~PrettyJsonWriter() {}
 
   // rapidjson methods

--- a/CesiumJsonWriter/src/JsonWriter.cpp
+++ b/CesiumJsonWriter/src/JsonWriter.cpp
@@ -138,7 +138,7 @@ std::string_view JsonWriter::toStringView() {
 }
 
 std::vector<std::byte> JsonWriter::toBytes() {
-  auto view = this->toStringView();
+  const auto view = this->toStringView();
   std::vector<std::byte> result(view.size(), std::byte(0));
   std::uint8_t* u8Pointer = reinterpret_cast<std::uint8_t*>(result.data());
   std::copy(view.begin(), view.end(), u8Pointer);

--- a/CesiumJsonWriter/src/PrettyJsonWriter.cpp
+++ b/CesiumJsonWriter/src/PrettyJsonWriter.cpp
@@ -5,7 +5,7 @@
 #include <string_view>
 
 namespace CesiumJsonWriter {
-PrettyJsonWriter::PrettyJsonWriter() {
+PrettyJsonWriter::PrettyJsonWriter() noexcept {
   auto writer = rapidjson::PrettyWriter<rapidjson::StringBuffer>(_prettyBuffer);
   writer.SetFormatOptions(
       rapidjson::PrettyFormatOptions::kFormatSingleLineArray);

--- a/CesiumJsonWriter/src/PrettyJsonWriter.cpp
+++ b/CesiumJsonWriter/src/PrettyJsonWriter.cpp
@@ -155,7 +155,7 @@ std::string_view PrettyJsonWriter::toStringView() {
 }
 
 std::vector<std::byte> PrettyJsonWriter::toBytes() {
-  auto view = this->toStringView();
+  const auto view = this->toStringView();
   std::vector<std::byte> result(view.size(), std::byte(0));
   std::uint8_t* u8Pointer = reinterpret_cast<std::uint8_t*>(result.data());
   std::copy(view.begin(), view.end(), u8Pointer);

--- a/CesiumUtility/include/CesiumUtility/IntrusivePointer.h
+++ b/CesiumUtility/include/CesiumUtility/IntrusivePointer.h
@@ -101,7 +101,7 @@ public:
   /**
    * @brief Returns the internal pointer.
    */
-  T* get() const { return this->_p; }
+  T* get() const noexcept { return this->_p; }
 
   /**
    * @brief Returns `true` if two pointers are equal.

--- a/CesiumUtility/include/CesiumUtility/JsonValue.h
+++ b/CesiumUtility/include/CesiumUtility/JsonValue.h
@@ -77,7 +77,7 @@ public:
   /**
    * @brief Default constructor.
    */
-  JsonValue() : value() {}
+  JsonValue() noexcept : value() {}
 
   /**
    * @brief Creates a `null` JSON value.

--- a/CesiumUtility/include/CesiumUtility/JsonValue.h
+++ b/CesiumUtility/include/CesiumUtility/JsonValue.h
@@ -82,14 +82,14 @@ public:
   /**
    * @brief Creates a `null` JSON value.
    */
-  JsonValue(std::nullptr_t) : value(nullptr) {}
+  JsonValue(std::nullptr_t) noexcept : value(nullptr) {}
 
   /**
    * @brief Creates a `Number` JSON value.
    *
    * NaN and ±Infinity are represented as {@link JsonValue::Null}.
    */
-  JsonValue(double v) {
+  JsonValue(double v) noexcept {
     if (std::isnan(v) || std::isinf(v)) {
       value = nullptr;
     } else {
@@ -101,52 +101,52 @@ public:
    * @brief Creates a `std::int64_t` JSON value (Widening conversion from
    * std::int8_t).
    */
-  JsonValue(std::int8_t v) : value(static_cast<std::int64_t>(v)) {}
+  JsonValue(std::int8_t v) noexcept : value(static_cast<std::int64_t>(v)) {}
 
   /**
    * @brief Creates a `std::uint64_t` JSON value (Widening conversion from
    * std::uint8_t).
    */
-  JsonValue(std::uint8_t v) : value(static_cast<std::uint64_t>(v)) {}
+  JsonValue(std::uint8_t v) noexcept : value(static_cast<std::uint64_t>(v)) {}
 
   /**
    * @brief Creates a `std::int64_t` JSON value (Widening conversion from
    * std::int16_t).
    */
-  JsonValue(std::int16_t v) : value(static_cast<std::int64_t>(v)) {}
+  JsonValue(std::int16_t v) noexcept : value(static_cast<std::int64_t>(v)) {}
 
   /**
    * @brief Creates a `std::uint64_t` JSON value (Widening conversion from
    * std::uint16_t).
    */
-  JsonValue(std::uint16_t v) : value(static_cast<std::uint64_t>(v)) {}
+  JsonValue(std::uint16_t v) noexcept : value(static_cast<std::uint64_t>(v)) {}
 
   /**
    * @brief Creates a `std::int64_t` JSON value (Widening conversion from
    * std::int32_t).
    */
-  JsonValue(std::int32_t v) : value(static_cast<std::int64_t>(v)) {}
+  JsonValue(std::int32_t v) noexcept : value(static_cast<std::int64_t>(v)) {}
 
   /**
    * @brief Creates a `std::uint64_t` JSON value (Widening conversion from
    * std::uint32_t).
    */
-  JsonValue(std::uint32_t v) : value(static_cast<std::uint64_t>(v)) {}
+  JsonValue(std::uint32_t v) noexcept : value(static_cast<std::uint64_t>(v)) {}
 
   /**
    * @brief Creates a `std::int64_t` JSON value.
    */
-  JsonValue(std::int64_t v) : value(v) {}
+  JsonValue(std::int64_t v) noexcept : value(v) {}
 
   /**
    * @brief Creates a `std::uint64_t` JSON value.
    */
-  JsonValue(std::uint64_t v) : value(v) {}
+  JsonValue(std::uint64_t v) noexcept : value(v) {}
 
   /**
    * @brief Creates a `Bool` JSON value.
    */
-  JsonValue(bool v) : value(v) {}
+  JsonValue(bool v) noexcept : value(v) {}
 
   /**
    * @brief Creates a `String` JSON value.
@@ -156,7 +156,7 @@ public:
   /**
    * @brief Creates a `String` JSON value.
    */
-  JsonValue(std::string&& v) : value(std::move(v)) {}
+  JsonValue(std::string&& v) noexcept : value(std::move(v)) {}
 
   /**
    * @brief Creates a `String` JSON value.
@@ -181,7 +181,7 @@ public:
   /**
    * @brief Creates an `Array` JSON value with the given elements.
    */
-  JsonValue(std::vector<JsonValue>&& v) : value(std::move(v)) {}
+  JsonValue(std::vector<JsonValue>&& v) noexcept : value(std::move(v)) {}
 
   /**
    * @brief Creates an JSON value from the given initializer list.
@@ -462,7 +462,7 @@ public:
    * @brief Gets the bool from the value or returns defaultValue
    * @return The bool or defaultValue if this->value is not a bool.
    */
-  [[nodiscard]] inline bool getBoolOrDefault(bool defaultValue) const {
+  [[nodiscard]] inline bool getBoolOrDefault(bool defaultValue) const noexcept {
     const auto* v = std::get_if<bool>(&this->value);
     if (v) {
       return *v;
@@ -489,7 +489,8 @@ public:
    * @brief Gets the double from the value or returns defaultValue
    * @return The double or defaultValue if this->value is not a double.
    */
-  [[nodiscard]] inline double getDoubleOrDefault(double defaultValue) const {
+  [[nodiscard]] inline double
+  getDoubleOrDefault(double defaultValue) const noexcept {
     const auto* v = std::get_if<double>(&this->value);
     if (v) {
       return *v;
@@ -503,7 +504,7 @@ public:
    * @return The uint64_t or defaultValue if this->value is not a uint64_t.
    */
   [[nodiscard]] inline std::uint64_t
-  getUint64OrDefault(std::uint64_t defaultValue) const {
+  getUint64OrDefault(std::uint64_t defaultValue) const noexcept {
     const auto* v = std::get_if<std::uint64_t>(&this->value);
     if (v) {
       return *v;
@@ -517,7 +518,7 @@ public:
    * @return The int64_t or defaultValue if this->value is not a int64_t.
    */
   [[nodiscard]] inline std::int64_t
-  getInt64OrDefault(std::int64_t defaultValue) const {
+  getInt64OrDefault(std::int64_t defaultValue) const noexcept {
     const auto* v = std::get_if<std::int64_t>(&this->value);
     if (v) {
       return *v;

--- a/CesiumUtility/include/CesiumUtility/Math.h
+++ b/CesiumUtility/include/CesiumUtility/Math.h
@@ -382,7 +382,7 @@ public:
    * @snippet TestMath.cpp convertLongitudeRange
    */
   static double convertLongitudeRange(double angle) noexcept {
-    const double twoPi = Math::TWO_PI;
+    constexpr double twoPi = Math::TWO_PI;
 
     const double simplified = angle - glm::floor(angle / twoPi) * twoPi;
 

--- a/CesiumUtility/include/CesiumUtility/Math.h
+++ b/CesiumUtility/include/CesiumUtility/Math.h
@@ -184,7 +184,7 @@ public:
       double right,
       double relativeEpsilon,
       double absoluteEpsilon) noexcept {
-    double diff = glm::abs(left - right);
+    const double diff = glm::abs(left - right);
     return diff <= absoluteEpsilon ||
            diff <= relativeEpsilonToAbsolute(left, right, relativeEpsilon);
   }
@@ -218,7 +218,7 @@ public:
       const glm::vec<L, T, Q>& right,
       double relativeEpsilon,
       double absoluteEpsilon) noexcept {
-    glm::vec<L, T, Q> diff = glm::abs(left - right);
+    const glm::vec<L, T, Q> diff = glm::abs(left - right);
     return glm::lessThanEqual(diff, glm::vec<L, T, Q>(absoluteEpsilon)) ==
                glm::vec<L, bool, Q>(true) ||
            glm::lessThanEqual(
@@ -277,7 +277,7 @@ public:
    * @returns The angle in the range [0, `Math::TWO_PI`].
    */
   static double zeroToTwoPi(double angle) noexcept {
-    double mod = Math::mod(angle, Math::TWO_PI);
+    const double mod = Math::mod(angle, Math::TWO_PI);
     if (glm::abs(mod) < Math::EPSILON14 && glm::abs(angle) > Math::EPSILON14) {
       return Math::TWO_PI;
     }
@@ -382,9 +382,9 @@ public:
    * @snippet TestMath.cpp convertLongitudeRange
    */
   static double convertLongitudeRange(double angle) noexcept {
-    double twoPi = Math::TWO_PI;
+    const double twoPi = Math::TWO_PI;
 
-    double simplified = angle - glm::floor(angle / twoPi) * twoPi;
+    const double simplified = angle - glm::floor(angle / twoPi) * twoPi;
 
     if (simplified < -Math::ONE_PI) {
       return simplified + twoPi;
@@ -407,8 +407,8 @@ public:
    * @return The rounded value.
    */
   static double roundUp(double value, double tolerance) noexcept {
-    double up = glm::ceil(value);
-    double down = glm::floor(value);
+    const double up = glm::ceil(value);
+    const double down = glm::floor(value);
     if (value - down < tolerance) {
       return down;
     } else {
@@ -427,8 +427,8 @@ public:
    * @return The rounded value.
    */
   static double roundDown(double value, double tolerance) noexcept {
-    double up = glm::ceil(value);
-    double down = glm::floor(value);
+    const double up = glm::ceil(value);
+    const double down = glm::floor(value);
     if (up - value < tolerance) {
       return up;
     } else {

--- a/CesiumUtility/include/CesiumUtility/Math.h
+++ b/CesiumUtility/include/CesiumUtility/Math.h
@@ -406,7 +406,7 @@ public:
    * lower integer, it is rounded down instead.
    * @return The rounded value.
    */
-  static double roundUp(double value, double tolerance) {
+  static double roundUp(double value, double tolerance) noexcept {
     double up = glm::ceil(value);
     double down = glm::floor(value);
     if (value - down < tolerance) {
@@ -426,7 +426,7 @@ public:
    * higher integer, it is rounded up instead.
    * @return The rounded value.
    */
-  static double roundDown(double value, double tolerance) {
+  static double roundDown(double value, double tolerance) noexcept {
     double up = glm::ceil(value);
     double down = glm::floor(value);
     if (up - value < tolerance) {

--- a/CesiumUtility/include/CesiumUtility/SpanHelper.h
+++ b/CesiumUtility/include/CesiumUtility/SpanHelper.h
@@ -10,7 +10,7 @@ namespace CesiumUtility {
  * carefully
  */
 template <typename To, typename From>
-gsl::span<To> reintepretCastSpan(const gsl::span<From>& from) {
+gsl::span<To> reintepretCastSpan(const gsl::span<From>& from) noexcept {
   return gsl::span<To>(
       reinterpret_cast<To*>(from.data()),
       from.size() * sizeof(From) / sizeof(To));

--- a/CesiumUtility/src/JsonHelpers.cpp
+++ b/CesiumUtility/src/JsonHelpers.cpp
@@ -6,7 +6,7 @@ namespace CesiumUtility {
 std::optional<double> JsonHelpers::getScalarProperty(
     const rapidjson::Value& tileJson,
     const std::string& key) {
-  auto it = tileJson.FindMember(key.c_str());
+  const auto it = tileJson.FindMember(key.c_str());
   if (it == tileJson.MemberEnd() || !it->value.IsNumber()) {
     return std::nullopt;
   }
@@ -17,7 +17,7 @@ std::optional<double> JsonHelpers::getScalarProperty(
 std::optional<glm::dmat4x4> JsonHelpers::getTransformProperty(
     const rapidjson::Value& tileJson,
     const std::string& key) {
-  auto it = tileJson.FindMember(key.c_str());
+  const auto it = tileJson.FindMember(key.c_str());
   if (it == tileJson.MemberEnd() || !it->value.IsArray() ||
       it->value.Size() < 16) {
     return std::nullopt;
@@ -58,7 +58,7 @@ std::optional<std::vector<double>> JsonHelpers::getDoubles(
     const rapidjson::Value& json,
     int32_t expectedSize,
     const std::string& key) {
-  auto it = json.FindMember(key.c_str());
+  const auto it = json.FindMember(key.c_str());
   if (it == json.MemberEnd()) {
     return std::nullopt;
   }
@@ -86,7 +86,7 @@ std::string JsonHelpers::getStringOrDefault(
     const rapidjson::Value& json,
     const std::string& key,
     const std::string& defaultValue) {
-  auto it = json.FindMember(key.c_str());
+  const auto it = json.FindMember(key.c_str());
   return it == json.MemberEnd()
              ? defaultValue
              : JsonHelpers::getStringOrDefault(it->value, defaultValue);
@@ -105,7 +105,7 @@ double JsonHelpers::getDoubleOrDefault(
     const rapidjson::Value& json,
     const std::string& key,
     double defaultValue) {
-  auto it = json.FindMember(key.c_str());
+  const auto it = json.FindMember(key.c_str());
   return it == json.MemberEnd()
              ? defaultValue
              : JsonHelpers::getDoubleOrDefault(it->value, defaultValue);
@@ -124,7 +124,7 @@ uint32_t JsonHelpers::getUint32OrDefault(
     const rapidjson::Value& json,
     const std::string& key,
     uint32_t defaultValue) {
-  auto it = json.FindMember(key.c_str());
+  const auto it = json.FindMember(key.c_str());
   return it == json.MemberEnd()
              ? defaultValue
              : JsonHelpers::getUint32OrDefault(it->value, defaultValue);
@@ -143,7 +143,7 @@ int32_t JsonHelpers::getInt32OrDefault(
     const rapidjson::Value& json,
     const std::string& key,
     int32_t defaultValue) {
-  auto it = json.FindMember(key.c_str());
+  const auto it = json.FindMember(key.c_str());
   return it == json.MemberEnd()
              ? defaultValue
              : JsonHelpers::getInt32OrDefault(it->value, defaultValue);
@@ -162,7 +162,7 @@ uint64_t JsonHelpers::getUint64OrDefault(
     const rapidjson::Value& json,
     const std::string& key,
     uint64_t defaultValue) {
-  auto it = json.FindMember(key.c_str());
+  const auto it = json.FindMember(key.c_str());
   return it == json.MemberEnd()
              ? defaultValue
              : JsonHelpers::getUint64OrDefault(it->value, defaultValue);
@@ -181,7 +181,7 @@ int64_t JsonHelpers::getInt64OrDefault(
     const rapidjson::Value& json,
     const std::string& key,
     int64_t defaultValue) {
-  auto it = json.FindMember(key.c_str());
+  const auto it = json.FindMember(key.c_str());
   return it == json.MemberEnd()
              ? defaultValue
              : JsonHelpers::getInt64OrDefault(it->value, defaultValue);
@@ -200,7 +200,7 @@ bool JsonHelpers::getBoolOrDefault(
     const rapidjson::Value& json,
     const std::string& key,
     bool defaultValue) {
-  auto it = json.FindMember(key.c_str());
+  const auto it = json.FindMember(key.c_str());
   return it == json.MemberEnd()
              ? defaultValue
              : JsonHelpers::getBoolOrDefault(it->value, defaultValue);
@@ -219,7 +219,7 @@ std::vector<std::string>
 JsonHelpers::getStrings(const rapidjson::Value& json, const std::string& key) {
   std::vector<std::string> result;
 
-  auto it = json.FindMember(key.c_str());
+  const auto it = json.FindMember(key.c_str());
   if (it != json.MemberEnd() && it->value.IsArray()) {
     const auto& valueJson = it->value;
 
@@ -240,7 +240,7 @@ std::vector<int64_t>
 JsonHelpers::getInt64s(const rapidjson::Value& json, const std::string& key) {
   std::vector<int64_t> result;
 
-  auto it = json.FindMember(key.c_str());
+  const auto it = json.FindMember(key.c_str());
   if (it != json.MemberEnd() && it->value.IsArray()) {
     const auto& valueJson = it->value;
 

--- a/CesiumUtility/src/Uri.cpp
+++ b/CesiumUtility/src/Uri.cpp
@@ -114,7 +114,7 @@ std::string Uri::substituteTemplateParameters(
 
     // Find the end of this parameter
     ++nextPos;
-    size_t endPos = templateUri.find('}', nextPos);
+    const size_t endPos = templateUri.find('}', nextPos);
     if (endPos == std::string::npos) {
       throw std::runtime_error("Unclosed template parameter");
     }


### PR DESCRIPTION
This addresses https://github.com/CesiumGS/cesium-native/issues/30 (but of course, it's open-ended...).

When running the analysis with the Visual Studio analysis plugin, as described in the linked issue, it initially generated 44877 warnings. No, I'm not trembling due to a caffeine overdose: This is not 487, but 44877. But of course, many (most) of these are in "external" projects (and for some reason, the filtering mechanism to exclude these does not work as desired). And many of them are duplicates, in that they are reported multiple times, e.g. when there is an include of a templated class.

This PR addresses the following warnings:

---

### Exception specifiers

These are mainly missing `noexcept` specifiers, as reported via

- C26440: Function ... can be declared noexcept
- C26455: Default constructor may not throw. Declare it 'noexcept'

This has been a bit of back and forth, because after adding the `noexcept` in the places where it was possible, ... the analyzer found _new_ places where it could _also_ be added. Conversely, there are some places where it _should_ be added, but it was not immediately possible. Some (probably not all) of them are listed here:

- `GltfReader` default constructor calls `registerExtension`, which may throw
- `SchedulerScope` default constructor may throw (if called with an argument - is this still a "default constructor" then?)

- In `Math.h`

        static double lerp(double p, double q, double time) noexcept {
          return glm::mix(p, q, time);
        }

  may throw. Why? Maybe we should just insert our own `mix` there. It's trivial, and the type is pinned to `double` anyhow.

- Tileset destructor calls
   `this->_asyncSystem.dispatchMainThreadTasks();`
  which may throw...
  
(An aside: I think that methods in interfaces should be `noexcept`,   unless there is an *explicit*, documented (!) throws specification)



---

## Missing `const` or `constexpr`

As reported via 

- C26496: The variable ... is assigned only once, mark it as const
- C26814: The const variable ... can be computed at compile-time. Consider using constexpr

This may be the least controversial one. Just add them. It cannot harm.

<sup>Although I already see myself replacing some `const auto` with `auto const`, for sake of "consistency")</sup>


---

## Uninitialized members

As reported via

- C26495: Variable ... is uninitialized. Always initialize a member variable.

Initialized them (everything else could lead to UB, to my understanding - particularly for pointers). Sometimes hesitating about the "most sensible initial value", but usually used `value{}`, with a few cases of `p=nullptr`, `i=0` or `i=-1` for clarity.

---

## Unscoped enum

As reported vie 

- C26812: The enum type 'CesiumGeometry::Axis' is unscoped. Prefer 'enum class' over 'enum'

(Only this case)


---

## Unnecessary copy

As reported via 

- C26817: Potentially expensive copy of variable 'coverageArea' in range-for loop. Consider making it a const reference (es.71).

(Only this case)


---

## Wrong parameter type

As reported via

- C6330: 'char' passed as _Param_(1) when 'unsigned char' is required in call to 'isspace'.

(Only one place)

---

## Reference parameters that can be const

As reported via

- C26460: The reference argument ... for function ... can be marked as const

Fairly uncontroversial, too...

---

# TODO:

Unrelated: The implementation of `RasterizedPolygonsTileExcluder` `getOverlay` is not found

There are still 39941 warnings left, with many of them in our code, and some of them are "critical". For example, there are further functions that are declared `noexcept`, but call throwing functions. It's not always clear how to fix this.

Many other warnings are related to casts or certain security checks (e.g. `nullptr`-checks, or indexed access checks), and I'll address them dedicately in a second pass (and maybe more fine-grained than this PR). 

There are further warnings, of which I don't exactly know (yet) what they mean, even less have an idea how to fix them. Among them are "beautiful" ones like 

> 45>C:\...\cesium-native\Cesium3DTilesSelection\src\TileContentFactory.cpp(97): warning C26426: Global initializer calls a non-constexpr function 'std::unordered_map<std::basic_string<char,std::char_traits<char>,std::allocator<char> >,std::shared_ptr<Cesium3DTilesSelection::TileContentLoader>,std::hash<std::basic_string<char,std::char_traits<char>,std::allocator<char> > >,std::equal_to<std::basic_string<char,std::char_traits<char>,std::allocator<char> > >,std::allocator<std::pair<std::basic_string<char,std::char_traits<char>,std::allocator<char> > const ,std::shared_ptr<Cesium3DTilesSelection::TileContentLoader> > > >::unordered_map<std::basic_string<char,std::char_traits<char>,std::allocator<char> >,std::shared_ptr<Cesium3DTilesSelection::TileContentLoader>,std::hash<std::basic_string<char,std::char_traits<char>,std::allocator<char> > >,std::equal_to<std::basic_string<char,std::char_traits<char>,std::allocator<char> > >,std::allocator<std::pair<std::basic_string<char,std::char_traits<char>,std::allocator<char> > const ,std::shared_ptr<Cesium3DTilesSelection::TileContentLoader> > > >' (i.22).

I'll have a closer look at these, and bring them up as necessary.

The commits in this PR should *largely* be organized by the warning class that was addressed (with `noexcept` being spread over multiple commits), maybe somebody wants ot have a short look.

