### PR TITLE
Fix `@brief` when schema is missing description

### DIFF
--- a/CesiumGltf/include/CesiumGltf/KHR_draco_mesh_compression.h
+++ b/CesiumGltf/include/CesiumGltf/KHR_draco_mesh_compression.h
@@ -10,7 +10,7 @@
 
 namespace CesiumGltf {
 /**
- * @brief undefined
+ * @brief KHR_draco_mesh_compression extension
  */
 struct CESIUMGLTF_API KHR_draco_mesh_compression final
     : public ExtensibleObject {

--- a/CesiumGltf/include/CesiumGltf/MaterialNormalTextureInfo.h
+++ b/CesiumGltf/include/CesiumGltf/MaterialNormalTextureInfo.h
@@ -7,7 +7,7 @@
 
 namespace CesiumGltf {
 /**
- * @brief undefined
+ * @brief Material Normal Texture Info
  */
 struct CESIUMGLTF_API MaterialNormalTextureInfo final : public TextureInfo {
   static inline constexpr const char* TypeName = "MaterialNormalTextureInfo";

--- a/CesiumGltf/include/CesiumGltf/MaterialOcclusionTextureInfo.h
+++ b/CesiumGltf/include/CesiumGltf/MaterialOcclusionTextureInfo.h
@@ -7,7 +7,7 @@
 
 namespace CesiumGltf {
 /**
- * @brief undefined
+ * @brief Material Occlusion Texture Info
  */
 struct CESIUMGLTF_API MaterialOcclusionTextureInfo final : public TextureInfo {
   static inline constexpr const char* TypeName = "MaterialOcclusionTextureInfo";

--- a/tools/generate-gltf-classes/generate.js
+++ b/tools/generate-gltf-classes/generate.js
@@ -73,7 +73,7 @@ function generate(options, schema) {
 
         namespace ${namespace} {
             /**
-             * @brief ${schema.description}
+             * @brief ${schema.description ? schema.description : schema.title}
              */
             struct ${namespace.toUpperCase()}_API ${name}${thisConfig.toBeInherited ? "Spec" : (thisConfig.isBaseClass ? "" : " final")} : public ${base} {
                 static inline constexpr const char* TypeName = "${name}";


### PR DESCRIPTION
If the schema is missing a description use the title instead.