### PR TITLE
Remove unused KhronosGroup/glTF submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,9 +28,6 @@
 [submodule "extern/rapidjson"]
 	path = extern/rapidjson
 	url = https://github.com/Tencent/rapidjson.git
-[submodule "extern/glTF"]
-	path = extern/glTF
-	url = https://github.com/KhronosGroup/glTF.git
 [submodule "extern/stb"]
 	path = extern/stb
 	url = https://github.com/nothings/stb.git


### PR DESCRIPTION
There's no `extern/glTF` folder when cesium-native is cloned. The submodule seems to have been removed everywhere except in `.gitmodules`.