### PR TITLE
Improve precision when using rapidjson

### DIFF
--- a/CesiumJsonReader/src/JsonReader.cpp
+++ b/CesiumJsonReader/src/JsonReader.cpp
@@ -141,7 +141,8 @@ void JsonReader::FinalJsonHandler::setInputStream(
 
   bool success = true;
   while (success && !reader.IterativeParseComplete()) {
-    success = reader.IterativeParseNext<rapidjson::kParseDefaultFlags>(
+    success = reader.IterativeParseNext<
+        rapidjson::kParseDefaultFlags | rapidjson::kParseFullPrecisionFlag>(
         inputStream,
         dispatcher);
   }


### PR DESCRIPTION
This PR fixes two precision problems with the JSON readers/writers. My setup is a round trip from glTF to JSON to glTF to JSON.

Old behavior:
`0.20116522777145346` - original number that's perfectly representable as float64
`0.20116522777145347` - string that's stored in the JSON
`0.2011652277714535` - value that's parsed from JSON

New behavior:
`0.20116522777145346` - original number that's perfectly representable as float64
`0.20116522777145346` - string that's stored in the JSON
`0.20116522777145346` - value that's parsed from JSON

1) Adding `kParseFullPrecisionFlag` makes it parse as `0.20116522777145346` instead of `0.2011652277714535` :heavy_check_mark: 
2) The newest version of rapidjson stores `0.20116522777145346` instead of `0.20116522777145347` in JSON. Even though these two strings are parsed as the same float64 binary value (`0.20116522777145346`), it's nice that the JSON is exact :heavy_check_mark: 

I have not measured performance for `kParseFullPrecisionFlag`. Full precision is important for the glTF readers / writers to preserve the user data exactly but may not be as important for rendering glTF. If necessary there could be a reader/writer option for fast vs accurate.  

Here's some code demonstrating the fix:
[rapidjson-tester.zip](https://github.com/CesiumGS/cesium-native/files/7529831/rapidjson-tester.zip)

Setup:
```
git init
git submodule add git@github.com:CesiumGS/cesium-native extern/cesium-native
git submodule update --init --recursive
cd extern/cesium-native
git checkout rapidjson-precision
cd ../..
cmake -B build
cmake --build build
./build/test
```

