### PR TITLE
Added stricter GLM defines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,10 +92,12 @@ function(configure_cesium_library targetName)
         CXX_EXTENSIONS NO
     )
 
-    target_compile_definitions( ${targetName} PUBLIC
-        GLM_FORCE_XYZW_ONLY # Disable .rgba and .stpq to make it easier to view values from debugger
-        GLM_FORCE_EXPLICIT_CTOR # Disallow implicit conversions between dvec3 <-> dvec4, dvec3 <-> fvec3, etc
-        GLM_FORCE_SIZE_T_LENGTH # Make vec.length() and vec[idx] use size_t instead of int
+    target_compile_definitions(
+        ${targetName}
+        PUBLIC
+            GLM_FORCE_XYZW_ONLY # Disable .rgba and .stpq to make it easier to view values from debugger
+            GLM_FORCE_EXPLICIT_CTOR # Disallow implicit conversions between dvec3 <-> dvec4, dvec3 <-> fvec3, etc
+            GLM_FORCE_SIZE_T_LENGTH # Make vec.length() and vec[idx] use size_t instead of int
     )
 
     if (BUILD_SHARED_LIBS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ function(configure_cesium_library targetName)
         CXX_EXTENSIONS NO
     )
 
-    target_compile_definitions( ${targetName} PRIVATE
+    target_compile_definitions( ${targetName} PUBLIC
         GLM_FORCE_XYZW_ONLY # Disable .rgba and .stpq to make it easier to view values from debugger
         GLM_FORCE_EXPLICIT_CTOR # Disallow implicit conversions between dvec3 <-> dvec4, dvec3 <-> fvec3, etc
         GLM_FORCE_SIZE_T_LENGTH # Make vec.length() and vec[idx] use size_t instead of int

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,12 @@ function(configure_cesium_library targetName)
         CXX_EXTENSIONS NO
     )
 
+    target_compile_definitions( ${targetName} PRIVATE
+        GLM_FORCE_XYZW_ONLY # Disable .rgba and .stpq to make it easier to view values from debugger
+        GLM_FORCE_EXPLICIT_CTOR # Disallow implicit conversions between dvec3 <-> dvec4, dvec3 <-> fvec3, etc
+        GLM_FORCE_SIZE_T_LENGTH # Make vec.length() and vec[idx] use size_t instead of int
+    )
+
     if (BUILD_SHARED_LIBS)
         target_compile_definitions(
             ${targetName}

--- a/Cesium3DTilesSelection/src/BoundingVolume.cpp
+++ b/Cesium3DTilesSelection/src/BoundingVolume.cpp
@@ -13,7 +13,7 @@ BoundingVolume transformBoundingVolume(
 
     BoundingVolume operator()(const OrientedBoundingBox& boundingBox) {
       const glm::dvec3 center =
-          transform * glm::dvec4(boundingBox.getCenter(), 1.0);
+          glm::dvec3(transform * glm::dvec4(boundingBox.getCenter(), 1.0));
       const glm::dmat3 halfAxes =
           glm::dmat3(transform) * boundingBox.getHalfAxes();
       return OrientedBoundingBox(center, halfAxes);
@@ -26,7 +26,7 @@ BoundingVolume transformBoundingVolume(
 
     BoundingVolume operator()(const BoundingSphere& boundingSphere) {
       const glm::dvec3 center =
-          transform * glm::dvec4(boundingSphere.getCenter(), 1.0);
+          glm::dvec3(transform * glm::dvec4(boundingSphere.getCenter(), 1.0));
 
       const double uniformScale = glm::max(
           glm::max(

--- a/Cesium3DTilesSelection/src/GltfContent.cpp
+++ b/Cesium3DTilesSelection/src/GltfContent.cpp
@@ -120,7 +120,8 @@ static int generateOverlayTextureCoordinates(
   for (int64_t i = 0; i < positionView.size(); ++i) {
     // Get the ECEF position
     const glm::vec3 position = positionView[i];
-    const glm::dvec3 positionEcef = transform * glm::dvec4(position, 1.0);
+    const glm::dvec3 positionEcef =
+        glm::dvec3(transform * glm::dvec4(position, 1.0));
 
     // Convert it to cartographic
     std::optional<CesiumGeospatial::Cartographic> cartographic =
@@ -156,9 +157,9 @@ static int generateOverlayTextureCoordinates(
           projectPosition(projection, cartographic.value());
 
       const double distance1 =
-          rectangle.computeSignedDistance(projectedPosition);
+          rectangle.computeSignedDistance(glm::dvec2(projectedPosition));
       const double distance2 =
-          rectangle.computeSignedDistance(projectedPosition2);
+          rectangle.computeSignedDistance(glm::dvec2(projectedPosition2));
 
       if (distance2 < distance1) {
         projectedPosition = projectedPosition2;

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -32,7 +32,7 @@ Tile::Tile() noexcept
     : _pContext(nullptr),
       _pParent(nullptr),
       _children(),
-      _boundingVolume(OrientedBoundingBox(glm::dvec3(), glm::dmat4())),
+      _boundingVolume(OrientedBoundingBox(glm::dvec3(), glm::dmat3())),
       _viewerRequestVolume(),
       _geometricError(0.0),
       _refine(TileRefine::Replace),

--- a/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.cpp
+++ b/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.cpp
@@ -932,14 +932,9 @@ static void addSkirt(
         position -= center;
 
         for (uint32_t c = 0; c < 3; ++c) {
-          output.push_back(
-              static_cast<float>(position[static_cast<int32_t>(c)]));
-          attribute.minimums[c] = glm::min(
-              attribute.minimums[c],
-              position[static_cast<int32_t>(c)]);
-          attribute.maximums[c] = glm::max(
-              attribute.maximums[c],
-              position[static_cast<int32_t>(c)]);
+          output.push_back(static_cast<float>(position[c]));
+          attribute.minimums[c] = glm::min(attribute.minimums[c], position[c]);
+          attribute.maximums[c] = glm::max(attribute.maximums[c], position[c]);
         }
       } else {
         for (uint32_t c = 0;

--- a/CesiumGeometry/test/TestOrientedBoundingBox.cpp
+++ b/CesiumGeometry/test/TestOrientedBoundingBox.cpp
@@ -26,30 +26,31 @@ TEST_CASE("OrientedBoundingBox::intersectPlane") {
       // rotated
       TestCase{
           glm::dvec3(0.0),
-          glm::rotate(glm::dmat4(), 1.2, glm::dvec3(0.5, 1.5, -1.2))},
+          glm::dmat3(
+              glm::rotate(glm::dmat4(), 1.2, glm::dvec3(0.5, 1.5, -1.2)))},
       // scaled
       TestCase{
           glm::dvec3(0.0),
-          glm::scale(glm::dmat4(), glm::dvec3(1.5, 0.4, 20.6))},
+          glm::dmat3(glm::scale(glm::dmat4(), glm::dvec3(1.5, 0.4, 20.6)))},
       TestCase{
           glm::dvec3(0.0),
-          glm::scale(glm::dmat4(), glm::dvec3(0.0, 0.4, 20.6))},
+          glm::dmat3(glm::scale(glm::dmat4(), glm::dvec3(0.0, 0.4, 20.6)))},
       TestCase{
           glm::dvec3(0.0),
-          glm::scale(glm::dmat4(), glm::dvec3(1.5, 0.0, 20.6))},
+          glm::dmat3(glm::scale(glm::dmat4(), glm::dvec3(1.5, 0.0, 20.6)))},
       TestCase{
           glm::dvec3(0.0),
-          glm::scale(glm::dmat4(), glm::dvec3(1.5, 0.4, 0.0))},
+          glm::dmat3(glm::scale(glm::dmat4(), glm::dvec3(1.5, 0.4, 0.0)))},
       TestCase{
           glm::dvec3(0.0),
-          glm::scale(glm::dmat4(), glm::dvec3(0.0, 0.0, 0.0))},
+          glm::dmat3(glm::scale(glm::dmat4(), glm::dvec3(0.0, 0.0, 0.0)))},
       // arbitrary box
       TestCase{
           glm::dvec3(-5.1, 0.0, 0.1),
-          glm::rotate(
+          glm::dmat3(glm::rotate(
               glm::scale(glm::dmat4(), glm::dvec3(1.5, 80.4, 2.6)),
               1.2,
-              glm::dvec3(0.5, 1.5, -1.2))});
+              glm::dvec3(0.5, 1.5, -1.2)))});
 
   SECTION("test corners, edges, faces") {
     const double SQRT1_2 = pow(1.0 / 2.0, 1 / 2.0);

--- a/CesiumGeospatial/src/EllipsoidTangentPlane.cpp
+++ b/CesiumGeospatial/src/EllipsoidTangentPlane.cpp
@@ -26,7 +26,9 @@ EllipsoidTangentPlane::EllipsoidTangentPlane(
       _origin(eastNorthUpToFixedFrame[3]),
       _xAxis(eastNorthUpToFixedFrame[0]),
       _yAxis(eastNorthUpToFixedFrame[1]),
-      _plane(eastNorthUpToFixedFrame[3], eastNorthUpToFixedFrame[2]) {}
+      _plane(
+          glm::dvec3(eastNorthUpToFixedFrame[3]),
+          glm::dvec3(eastNorthUpToFixedFrame[2])) {}
 
 glm::dvec2 EllipsoidTangentPlane::projectPointToNearestOnPlane(
     const glm::dvec3& cartesian) const noexcept {


### PR DESCRIPTION
The [GLM manual](https://github.com/g-truc/glm/blob/master/manual.md#section2) has some defines we can set to make GLM more strict and hopefully avoid bugs:

```
GLM_FORCE_XYZW_ONLY # Disable .rgba and .stpq to make it easier to view values from debugger
GLM_FORCE_EXPLICIT_CTOR # Disallow implicit conversions between dvec3 <-> dvec4, dvec3 <-> fvec3, etc
GLM_FORCE_SIZE_T_LENGTH # Make vec.length() and vec[idx] use size_t instead of int
```

I was also thinking about adding `GLM_FORCE_INLINE` but there was a compilation failure in one of the unit tests where the GLM function could not be inlined. I haven't checked if `GLM_FORCE_INLINE` has any runtime improvement so it could be worth looking into some other time.