### PR TITLE
Fixes handling of reserved c++ keywords in gltf reader generator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 ##### Fixes :wrench:
 
 - Errors and warnings that occur while loading glTF textures are now include in the model load errors and warnings.
+- Fixes how `generate-classes` deals with reserved C++ keywords. Property names that are C++ keywords should be appended with "Property" as was already done,
+but when parsing JSONs the original property name string should be used. 
 
 ### v0.8.0 - 2021-10-01
 

--- a/CesiumGltf/include/CesiumGltf/FeatureTexture.h
+++ b/CesiumGltf/include/CesiumGltf/FeatureTexture.h
@@ -7,7 +7,6 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
-#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -25,7 +24,7 @@ struct CESIUMGLTF_API FeatureTexture final
    * @brief The class this feature texture conforms to. The value must be a
    * class ID declared in the `classes` dictionary.
    */
-  std::optional<std::string> classProperty;
+  std::string classProperty;
 
   /**
    * @brief A dictionary, where each key corresponds to a property ID in the

--- a/CesiumGltfReader/generated/GeneratedJsonHandlers.cpp
+++ b/CesiumGltfReader/generated/GeneratedJsonHandlers.cpp
@@ -480,8 +480,8 @@ FeatureTextureJsonHandler::readObjectKeyFeatureTexture(
     FeatureTexture& o) {
   using namespace std::string_literals;
 
-  if ("classProperty"s == str)
-    return property("classProperty", this->_classProperty, o.classProperty);
+  if ("class"s == str)
+    return property("class", this->_classProperty, o.classProperty);
   if ("properties"s == str)
     return property("properties", this->_properties, o.properties);
 
@@ -528,8 +528,8 @@ FeatureTableJsonHandler::readObjectKeyFeatureTable(
     FeatureTable& o) {
   using namespace std::string_literals;
 
-  if ("classProperty"s == str)
-    return property("classProperty", this->_classProperty, o.classProperty);
+  if ("class"s == str)
+    return property("class", this->_classProperty, o.classProperty);
   if ("count"s == str)
     return property("count", this->_count, o.count);
   if ("properties"s == str)
@@ -1018,11 +1018,8 @@ ClassPropertyJsonHandler::readObjectKeyClassProperty(
     return property("max", this->_max, o.max);
   if ("min"s == str)
     return property("min", this->_min, o.min);
-  if ("defaultProperty"s == str)
-    return property(
-        "defaultProperty",
-        this->_defaultProperty,
-        o.defaultProperty);
+  if ("default"s == str)
+    return property("default", this->_defaultProperty, o.defaultProperty);
   if ("optional"s == str)
     return property("optional", this->_optional, o.optional);
   if ("semantic"s == str)

--- a/tools/generate-classes/generate.js
+++ b/tools/generate-classes/generate.js
@@ -226,7 +226,7 @@ function generate(options, schema) {
     const initializerList = properties
       .filter((p) => p.readerType.toLowerCase().indexOf("jsonhandler") != -1)
       .map(
-        (p) => `_${p.name}(${p.schemas && p.schemas.length > 0 ? varName : ""})`
+        (p) => `_${p.cppSafeName}(${p.schemas && p.schemas.length > 0 ? varName : ""})`
       )
       .join(", ");
     return initializerList == "" ? "" : ", " + initializerList;
@@ -308,14 +308,14 @@ function formatProperty(property) {
 
   let result = "";
 
-  result += `/**\n * @brief ${property.briefDoc || property.name}\n`;
+  result += `/**\n * @brief ${property.briefDoc || property.cppSafeName}\n`;
   if (property.fullDoc) {
     result += ` *\n * ${property.fullDoc.split("\n").join("\n * ")}\n`;
   }
 
   result += ` */\n`;
 
-  result += `${property.type} ${property.name}`;
+  result += `${property.type} ${property.cppSafeName}`;
 
   if (property.defaultValue !== undefined) {
     result += " = " + property.defaultValue;
@@ -329,11 +329,11 @@ function formatProperty(property) {
 }
 
 function formatReaderProperty(property) {
-  return `${property.readerType} _${property.name};`;
+  return `${property.readerType} _${property.cppSafeName};`;
 }
 
 function formatReaderPropertyImpl(property) {
-  return `if ("${property.name}"s == str) return property("${property.name}", this->_${property.name}, o.${property.name});`;
+  return `if ("${property.name}"s == str) return property("${property.name}", this->_${property.cppSafeName}, o.${property.cppSafeName});`;
 }
 
 function privateSpecConstructor(name) {


### PR DESCRIPTION
Properties with names that are reserved C++ keywords are appended with "Property" so that they do not cause issues in the C++ GltfReader code. But when actually parsing a gltf we should check the JSON for the original string, even if it is a C++ keyword. 