### PR TITLE
Add DebugColorizeTilesRasterOverlay

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - `RasterOverlay::loadTileProvider` now returns a `SharedFuture`, making it easy to attach a continuation to run when the load completes.
 - Added `GltfContent::applyRtcCenter` and `applyGltfUpAxisTransform`.
 - Clipping polygon edges now remain sharp even when zooming in past the available geometry detail.
+- Added `DebugColorizeTilesRasterOverlay`.
 
 ### v0.9.0 - 2021-11-01
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/DebugColorizeTilesRasterOverlay.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/DebugColorizeTilesRasterOverlay.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "RasterOverlay.h"
+
+namespace Cesium3DTilesSelection {
+
+/**
+ * @brief A raster overlay that gives each tile to which it is attached a random
+ * color with 50% opacity. This is useful for debugging a tileset, to visualize
+ * how it is divided into tiles.
+ */
+class CESIUM3DTILESSELECTION_API DebugColorizeTilesRasterOverlay
+    : public RasterOverlay {
+public:
+  /**
+   * @copydoc RasterOverlay::RasterOverlay
+   */
+  DebugColorizeTilesRasterOverlay(
+      const std::string& name,
+      const RasterOverlayOptions& overlayOptions = RasterOverlayOptions());
+
+  /**
+   * @copydoc RasterOverlay::createTileProvider
+   */
+  virtual CesiumAsync::Future<std::unique_ptr<RasterOverlayTileProvider>>
+  createTileProvider(
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+      const std::shared_ptr<CreditSystem>& pCreditSystem,
+      const std::shared_ptr<IPrepareRendererResources>&
+          pPrepareRendererResources,
+      const std::shared_ptr<spdlog::logger>& pLogger,
+      RasterOverlay* pOwner) override;
+};
+
+} // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/DebugColorizeTilesRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/DebugColorizeTilesRasterOverlay.cpp
@@ -1,0 +1,90 @@
+#include "Cesium3DTilesSelection/DebugColorizeTilesRasterOverlay.h"
+
+#include "Cesium3DTilesSelection/RasterOverlayTileProvider.h"
+
+#include <CesiumGeospatial/GeographicProjection.h>
+#include <CesiumUtility/SpanHelper.h>
+
+using namespace Cesium3DTilesSelection;
+using namespace CesiumGeospatial;
+using namespace CesiumGltf;
+using namespace CesiumUtility;
+
+namespace {
+
+class DebugTileProvider : public RasterOverlayTileProvider {
+public:
+  DebugTileProvider(
+      RasterOverlay& owner,
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+      const std::shared_ptr<IPrepareRendererResources>&
+          pPrepareRendererResources,
+      const std::shared_ptr<spdlog::logger>& pLogger)
+      : RasterOverlayTileProvider(
+            owner,
+            asyncSystem,
+            pAssetAccessor,
+            std::nullopt,
+            pPrepareRendererResources,
+            pLogger,
+            GeographicProjection(),
+            GeographicProjection::computeMaximumProjectedRectangle()) {}
+
+  virtual CesiumAsync::Future<LoadedRasterOverlayImage>
+  loadTileImage(RasterOverlayTile& overlayTile) override {
+    LoadedRasterOverlayImage result;
+
+    // Indicate that there is no more detail available so that tiles won't get
+    // refined on our behalf.
+    result.moreDetailAvailable = false;
+
+    result.rectangle = overlayTile.getRectangle();
+
+    ImageCesium& image = result.image.emplace();
+    image.width = 1;
+    image.height = 1;
+    image.channels = 4;
+    image.bytesPerChannel = 1;
+    image.pixelData.resize(4);
+    gsl::span<uint32_t> pixels =
+        reintepretCastSpan<uint32_t>(gsl::span(image.pixelData));
+    int red = rand() % 255;
+    int green = rand() % 255;
+    int blue = rand() % 255;
+    uint32_t color = 0x7F000000;
+    color += uint32_t(red) << 16;
+    color += uint32_t(green) << 8;
+    color += uint32_t(blue);
+    pixels[0] = color;
+
+    return this->getAsyncSystem().createResolvedFuture(std::move(result));
+  }
+};
+
+} // namespace
+
+DebugColorizeTilesRasterOverlay::DebugColorizeTilesRasterOverlay(
+    const std::string& name,
+    const RasterOverlayOptions& overlayOptions)
+    : RasterOverlay(name, overlayOptions) {}
+
+CesiumAsync::Future<std::unique_ptr<RasterOverlayTileProvider>>
+DebugColorizeTilesRasterOverlay::createTileProvider(
+    const CesiumAsync::AsyncSystem& asyncSystem,
+    const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+    const std::shared_ptr<CreditSystem>& /* pCreditSystem */,
+    const std::shared_ptr<IPrepareRendererResources>& pPrepareRendererResources,
+    const std::shared_ptr<spdlog::logger>& pLogger,
+    RasterOverlay* pOwner) {
+  pOwner = pOwner ? pOwner : this;
+
+  return asyncSystem.createResolvedFuture(
+      (std::unique_ptr<RasterOverlayTileProvider>)
+          std::make_unique<DebugTileProvider>(
+              *this,
+              asyncSystem,
+              pAssetAccessor,
+              pPrepareRendererResources,
+              pLogger));
+}


### PR DESCRIPTION
This is a simple raster overlay that adds a random 50% opaque color to every tile, which is useful for visualizing how a tileset is broken up into tiles. Here's Melbourne:

![image](https://user-images.githubusercontent.com/924374/141924444-b15704ed-c7be-4442-b497-bfb1f8eeef75.png)

There are lots of ways to do this, but the nice part about doing it with a raster overlay (a 1x1 texture per tile) is that it doesn't require any changes to existing code, just a new raster overlay.