### PR TITLE
Notify tile done loading when ion response can't be parsed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v0.12.0 - ????
+
+##### Fixes :wrench:
+
+- Fixes a bug where `notifyTileDoneLoading` is not called when encountering Ion responses that can't be parsed.
+ 
 ### v0.11.0 - 2022-01-03
 
 ##### Breaking Changes :mega:

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -186,6 +186,7 @@ Tileset::_handleAssetResponse(std::shared_ptr<IAssetRequest>&& pRequest) {
         "offset {}",
         ionResponse.GetParseError(),
         ionResponse.GetErrorOffset());
+    this->notifyTileDoneLoading(nullptr);
     return this->getAsyncSystem().createResolvedFuture();
   }
 


### PR DESCRIPTION
We forget to notify tile done loading when ion response can't be parsed, which makes the tileset unable to be destructed