### PR TITLE
Fix macOS test failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,6 @@ jobs:
       osx_image: xcode12
       script:
         - cmake --build . --config Debug
-        - # Tests fail on macOS, see https://github.com/CesiumGS/cesium-native/issues/394
-        - ctest -V || echo "There are test failures, but we're not failing the build. See https://github.com/CesiumGS/cesium-native/issues/394"
+        - ctest -V
         - # Doc build doesn't work on Mac (missing Doxygen). Let's just skip it.
         - #cmake --build . --config Debug --target cesium-native-docs

--- a/Cesium3DTilesSelection/test/TestUpgradeBatchTableToExtFeatureMetadata.cpp
+++ b/Cesium3DTilesSelection/test/TestUpgradeBatchTableToExtFeatureMetadata.cpp
@@ -129,7 +129,9 @@ static void createTestForScalarJson(
           batchTableJson.GetAllocator());
       scalarProperty.PushBack(value, batchTableJson.GetAllocator());
     } else {
-      scalarProperty.PushBack(expected[i], batchTableJson.GetAllocator());
+      scalarProperty.PushBack(
+          ExpectedType(expected[i]),
+          batchTableJson.GetAllocator());
     }
   }
 
@@ -202,7 +204,9 @@ static void createTestForArrayJson(
             batchTableJson.GetAllocator());
         innerArray.PushBack(value, batchTableJson.GetAllocator());
       } else {
-        innerArray.PushBack(expected[i][j], batchTableJson.GetAllocator());
+        innerArray.PushBack(
+            ExpectedType(expected[i][j]),
+            batchTableJson.GetAllocator());
       }
     }
     fixedArrayProperties.PushBack(innerArray, batchTableJson.GetAllocator());

--- a/CesiumAsync/test/TestAsyncSystem.cpp
+++ b/CesiumAsync/test/TestAsyncSystem.cpp
@@ -8,6 +8,8 @@
 
 using namespace CesiumAsync;
 
+namespace {
+
 class MockTaskProcessor : public ITaskProcessor {
 public:
   std::atomic<int32_t> tasksStarted = 0;
@@ -17,6 +19,8 @@ public:
     std::thread(f).detach();
   }
 };
+
+} // namespace
 
 TEST_CASE("AsyncSystem") {
   std::shared_ptr<MockTaskProcessor> pTaskProcessor =

--- a/CesiumAsync/test/TestCacheAssetAccessor.cpp
+++ b/CesiumAsync/test/TestCacheAssetAccessor.cpp
@@ -14,6 +14,8 @@
 
 using namespace CesiumAsync;
 
+namespace {
+
 class MockStoreCacheDatabase : public ICacheDatabase {
 public:
   struct StoreRequestParameters {
@@ -113,6 +115,8 @@ class MockTaskProcessor : public ITaskProcessor {
 public:
   virtual void startTask(std::function<void()> f) override { f(); }
 };
+
+} // namespace
 
 TEST_CASE("Test the condition of caching the request") {
   SECTION("Cache request") {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium-native",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Fixes #394 

I think the problem is that `operator[]` for `std::vector<bool>` doesn't return an actual bool on this platform, but rather something that can be implicitly converted to bool. When we pass that thing to RapidJSON's PushBack, it still doesn't get implicitly converted to a bool. So the JSON ends up incorrect. Fixed by explicitly casting return return value of `operator[]` to the right type.