### PR TITLE
set indices accessor offset value to 0 after decode draco mesh

### DIFF
--- a/CesiumGltfReader/src/decodeDraco.cpp
+++ b/CesiumGltfReader/src/decodeDraco.cpp
@@ -151,6 +151,7 @@ void copyDecodedIndices(
   indicesBufferView.byteOffset = 0;
   indicesBufferView.target = BufferView::Target::ELEMENT_ARRAY_BUFFER;
   pIndicesAccessor->type = Accessor::Type::SCALAR;
+  pIndicesAccessor->byteOffset = 0;
 
   static_assert(sizeof(draco::PointIndex) == sizeof(uint32_t));
 


### PR DESCRIPTION
i think accessor offset value should set to 0, because we create a new bufferview and buffer.