### PR TITLE
Don't ignore RTC_CENTER when it has an integer coordinate value.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 - Made tile content loading asynchronous and allowed it to make further network requests, to Cesium ion or otherwise.
 
+##### Fixes :wrench:
+
+- Fixed a bug that caused the `RTC_CENTER` semantic in a B3DM feature table to be ignored if any of the values happened to be integers rather than floating-point numbers. This caused these tiles to render in the wrong location.
+
 ### v0.7.2 - 2021-09-14
 
 ##### Fixes :wrench:

--- a/Cesium3DTilesSelection/src/Batched3DModelContent.cpp
+++ b/Cesium3DTilesSelection/src/Batched3DModelContent.cpp
@@ -60,8 +60,8 @@ rapidjson::Document parseFeatureTableJsonData(
 
   const auto rtcIt = document.FindMember("RTC_CENTER");
   if (rtcIt != document.MemberEnd() && rtcIt->value.IsArray() &&
-      rtcIt->value.Size() == 3 && rtcIt->value[0].IsDouble() &&
-      rtcIt->value[1].IsDouble() && rtcIt->value[2].IsDouble()) {
+      rtcIt->value.Size() == 3 && rtcIt->value[0].IsNumber() &&
+      rtcIt->value[1].IsNumber() && rtcIt->value[2].IsNumber()) {
     // Add the RTC_CENTER value to the glTF itself.
     rapidjson::Value& rtcValue = rtcIt->value;
     gltf.extras["RTC_CENTER"] = {


### PR DESCRIPTION
Fixes problems with the "Washington State" tileset, ion asset ID 55416.

Much to my surprise, RapidJSON's `IsDouble` returns false for integers, even though `GetDouble` works and performs the expected conversion, and `IsInt64` returns true for a 32-bit integer. So in the problem tileset, one of the RTC_CENTER coordinate values happened to have an integer value, and so `IsDouble` was returning false, and so we were assuming the RTC_CENTER value was invalid and ignoring it, and so the tileset was rendered in the wrong place.

This PR checks for _any_ number and then converts it to a double.

CC @argallegos @nithinp7 
