### PR TITLE
Allow a continuation attached to a SharedFuture to return a Future (rather than a normal value)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 ##### Fixes :wrench:
 
 - Fixes a bug where `notifyTileDoneLoading` is not called when encountering Ion responses that can't be parsed.
+- Fixed a bug that prevented a continuation attached to a `SharedFuture` from returning a `Future` itself.
 
 ### v0.11.0 - 2022-01-03
 

--- a/CesiumAsync/include/CesiumAsync/Impl/WithTracing.h
+++ b/CesiumAsync/include/CesiumAsync/Impl/WithTracing.h
@@ -59,7 +59,7 @@ template <typename T> struct WithTracingShared {
       return result;
     };
 #else
-    return Impl::unwrapFuture<Func, T>(std::forward<Func>(f));
+    return Impl::unwrapSharedFuture<Func, T>(std::forward<Func>(f));
 #endif
   }
 
@@ -67,7 +67,7 @@ template <typename T> struct WithTracingShared {
   static auto end([[maybe_unused]] const char* tracingName, Func&& f) {
 #if CESIUM_TRACING_ENABLED
     return [tracingName,
-            f = Impl::unwrapFuture<Func, T>(std::forward<Func>(f)),
+            f = Impl::unwrapSharedFuture<Func, T>(std::forward<Func>(f)),
             CESIUM_TRACE_LAMBDA_CAPTURE_TRACK()](const T& result) mutable {
       CESIUM_TRACE_USE_CAPTURED_TRACK();
       if (tracingName) {
@@ -76,7 +76,7 @@ template <typename T> struct WithTracingShared {
       return f(result);
     };
 #else
-    return Impl::unwrapFuture<Func, T>(std::forward<Func>(f));
+    return Impl::unwrapSharedFuture<Func, T>(std::forward<Func>(f));
 #endif
   }
 };

--- a/CesiumAsync/include/CesiumAsync/Impl/unwrapFuture.h
+++ b/CesiumAsync/include/CesiumAsync/Impl/unwrapFuture.h
@@ -26,9 +26,8 @@ template <typename T> struct ParameterizedTaskUnwrapper {
   }
 
   template <typename Func> static auto unwrapShared(Func&& f) {
-    return [f = std::forward<Func>(f)](const T& t) mutable {
-      return f(t)._task;
-    };
+    return
+        [f = std::forward<Func>(f)](const T& t) mutable { return f(t)._task; };
   }
 };
 

--- a/CesiumAsync/include/CesiumAsync/Impl/unwrapFuture.h
+++ b/CesiumAsync/include/CesiumAsync/Impl/unwrapFuture.h
@@ -12,12 +12,22 @@ struct IdentityUnwrapper {
   template <typename Func> static Func unwrap(Func&& f) {
     return std::forward<Func>(f);
   }
+
+  template <typename Func> static Func unwrapShared(Func&& f) {
+    return std::forward<Func>(f);
+  }
 };
 
 template <typename T> struct ParameterizedTaskUnwrapper {
   template <typename Func> static auto unwrap(Func&& f) {
     return [f = std::forward<Func>(f)](T&& t) mutable {
       return f(std::move(t))._task;
+    };
+  }
+
+  template <typename Func> static auto unwrapShared(Func&& f) {
+    return [f = std::forward<Func>(f)](const T& t) mutable {
+      return f(t)._task;
     };
   }
 };
@@ -38,6 +48,16 @@ template <typename Func, typename T> auto unwrapFuture(Func&& f) {
       ParameterizedTaskUnwrapper<T>>::type::unwrap(std::forward<Func>(f));
 }
 
+template <typename Func, typename T> auto unwrapSharedFuture(Func&& f) {
+  return std::conditional<
+      std::is_same<
+          typename ContinuationReturnType<Func, T>::type,
+          typename RemoveFuture<
+              typename ContinuationFutureType<Func, T>::type>::type>::value,
+      IdentityUnwrapper,
+      ParameterizedTaskUnwrapper<T>>::type::unwrapShared(std::forward<Func>(f));
+}
+
 template <typename Func> auto unwrapFuture(Func&& f) {
   return std::conditional<
       std::is_same<
@@ -46,6 +66,10 @@ template <typename Func> auto unwrapFuture(Func&& f) {
               typename ContinuationFutureType<Func, void>::type>::type>::value,
       IdentityUnwrapper,
       TaskUnwrapper>::type::unwrap(std::forward<Func>(f));
+}
+
+template <typename Func> auto unwrapSharedFuture(Func&& f) {
+  return unwrapFuture(std::forward<Func>(f));
 }
 
 //! @endcond


### PR DESCRIPTION
Previously this would result in a compiler error.

Builds on #422 so merge that first.
