### PR TITLE
Update generated files with newer glTF schema

### DIFF
--- a/CesiumGltf/include/CesiumGltf/AccessorSparse.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorSparse.h
@@ -10,31 +10,27 @@
 
 namespace CesiumGltf {
 /**
- * @brief Sparse storage of attributes that deviate from their initialization
- * value.
+ * @brief Sparse storage of accessor values that deviate from their
+ * initialization value.
  */
 struct CESIUMGLTF_API AccessorSparse final : public ExtensibleObject {
   static inline constexpr const char* TypeName = "AccessorSparse";
 
   /**
-   * @brief Number of entries stored in the sparse array.
-   *
-   * The number of attributes encoded in this sparse accessor.
+   * @brief Number of deviating accessor values stored in the sparse array.
    */
   int64_t count = int64_t();
 
   /**
-   * @brief Index array of size `count` that points to those accessor attributes
-   * that deviate from their initialization value. Indices must strictly
-   * increase.
+   * @brief An object pointing to a buffer view containing the indices of
+   * deviating accessor values. The number of indices is equal to `count`.
+   * Indices **MUST** strictly increase.
    */
   AccessorSparseIndices indices;
 
   /**
-   * @brief Array of size `count` times number of components, storing the
-   * displaced accessor attributes pointed by `indices`. Substituted values must
-   * have the same `componentType` and number of components as the base
-   * accessor.
+   * @brief An object pointing to a buffer view containing the deviating
+   * accessor values.
    */
   AccessorSparseValues values;
 };

--- a/CesiumGltf/include/CesiumGltf/AccessorSparseIndices.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorSparseIndices.h
@@ -8,8 +8,9 @@
 
 namespace CesiumGltf {
 /**
- * @brief Indices of those attributes that deviate from their initialization
- * value.
+ * @brief An object pointing to a buffer view containing the indices of
+ * deviating accessor values. The number of indices is equal to
+ * `accessor.sparse.count`. Indices **MUST** strictly increase.
  */
 struct CESIUMGLTF_API AccessorSparseIndices final : public ExtensibleObject {
   static inline constexpr const char* TypeName = "AccessorSparseIndices";
@@ -26,14 +27,15 @@ struct CESIUMGLTF_API AccessorSparseIndices final : public ExtensibleObject {
   };
 
   /**
-   * @brief The index of the bufferView with sparse indices. Referenced
-   * bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
+   * @brief The index of the buffer view with sparse indices. The referenced
+   * buffer view **MUST NOT** have its `target` or `byteStride` properties
+   * defined. The buffer view and the optional `byteOffset` **MUST** be aligned
+   * to the `componentType` byte length.
    */
   int32_t bufferView = -1;
 
   /**
-   * @brief The offset relative to the start of the bufferView in bytes. Must be
-   * aligned.
+   * @brief The offset relative to the start of the buffer view in bytes.
    */
   int64_t byteOffset = 0;
 
@@ -42,9 +44,6 @@ struct CESIUMGLTF_API AccessorSparseIndices final : public ExtensibleObject {
    *
    * Known values are defined in {@link ComponentType}.
    *
-   *
-   * Valid values correspond to WebGL enums: `5121` (UNSIGNED_BYTE), `5123`
-   * (UNSIGNED_SHORT), `5125` (UNSIGNED_INT).
    */
   int32_t componentType = ComponentType::UNSIGNED_BYTE;
 };

--- a/CesiumGltf/include/CesiumGltf/AccessorSparseValues.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorSparseValues.h
@@ -8,22 +8,24 @@
 
 namespace CesiumGltf {
 /**
- * @brief Array of size `accessor.sparse.count` times number of components
- * storing the displaced accessor attributes pointed by
- * `accessor.sparse.indices`.
+ * @brief An object pointing to a buffer view containing the deviating accessor
+ * values. The number of elements is equal to `accessor.sparse.count` times
+ * number of components. The elements have the same component type as the base
+ * accessor. The elements are tightly packed. Data **MUST** be aligned following
+ * the same rules as the base accessor.
  */
 struct CESIUMGLTF_API AccessorSparseValues final : public ExtensibleObject {
   static inline constexpr const char* TypeName = "AccessorSparseValues";
 
   /**
-   * @brief The index of the bufferView with sparse values. Referenced
-   * bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
+   * @brief The index of the bufferView with sparse values. The referenced
+   * buffer view **MUST NOT** have its `target` or `byteStride` properties
+   * defined.
    */
   int32_t bufferView = -1;
 
   /**
-   * @brief The offset relative to the start of the bufferView in bytes. Must be
-   * aligned.
+   * @brief The offset relative to the start of the bufferView in bytes.
    */
   int64_t byteOffset = 0;
 };

--- a/CesiumGltf/include/CesiumGltf/AccessorSpec.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorSpec.h
@@ -11,16 +11,13 @@
 
 namespace CesiumGltf {
 /**
- * @brief A typed view into a bufferView.  A bufferView contains raw binary
- * data.  An accessor provides a typed view into a bufferView or a subset of a
- * bufferView similar to how WebGL's `vertexAttribPointer()` defines an
- * attribute in a buffer.
+ * @brief A typed view into a buffer view that contains raw binary data.
  */
 struct CESIUMGLTF_API AccessorSpec : public NamedObject {
   static inline constexpr const char* TypeName = "Accessor";
 
   /**
-   * @brief Known values for The datatype of components in the attribute.
+   * @brief Known values for The datatype of the accessor's components.
    */
   struct ComponentType {
     static constexpr int32_t BYTE = 5120;
@@ -37,8 +34,8 @@ struct CESIUMGLTF_API AccessorSpec : public NamedObject {
   };
 
   /**
-   * @brief Known values for Specifies if the attribute is a scalar, vector, or
-   * matrix.
+   * @brief Known values for Specifies if the accessor's elements are scalars,
+   * vectors, or matrices.
    */
   struct Type {
     inline static const std::string SCALAR = "SCALAR";
@@ -59,52 +56,52 @@ struct CESIUMGLTF_API AccessorSpec : public NamedObject {
   /**
    * @brief The index of the bufferView.
    *
-   * When not defined, accessor must be initialized with zeros; `sparse`
-   * property or extensions could override zeros with actual values.
+   * The index of the buffer view. When undefined, the accessor **MUST** be
+   * initialized with zeros; `sparse` property or extensions **MAY** override
+   * zeros with actual values.
    */
   int32_t bufferView = -1;
 
   /**
-   * @brief The offset relative to the start of the bufferView in bytes.
+   * @brief The offset relative to the start of the buffer view in bytes.
    *
-   * This must be a multiple of the size of the component datatype.
+   * This **MUST** be a multiple of the size of the component datatype. This
+   * property **MUST NOT** be defined when `bufferView` is undefined.
    */
   int64_t byteOffset = 0;
 
   /**
-   * @brief The datatype of components in the attribute.
+   * @brief The datatype of the accessor's components.
    *
    * Known values are defined in {@link ComponentType}.
    *
    *
-   * All valid values correspond to WebGL enums.  The corresponding typed arrays
-   * are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, `Uint32Array`,
-   * and `Float32Array`, respectively.  5125 (UNSIGNED_INT) is only allowed when
-   * the accessor contains indices, i.e., the accessor is only referenced by
-   * `primitive.indices`.
+   * UNSIGNED_INT type **MUST NOT** be used for any accessor that is not
+   * referenced by `mesh.primitive.indices`.
    */
   int32_t componentType = ComponentType::BYTE;
 
   /**
-   * @brief Specifies whether integer data values should be normalized.
+   * @brief Specifies whether integer data values are normalized before usage.
    *
-   * Specifies whether integer data values should be normalized (`true`) to [0,
-   * 1] (for unsigned types) or [-1, 1] (for signed types), or converted
-   * directly (`false`) when they are accessed. This property is defined only
-   * for accessors that contain vertex attributes or animation output data.
+   * Specifies whether integer data values are normalized (`true`) to [0, 1]
+   * (for unsigned types) or to [-1, 1] (for signed types) when they are
+   * accessed. This property **MUST NOT** be set to `true` for accessors with
+   * `FLOAT` or `UNSIGNED_INT` component type.
    */
   bool normalized = false;
 
   /**
-   * @brief The number of attributes referenced by this accessor.
+   * @brief The number of elements referenced by this accessor.
    *
-   * The number of attributes referenced by this accessor, not to be confused
-   * with the number of bytes or number of components.
+   * The number of elements referenced by this accessor, not to be confused with
+   * the number of bytes or number of components.
    */
   int64_t count = int64_t();
 
   /**
-   * @brief Specifies if the attribute is a scalar, vector, or matrix.
+   * @brief Specifies if the accessor's elements are scalars, vectors, or
+   * matrices.
    *
    * Known values are defined in {@link Type}.
    *
@@ -112,37 +109,37 @@ struct CESIUMGLTF_API AccessorSpec : public NamedObject {
   std::string type = Type::SCALAR;
 
   /**
-   * @brief Maximum value of each component in this attribute.
+   * @brief Maximum value of each component in this accessor.
    *
-   * Array elements must be treated as having the same data type as accessor's
-   * `componentType`. Both min and max arrays have the same length.  The length
-   * is determined by the value of the type property; it can be 1, 2, 3, 4, 9,
-   * or 16.
+   * Array elements **MUST** be treated as having the same data type as
+   * accessor's `componentType`. Both `min` and `max` arrays have the same
+   * length.  The length is determined by the value of the `type` property; it
+   * can be 1, 2, 3, 4, 9, or 16.
    *
    * `normalized` property has no effect on array values: they always correspond
-   * to the actual values stored in the buffer. When accessor is sparse, this
-   * property must contain max values of accessor data with sparse substitution
-   * applied.
+   * to the actual values stored in the buffer. When the accessor is sparse,
+   * this property **MUST** contain maximum values of accessor data with sparse
+   * substitution applied.
    */
   std::vector<double> max;
 
   /**
-   * @brief Minimum value of each component in this attribute.
+   * @brief Minimum value of each component in this accessor.
    *
-   * Array elements must be treated as having the same data type as accessor's
-   * `componentType`. Both min and max arrays have the same length.  The length
-   * is determined by the value of the type property; it can be 1, 2, 3, 4, 9,
-   * or 16.
+   * Array elements **MUST** be treated as having the same data type as
+   * accessor's `componentType`. Both `min` and `max` arrays have the same
+   * length.  The length is determined by the value of the `type` property; it
+   * can be 1, 2, 3, 4, 9, or 16.
    *
    * `normalized` property has no effect on array values: they always correspond
-   * to the actual values stored in the buffer. When accessor is sparse, this
-   * property must contain min values of accessor data with sparse substitution
-   * applied.
+   * to the actual values stored in the buffer. When the accessor is sparse,
+   * this property **MUST** contain minimum values of accessor data with sparse
+   * substitution applied.
    */
   std::vector<double> min;
 
   /**
-   * @brief Sparse storage of attributes that deviate from their initialization
+   * @brief Sparse storage of elements that deviate from their initialization
    * value.
    */
   std::optional<AccessorSparse> sparse;

--- a/CesiumGltf/include/CesiumGltf/Animation.h
+++ b/CesiumGltf/include/CesiumGltf/Animation.h
@@ -16,16 +16,16 @@ struct CESIUMGLTF_API Animation final : public NamedObject {
   static inline constexpr const char* TypeName = "Animation";
 
   /**
-   * @brief An array of animation channels, each of which targets an animation's
-   * sampler at a node's property. Different channels of the same animation
-   * **MUST NOT** have the same targets.
+   * @brief An array of animation channels. An animation channel combines an
+   * animation sampler with a target property being animated. Different channels
+   * of the same animation **MUST NOT** have the same targets.
    */
   std::vector<AnimationChannel> channels;
 
   /**
-   * @brief An array of animation samplers that combines input and output
-   * accessors with an interpolation algorithm to define a keyframe graph (but
-   * not its target).
+   * @brief An array of animation samplers. An animation sampler combines
+   * timestamps with a sequence of output values and defines an interpolation
+   * algorithm.
    */
   std::vector<AnimationSampler> samplers;
 };

--- a/CesiumGltf/include/CesiumGltf/Animation.h
+++ b/CesiumGltf/include/CesiumGltf/Animation.h
@@ -16,15 +16,16 @@ struct CESIUMGLTF_API Animation final : public NamedObject {
   static inline constexpr const char* TypeName = "Animation";
 
   /**
-   * @brief An array of channels, each of which targets an animation's sampler
-   * at a node's property. Different channels of the same animation can't have
-   * equal targets.
+   * @brief An array of animation channels, each of which targets an animation's
+   * sampler at a node's property. Different channels of the same animation
+   * **MUST NOT** have the same targets.
    */
   std::vector<AnimationChannel> channels;
 
   /**
-   * @brief An array of samplers that combines input and output accessors with
-   * an interpolation algorithm to define a keyframe graph (but not its target).
+   * @brief An array of animation samplers that combines input and output
+   * accessors with an interpolation algorithm to define a keyframe graph (but
+   * not its target).
    */
   std::vector<AnimationSampler> samplers;
 };

--- a/CesiumGltf/include/CesiumGltf/AnimationChannel.h
+++ b/CesiumGltf/include/CesiumGltf/AnimationChannel.h
@@ -9,7 +9,8 @@
 
 namespace CesiumGltf {
 /**
- * @brief Targets an animation's sampler at a node's property.
+ * @brief An animation channel combines an animation sampler with a target
+ * property being animated.
  */
 struct CESIUMGLTF_API AnimationChannel final : public ExtensibleObject {
   static inline constexpr const char* TypeName = "AnimationChannel";
@@ -24,7 +25,7 @@ struct CESIUMGLTF_API AnimationChannel final : public ExtensibleObject {
   int32_t sampler = -1;
 
   /**
-   * @brief The index of the node and TRS property to target.
+   * @brief The descriptor of the animated property.
    */
   AnimationChannelTarget target;
 };

--- a/CesiumGltf/include/CesiumGltf/AnimationChannelTarget.h
+++ b/CesiumGltf/include/CesiumGltf/AnimationChannelTarget.h
@@ -16,12 +16,12 @@ struct CESIUMGLTF_API AnimationChannelTarget final : public ExtensibleObject {
 
   /**
    * @brief Known values for The name of the node's TRS property to modify, or
-   * the "weights" of the Morph Targets it instantiates. For the "translation"
-   * property, the values that are provided by the sampler are the translation
-   * along the x, y, and z axes. For the "rotation" property, the values are a
-   * quaternion in the order (x, y, z, w), where w is the scalar. For the
-   * "scale" property, the values are the scaling factors along the x, y, and z
-   * axes.
+   * the `"weights"` of the Morph Targets it instantiates. For the
+   * `"translation"` property, the values that are provided by the sampler are
+   * the translation along the X, Y, and Z axes. For the `"rotation"` property,
+   * the values are a quaternion in the order (x, y, z, w), where w is the
+   * scalar. For the `"scale"` property, the values are the scaling factors
+   * along the X, Y, and Z axes.
    */
   struct Path {
     inline static const std::string translation = "translation";
@@ -39,12 +39,12 @@ struct CESIUMGLTF_API AnimationChannelTarget final : public ExtensibleObject {
   int32_t node = -1;
 
   /**
-   * @brief The name of the node's TRS property to modify, or the "weights" of
-   * the Morph Targets it instantiates. For the "translation" property, the
-   * values that are provided by the sampler are the translation along the x, y,
-   * and z axes. For the "rotation" property, the values are a quaternion in the
-   * order (x, y, z, w), where w is the scalar. For the "scale" property, the
-   * values are the scaling factors along the x, y, and z axes.
+   * @brief The name of the node's TRS property to modify, or the `"weights"` of
+   * the Morph Targets it instantiates. For the `"translation"` property, the
+   * values that are provided by the sampler are the translation along the X, Y,
+   * and Z axes. For the `"rotation"` property, the values are a quaternion in
+   * the order (x, y, z, w), where w is the scalar. For the `"scale"` property,
+   * the values are the scaling factors along the X, Y, and Z axes.
    *
    * Known values are defined in {@link Path}.
    *

--- a/CesiumGltf/include/CesiumGltf/AnimationChannelTarget.h
+++ b/CesiumGltf/include/CesiumGltf/AnimationChannelTarget.h
@@ -8,14 +8,13 @@
 
 namespace CesiumGltf {
 /**
- * @brief The index of the node and TRS property that an animation channel
- * targets.
+ * @brief The descriptor of the animated property.
  */
 struct CESIUMGLTF_API AnimationChannelTarget final : public ExtensibleObject {
   static inline constexpr const char* TypeName = "AnimationChannelTarget";
 
   /**
-   * @brief Known values for The name of the node's TRS property to modify, or
+   * @brief Known values for The name of the node's TRS property to animate, or
    * the `"weights"` of the Morph Targets it instantiates. For the
    * `"translation"` property, the values that are provided by the sampler are
    * the translation along the X, Y, and Z axes. For the `"rotation"` property,
@@ -34,13 +33,14 @@ struct CESIUMGLTF_API AnimationChannelTarget final : public ExtensibleObject {
   };
 
   /**
-   * @brief The index of the node to target.
+   * @brief The index of the node to animate. When undefined, the animated
+   * object **MAY** be defined by an extension.
    */
   int32_t node = -1;
 
   /**
-   * @brief The name of the node's TRS property to modify, or the `"weights"` of
-   * the Morph Targets it instantiates. For the `"translation"` property, the
+   * @brief The name of the node's TRS property to animate, or the `"weights"`
+   * of the Morph Targets it instantiates. For the `"translation"` property, the
    * values that are provided by the sampler are the translation along the X, Y,
    * and Z axes. For the `"rotation"` property, the values are a quaternion in
    * the order (x, y, z, w), where w is the scalar. For the `"scale"` property,

--- a/CesiumGltf/include/CesiumGltf/AnimationSampler.h
+++ b/CesiumGltf/include/CesiumGltf/AnimationSampler.h
@@ -29,9 +29,9 @@ struct CESIUMGLTF_API AnimationSampler final : public ExtensibleObject {
    * @brief The index of an accessor containing keyframe input values, e.g.,
    * time.
    *
-   * That accessor must have componentType `FLOAT`. The values represent time in
-   * seconds with `time[0] >= 0.0`, and strictly increasing values, i.e.,
-   * `time[n + 1] > time[n]`.
+   * That accessor **MUST** have floating-point components. The values represent
+   * time in seconds with `time[0] >= 0.0`, and strictly increasing values,
+   * i.e., `time[n + 1] > time[n]`.
    */
   int32_t input = -1;
 
@@ -45,13 +45,6 @@ struct CESIUMGLTF_API AnimationSampler final : public ExtensibleObject {
 
   /**
    * @brief The index of an accessor, containing keyframe output values.
-   *
-   * The index of an accessor containing keyframe output values. When targeting
-   * translation or scale paths, the `accessor.componentType` of the output
-   * values must be `FLOAT`. When targeting rotation or morph weights, the
-   * `accessor.componentType` of the output values must be `FLOAT` or normalized
-   * integer. For weights, each output element stores `SCALAR` values with a
-   * count equal to the number of morph targets.
    */
   int32_t output = -1;
 };

--- a/CesiumGltf/include/CesiumGltf/AnimationSampler.h
+++ b/CesiumGltf/include/CesiumGltf/AnimationSampler.h
@@ -8,8 +8,8 @@
 
 namespace CesiumGltf {
 /**
- * @brief Combines input and output accessors with an interpolation algorithm to
- * define a keyframe graph (but not its target).
+ * @brief An animation sampler combines timestamps with a sequence of output
+ * values and defines an interpolation algorithm.
  */
 struct CESIUMGLTF_API AnimationSampler final : public ExtensibleObject {
   static inline constexpr const char* TypeName = "AnimationSampler";
@@ -26,12 +26,11 @@ struct CESIUMGLTF_API AnimationSampler final : public ExtensibleObject {
   };
 
   /**
-   * @brief The index of an accessor containing keyframe input values, e.g.,
-   * time.
+   * @brief The index of an accessor containing keyframe timestamps.
    *
-   * That accessor **MUST** have floating-point components. The values represent
-   * time in seconds with `time[0] >= 0.0`, and strictly increasing values,
-   * i.e., `time[n + 1] > time[n]`.
+   * The accessor **MUST** be of scalar type with floating-point components. The
+   * values represent time in seconds with `time[0] >= 0.0`, and strictly
+   * increasing values, i.e., `time[n + 1] > time[n]`.
    */
   int32_t input = -1;
 

--- a/CesiumGltf/include/CesiumGltf/Asset.h
+++ b/CesiumGltf/include/CesiumGltf/Asset.h
@@ -26,12 +26,15 @@ struct CESIUMGLTF_API Asset final : public ExtensibleObject {
   std::optional<std::string> generator;
 
   /**
-   * @brief The glTF version that this asset targets.
+   * @brief The glTF version in the form of `<major>.<minor>` that this asset
+   * targets.
    */
   std::string version;
 
   /**
-   * @brief The minimum glTF version that this asset targets.
+   * @brief The minimum glTF version in the form of `<major>.<minor>` that this
+   * asset targets. This property **MUST NOT** be greater than the asset
+   * version.
    */
   std::optional<std::string> minVersion;
 };

--- a/CesiumGltf/include/CesiumGltf/BufferSpec.h
+++ b/CesiumGltf/include/CesiumGltf/BufferSpec.h
@@ -16,10 +16,10 @@ struct CESIUMGLTF_API BufferSpec : public NamedObject {
   static inline constexpr const char* TypeName = "Buffer";
 
   /**
-   * @brief The uri of the buffer.
+   * @brief The URI (or IRI) of the buffer.
    *
-   * Relative paths are relative to the .gltf file.  Instead of referencing an
-   * external file, the uri can also be a data-uri.
+   * Relative paths are relative to the current glTF asset.  Instead of
+   * referencing an external file, this field **MAY** contain a `data:`-URI.
    */
   std::optional<std::string> uri;
 

--- a/CesiumGltf/include/CesiumGltf/BufferView.h
+++ b/CesiumGltf/include/CesiumGltf/BufferView.h
@@ -15,7 +15,8 @@ struct CESIUMGLTF_API BufferView final : public NamedObject {
   static inline constexpr const char* TypeName = "BufferView";
 
   /**
-   * @brief Known values for The target that the GPU buffer should be bound to.
+   * @brief Known values for The hint representing the intended GPU buffer type
+   * to use with this buffer view.
    */
   struct Target {
     static constexpr int32_t ARRAY_BUFFER = 34962;
@@ -42,13 +43,14 @@ struct CESIUMGLTF_API BufferView final : public NamedObject {
    * @brief The stride, in bytes.
    *
    * The stride, in bytes, between vertex attributes.  When this is not defined,
-   * data is tightly packed. When two or more accessors use the same bufferView,
-   * this field must be defined.
+   * data is tightly packed. When two or more accessors use the same buffer
+   * view, this field **MUST** be defined.
    */
   std::optional<int64_t> byteStride;
 
   /**
-   * @brief The target that the GPU buffer should be bound to.
+   * @brief The hint representing the intended GPU buffer type to use with this
+   * buffer view.
    *
    * Known values are defined in {@link Target}.
    *

--- a/CesiumGltf/include/CesiumGltf/Camera.h
+++ b/CesiumGltf/include/CesiumGltf/Camera.h
@@ -10,7 +10,7 @@
 
 namespace CesiumGltf {
 /**
- * @brief A camera's projection.  A node can reference a camera to apply a
+ * @brief A camera's projection.  A node **MAY** reference a camera to apply a
  * transform to place the camera in the scene.
  */
 struct CESIUMGLTF_API Camera final : public NamedObject {
@@ -28,13 +28,15 @@ struct CESIUMGLTF_API Camera final : public NamedObject {
 
   /**
    * @brief An orthographic camera containing properties to create an
-   * orthographic projection matrix.
+   * orthographic projection matrix. This property **MUST NOT** be defined when
+   * `perspective` is defined.
    */
   std::optional<CameraOrthographic> orthographic;
 
   /**
    * @brief A perspective camera containing properties to create a perspective
-   * projection matrix.
+   * projection matrix. This property **MUST NOT** be defined when
+   * `orthographic` is defined.
    */
   std::optional<CameraPerspective> perspective;
 
@@ -46,7 +48,7 @@ struct CESIUMGLTF_API Camera final : public NamedObject {
    *
    *
    * Based on this, either the camera's `perspective` or `orthographic` property
-   * will be defined.
+   * **MUST** be defined.
    */
   std::string type = Type::perspective;
 };

--- a/CesiumGltf/include/CesiumGltf/CameraOrthographic.h
+++ b/CesiumGltf/include/CesiumGltf/CameraOrthographic.h
@@ -14,20 +14,20 @@ struct CESIUMGLTF_API CameraOrthographic final : public ExtensibleObject {
   static inline constexpr const char* TypeName = "CameraOrthographic";
 
   /**
-   * @brief The floating-point horizontal magnification of the view. Must not be
-   * zero.
+   * @brief The floating-point horizontal magnification of the view. This value
+   * **MUST NOT** be equal to zero. This value **SHOULD NOT** be negative.
    */
   double xmag = double();
 
   /**
-   * @brief The floating-point vertical magnification of the view. Must not be
-   * zero.
+   * @brief The floating-point vertical magnification of the view. This value
+   * **MUST NOT** be equal to zero. This value **SHOULD NOT** be negative.
    */
   double ymag = double();
 
   /**
-   * @brief The floating-point distance to the far clipping plane. `zfar` must
-   * be greater than `znear`.
+   * @brief The floating-point distance to the far clipping plane. This value
+   * **MUST NOT** be equal to zero. `zfar` **MUST** be greater than `znear`.
    */
   double zfar = double();
 

--- a/CesiumGltf/include/CesiumGltf/CameraPerspective.h
+++ b/CesiumGltf/include/CesiumGltf/CameraPerspective.h
@@ -17,20 +17,23 @@ struct CESIUMGLTF_API CameraPerspective final : public ExtensibleObject {
   /**
    * @brief The floating-point aspect ratio of the field of view.
    *
-   * When this is undefined, the aspect ratio of the canvas is used.
+   * When undefined, the aspect ratio of the rendering viewport **MUST** be
+   * used.
    */
   std::optional<double> aspectRatio;
 
   /**
-   * @brief The floating-point vertical field of view in radians.
+   * @brief The floating-point vertical field of view in radians. This value
+   * **SHOULD** be less than π.
    */
   double yfov = double();
 
   /**
    * @brief The floating-point distance to the far clipping plane.
    *
-   * When defined, `zfar` must be greater than `znear`. If `zfar` is undefined,
-   * runtime must use infinite projection matrix.
+   * When defined, `zfar` **MUST** be greater than `znear`. If `zfar` is
+   * undefined, client implementations **SHOULD** use infinite projection
+   * matrix.
    */
   std::optional<double> zfar;
 

--- a/CesiumGltf/include/CesiumGltf/FeatureTableProperty.h
+++ b/CesiumGltf/include/CesiumGltf/FeatureTableProperty.h
@@ -20,10 +20,11 @@ struct CESIUMGLTF_API FeatureTableProperty final : public ExtensibleObject {
    * `type` is `BOOLEAN` values are packed into a bitfield. When `type` is
    * `STRING` values are stored as byte sequences and decoded as UTF-8 strings.
    * When `type` is a numeric type values are stored as the provided `type`.
-   * When `type` is `ENUM` values are stored as the enum's `valueType`. When
-   * `type` is `ARRAY` elements are packed tightly together and the data type is
-   * based on the `componentType` following the same rules as above.
-   * `arrayOffsetBufferView` is required for variable-size arrays and
+   * When `type` is `ENUM` values are stored as the enum's `valueType`. Each
+   * enum value in the buffer must match one of the allowed values in the enum
+   * definition. When `type` is `ARRAY` elements are packed tightly together and
+   * the data type is based on the `componentType` following the same rules as
+   * above. `arrayOffsetBufferView` is required for variable-size arrays and
    * `stringOffsetBufferView` is required for strings (for variable-length
    * arrays of strings, both are required). The buffer view `byteOffset` must be
    * aligned to a multiple of 8 bytes. If the buffer view's `buffer` is the

--- a/CesiumGltf/include/CesiumGltf/ImageSpec.h
+++ b/CesiumGltf/include/CesiumGltf/ImageSpec.h
@@ -10,15 +10,15 @@
 
 namespace CesiumGltf {
 /**
- * @brief Image data used to create a texture. Image can be referenced by URI or
- * `bufferView` index. `mimeType` is required in the latter case.
+ * @brief Image data used to create a texture. Image **MAY** be referenced by an
+ * URI (or IRI) or a buffer view index.
  */
 struct CESIUMGLTF_API ImageSpec : public NamedObject {
   static inline constexpr const char* TypeName = "Image";
 
   /**
-   * @brief Known values for The image's MIME type. Required if `bufferView` is
-   * defined.
+   * @brief Known values for The image's media type. This field **MUST** be
+   * defined when `bufferView` is defined.
    */
   struct MimeType {
     inline static const std::string image_jpeg = "image/jpeg";
@@ -27,16 +27,17 @@ struct CESIUMGLTF_API ImageSpec : public NamedObject {
   };
 
   /**
-   * @brief The uri of the image.
+   * @brief The URI (or IRI) of the image.
    *
-   * Relative paths are relative to the .gltf file.  Instead of referencing an
-   * external file, the uri can also be a data-uri.  The image format must be
-   * jpg or png.
+   * Relative paths are relative to the current glTF asset.  Instead of
+   * referencing an external file, this field **MAY** contain a `data:`-URI.
+   * This field **MUST NOT** be defined when `bufferView` is defined.
    */
   std::optional<std::string> uri;
 
   /**
-   * @brief The image's MIME type. Required if `bufferView` is defined.
+   * @brief The image's media type. This field **MUST** be defined when
+   * `bufferView` is defined.
    *
    * Known values are defined in {@link MimeType}.
    *
@@ -44,8 +45,8 @@ struct CESIUMGLTF_API ImageSpec : public NamedObject {
   std::optional<std::string> mimeType = MimeType::image_jpeg;
 
   /**
-   * @brief The index of the bufferView that contains the image. Use this
-   * instead of the image's uri property.
+   * @brief The index of the bufferView that contains the image. This field
+   * **MUST NOT** be defined when `uri` is defined.
    */
   int32_t bufferView = -1;
 

--- a/CesiumGltf/include/CesiumGltf/Material.h
+++ b/CesiumGltf/include/CesiumGltf/Material.h
@@ -18,7 +18,7 @@ namespace CesiumGltf {
 struct CESIUMGLTF_API Material final : public NamedObject {
   static inline constexpr const char* TypeName = "Material";
 
-  /**generate
+  /**
    * @brief Known values for The alpha rendering mode of the material.
    */
   struct AlphaMode {

--- a/CesiumGltf/include/CesiumGltf/Material.h
+++ b/CesiumGltf/include/CesiumGltf/Material.h
@@ -18,7 +18,7 @@ namespace CesiumGltf {
 struct CESIUMGLTF_API Material final : public NamedObject {
   static inline constexpr const char* TypeName = "Material";
 
-  /**
+  /**generate
    * @brief Known values for The alpha rendering mode of the material.
    */
   struct AlphaMode {
@@ -31,53 +31,51 @@ struct CESIUMGLTF_API Material final : public NamedObject {
 
   /**
    * @brief A set of parameter values that are used to define the
-   * metallic-roughness material model from Physically-Based Rendering (PBR)
-   * methodology. When not specified, all the default values of
-   * `pbrMetallicRoughness` apply.
+   * metallic-roughness material model from Physically Based Rendering (PBR)
+   * methodology. When undefined, all the default values of
+   * `pbrMetallicRoughness` **MUST** apply.
    */
   std::optional<MaterialPBRMetallicRoughness> pbrMetallicRoughness;
 
   /**
-   * @brief The normal map texture.
+   * @brief The tangent space normal texture.
    *
-   * A tangent space normal map. The texture contains RGB components in linear
-   * space. Each texel represents the XYZ components of a normal vector in
-   * tangent space. Red [0 to 255] maps to X [-1 to 1]. Green [0 to 255] maps to
-   * Y [-1 to 1]. Blue [128 to 255] maps to Z [1/255 to 1]. The normal vectors
-   * use the convention +X is right and +Y is up. +Z points toward the viewer.
-   * In GLSL, this vector would be unpacked like so: `vec3 normalVector =
-   * tex2D(<sampled normal map texture value>, texCoord) * 2 - 1`. Client
-   * implementations should normalize the normal vectors before using them in
-   * lighting equations.
+   * The texture encodes RGB components with linear transfer function. Each
+   * texel represents the XYZ components of a normal vector in tangent space.
+   * The normal vectors use the convention +X is right and +Y is up. +Z points
+   * toward the viewer. If a fourth component (A) is present, it **MUST** be
+   * ignored. When undefined, the material does not have a tangent space normal
+   * texture.
    */
   std::optional<MaterialNormalTextureInfo> normalTexture;
 
   /**
-   * @brief The occlusion map texture.
+   * @brief The occlusion texture.
    *
-   * The occlusion values are sampled from the R channel. Higher values indicate
-   * areas that should receive full indirect lighting and lower values indicate
-   * no indirect lighting. These values are linear. If other channels are
-   * present (GBA), they are ignored for occlusion calculations.
+   * The occlusion values are linearly sampled from the R channel. Higher values
+   * indicate areas that receive full indirect lighting and lower values
+   * indicate no indirect lighting. If other channels are present (GBA), they
+   * **MUST** be ignored for occlusion calculations. When undefined, the
+   * material does not have an occlusion texture.
    */
   std::optional<MaterialOcclusionTextureInfo> occlusionTexture;
 
   /**
-   * @brief The emissive map texture.
+   * @brief The emissive texture.
    *
-   * The emissive map controls the color and intensity of the light being
-   * emitted by the material. This texture contains RGB components encoded with
-   * the sRGB transfer function. If a fourth component (A) is present, it is
-   * ignored.
+   * It controls the color and intensity of the light being emitted by the
+   * material. This texture contains RGB components encoded with the sRGB
+   * transfer function. If a fourth component (A) is present, it **MUST** be
+   * ignored. When undefined, the texture **MUST** be sampled as having `1.0` in
+   * RGB components.
    */
   std::optional<TextureInfo> emissiveTexture;
 
   /**
-   * @brief The emissive color of the material.
+   * @brief The factors for the emissive color of the material.
    *
-   * The RGB components of the emissive color of the material. These values are
-   * linear. If an emissiveTexture is specified, this value is multiplied with
-   * the texel values.
+   * This value defines linear multipliers for the sampled texels of the
+   * emissive texture.
    */
   std::vector<double> emissiveFactor = {0, 0, 0};
 
@@ -88,18 +86,19 @@ struct CESIUMGLTF_API Material final : public NamedObject {
    *
    *
    * The material's alpha rendering mode enumeration specifying the
-   * interpretation of the alpha value of the main factor and texture.
+   * interpretation of the alpha value of the base color.
    */
   std::string alphaMode = AlphaMode::OPAQUE;
 
   /**
    * @brief The alpha cutoff value of the material.
    *
-   * Specifies the cutoff threshold when in `MASK` mode. If the alpha value is
-   * greater than or equal to this value then it is rendered as fully opaque,
-   * otherwise, it is rendered as fully transparent. A value greater than 1.0
-   * will render the entire material as fully transparent. This value is ignored
-   * for other modes.
+   * Specifies the cutoff threshold when in `MASK` alpha mode. If the alpha
+   * value is greater than or equal to this value then it is rendered as fully
+   * opaque, otherwise, it is rendered as fully transparent. A value greater
+   * than `1.0` will render the entire material as fully transparent. This value
+   * **MUST** be ignored for other alpha modes. When `alphaMode` is not defined,
+   * this value **MUST NOT** be defined.
    */
   double alphaCutoff = 0.5;
 
@@ -107,9 +106,9 @@ struct CESIUMGLTF_API Material final : public NamedObject {
    * @brief Specifies whether the material is double sided.
    *
    * When this value is false, back-face culling is enabled. When this value is
-   * true, back-face culling is disabled and double sided lighting is enabled.
-   * The back-face must have its normals reversed before the lighting equation
-   * is evaluated.
+   * true, back-face culling is disabled and double-sided lighting is enabled.
+   * The back-face **MUST** have its normals reversed before the lighting
+   * equation is evaluated.
    */
   bool doubleSided = false;
 };

--- a/CesiumGltf/include/CesiumGltf/MaterialNormalTextureInfo.h
+++ b/CesiumGltf/include/CesiumGltf/MaterialNormalTextureInfo.h
@@ -13,14 +13,13 @@ struct CESIUMGLTF_API MaterialNormalTextureInfo final : public TextureInfo {
   static inline constexpr const char* TypeName = "MaterialNormalTextureInfo";
 
   /**
-   * @brief The scalar multiplier applied to each normal vector of the normal
+   * @brief The scalar parameter applied to each normal vector of the normal
    * texture.
    *
-   * The scalar multiplier applied to each normal vector of the texture. This
-   * value scales the normal vector using the formula: `scaledNormal =
-   * normalize((<sampled normal texture value> * 2.0 - 1.0) * vec3(<normal
-   * scale>, <normal scale>, 1.0))`. This value is ignored if normalTexture is
-   * not specified. This value is linear.
+   * The scalar parameter applied to each normal vector of the texture. This
+   * value scales the normal vector in X and Y directions using the formula:
+   * `scaledNormal =  normalize((<sampled normal texture value> * 2.0 - 1.0) *
+   * vec3(<normal scale>, <normal scale>, 1.0))`.
    */
   double scale = 1;
 };

--- a/CesiumGltf/include/CesiumGltf/MaterialOcclusionTextureInfo.h
+++ b/CesiumGltf/include/CesiumGltf/MaterialOcclusionTextureInfo.h
@@ -15,11 +15,10 @@ struct CESIUMGLTF_API MaterialOcclusionTextureInfo final : public TextureInfo {
   /**
    * @brief A scalar multiplier controlling the amount of occlusion applied.
    *
-   * A value of 0.0 means no occlusion. A value of 1.0 means full occlusion.
-   * This value affects the resulting color using the formula: `occludedColor =
-   * lerp(color, color * <sampled occlusion texture value>, <occlusion
-   * strength>)`. This value is ignored if the corresponding texture is not
-   * specified. This value is linear.
+   * A scalar parameter controlling the amount of occlusion applied. A value of
+   * `0.0` means no occlusion. A value of `1.0` means full occlusion. This value
+   * affects the final occlusion value as: `1.0 + strength * (<sampled occlusion
+   * texture value> - 1.0)`.
    */
   double strength = 1;
 };

--- a/CesiumGltf/include/CesiumGltf/MaterialPBRMetallicRoughness.h
+++ b/CesiumGltf/include/CesiumGltf/MaterialPBRMetallicRoughness.h
@@ -19,46 +19,39 @@ struct CESIUMGLTF_API MaterialPBRMetallicRoughness final
   static inline constexpr const char* TypeName = "MaterialPBRMetallicRoughness";
 
   /**
-   * @brief The material's base color factor.
+   * @brief The factors for the base color of the material.
    *
-   * The RGBA components of the base color of the material. The fourth component
-   * (A) is the alpha coverage of the material. The `alphaMode` property
-   * specifies how alpha is interpreted. These values are linear. If a
-   * baseColorTexture is specified, this value is multiplied with the texel
-   * values.
+   * This value defines linear multipliers for the sampled texels of the base
+   * color texture.
    */
   std::vector<double> baseColorFactor = {1, 1, 1, 1};
 
   /**
    * @brief The base color texture.
    *
-   * The first three components (RGB) are encoded with the sRGB transfer
+   * The first three components (RGB) **MUST** be encoded with the sRGB transfer
    * function. They specify the base color of the material. If the fourth
    * component (A) is present, it represents the linear alpha coverage of the
-   * material. Otherwise, an alpha of 1.0 is assumed. The `alphaMode` property
-   * specifies how alpha is interpreted. The stored texels must not be
-   * premultiplied.
+   * material. Otherwise, the alpha coverage is equal to `1.0`. The
+   * `material.alphaMode` property specifies how alpha is interpreted. The
+   * stored texels **MUST NOT** be premultiplied. When undefined, the texture
+   * **MUST** be sampled as having `1.0` in all components.
    */
   std::optional<TextureInfo> baseColorTexture;
 
   /**
-   * @brief The metalness of the material.
+   * @brief The factor for the metalness of the material.
    *
-   * A value of 1.0 means the material is a metal. A value of 0.0 means the
-   * material is a dielectric. Values in between are for blending between metals
-   * and dielectrics such as dirty metallic surfaces. This value is linear. If a
-   * metallicRoughnessTexture is specified, this value is multiplied with the
-   * metallic texel values.
+   * This value defines a linear multiplier for the sampled metalness values of
+   * the metallic-roughness texture.
    */
   double metallicFactor = 1;
 
   /**
-   * @brief The roughness of the material.
+   * @brief The factor for the roughness of the material.
    *
-   * A value of 1.0 means the material is completely rough. A value of 0.0 means
-   * the material is completely smooth. This value is linear. If a
-   * metallicRoughnessTexture is specified, this value is multiplied with the
-   * roughness texel values.
+   * This value defines a linear multiplier for the sampled roughness values of
+   * the metallic-roughness texture.
    */
   double roughnessFactor = 1;
 
@@ -66,8 +59,10 @@ struct CESIUMGLTF_API MaterialPBRMetallicRoughness final
    * @brief The metallic-roughness texture.
    *
    * The metalness values are sampled from the B channel. The roughness values
-   * are sampled from the G channel. These values are linear. If other channels
-   * are present (R or A), they are ignored for metallic-roughness calculations.
+   * are sampled from the G channel. These values **MUST** be encoded with a
+   * linear transfer function. If other channels are present (R or A), they
+   * **MUST** be ignored for metallic-roughness calculations. When undefined,
+   * the texture **MUST** be sampled as having `1.0` in G and B components.
    */
   std::optional<TextureInfo> metallicRoughnessTexture;
 };

--- a/CesiumGltf/include/CesiumGltf/Mesh.h
+++ b/CesiumGltf/include/CesiumGltf/Mesh.h
@@ -9,20 +9,20 @@
 
 namespace CesiumGltf {
 /**
- * @brief A set of primitives to be rendered.  A node can contain one mesh.  A
- * node's transform places the mesh in the scene.
+ * @brief A set of primitives to be rendered.  Its global transform is defined
+ * by a node that references it.
  */
 struct CESIUMGLTF_API Mesh final : public NamedObject {
   static inline constexpr const char* TypeName = "Mesh";
 
   /**
-   * @brief An array of primitives, each defining geometry to be rendered with a
-   * material.
+   * @brief An array of primitives, each defining geometry to be rendered.
    */
   std::vector<MeshPrimitive> primitives;
 
   /**
-   * @brief Array of weights to be applied to the Morph Targets.
+   * @brief Array of weights to be applied to the morph targets. The number of
+   * array elements **MUST** match the number of morph targets.
    */
   std::vector<double> weights;
 };

--- a/CesiumGltf/include/CesiumGltf/MeshPrimitive.h
+++ b/CesiumGltf/include/CesiumGltf/MeshPrimitive.h
@@ -16,7 +16,7 @@ struct CESIUMGLTF_API MeshPrimitive final : public ExtensibleObject {
   static inline constexpr const char* TypeName = "MeshPrimitive";
 
   /**
-   * @brief Known values for The type of primitives to render.
+   * @brief Known values for The topology type of primitives to render.
    */
   struct Mode {
     static constexpr int32_t POINTS = 0;
@@ -35,30 +35,18 @@ struct CESIUMGLTF_API MeshPrimitive final : public ExtensibleObject {
   };
 
   /**
-   * @brief A dictionary object, where each key corresponds to mesh attribute
+   * @brief A plain JSON object, where each key corresponds to a mesh attribute
    * semantic and each value is the index of the accessor containing attribute's
    * data.
    */
   std::unordered_map<std::string, int32_t> attributes;
 
   /**
-   * @brief The index of the accessor that contains the indices.
+   * @brief The index of the accessor that contains the vertex indices.
    *
-   * The index of the accessor that contains mesh indices.  When this is not
-   * defined, the primitives should be rendered without indices using
-   * `drawArrays()`.  When defined, the accessor must contain indices: the
-   * `bufferView` referenced by the accessor should have a `target` equal to
-   * 34963 (ELEMENT_ARRAY_BUFFER); `componentType` must be 5121 (UNSIGNED_BYTE),
-   * 5123 (UNSIGNED_SHORT) or 5125 (UNSIGNED_INT), the latter may require
-   * enabling additional hardware support; `type` must be `"SCALAR"`. For
-   * triangle primitives, the front face has a counter-clockwise (CCW) winding
-   * order. Values of the index accessor must not include the maximum value for
-   * the given component type, which triggers primitive restart in several
-   * graphics APIs and would require client implementations to rebuild the index
-   * buffer. Primitive restart values are disallowed and all index values must
-   * refer to actual vertices. As a result, the index accessor's values must not
-   * exceed the following maxima: BYTE `< 255`, UNSIGNED_SHORT `< 65535`,
-   * UNSIGNED_INT `< 4294967295`.
+   * When this is undefined, the primitive defines non-indexed geometry.  When
+   * defined, the accessor **MUST** have `SCALAR` type and an unsigned integer
+   * component type.
    */
   int32_t indices = -1;
 
@@ -68,19 +56,15 @@ struct CESIUMGLTF_API MeshPrimitive final : public ExtensibleObject {
   int32_t material = -1;
 
   /**
-   * @brief The type of primitives to render.
+   * @brief The topology type of primitives to render.
    *
    * Known values are defined in {@link Mode}.
    *
-   *
-   * All valid values correspond to WebGL enums.
    */
   int32_t mode = Mode::TRIANGLES;
 
   /**
-   * @brief An array of Morph Targets, each  Morph Target is a dictionary
-   * mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to
-   * their deviations in the Morph Target.
+   * @brief An array of morph targets.
    */
   std::vector<std::unordered_map<std::string, int32_t>> targets;
 };

--- a/CesiumGltf/include/CesiumGltf/ModelSpec.h
+++ b/CesiumGltf/include/CesiumGltf/ModelSpec.h
@@ -30,7 +30,7 @@ struct CESIUMGLTF_API ModelSpec : public ExtensibleObject {
   static inline constexpr const char* TypeName = "Model";
 
   /**
-   * @brief Names of glTF extensions used somewhere in this asset.
+   * @brief Names of glTF extensions used in this asset.
    */
   std::vector<std::string> extensionsUsed;
 
@@ -113,6 +113,8 @@ struct CESIUMGLTF_API ModelSpec : public ExtensibleObject {
 
   /**
    * @brief The index of the default scene.
+   *
+   * This property **MUST NOT** be defined, when `scenes` is undefined.
    */
   int32_t scene = -1;
 

--- a/CesiumGltf/include/CesiumGltf/Node.h
+++ b/CesiumGltf/include/CesiumGltf/Node.h
@@ -10,15 +10,14 @@
 namespace CesiumGltf {
 /**
  * @brief A node in the node hierarchy.  When the node contains `skin`, all
- * `mesh.primitives` must contain `JOINTS_0` and `WEIGHTS_0` attributes.  A node
- * can have either a `matrix` or any combination of
+ * `mesh.primitives` **MUST** contain `JOINTS_0` and `WEIGHTS_0` attributes.  A
+ * node **MAY** have either a `matrix` or any combination of
  * `translation`/`rotation`/`scale` (TRS) properties. TRS properties are
  * converted to matrices and postmultiplied in the `T * R * S` order to compose
  * the transformation matrix; first the scale is applied to the vertices, then
  * the rotation, and then the translation. If none are provided, the transform
  * is the identity. When a node is targeted for animation (referenced by an
- * animation.channel.target), only TRS properties may be present; `matrix` will
- * not be present.
+ * animation.channel.target), `matrix` **MUST NOT** be present.
  */
 struct CESIUMGLTF_API Node final : public NamedObject {
   static inline constexpr const char* TypeName = "Node";
@@ -37,7 +36,8 @@ struct CESIUMGLTF_API Node final : public NamedObject {
    * @brief The index of the skin referenced by this node.
    *
    * When a skin is referenced by a node within a scene, all joints used by the
-   * skin must belong to the same scene.
+   * skin **MUST** belong to the same scene. When defined, `mesh` **MUST** also
+   * be defined.
    */
   int32_t skin = -1;
 
@@ -70,8 +70,9 @@ struct CESIUMGLTF_API Node final : public NamedObject {
   std::vector<double> translation = {0, 0, 0};
 
   /**
-   * @brief The weights of the instantiated Morph Target. Number of elements
-   * must match number of Morph Targets of used mesh.
+   * @brief The weights of the instantiated morph target. The number of array
+   * elements **MUST** match the number of morph targets of the referenced mesh.
+   * When defined, `mesh` **MUST** also be defined.
    */
   std::vector<double> weights;
 };

--- a/CesiumGltf/include/CesiumGltf/Sampler.h
+++ b/CesiumGltf/include/CesiumGltf/Sampler.h
@@ -40,7 +40,7 @@ struct CESIUMGLTF_API Sampler final : public NamedObject {
   };
 
   /**
-   * @brief Known values for s wrapping mode.
+   * @brief Known values for S (U) wrapping mode.
    */
   struct WrapS {
     static constexpr int32_t CLAMP_TO_EDGE = 33071;
@@ -51,7 +51,7 @@ struct CESIUMGLTF_API Sampler final : public NamedObject {
   };
 
   /**
-   * @brief Known values for t wrapping mode.
+   * @brief Known values for T (V) wrapping mode.
    */
   struct WrapT {
     static constexpr int32_t CLAMP_TO_EDGE = 33071;
@@ -66,9 +66,6 @@ struct CESIUMGLTF_API Sampler final : public NamedObject {
    *
    * Known values are defined in {@link MagFilter}.
    *
-   *
-   * Valid values correspond to WebGL enums: `9728` (NEAREST) and `9729`
-   * (LINEAR).
    */
   std::optional<int32_t> magFilter = MagFilter::NEAREST;
 
@@ -77,28 +74,24 @@ struct CESIUMGLTF_API Sampler final : public NamedObject {
    *
    * Known values are defined in {@link MinFilter}.
    *
-   *
-   * All valid values correspond to WebGL enums.
    */
   std::optional<int32_t> minFilter = MinFilter::NEAREST;
 
   /**
-   * @brief s wrapping mode.
+   * @brief S (U) wrapping mode.
    *
    * Known values are defined in {@link WrapS}.
    *
    *
-   * S (U) wrapping mode.  All valid values correspond to WebGL enums.
+   * All valid values correspond to WebGL enums.
    */
   int32_t wrapS = WrapS::REPEAT;
 
   /**
-   * @brief t wrapping mode.
+   * @brief T (V) wrapping mode.
    *
    * Known values are defined in {@link WrapT}.
    *
-   *
-   * T (V) wrapping mode.  All valid values correspond to WebGL enums.
    */
   int32_t wrapT = WrapT::REPEAT;
 };

--- a/CesiumGltf/include/CesiumGltf/Skin.h
+++ b/CesiumGltf/include/CesiumGltf/Skin.h
@@ -16,24 +16,24 @@ struct CESIUMGLTF_API Skin final : public NamedObject {
 
   /**
    * @brief The index of the accessor containing the floating-point 4x4
-   * inverse-bind matrices.  The default is that each matrix is a 4x4 identity
-   * matrix, which implies that inverse-bind matrices were pre-applied.
+   * inverse-bind matrices.
+   *
+   * Its `accessor.count` property **MUST** be greater than or equal to the
+   * number of elements of the `joints` array. When undefined, each matrix is a
+   * 4x4 identity matrix.
    */
   int32_t inverseBindMatrices = -1;
 
   /**
    * @brief The index of the node used as a skeleton root.
    *
-   * The node must be the closest common root of the joints hierarchy or a
+   * The node **MUST** be the closest common root of the joints hierarchy or a
    * direct or indirect parent node of the closest common root.
    */
   int32_t skeleton = -1;
 
   /**
    * @brief Indices of skeleton nodes, used as joints in this skin.
-   *
-   * The array length must be the same as the `count` property of the
-   * `inverseBindMatrices` accessor (when defined).
    */
   std::vector<int32_t> joints;
 };

--- a/CesiumGltf/include/CesiumGltf/Texture.h
+++ b/CesiumGltf/include/CesiumGltf/Texture.h
@@ -15,14 +15,14 @@ struct CESIUMGLTF_API Texture final : public NamedObject {
 
   /**
    * @brief The index of the sampler used by this texture. When undefined, a
-   * sampler with repeat wrapping and auto filtering should be used.
+   * sampler with repeat wrapping and auto filtering **SHOULD** be used.
    */
   int32_t sampler = -1;
 
   /**
-   * @brief The index of the image used by this texture. When undefined, it is
-   * expected that an extension or other mechanism will supply an alternate
-   * texture source, otherwise behavior is undefined.
+   * @brief The index of the image used by this texture. When undefined, an
+   * extension or other mechanism **SHOULD** supply an alternate texture source,
+   * otherwise behavior is undefined.
    */
   int32_t source = -1;
 };

--- a/CesiumGltf/include/CesiumGltf/TextureInfo.h
+++ b/CesiumGltf/include/CesiumGltf/TextureInfo.h
@@ -24,9 +24,9 @@ struct CESIUMGLTF_API TextureInfo : public ExtensibleObject {
    *
    * This integer value is used to construct a string in the format
    * `TEXCOORD_<set index>` which is a reference to a key in
-   * mesh.primitives.attributes (e.g. A value of `0` corresponds to
-   * `TEXCOORD_0`). Mesh must have corresponding texture coordinate attributes
-   * for the material to be applicable to it.
+   * `mesh.primitives.attributes` (e.g. a value of `0` corresponds to
+   * `TEXCOORD_0`). A mesh primitive **MUST** have the corresponding texture
+   * coordinate attributes for the material to be applicable to it.
    */
   int64_t texCoord = 0;
 };

--- a/tools/generate-gltf-classes/glTF.json
+++ b/tools/generate-gltf-classes/glTF.json
@@ -35,7 +35,7 @@
         {
             "className": "ModelEXT_feature_metadata",
             "extensionName": "EXT_feature_metadata",
-            "schema": "Vendor/EXT_feature_metadata/1.0.0/schema/gltf.EXT_feature_metadata.schema.json",
+            "schema": "Vendor/EXT_feature_metadata/schema/gltf.EXT_feature_metadata.schema.json",
             "attachTo": [
                 "glTF"
             ]
@@ -43,7 +43,7 @@
         {
             "className": "MeshPrimitiveEXT_feature_metadata",
             "extensionName": "EXT_feature_metadata",
-            "schema": "Vendor/EXT_feature_metadata/1.0.0/schema/primitive.EXT_feature_metadata.schema.json",
+            "schema": "Vendor/EXT_feature_metadata/schema/primitive.EXT_feature_metadata.schema.json",
             "attachTo": [
                 "mesh.primitive"
             ]

--- a/tools/generate-gltf-classes/package.json
+++ b/tools/generate-gltf-classes/package.json
@@ -4,8 +4,8 @@
   "description": "Generate CesiumGltf C++ classes from the glTF spec.",
   "main": "index.js",
   "scripts": {
-    "test": "node index.js --schema https://raw.githubusercontent.com/kring/glTF/metadata-schema-cleanup/specification/2.0/schema/ --output test_output/model --readerOutput test_output/reader --extensions https://raw.githubusercontent.com/kring/glTF/metadata-schema-cleanup/extensions/2.0/ --config glTF.json",
-    "generate": "node index.js --schema https://raw.githubusercontent.com/kring/glTF/metadata-schema-cleanup/specification/2.0/schema/ --output ../../CesiumGltf --readerOutput ../../CesiumGltfReader --extensions https://raw.githubusercontent.com/kring/glTF/metadata-schema-cleanup/extensions/2.0/ --config glTF.json"
+    "test": "node index.js --schema https://raw.githubusercontent.com/CesiumGS/glTF/3d-tiles-next/specification/2.0/schema/ --output test_output/model --readerOutput test_output/reader --extensions https://raw.githubusercontent.com/CesiumGS/glTF/3d-tiles-next/extensions/2.0/ --config glTF.json",
+    "generate": "node index.js --schema https://raw.githubusercontent.com/CesiumGS/glTF/3d-tiles-next/specification/2.0/schema/ --output ../../CesiumGltf --readerOutput ../../CesiumGltfReader --extensions https://raw.githubusercontent.com/CesiumGS/glTF/3d-tiles-next/extensions/2.0/ --config glTF.json"
   },
   "author": "CesiumGS, Inc.",
   "license": "UNLICENSED",


### PR DESCRIPTION
There have been a series of language revisions to the glTF spec recently, e.g. https://github.com/KhronosGroup/glTF/pull/1997 and https://github.com/KhronosGroup/glTF/pull/2028. This PR updates the generated glTF reader files with those changes. There are no functional changes as far as I can tell, just documentation.

The `npm run generate` command now uses `CesiumGS/glTF/3d-tiles-next` instead of `kring/glTF/metadata-schema-cleanup` since https://github.com/CesiumGS/glTF/pull/10 was merged and `3d-tiles-next` branch is now synced up with KhronosGroup `main`. Also the subfolders for `EXT_feature_metadata` were removed so `1.0.0` was removed from `glTF.json`.

I built locally and spot-checked the generated Doxygen documentation, no issues.

Just as a warning, we may need to support both draft4 schemas and 2020-12 schemas once https://github.com/KhronosGroup/glTF/pull/2034 is merged since glTF will be using 2020-12 exclusively but glTF extensions and 3D Tiles will be on draft4 for at least a little bit longer.