### PR TITLE
WIP support for layers of quantized-mesh terrain.

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContext.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContext.h
@@ -166,6 +166,18 @@ public:
    * properties of its parent context.
    */
   ContextInitializerCallback contextInitializerCallback;
+
+  /**
+   * @brief Another tiling context underlying this one, if any.
+   *
+   * If a tile is not available from this tiling context, we check the
+   * underlyingContext to see if it is available from that one instead. This
+   * allows one implicitly-tiled tileset to be layered on top of another one.
+   * For example, custom terrain for a small area layered on top of Cesium World
+   * Terrain. In this scenario, Cesium World Terrain would be the
+   * underlyingContext.
+   */
+  std::unique_ptr<TileContext> pUnderlyingContext;
 };
 
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -348,7 +348,9 @@ private:
    * @param pRequest The request for which the response was received.
    * @return The LoadResult structure
    */
-  static LoadResult _handleTilesetResponse(
+  static CesiumAsync::Future<LoadResult> _handleTilesetResponse(
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       std::shared_ptr<CesiumAsync::IAssetRequest>&& pRequest,
       std::unique_ptr<TileContext>&& pContext,
       const std::shared_ptr<spdlog::logger>& pLogger,
@@ -367,10 +369,12 @@ private:
       TileRefine parentRefine,
       const TileContext& context,
       const std::shared_ptr<spdlog::logger>& pLogger);
-  static void _createTerrainTile(
-      Tile& tile,
+  static CesiumAsync::Future<LoadResult> _createTerrainTile(
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      std::unique_ptr<Tile>&& pTile,
       const rapidjson::Value& layerJson,
-      TileContext& context,
+      std::unique_ptr<TileContext>&& pContext,
       const std::shared_ptr<spdlog::logger>& pLogger,
       bool useWaterMask);
   FailedTileAction _onIonTileFailed(Tile& failedTile);

--- a/Cesium3DTilesSelection/src/TerrainLayerJson.cpp
+++ b/Cesium3DTilesSelection/src/TerrainLayerJson.cpp
@@ -1,0 +1,141 @@
+#include "TerrainLayerJson.h"
+
+#include <CesiumAsync/IAssetResponse.h>
+#include <CesiumUtility/JsonHelpers.h>
+#include <CesiumUtility/Uri.h>
+
+using namespace Cesium3DTilesSelection;
+using namespace CesiumAsync;
+using namespace CesiumGeospatial;
+using namespace CesiumUtility;
+
+CesiumAsync::Future<TerrainLayerJson> TerrainLayerJson::resolveParents(
+    const AsyncSystem& asyncSystem,
+    const std::shared_ptr<IAssetAccessor>& pAssetAccessor,
+    const std::shared_ptr<spdlog::logger>& pLogger,
+    const std::string& baseUrl,
+    const std::vector<IAssetAccessor::THeader>& requestHeaders) && {
+  if (this->parentUrl.empty()) {
+    return asyncSystem.createResolvedFuture<TerrainLayerJson>(std::move(*this));
+  }
+
+  std::string resolvedUrl = Uri::resolve(baseUrl, this->parentUrl);
+  return pAssetAccessor->requestAsset(asyncSystem, resolvedUrl, requestHeaders)
+      .thenInWorkerThread(
+          [layerJson = std::move(*this),
+           asyncSystem,
+           pAssetAccessor,
+           pLogger,
+           requestHeaders](std::shared_ptr<IAssetRequest>&& pRequest) mutable {
+            const IAssetResponse* pResponse = pRequest->response();
+            if (!pResponse) {
+              SPDLOG_LOGGER_ERROR(
+                  pLogger,
+                  "Did not receive a valid response for parent layer.json {}",
+                  pRequest->url());
+              return asyncSystem.createResolvedFuture<TerrainLayerJson>(
+                  std::move(layerJson));
+            }
+
+            if (pResponse->statusCode() != 0 &&
+                (pResponse->statusCode() < 200 ||
+                 pResponse->statusCode() >= 300)) {
+              SPDLOG_LOGGER_ERROR(
+                  pLogger,
+                  "Received status code {} for parent layer.json {}",
+                  pResponse->statusCode(),
+                  pRequest->url());
+              return asyncSystem.createResolvedFuture<TerrainLayerJson>(
+                  std::move(layerJson));
+            }
+
+            TerrainLayerJson parent =
+                TerrainLayerJson::parse(pLogger, pResponse->data());
+
+            // Also resolve this parent layer.json's parentUrl, if any.
+            return std::move(parent)
+                .resolveParents(
+                    asyncSystem,
+                    pAssetAccessor,
+                    pLogger,
+                    pRequest->url(),
+                    requestHeaders)
+                .thenImmediately([layerJson = std::move(layerJson)](
+                                     TerrainLayerJson&& parent) mutable {
+                  layerJson.pResolvedParent =
+                      std::make_unique<TerrainLayerJson>(std::move(parent));
+                  return std::move(layerJson);
+                });
+          });
+}
+
+/*static*/ TerrainLayerJson TerrainLayerJson::parse(
+    const std::shared_ptr<spdlog::logger>& pLogger,
+    const gsl::span<const std::byte>& data) {
+  rapidjson::Document document;
+  document.Parse(reinterpret_cast<const char*>(data.data()), data.size());
+
+  if (document.HasParseError()) {
+    SPDLOG_LOGGER_ERROR(
+        pLogger,
+        "Error when parsing layer.json, error code {} at byte offset "
+        "{}",
+        document.GetParseError(),
+        document.GetErrorOffset());
+    return TerrainLayerJson();
+  }
+
+  return TerrainLayerJson::parse(pLogger, document);
+}
+
+/*static*/ TerrainLayerJson TerrainLayerJson::parse(
+    const std::shared_ptr<spdlog::logger>& pLogger,
+    const rapidjson::Value& jsonValue) {
+  TerrainLayerJson result;
+
+  if (!jsonValue.IsObject()) {
+    SPDLOG_LOGGER_ERROR(
+        pLogger,
+        "Could not parse terrain layer.json because it is not a JSON object.");
+    return result;
+  }
+
+  result.attribution =
+      JsonHelpers::getStringOrDefault(jsonValue, "attribution", "");
+  result.description =
+      JsonHelpers::getStringOrDefault(jsonValue, "description", "");
+  result.extensions = JsonHelpers::getStrings(jsonValue, "extensions");
+  result.format = JsonHelpers::getStringOrDefault(jsonValue, "format", "");
+  result.maxzoom = JsonHelpers::getInt32OrDefault(jsonValue, "maxzoom", 30);
+  result.metadataAvailability =
+      JsonHelpers::getInt32OrDefault(jsonValue, "metadataAvailability", 0);
+  result.minzoom = JsonHelpers::getInt32OrDefault(jsonValue, "minzoom", 30);
+  result.parentUrl =
+      JsonHelpers::getStringOrDefault(jsonValue, "parentUrl", "");
+  result.projection =
+      JsonHelpers::getStringOrDefault(jsonValue, "projection", "");
+  result.scheme = JsonHelpers::getStringOrDefault(jsonValue, "scheme", "");
+  result.tiles = JsonHelpers::getStrings(jsonValue, "tiles");
+  result.version = JsonHelpers::getStringOrDefault(jsonValue, "version", "");
+
+  std::optional<std::vector<double>> bounds =
+      JsonHelpers::getDoubles(jsonValue, 4, "bounds");
+  if (bounds) {
+    result.bounds = GlobeRectangle::fromDegrees(
+        bounds->at(0),
+        bounds->at(1),
+        bounds->at(2),
+        bounds->at(3));
+  }
+
+  // If there's a metadata extension we'll get availability from there, so don't
+  // waste time parsing the `available` property.
+  if (std::find(
+          result.extensions.begin(),
+          result.extensions.end(),
+          "metadata") == result.extensions.end()) {
+    // TODO: parse availability
+  }
+
+  return result;
+}

--- a/Cesium3DTilesSelection/src/TerrainLayerJson.h
+++ b/Cesium3DTilesSelection/src/TerrainLayerJson.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "Cesium3DTilesSelection/spdlog-cesium.h"
+
+#include <CesiumAsync/Future.h>
+#include <CesiumAsync/IAssetAccessor.h>
+#include <CesiumGeometry/QuadtreeTileRectangularRange.h>
+#include <CesiumGeospatial/GlobeRectangle.h>
+
+#include <rapidjson/document.h>
+
+#include <string>
+#include <vector>
+
+namespace Cesium3DTilesSelection {
+
+struct TerrainLayerJson {
+  std::string attribution;
+  std::vector<CesiumGeometry::QuadtreeTileRectangularRange> available;
+  CesiumGeospatial::GlobeRectangle bounds;
+  std::string description;
+  std::vector<std::string> extensions;
+  std::string format;
+  int32_t maxzoom = 0;
+  int32_t metadataAvailability = 0;
+  int32_t minzoom = 0;
+  std::string name;
+  std::string parentUrl;
+  std::string projection;
+  std::string scheme;
+  std::vector<std::string> tiles;
+  std::string version;
+
+  std::unique_ptr<TerrainLayerJson> pResolvedParent;
+
+  CesiumAsync::Future<TerrainLayerJson> resolveParents(
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+      const std::shared_ptr<spdlog::logger>& pLogger,
+      const std::string& baseUrl,
+      const std::vector<CesiumAsync::IAssetAccessor::THeader>&
+          requestHeaders) &&;
+
+  static TerrainLayerJson parse(
+      const std::shared_ptr<spdlog::logger>& pLogger,
+      const gsl::span<const std::byte>& data);
+
+  static TerrainLayerJson parse(
+      const std::shared_ptr<spdlog::logger>& pLogger,
+      const rapidjson::Value& jsonValue);
+};
+
+} // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -913,7 +913,7 @@ std::optional<ImplicitTilingContext> createImplicitContextFromLayerJson(
   CesiumGeospatial::Projection projection;
   CesiumGeospatial::GlobeRectangle quadtreeRectangleGlobe(0.0, 0.0, 0.0, 0.0);
   CesiumGeometry::Rectangle quadtreeRectangleProjected(0.0, 0.0, 0.0, 0.0);
-  int32_t quadtreeXTiles;
+  uint32_t quadtreeXTiles;
 
   if (layerJson.projection == "EPSG:4326") {
     CesiumGeospatial::GeographicProjection geographic;
@@ -950,9 +950,7 @@ std::optional<ImplicitTilingContext> createImplicitContextFromLayerJson(
       layerJson.tiles,
       tilingScheme,
       projection,
-      CesiumGeometry::QuadtreeTileAvailability(
-          tilingScheme,
-          layerJson.maxzoom)};
+      QuadtreeTileAvailability(tilingScheme, uint32_t(layerJson.maxzoom))};
 
   // Request normals, watermask, and metadata if they're available
   std::vector<std::string> knownExtensions = {"octvertexnormals", "metadata"};
@@ -1002,11 +1000,11 @@ void applyResolvedLayerJson(
       context.implicitContext->tilingScheme;
   const Projection& projection = context.implicitContext->projection;
 
-  int32_t quadtreeXTiles =
+  uint32_t quadtreeXTiles =
       context.implicitContext->tilingScheme.getRootTilesX();
   tile.createChildTiles(quadtreeXTiles);
 
-  for (int32_t i = 0; i < quadtreeXTiles; ++i) {
+  for (uint32_t i = 0; i < quadtreeXTiles; ++i) {
     Tile& childTile = tile.getChildren()[i];
     QuadtreeTileID id(0, i, 0);
 

--- a/CesiumGeometry/include/CesiumGeometry/QuadtreeTileAvailability.h
+++ b/CesiumGeometry/include/CesiumGeometry/QuadtreeTileAvailability.h
@@ -18,6 +18,13 @@ namespace CesiumGeometry {
 class CESIUMGEOMETRY_API QuadtreeTileAvailability final {
 public:
   /**
+   * @brief Creates a new instance that tiles a rectangle with coordinates from
+   * 0.0 to 1.0, starting with a single tile at the root and proceeding through
+   * level 30.
+   */
+  QuadtreeTileAvailability() noexcept;
+
+  /**
    * @brief Creates a new instance.
    *
    * @param tilingScheme The {@link QuadtreeTilingScheme}.

--- a/CesiumGeometry/src/QuadtreeTileAvailability.cpp
+++ b/CesiumGeometry/src/QuadtreeTileAvailability.cpp
@@ -6,6 +6,11 @@
 
 namespace CesiumGeometry {
 
+QuadtreeTileAvailability::QuadtreeTileAvailability() noexcept
+    : QuadtreeTileAvailability(
+          QuadtreeTilingScheme(Rectangle(0.0, 0.0, 1.0, 1.0), 1, 1),
+          30) {}
+
 QuadtreeTileAvailability::QuadtreeTileAvailability(
     const QuadtreeTilingScheme& tilingScheme,
     uint32_t maximumLevel) noexcept

--- a/CesiumGeospatial/include/CesiumGeospatial/GlobeRectangle.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/GlobeRectangle.h
@@ -21,6 +21,11 @@ namespace CesiumGeospatial {
 class CESIUMGEOSPATIAL_API GlobeRectangle final {
 public:
   /**
+   * @brief Constructs a new instance with all coordinate values set to 0.0.
+   */
+  constexpr GlobeRectangle() noexcept : GlobeRectangle(0.0, 0.0, 0.0, 0.0) {}
+
+  /**
    * @brief Constructs a new instance.
    *
    * @param west The westernmost longitude, in radians, in the range [-Pi, Pi].


### PR DESCRIPTION
This is a start toward fixing #253: Add support for multiple layers of quantized mesh. It doesn't work yet because it doesn't know when to load quantized-mesh tiles from the various layers in order to learn about their availability. When I started this, I thought it would be mostly orthogonal to #355, and I think the conflict in what I've done so far is minimal. But now that I've come this far, it's clear there's a lot of overlap on this issue of loading availability information, so I'm putting this aside for the moment until after #355 is merged.

Fixes #253 
(well, it will when this is really ready to be merged)