### PR TITLE
Use 2 space indentation for glTF writer

### DIFF
--- a/CesiumJsonWriter/src/PrettyJsonWriter.cpp
+++ b/CesiumJsonWriter/src/PrettyJsonWriter.cpp
@@ -12,6 +12,7 @@ PrettyJsonWriter::PrettyJsonWriter() noexcept {
       rapidjson::PrettyFormatOptions::kFormatSingleLineArray);
   pretty = std::make_unique<rapidjson::PrettyWriter<rapidjson::StringBuffer>>(
       std::move(writer));
+  pretty->SetIndent(' ', 2);
 }
 
 bool PrettyJsonWriter::Null() { return pretty->Null(); }


### PR DESCRIPTION
Thoughts on changing the default indentation from 4 spaces to 2 spaces for the glTF writer?