### PR TITLE
Regenerate classes for EXT_feature_metadata

### DIFF
--- a/Cesium3DTilesSelection/test/TestUpgradeBatchTableToExtFeatureMetadata.cpp
+++ b/Cesium3DTilesSelection/test/TestUpgradeBatchTableToExtFeatureMetadata.cpp
@@ -28,7 +28,7 @@ static void checkScalarProperty(
     size_t expectedTotalInstances) {
   const ClassProperty& property = metaClass.properties.at(propertyName);
   REQUIRE(property.type == expectedPropertyType);
-  REQUIRE(property.componentType.isNull());
+  REQUIRE(property.componentType == std::nullopt);
   REQUIRE(property.componentCount == std::nullopt);
 
   MetadataFeatureTableView view(&model, &featureTable);
@@ -62,7 +62,7 @@ static void checkArrayProperty(
     size_t expectedTotalInstances) {
   const ClassProperty& property = metaClass.properties.at(propertyName);
   REQUIRE(property.type == "ARRAY");
-  REQUIRE(property.componentType.getString() == expectedComponentType);
+  REQUIRE(property.componentType == expectedComponentType);
   if (expectedComponentCount > 0) {
     REQUIRE(
         property.componentCount.value() ==

--- a/CesiumGltf/include/CesiumGltf/ClassProperty.h
+++ b/CesiumGltf/include/CesiumGltf/ClassProperty.h
@@ -20,6 +20,75 @@ struct CESIUMGLTF_API ClassProperty final
   static inline constexpr const char* TypeName = "ClassProperty";
 
   /**
+   * @brief Known values for The property type. If `ENUM` is used, then
+   * `enumType` must also be specified. If `ARRAY` is used, then `componentType`
+   * must also be specified. `ARRAY` is a fixed-length array when
+   * `componentCount` is defined, and variable-length otherwise.
+   */
+  struct Type {
+    inline static const std::string INT8 = "INT8";
+
+    inline static const std::string UINT8 = "UINT8";
+
+    inline static const std::string INT16 = "INT16";
+
+    inline static const std::string UINT16 = "UINT16";
+
+    inline static const std::string INT32 = "INT32";
+
+    inline static const std::string UINT32 = "UINT32";
+
+    inline static const std::string INT64 = "INT64";
+
+    inline static const std::string UINT64 = "UINT64";
+
+    inline static const std::string FLOAT32 = "FLOAT32";
+
+    inline static const std::string FLOAT64 = "FLOAT64";
+
+    inline static const std::string BOOLEAN = "BOOLEAN";
+
+    inline static const std::string STRING = "STRING";
+
+    inline static const std::string ENUM = "ENUM";
+
+    inline static const std::string ARRAY = "ARRAY";
+  };
+
+  /**
+   * @brief Known values for When `type` is `ARRAY` this indicates the type of
+   * each component of the array. If `ENUM` is used, then `enumType` must also
+   * be specified.
+   */
+  struct ComponentType {
+    inline static const std::string INT8 = "INT8";
+
+    inline static const std::string UINT8 = "UINT8";
+
+    inline static const std::string INT16 = "INT16";
+
+    inline static const std::string UINT16 = "UINT16";
+
+    inline static const std::string INT32 = "INT32";
+
+    inline static const std::string UINT32 = "UINT32";
+
+    inline static const std::string INT64 = "INT64";
+
+    inline static const std::string UINT64 = "UINT64";
+
+    inline static const std::string FLOAT32 = "FLOAT32";
+
+    inline static const std::string FLOAT64 = "FLOAT64";
+
+    inline static const std::string BOOLEAN = "BOOLEAN";
+
+    inline static const std::string STRING = "STRING";
+
+    inline static const std::string ENUM = "ENUM";
+  };
+
+  /**
    * @brief The name of the property, e.g. for display purposes.
    */
   std::optional<std::string> name;
@@ -34,8 +103,11 @@ struct CESIUMGLTF_API ClassProperty final
    * specified. If `ARRAY` is used, then `componentType` must also be specified.
    * `ARRAY` is a fixed-length array when `componentCount` is defined, and
    * variable-length otherwise.
+   *
+   * Known values are defined in {@link Type}.
+   *
    */
-  std::string type;
+  std::string type = Type::INT8;
 
   /**
    * @brief An enum ID as declared in the `enums` dictionary. This value must be
@@ -46,8 +118,11 @@ struct CESIUMGLTF_API ClassProperty final
   /**
    * @brief When `type` is `ARRAY` this indicates the type of each component of
    * the array. If `ENUM` is used, then `enumType` must also be specified.
+   *
+   * Known values are defined in {@link ComponentType}.
+   *
    */
-  CesiumUtility::JsonValue componentType;
+  std::optional<std::string> componentType;
 
   /**
    * @brief The number of components per element for `ARRAY` elements.

--- a/CesiumGltf/include/CesiumGltf/Enum.h
+++ b/CesiumGltf/include/CesiumGltf/Enum.h
@@ -19,6 +19,27 @@ struct CESIUMGLTF_API Enum final : public CesiumUtility::ExtensibleObject {
   static inline constexpr const char* TypeName = "Enum";
 
   /**
+   * @brief Known values for The type of the integer enum value.
+   */
+  struct ValueType {
+    inline static const std::string INT8 = "INT8";
+
+    inline static const std::string UINT8 = "UINT8";
+
+    inline static const std::string INT16 = "INT16";
+
+    inline static const std::string UINT16 = "UINT16";
+
+    inline static const std::string INT32 = "INT32";
+
+    inline static const std::string UINT32 = "UINT32";
+
+    inline static const std::string INT64 = "INT64";
+
+    inline static const std::string UINT64 = "UINT64";
+  };
+
+  /**
    * @brief The name of the enum, e.g. for display purposes.
    */
   std::optional<std::string> name;
@@ -30,8 +51,11 @@ struct CESIUMGLTF_API Enum final : public CesiumUtility::ExtensibleObject {
 
   /**
    * @brief The type of the integer enum value.
+   *
+   * Known values are defined in {@link ValueType}.
+   *
    */
-  std::string valueType = "UINT16";
+  std::string valueType = ValueType::UINT16;
 
   /**
    * @brief An array of enum values. Duplicate names or duplicate integer values

--- a/CesiumGltf/include/CesiumGltf/FeatureTableProperty.h
+++ b/CesiumGltf/include/CesiumGltf/FeatureTableProperty.h
@@ -7,7 +7,6 @@
 #include <CesiumUtility/ExtensibleObject.h>
 
 #include <cstdint>
-#include <string>
 
 namespace CesiumGltf {
 /**
@@ -16,6 +15,20 @@ namespace CesiumGltf {
 struct CESIUMGLTF_API FeatureTableProperty final
     : public CesiumUtility::ExtensibleObject {
   static inline constexpr const char* TypeName = "FeatureTableProperty";
+
+  /**
+   * @brief Known values for The type of values in `arrayOffsetBufferView` and
+   * `stringOffsetBufferView`.
+   */
+  struct OffsetType {
+    inline static const std::string UINT8 = "UINT8";
+
+    inline static const std::string UINT16 = "UINT16";
+
+    inline static const std::string UINT32 = "UINT32";
+
+    inline static const std::string UINT64 = "UINT64";
+  };
 
   /**
    * @brief The index of the buffer view containing property values. The data
@@ -40,8 +53,11 @@ struct CESIUMGLTF_API FeatureTableProperty final
   /**
    * @brief The type of values in `arrayOffsetBufferView` and
    * `stringOffsetBufferView`.
+   *
+   * Known values are defined in {@link OffsetType}.
+   *
    */
-  std::string offsetType = "UINT32";
+  std::string offsetType = OffsetType::UINT32;
 
   /**
    * @brief The index of the buffer view containing offsets for variable-length

--- a/CesiumGltf/include/CesiumGltf/MetadataFeatureTableView.h
+++ b/CesiumGltf/include/CesiumGltf/MetadataFeatureTableView.h
@@ -93,9 +93,9 @@ public:
 
     PropertyType type = convertStringToPropertyType(pClassProperty->type);
     PropertyType componentType = PropertyType::None;
-    if (pClassProperty->componentType.isString()) {
-      componentType = convertStringToPropertyType(
-          pClassProperty->componentType.getString());
+    if (pClassProperty->componentType.has_value()) {
+      componentType =
+          convertStringToPropertyType(pClassProperty->componentType.value());
     }
 
     if (type != PropertyType::Array) {
@@ -108,7 +108,7 @@ public:
       getArrayPropertyViewImpl(
           propertyName,
           *pClassProperty,
-          type,
+          componentType,
           std::forward<Callback>(callback));
     }
   }
@@ -395,18 +395,18 @@ private:
   MetadataPropertyView<MetadataArrayView<T>> getPrimitiveArrayPropertyValues(
       const ClassProperty& classProperty,
       const FeatureTableProperty& featureTableProperty) const {
-    if (classProperty.type != "ARRAY") {
+    if (classProperty.type != ClassProperty::Type::ARRAY) {
       return createInvalidPropertyView<MetadataArrayView<T>>(
           MetadataPropertyViewStatus::InvalidTypeMismatch);
     }
 
-    if (!classProperty.componentType.isString()) {
+    if (!classProperty.componentType.has_value()) {
       return createInvalidPropertyView<MetadataArrayView<T>>(
           MetadataPropertyViewStatus::InvalidTypeMismatch);
     }
 
     const PropertyType componentType =
-        convertStringToPropertyType(classProperty.componentType.getString());
+        convertStringToPropertyType(classProperty.componentType.value());
     if (TypeToPropertyType<T>::value != componentType) {
       return createInvalidPropertyView<MetadataArrayView<T>>(
           MetadataPropertyViewStatus::InvalidTypeMismatch);

--- a/CesiumGltf/include/CesiumGltf/ModelEXT_feature_metadata.h
+++ b/CesiumGltf/include/CesiumGltf/ModelEXT_feature_metadata.h
@@ -29,7 +29,7 @@ struct CESIUMGLTF_API ModelEXT_feature_metadata final
   std::optional<Schema> schema;
 
   /**
-   * @brief A uri to an external schema file.
+   * @brief The URI (or IRI) of the external schema file.
    */
   std::optional<std::string> schemaUri;
 

--- a/CesiumGltf/src/MetadataFeatureTableView.cpp
+++ b/CesiumGltf/src/MetadataFeatureTableView.cpp
@@ -191,7 +191,7 @@ MetadataPropertyView<std::string_view>
 MetadataFeatureTableView::getStringPropertyValues(
     const ClassProperty& classProperty,
     const FeatureTableProperty& featureTableProperty) const {
-  if (classProperty.type != "STRING") {
+  if (classProperty.type != ClassProperty::Type::STRING) {
     return createInvalidPropertyView<std::string_view>(
         MetadataPropertyViewStatus::InvalidTypeMismatch);
   }
@@ -235,13 +235,12 @@ MetadataPropertyView<MetadataArrayView<std::string_view>>
 MetadataFeatureTableView::getStringArrayPropertyValues(
     const ClassProperty& classProperty,
     const FeatureTableProperty& featureTableProperty) const {
-  if (classProperty.type != "ARRAY") {
+  if (classProperty.type != ClassProperty::Type::ARRAY) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
         MetadataPropertyViewStatus::InvalidTypeMismatch);
   }
 
-  if (!classProperty.componentType.isString() ||
-      classProperty.componentType.getString() != "STRING") {
+  if (classProperty.componentType != ClassProperty::ComponentType::STRING) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
         MetadataPropertyViewStatus::InvalidTypeMismatch);
   }

--- a/CesiumGltf/src/PropertyType.cpp
+++ b/CesiumGltf/src/PropertyType.cpp
@@ -1,7 +1,6 @@
 #include "CesiumGltf/PropertyType.h"
 
 #include "CesiumGltf/ClassProperty.h"
-
 #include "CesiumGltf/FeatureTable.h"
 
 namespace CesiumGltf {

--- a/CesiumGltf/src/PropertyType.cpp
+++ b/CesiumGltf/src/PropertyType.cpp
@@ -1,97 +1,101 @@
 #include "CesiumGltf/PropertyType.h"
 
+#include "CesiumGltf/ClassProperty.h"
+
+#include "CesiumGltf/FeatureTable.h"
+
 namespace CesiumGltf {
 std::string convertPropertyTypeToString(CesiumGltf::PropertyType type) {
   switch (type) {
   case PropertyType::None:
     return "NONE";
   case PropertyType::Uint8:
-    return "UINT8";
+    return ClassProperty::Type::UINT8;
   case PropertyType::Int8:
-    return "INT8";
+    return ClassProperty::Type::INT8;
   case PropertyType::Uint16:
-    return "UINT16";
+    return ClassProperty::Type::UINT16;
   case PropertyType::Int16:
-    return "INT16";
+    return ClassProperty::Type::INT16;
   case PropertyType::Uint32:
-    return "UINT32";
+    return ClassProperty::Type::UINT32;
   case PropertyType::Int32:
-    return "INT32";
+    return ClassProperty::Type::INT32;
   case PropertyType::Uint64:
-    return "UINT64";
+    return ClassProperty::Type::UINT64;
   case PropertyType::Int64:
-    return "INT64";
+    return ClassProperty::Type::INT64;
   case PropertyType::Float32:
-    return "FLOAT32";
+    return ClassProperty::Type::FLOAT32;
   case PropertyType::Float64:
-    return "FLOAT64";
+    return ClassProperty::Type::FLOAT64;
   case PropertyType::Boolean:
-    return "BOOLEAN";
+    return ClassProperty::Type::BOOLEAN;
   case PropertyType::Enum:
-    return "ENUM";
+    return ClassProperty::Type::ENUM;
   case PropertyType::String:
-    return "STRING";
+    return ClassProperty::Type::STRING;
   case PropertyType::Array:
-    return "ARRAY";
+    return ClassProperty::Type::ARRAY;
   default:
     return "NONE";
   }
 }
 
 PropertyType convertStringToPropertyType(const std::string& str) {
-  if (str == "UINT8") {
+  if (str == ClassProperty::Type::UINT8) {
     return PropertyType::Uint8;
   }
 
-  if (str == "INT8") {
+  if (str == ClassProperty::Type::INT8) {
     return PropertyType::Int8;
   }
 
-  if (str == "UINT16") {
+  if (str == ClassProperty::Type::UINT16) {
     return PropertyType::Uint16;
   }
 
-  if (str == "INT16") {
+  if (str == ClassProperty::Type::INT16) {
     return PropertyType::Int16;
   }
 
-  if (str == "UINT32") {
+  if (str == ClassProperty::Type::UINT32) {
     return PropertyType::Uint32;
   }
 
-  if (str == "INT32") {
+  if (str == ClassProperty::Type::INT32) {
     return PropertyType::Int32;
   }
 
-  if (str == "UINT64") {
+  if (str == ClassProperty::Type::UINT64) {
     return PropertyType::Uint64;
   }
 
-  if (str == "INT64") {
+  if (str == ClassProperty::Type::INT64) {
     return PropertyType::Int64;
   }
 
-  if (str == "FLOAT32") {
+  if (str == ClassProperty::Type::FLOAT32) {
     return PropertyType::Float32;
   }
 
-  if (str == "FLOAT64") {
+  if (str == ClassProperty::Type::FLOAT64) {
     return PropertyType::Float64;
   }
 
-  if (str == "BOOLEAN") {
+  if (str == ClassProperty::Type::BOOLEAN) {
     return PropertyType::Boolean;
   }
 
-  if (str == "STRING") {
+  if (str == ClassProperty::Type::STRING) {
     return PropertyType::String;
   }
 
-  if (str == "ENUM") {
+  if (str == ClassProperty::Type::ENUM) {
     return PropertyType::Enum;
   }
 
-  if (str == "ARRAY") {
+  if (str == ClassProperty::Type::ARRAY) {
     return PropertyType::Array;
   }
 
@@ -99,19 +103,19 @@ PropertyType convertStringToPropertyType(const std::string& str) {
 }
 
 PropertyType convertOffsetStringToPropertyType(const std::string& str) {
-  if (str == "UINT8") {
+  if (str == FeatureTableProperty::OffsetType::UINT8) {
     return PropertyType::Uint8;
   }
 
-  if (str == "UINT16") {
+  if (str == FeatureTableProperty::OffsetType::UINT16) {
     return PropertyType::Uint16;
   }
 
-  if (str == "UINT32") {
+  if (str == FeatureTableProperty::OffsetType::UINT32) {
     return PropertyType::Uint32;
   }
 
-  if (str == "UINT64") {
+  if (str == FeatureTableProperty::OffsetType::UINT64) {
     return PropertyType::Uint64;
   }
 

--- a/CesiumGltf/test/TestMetadataFeatureTableView.cpp
+++ b/CesiumGltf/test/TestMetadataFeatureTableView.cpp
@@ -60,7 +60,7 @@ TEST_CASE("Test numeric properties") {
       view.getClassProperty("TestClassProperty");
   REQUIRE(classProperty->type == "UINT32");
   REQUIRE(classProperty->componentCount == std::nullopt);
-  REQUIRE(classProperty->componentType.isNull());
+  REQUIRE(classProperty->componentType == std::nullopt);
 
   SECTION("Access correct type") {
     MetadataPropertyView<uint32_t> uint32Property =
@@ -248,7 +248,7 @@ TEST_CASE("Test boolean properties") {
       view.getClassProperty("TestClassProperty");
   REQUIRE(classProperty->type == "BOOLEAN");
   REQUIRE(classProperty->componentCount == std::nullopt);
-  REQUIRE(classProperty->componentType.isNull());
+  REQUIRE(classProperty->componentType == std::nullopt);
 
   SECTION("Access correct type") {
     MetadataPropertyView<bool> boolProperty =
@@ -358,7 +358,7 @@ TEST_CASE("Test string property") {
       view.getClassProperty("TestClassProperty");
   REQUIRE(classProperty->type == "STRING");
   REQUIRE(classProperty->componentCount == std::nullopt);
-  REQUIRE(classProperty->componentType.isNull());
+  REQUIRE(classProperty->componentType == std::nullopt);
 
   SECTION("Access correct type") {
     MetadataPropertyView<std::string_view> stringProperty =
@@ -473,7 +473,7 @@ TEST_CASE("Test fixed numeric array") {
       view.getClassProperty("TestClassProperty");
   REQUIRE(classProperty->type == "ARRAY");
   REQUIRE(classProperty->componentCount == 3);
-  REQUIRE(classProperty->componentType.getString() == "UINT32");
+  REQUIRE(classProperty->componentType == "UINT32");
 
   SECTION("Access the right type") {
     MetadataPropertyView<MetadataArrayView<uint32_t>> arrayProperty =
@@ -613,7 +613,7 @@ TEST_CASE("Test dynamic numeric array") {
   const ClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(classProperty->type == "ARRAY");
-  REQUIRE(classProperty->componentType.getString() == "UINT16");
+  REQUIRE(classProperty->componentType == "UINT16");
 
   SECTION("Access the correct type") {
     MetadataPropertyView<MetadataArrayView<uint16_t>> property =
@@ -716,7 +716,7 @@ TEST_CASE("Test fixed boolean array") {
       view.getClassProperty("TestClassProperty");
   REQUIRE(classProperty->type == "ARRAY");
   REQUIRE(classProperty->componentCount == 3);
-  REQUIRE(classProperty->componentType.getString() == "BOOLEAN");
+  REQUIRE(classProperty->componentType == "BOOLEAN");
 
   SECTION("Access correct type") {
     MetadataPropertyView<MetadataArrayView<bool>> boolProperty =
@@ -845,7 +845,7 @@ TEST_CASE("Test dynamic bool array") {
   const ClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(classProperty->type == "ARRAY");
-  REQUIRE(classProperty->componentType.getString() == "BOOLEAN");
+  REQUIRE(classProperty->componentType == "BOOLEAN");
 
   SECTION("Access correct type") {
     MetadataPropertyView<MetadataArrayView<bool>> boolProperty =
@@ -962,7 +962,7 @@ TEST_CASE("Test fixed array of string") {
       view.getClassProperty("TestClassProperty");
   REQUIRE(classProperty->type == "ARRAY");
   REQUIRE(classProperty->componentCount == 2);
-  REQUIRE(classProperty->componentType.getString() == "STRING");
+  REQUIRE(classProperty->componentType == "STRING");
 
   SECTION("Access correct type") {
     MetadataPropertyView<MetadataArrayView<std::string_view>> stringProperty =
@@ -1139,7 +1139,7 @@ TEST_CASE("Test dynamic array of string") {
   const ClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(classProperty->type == "ARRAY");
-  REQUIRE(classProperty->componentType.getString() == "STRING");
+  REQUIRE(classProperty->componentType == "STRING");
 
   SECTION("Access correct type") {
     MetadataPropertyView<MetadataArrayView<std::string_view>> stringProperty =

--- a/CesiumGltf/test/TestMetadataFeatureTableView.cpp
+++ b/CesiumGltf/test/TestMetadataFeatureTableView.cpp
@@ -42,7 +42,7 @@ TEST_CASE("Test numeric properties") {
   Schema& schema = metadata.schema.emplace();
   Class& testClass = schema.classes["TestClass"];
   ClassProperty& testClassProperty = testClass.properties["TestClassProperty"];
-  testClassProperty.type = "UINT32";
+  testClassProperty.type = ClassProperty::Type::UINT32;
 
   // setup feature table
   FeatureTable& featureTable = metadata.featureTables["TestFeatureTable"];
@@ -58,7 +58,7 @@ TEST_CASE("Test numeric properties") {
   MetadataFeatureTableView view(&model, &featureTable);
   const ClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
-  REQUIRE(classProperty->type == "UINT32");
+  REQUIRE(classProperty->type == ClassProperty::Type::UINT32);
   REQUIRE(classProperty->componentCount == std::nullopt);
   REQUIRE(classProperty->componentType == std::nullopt);
 
@@ -229,7 +229,7 @@ TEST_CASE("Test boolean properties") {
   Schema& schema = metadata.schema.emplace();
   Class& testClass = schema.classes["TestClass"];
   ClassProperty& testClassProperty = testClass.properties["TestClassProperty"];
-  testClassProperty.type = "BOOLEAN";
+  testClassProperty.type = ClassProperty::Type::BOOLEAN;
 
   // setup feature table
   FeatureTable& featureTable = metadata.featureTables["TestFeatureTable"];
@@ -246,7 +246,7 @@ TEST_CASE("Test boolean properties") {
   MetadataFeatureTableView view(&model, &featureTable);
   const ClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
-  REQUIRE(classProperty->type == "BOOLEAN");
+  REQUIRE(classProperty->type == ClassProperty::Type::BOOLEAN);
   REQUIRE(classProperty->componentCount == std::nullopt);
   REQUIRE(classProperty->componentType == std::nullopt);
 
@@ -337,7 +337,7 @@ TEST_CASE("Test string property") {
   Schema& schema = metadata.schema.emplace();
   Class& testClass = schema.classes["TestClass"];
   ClassProperty& testClassProperty = testClass.properties["TestClassProperty"];
-  testClassProperty.type = "STRING";
+  testClassProperty.type = ClassProperty::Type::STRING;
 
   // setup feature table
   FeatureTable& featureTable = metadata.featureTables["TestFeatureTable"];
@@ -347,7 +347,7 @@ TEST_CASE("Test string property") {
   // setup feature table property
   FeatureTableProperty& featureTableProperty =
       featureTable.properties["TestClassProperty"];
-  featureTableProperty.offsetType = "UINT32";
+  featureTableProperty.offsetType = FeatureTableProperty::OffsetType::UINT32;
   featureTableProperty.bufferView = static_cast<int32_t>(valueBufferViewIndex);
   featureTableProperty.stringOffsetBufferView =
       static_cast<int32_t>(offsetBufferViewIndex);
@@ -356,7 +356,7 @@ TEST_CASE("Test string property") {
   MetadataFeatureTableView view(&model, &featureTable);
   const ClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
-  REQUIRE(classProperty->type == "STRING");
+  REQUIRE(classProperty->type == ClassProperty::Type::STRING);
   REQUIRE(classProperty->componentCount == std::nullopt);
   REQUIRE(classProperty->componentType == std::nullopt);
 
@@ -370,14 +370,14 @@ TEST_CASE("Test string property") {
   }
 
   SECTION("Wrong offset type") {
-    featureTableProperty.offsetType = "UINT8";
+    featureTableProperty.offsetType = FeatureTableProperty::OffsetType::UINT8;
     MetadataPropertyView<std::string_view> stringProperty =
         view.getPropertyView<std::string_view>("TestClassProperty");
     REQUIRE(
         stringProperty.status() ==
         MetadataPropertyViewStatus::InvalidBufferViewSizeNotFitInstanceCount);
 
-    featureTableProperty.offsetType = "UINT64";
+    featureTableProperty.offsetType = FeatureTableProperty::OffsetType::UINT64;
     stringProperty =
         view.getPropertyView<std::string_view>("TestClassProperty");
     REQUIRE(
@@ -450,8 +450,8 @@ TEST_CASE("Test fixed numeric array") {
   Schema& schema = metadata.schema.emplace();
   Class& testClass = schema.classes["TestClass"];
   ClassProperty& testClassProperty = testClass.properties["TestClassProperty"];
-  testClassProperty.type = "ARRAY";
-  testClassProperty.componentType = "UINT32";
+  testClassProperty.type = ClassProperty::Type::ARRAY;
+  testClassProperty.componentType = ClassProperty::ComponentType::UINT32;
   testClassProperty.componentCount = 3;
 
   // setup feature table
@@ -471,9 +471,9 @@ TEST_CASE("Test fixed numeric array") {
   MetadataFeatureTableView view(&model, &featureTable);
   const ClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
-  REQUIRE(classProperty->type == "ARRAY");
+  REQUIRE(classProperty->type == ClassProperty::Type::ARRAY);
   REQUIRE(classProperty->componentCount == 3);
-  REQUIRE(classProperty->componentType == "UINT32");
+  REQUIRE(classProperty->componentType == ClassProperty::ComponentType::UINT32);
 
   SECTION("Access the right type") {
     MetadataPropertyView<MetadataArrayView<uint32_t>> arrayProperty =
@@ -489,7 +489,7 @@ TEST_CASE("Test fixed numeric array") {
   }
 
   SECTION("Wrong component type") {
-    testClassProperty.componentType = "UINT8";
+    testClassProperty.componentType = ClassProperty::ComponentType::UINT8;
     MetadataPropertyView<MetadataArrayView<uint32_t>> arrayProperty =
         view.getPropertyView<MetadataArrayView<uint32_t>>("TestClassProperty");
     REQUIRE(
@@ -592,8 +592,8 @@ TEST_CASE("Test dynamic numeric array") {
   Schema& schema = metadata.schema.emplace();
   Class& testClass = schema.classes["TestClass"];
   ClassProperty& testClassProperty = testClass.properties["TestClassProperty"];
-  testClassProperty.type = "ARRAY";
-  testClassProperty.componentType = "UINT16";
+  testClassProperty.type = ClassProperty::Type::ARRAY;
+  testClassProperty.componentType = ClassProperty::ComponentType::UINT16;
 
   // setup feature table
   FeatureTable& featureTable = metadata.featureTables["TestFeatureTable"];
@@ -606,14 +606,14 @@ TEST_CASE("Test dynamic numeric array") {
   featureTableProperty.bufferView = static_cast<int32_t>(valueBufferViewIndex);
   featureTableProperty.arrayOffsetBufferView =
       static_cast<int32_t>(offsetBufferViewIndex);
-  featureTableProperty.offsetType = "UINT64";
+  featureTableProperty.offsetType = FeatureTableProperty::OffsetType::UINT64;
 
   // test feature table view
   MetadataFeatureTableView view(&model, &featureTable);
   const ClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
-  REQUIRE(classProperty->type == "ARRAY");
-  REQUIRE(classProperty->componentType == "UINT16");
+  REQUIRE(classProperty->type == ClassProperty::Type::ARRAY);
+  REQUIRE(classProperty->componentType == ClassProperty::ComponentType::UINT16);
 
   SECTION("Access the correct type") {
     MetadataPropertyView<MetadataArrayView<uint16_t>> property =
@@ -693,8 +693,8 @@ TEST_CASE("Test fixed boolean array") {
   Schema& schema = metadata.schema.emplace();
   Class& testClass = schema.classes["TestClass"];
   ClassProperty& testClassProperty = testClass.properties["TestClassProperty"];
-  testClassProperty.type = "ARRAY";
-  testClassProperty.componentType = "BOOLEAN";
+  testClassProperty.type = ClassProperty::Type::ARRAY;
+  testClassProperty.componentType = ClassProperty::ComponentType::BOOLEAN;
   testClassProperty.componentCount = 3;
 
   // setup feature table
@@ -714,9 +714,10 @@ TEST_CASE("Test fixed boolean array") {
   MetadataFeatureTableView view(&model, &featureTable);
   const ClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
-  REQUIRE(classProperty->type == "ARRAY");
+  REQUIRE(classProperty->type == ClassProperty::Type::ARRAY);
   REQUIRE(classProperty->componentCount == 3);
-  REQUIRE(classProperty->componentType == "BOOLEAN");
+  REQUIRE(
+      classProperty->componentType == ClassProperty::ComponentType::BOOLEAN);
 
   SECTION("Access correct type") {
     MetadataPropertyView<MetadataArrayView<bool>> boolProperty =
@@ -824,8 +825,8 @@ TEST_CASE("Test dynamic bool array") {
   Schema& schema = metadata.schema.emplace();
   Class& testClass = schema.classes["TestClass"];
   ClassProperty& testClassProperty = testClass.properties["TestClassProperty"];
-  testClassProperty.type = "ARRAY";
-  testClassProperty.componentType = "BOOLEAN";
+  testClassProperty.type = ClassProperty::Type::ARRAY;
+  testClassProperty.componentType = ClassProperty::ComponentType::BOOLEAN;
 
   // setup feature table
   FeatureTable& featureTable = metadata.featureTables["TestFeatureTable"];
@@ -838,14 +839,15 @@ TEST_CASE("Test dynamic bool array") {
   featureTableProperty.bufferView = static_cast<int32_t>(valueBufferViewIndex);
   featureTableProperty.arrayOffsetBufferView =
       static_cast<int32_t>(offsetBufferViewIndex);
-  featureTableProperty.offsetType = "UINT64";
+  featureTableProperty.offsetType = FeatureTableProperty::OffsetType::UINT64;
 
   // test feature table view
   MetadataFeatureTableView view(&model, &featureTable);
   const ClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
-  REQUIRE(classProperty->type == "ARRAY");
-  REQUIRE(classProperty->componentType == "BOOLEAN");
+  REQUIRE(classProperty->type == ClassProperty::Type::ARRAY);
+  REQUIRE(
+      classProperty->componentType == ClassProperty::ComponentType::BOOLEAN);
 
   SECTION("Access correct type") {
     MetadataPropertyView<MetadataArrayView<bool>> boolProperty =
@@ -937,8 +939,8 @@ TEST_CASE("Test fixed array of string") {
   Schema& schema = metadata.schema.emplace();
   Class& testClass = schema.classes["TestClass"];
   ClassProperty& testClassProperty = testClass.properties["TestClassProperty"];
-  testClassProperty.type = "ARRAY";
-  testClassProperty.componentType = "STRING";
+  testClassProperty.type = ClassProperty::Type::ARRAY;
+  testClassProperty.componentType = ClassProperty::ComponentType::STRING;
   testClassProperty.componentCount = 2;
 
   // setup feature table
@@ -951,7 +953,7 @@ TEST_CASE("Test fixed array of string") {
   // setup feature table property
   FeatureTableProperty& featureTableProperty =
       featureTable.properties["TestClassProperty"];
-  featureTableProperty.offsetType = "UINT32";
+  featureTableProperty.offsetType = FeatureTableProperty::OffsetType::UINT32;
   featureTableProperty.bufferView = static_cast<int32_t>(valueBufferViewIndex);
   featureTableProperty.stringOffsetBufferView =
       static_cast<int32_t>(offsetBufferViewIndex);
@@ -960,9 +962,9 @@ TEST_CASE("Test fixed array of string") {
   MetadataFeatureTableView view(&model, &featureTable);
   const ClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
-  REQUIRE(classProperty->type == "ARRAY");
+  REQUIRE(classProperty->type == ClassProperty::Type::ARRAY);
   REQUIRE(classProperty->componentCount == 2);
-  REQUIRE(classProperty->componentType == "STRING");
+  REQUIRE(classProperty->componentType == ClassProperty::ComponentType::STRING);
 
   SECTION("Access correct type") {
     MetadataPropertyView<MetadataArrayView<std::string_view>> stringProperty =
@@ -999,7 +1001,7 @@ TEST_CASE("Test fixed array of string") {
   }
 
   SECTION("Offset type is unknown") {
-    featureTableProperty.offsetType = "INT8";
+    featureTableProperty.offsetType = "NONSENSE";
     MetadataPropertyView<MetadataArrayView<std::string_view>> stringProperty =
         view.getPropertyView<MetadataArrayView<std::string_view>>(
             "TestClassProperty");
@@ -1116,8 +1118,8 @@ TEST_CASE("Test dynamic array of string") {
   Schema& schema = metadata.schema.emplace();
   Class& testClass = schema.classes["TestClass"];
   ClassProperty& testClassProperty = testClass.properties["TestClassProperty"];
-  testClassProperty.type = "ARRAY";
-  testClassProperty.componentType = "STRING";
+  testClassProperty.type = ClassProperty::Type::ARRAY;
+  testClassProperty.componentType = ClassProperty::ComponentType::STRING;
 
   // setup feature table
   FeatureTable& featureTable = metadata.featureTables["TestFeatureTable"];
@@ -1127,7 +1129,7 @@ TEST_CASE("Test dynamic array of string") {
   // setup feature table property
   FeatureTableProperty& featureTableProperty =
       featureTable.properties["TestClassProperty"];
-  featureTableProperty.offsetType = "UINT32";
+  featureTableProperty.offsetType = FeatureTableProperty::OffsetType::UINT32;
   featureTableProperty.bufferView = static_cast<int32_t>(valueBufferViewIndex);
   featureTableProperty.arrayOffsetBufferView =
       static_cast<int32_t>(offsetBufferViewIndex);
@@ -1138,8 +1140,8 @@ TEST_CASE("Test dynamic array of string") {
   MetadataFeatureTableView view(&model, &featureTable);
   const ClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
-  REQUIRE(classProperty->type == "ARRAY");
-  REQUIRE(classProperty->componentType == "STRING");
+  REQUIRE(classProperty->type == ClassProperty::Type::ARRAY);
+  REQUIRE(classProperty->componentType == ClassProperty::ComponentType::STRING);
 
   SECTION("Access correct type") {
     MetadataPropertyView<MetadataArrayView<std::string_view>> stringProperty =

--- a/CesiumGltf/test/TestPropertyType.cpp
+++ b/CesiumGltf/test/TestPropertyType.cpp
@@ -1,147 +1,140 @@
+#include "CesiumGltf/ClassProperty.h"
+#include "CesiumGltf/FeatureTableProperty.h"
 #include "CesiumGltf/PropertyType.h"
 
 #include <catch2/catch.hpp>
 
+using namespace CesiumGltf;
+
 TEST_CASE("Test PropertyType utilities function") {
   SECTION("Convert string to PropertyType") {
     REQUIRE(
-        CesiumGltf::convertStringToPropertyType("UINT8") ==
-        CesiumGltf::PropertyType::Uint8);
+        convertStringToPropertyType(ClassProperty::Type::UINT8) ==
+        PropertyType::Uint8);
 
     REQUIRE(
-        CesiumGltf::convertStringToPropertyType("INT8") ==
-        CesiumGltf::PropertyType::Int8);
+        convertStringToPropertyType(ClassProperty::Type::INT8) ==
+        PropertyType::Int8);
 
     REQUIRE(
-        CesiumGltf::convertStringToPropertyType("UINT16") ==
-        CesiumGltf::PropertyType::Uint16);
+        convertStringToPropertyType(ClassProperty::Type::UINT16) ==
+        PropertyType::Uint16);
 
     REQUIRE(
-        CesiumGltf::convertStringToPropertyType("INT16") ==
-        CesiumGltf::PropertyType::Int16);
+        convertStringToPropertyType(ClassProperty::Type::INT16) ==
+        PropertyType::Int16);
 
     REQUIRE(
-        CesiumGltf::convertStringToPropertyType("UINT32") ==
-        CesiumGltf::PropertyType::Uint32);
+        convertStringToPropertyType(ClassProperty::Type::UINT32) ==
+        PropertyType::Uint32);
 
     REQUIRE(
-        CesiumGltf::convertStringToPropertyType("INT32") ==
-        CesiumGltf::PropertyType::Int32);
+        convertStringToPropertyType(ClassProperty::Type::INT32) ==
+        PropertyType::Int32);
 
     REQUIRE(
-        CesiumGltf::convertStringToPropertyType("UINT64") ==
-        CesiumGltf::PropertyType::Uint64);
+        convertStringToPropertyType(ClassProperty::Type::UINT64) ==
+        PropertyType::Uint64);
 
     REQUIRE(
-        CesiumGltf::convertStringToPropertyType("INT64") ==
-        CesiumGltf::PropertyType::Int64);
+        convertStringToPropertyType(ClassProperty::Type::INT64) ==
+        PropertyType::Int64);
 
     REQUIRE(
-        CesiumGltf::convertStringToPropertyType("FLOAT32") ==
-        CesiumGltf::PropertyType::Float32);
+        convertStringToPropertyType(ClassProperty::Type::FLOAT32) ==
+        PropertyType::Float32);
 
     REQUIRE(
-        CesiumGltf::convertStringToPropertyType("FLOAT64") ==
-        CesiumGltf::PropertyType::Float64);
+        convertStringToPropertyType(ClassProperty::Type::FLOAT64) ==
+        PropertyType::Float64);
 
     REQUIRE(
-        CesiumGltf::convertStringToPropertyType("STRING") ==
-        CesiumGltf::PropertyType::String);
+        convertStringToPropertyType(ClassProperty::Type::STRING) ==
+        PropertyType::String);
 
     REQUIRE(
-        CesiumGltf::convertStringToPropertyType("BOOLEAN") ==
-        CesiumGltf::PropertyType::Boolean);
+        convertStringToPropertyType(ClassProperty::Type::BOOLEAN) ==
+        PropertyType::Boolean);
 
     REQUIRE(
-        CesiumGltf::convertStringToPropertyType("ARRAY") ==
-        CesiumGltf::PropertyType::Array);
+        convertStringToPropertyType(ClassProperty::Type::ARRAY) ==
+        PropertyType::Array);
 
-    REQUIRE(
-        CesiumGltf::convertStringToPropertyType("NONESENSE") ==
-        CesiumGltf::PropertyType::None);
+    REQUIRE(convertStringToPropertyType("NONESENSE") == PropertyType::None);
   }
 
   SECTION("PropertyType to String") {
     REQUIRE(
-        CesiumGltf::convertPropertyTypeToString(
-            CesiumGltf::PropertyType::Uint8) == "UINT8");
+        convertPropertyTypeToString(PropertyType::Uint8) ==
+        ClassProperty::Type::UINT8);
 
     REQUIRE(
-        CesiumGltf::convertPropertyTypeToString(
-            CesiumGltf::PropertyType::Int8) == "INT8");
+        convertPropertyTypeToString(PropertyType::Int8) ==
+        ClassProperty::Type::INT8);
 
     REQUIRE(
-        CesiumGltf::convertPropertyTypeToString(
-            CesiumGltf::PropertyType::Uint16) == "UINT16");
+        convertPropertyTypeToString(PropertyType::Uint16) ==
+        ClassProperty::Type::UINT16);
 
     REQUIRE(
-        CesiumGltf::convertPropertyTypeToString(
-            CesiumGltf::PropertyType::Int16) == "INT16");
+        convertPropertyTypeToString(PropertyType::Int16) ==
+        ClassProperty::Type::INT16);
 
     REQUIRE(
-        CesiumGltf::convertPropertyTypeToString(
-            CesiumGltf::PropertyType::Uint32) == "UINT32");
+        convertPropertyTypeToString(PropertyType::Uint32) ==
+        ClassProperty::Type::UINT32);
 
     REQUIRE(
-        CesiumGltf::convertPropertyTypeToString(
-            CesiumGltf::PropertyType::Int32) == "INT32");
+        convertPropertyTypeToString(PropertyType::Int32) ==
+        ClassProperty::Type::INT32);
 
     REQUIRE(
-        CesiumGltf::convertPropertyTypeToString(
-            CesiumGltf::PropertyType::Uint64) == "UINT64");
+        convertPropertyTypeToString(PropertyType::Uint64) ==
+        ClassProperty::Type::UINT64);
 
     REQUIRE(
-        CesiumGltf::convertPropertyTypeToString(
-            CesiumGltf::PropertyType::Int64) == "INT64");
+        convertPropertyTypeToString(PropertyType::Int64) ==
+        ClassProperty::Type::INT64);
 
     REQUIRE(
-        CesiumGltf::convertPropertyTypeToString(
-            CesiumGltf::PropertyType::Float32) == "FLOAT32");
+        convertPropertyTypeToString(PropertyType::Float32) ==
+        ClassProperty::Type::FLOAT32);
 
     REQUIRE(
-        CesiumGltf::convertPropertyTypeToString(
-            CesiumGltf::PropertyType::Float64) == "FLOAT64");
+        convertPropertyTypeToString(PropertyType::Float64) ==
+        ClassProperty::Type::FLOAT64);
 
     REQUIRE(
-        CesiumGltf::convertPropertyTypeToString(
-            CesiumGltf::PropertyType::String) == "STRING");
+        convertPropertyTypeToString(PropertyType::String) ==
+        ClassProperty::Type::STRING);
 
     REQUIRE(
-        CesiumGltf::convertPropertyTypeToString(
-            CesiumGltf::PropertyType::Boolean) == "BOOLEAN");
+        convertPropertyTypeToString(PropertyType::Boolean) ==
+        ClassProperty::Type::BOOLEAN);
 
     REQUIRE(
-        CesiumGltf::convertPropertyTypeToString(
-            CesiumGltf::PropertyType::Array) == "ARRAY");
+        convertPropertyTypeToString(PropertyType::Array) ==
+        ClassProperty::Type::ARRAY);
   }
 
   SECTION("OffsetString to PropertyType") {
     REQUIRE(
-        CesiumGltf::convertOffsetStringToPropertyType("UINT8") ==
-        CesiumGltf::PropertyType::Uint8);
+        convertOffsetStringToPropertyType(
+            FeatureTableProperty::OffsetType::UINT8) == PropertyType::Uint8);
 
     REQUIRE(
-        CesiumGltf::convertOffsetStringToPropertyType("UINT16") ==
-        CesiumGltf::PropertyType::Uint16);
+        convertOffsetStringToPropertyType(
+            FeatureTableProperty::OffsetType::UINT16) == PropertyType::Uint16);
 
     REQUIRE(
-        CesiumGltf::convertOffsetStringToPropertyType("UINT32") ==
-        CesiumGltf::PropertyType::Uint32);
+        convertOffsetStringToPropertyType(
+            FeatureTableProperty::OffsetType::UINT32) == PropertyType::Uint32);
 
     REQUIRE(
-        CesiumGltf::convertOffsetStringToPropertyType("UINT64") ==
-        CesiumGltf::PropertyType::Uint64);
+        convertOffsetStringToPropertyType(
+            FeatureTableProperty::OffsetType::UINT64) == PropertyType::Uint64);
 
     REQUIRE(
-        CesiumGltf::convertOffsetStringToPropertyType("BOOLEAN") ==
-        CesiumGltf::PropertyType::None);
-
-    REQUIRE(
-        CesiumGltf::convertOffsetStringToPropertyType("ARRAY") ==
-        CesiumGltf::PropertyType::None);
-
-    REQUIRE(
-        CesiumGltf::convertOffsetStringToPropertyType("NONESENSE") ==
-        CesiumGltf::PropertyType::None);
+        convertOffsetStringToPropertyType("NONESENSE") == PropertyType::None);
   }
 }

--- a/CesiumGltfReader/generated/ClassPropertyJsonHandler.h
+++ b/CesiumGltfReader/generated/ClassPropertyJsonHandler.h
@@ -37,7 +37,7 @@ private:
   CesiumJsonReader::StringJsonHandler _description;
   CesiumJsonReader::StringJsonHandler _type;
   CesiumJsonReader::StringJsonHandler _enumType;
-  CesiumJsonReader::JsonObjectJsonHandler _componentType;
+  CesiumJsonReader::StringJsonHandler _componentType;
   CesiumJsonReader::IntegerJsonHandler<int64_t> _componentCount;
   CesiumJsonReader::BoolJsonHandler _normalized;
   CesiumJsonReader::JsonObjectJsonHandler _max;

--- a/tools/generate-classes/glTF.json
+++ b/tools/generate-classes/glTF.json
@@ -35,7 +35,7 @@
         {
             "className": "ModelEXT_feature_metadata",
             "extensionName": "EXT_feature_metadata",
-            "schema": "Vendor/EXT_feature_metadata/schema/gltf.EXT_feature_metadata.schema.json",
+            "schema": "Vendor/EXT_feature_metadata/schema/glTF.EXT_feature_metadata.schema.json",
             "attachTo": [
                 "glTF"
             ]


### PR DESCRIPTION
After cleaning up the `EXT_feature_metadata` schema in https://github.com/CesiumGS/glTF/pull/29 there were a few good changes that the code generator picked up - `Type`, `ComponentType`, and `OffsetType` are now "real" types instead of `CesiumUtility::JsonValue`. Updated the code to use these types instead of hardcoded strings.