### PR TITLE
Partial fix for broken upsampling with raster overlays.

### DIFF
--- a/Cesium3DTilesSelection/src/BoundingVolume.cpp
+++ b/Cesium3DTilesSelection/src/BoundingVolume.cpp
@@ -200,13 +200,13 @@ estimateGlobeRectangle(const BoundingVolume& boundingVolume) {
 const CesiumGeospatial::BoundingRegion*
 getBoundingRegionFromBoundingVolume(const BoundingVolume& boundingVolume) {
   const BoundingRegion* pResult = std::get_if<BoundingRegion>(&boundingVolume);
-  if (!pResult) {
-    const BoundingRegionWithLooseFittingHeights* pLoose =
-        std::get_if<BoundingRegionWithLooseFittingHeights>(&boundingVolume);
-    if (pLoose) {
-      pResult = &pLoose->getBoundingRegion();
-    }
-  }
+  // if (!pResult) {
+  //   const BoundingRegionWithLooseFittingHeights* pLoose =
+  //       std::get_if<BoundingRegionWithLooseFittingHeights>(&boundingVolume);
+  //   if (pLoose) {
+  //     pResult = &pLoose->getBoundingRegion();
+  //   }
+  // }
   return pResult;
 }
 

--- a/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.cpp
+++ b/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.cpp
@@ -456,7 +456,7 @@ static void upsamplePrimitiveForRasterOverlays(
 
     attributes.push_back(FloatVertexAttribute{
         buffer.cesium.data,
-        accessor.byteOffset,
+        bufferView.byteOffset + accessor.byteOffset,
         accessorByteStride,
         accessorComponentElements,
         attribute.second,


### PR DESCRIPTION
This fixes the problem mentioned in https://github.com/CesiumGS/cesium-native/pull/355#issuecomment-972805713 where geometry upsampled for raster overlays would just disappear. That was caused by failing to account for the bufferView's byteOffset when reading positions for upsampling.

But even with that fix, texture coordinates generated for raster overlays are sometimes broken. The problem appears to be that the bound region for upsampled tiles is (sometimes) very wrong. This PR fixes the symptom, but I need to spend some more time understanding what is really going on here, which is why this PR is a draft for the moment.