### PR TITLE
Use v2 of the Cesium ion tokens API.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,16 @@
 
 - Renamed `IAssetAccessor::requestAsset` to `get`.
 - Renamed `IAssetAccessor::post` to `request` and added a new parameter in the second position to specify the HTTP verb to use.
+- `Token` in `CesiumIonClient` has been updated to match Cesium ion's v2 REST API endpoint, so several fields have been renamed. The `tokens` method also now returns future that resolves to a `TokenList` instead of a plain vector of `Token` instances.
+
+##### Additions :tada:
+
+- Added new capabilities to `Connection` in `CesiumIonClient`:
+  - The `tokens` method now uses the v2 service endpoint and allows a number of options to be specified.
+  - Added a `token` method to allow details of a single token to be retrieved.
+  - Added `nextPage` and `previousPage` methods to allow paging through tokens.
+  - Added `modifyToken` method.
+  - Added static `getIdFromToken` method to obtain a token ID from a given token value.
 
 ##### Fixes :wrench:
 

--- a/CesiumIonClient/include/CesiumIonClient/Response.h
+++ b/CesiumIonClient/include/CesiumIonClient/Response.h
@@ -1,16 +1,39 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 
+namespace CesiumAsync {
+class IAssetRequest;
+}
+
 namespace CesiumIonClient {
+
 /**
  * @brief A response from Cesium ion.
  *
  * @tparam T The type of the response object.
  */
 template <typename T> struct Response final {
+  Response();
+
+  Response(
+      const std::shared_ptr<CesiumAsync::IAssetRequest>& pRequest,
+      T&& value);
+
+  Response(
+      T&& value,
+      uint16_t httpStatusCode,
+      const std::string& errorCode,
+      const std::string& errorMessage);
+
+  Response(
+      uint16_t httpStatusCode,
+      const std::string& errorCode,
+      const std::string& errorMessage);
+
   /**
    * @brief The response value, or `std::nullopt` if the response was
    * unsuccessful.
@@ -45,5 +68,27 @@ template <typename T> struct Response final {
    * message will contain further details of the error.
    */
   std::string errorMessage;
+
+  /**
+   * @brief The URL to use to obtain the next page of results, if there is a
+   * next page.
+   *
+   * Call {@link Connection::nextPage} rather than using this field directly.
+   */
+  std::optional<std::string> nextPageUrl;
+
+  /**
+   * @brief The URL to use to obtain the previous page of results, if there is
+   * one.
+   *
+   * Call {@link Connection::previousPage} rather than using this field directly.
+   */
+  std::optional<std::string> previousPageUrl;
 };
+
+/**
+ * @brief A non-value, for use with a valueless {@link Response}.
+ */
+struct NoValue {};
+
 } // namespace CesiumIonClient

--- a/CesiumIonClient/include/CesiumIonClient/Token.h
+++ b/CesiumIonClient/include/CesiumIonClient/Token.h
@@ -12,7 +12,7 @@ struct Token {
   /**
    * @brief The identifier of the token.
    */
-  std::string jti{};
+  std::string id{};
 
   /**
    * @brief The name of the token.
@@ -25,25 +25,43 @@ struct Token {
   std::string token{};
 
   /**
+   * @brief The date and time that this token was created, in RFC 3339 format.
+   */
+  std::string dateAdded{};
+
+  /**
+   * @brief The date and time that this token was last modified, in RFC 3339
+   * format.
+   */
+  std::string dateModified{};
+
+  /**
+   * @brief The date and time that this token was last used, in RFC 3339 format.
+   */
+  std::string dateLastUsed{};
+
+  /**
+   * @brief The IDs of the assets that can be accessed using this token.
+   *
+   * If `std::nullopt`, the token allows access to all assets.
+   */
+  std::optional<std::vector<int64_t>> assetIds{};
+
+  /**
    * @brief True if this is the default token.
    */
   bool isDefault{};
 
   /**
-   * @brief The date when this token was last used.
+   * @brief The URLs from which this token can be accessed.
+   *
+   * If `std::nullopt`, the token can be accessed from any URL.
    */
-  std::string lastUsed{};
+  std::optional<std::vector<std::string>> allowedUrls{};
 
   /**
    * @brief The scopes granted by this token.
    */
   std::vector<std::string> scopes{};
-
-  /**
-   * @brief The assets that this token my access.
-   *
-   * If `std::nullopt`, the token allows access to all assets.
-   */
-  std::optional<std::vector<int64_t>> assets{};
 };
 } // namespace CesiumIonClient

--- a/CesiumIonClient/include/CesiumIonClient/TokenList.h
+++ b/CesiumIonClient/include/CesiumIonClient/TokenList.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "Token.h"
+
+namespace CesiumIonClient {
+
+/**
+ * @brief A list of Cesium ion access tokens, as returned by the "List Tokens"
+ * service.
+ */
+struct TokenList {
+  /**
+   * @brief The tokens.
+   *
+   */
+  std::vector<Token> items;
+};
+
+} // namespace CesiumIonClient

--- a/CesiumIonClient/src/Connection.cpp
+++ b/CesiumIonClient/src/Connection.cpp
@@ -1,5 +1,7 @@
 #include "CesiumIonClient/Connection.h"
 
+#include "parseLinkHeader.h"
+
 #include <CesiumAsync/IAssetResponse.h>
 #include <CesiumUtility/JsonHelpers.h>
 #include <CesiumUtility/Uri.h>
@@ -51,9 +53,8 @@ std::string encodeBase64(const std::vector<uint8_t>& bytes) {
 
   return result;
 }
-} // namespace
 
-static std::string createSuccessHtml(const std::string& applicationName) {
+std::string createSuccessHtml(const std::string& applicationName) {
   return std::string("<html>") +
          "<h2 style=\"text-align: center;\">Successfully "
          "authorized!</h2><br/>" +
@@ -62,7 +63,7 @@ static std::string createSuccessHtml(const std::string& applicationName) {
          applicationName + ".</div>" + "<html>";
 }
 
-static std::string createGenericErrorHtml(
+std::string createGenericErrorHtml(
     const std::string& applicationName,
     const std::string& errorMessage,
     const std::string& errorDescription) {
@@ -74,7 +75,7 @@ static std::string createGenericErrorHtml(
          applicationName + " to try again.</div>" + "<html>";
 }
 
-static std::string createAuthorizationErrorHtml(
+std::string createAuthorizationErrorHtml(
     const std::string& applicationName,
     const std::exception& exception) {
   return std::string("<html>") +
@@ -90,6 +91,8 @@ static std::string createAuthorizationErrorHtml(
          "href=\"mailto:support@cesium.com\">support@cesium.com</a>.</div>" +
          "<html>";
 }
+
+} // namespace
 
 /*static*/ CesiumAsync::Future<Connection> Connection::authorize(
     const CesiumAsync::AsyncSystem& asyncSystem,
@@ -136,8 +139,6 @@ static std::string createAuthorizationErrorHtml(
   authorizeUrl = Uri::addQuery(authorizeUrl, "state", state);
   authorizeUrl = Uri::addQuery(authorizeUrl, "code_challenge_method", "S256");
   authorizeUrl = Uri::addQuery(authorizeUrl, "code_challenge", hashedChallenge);
-
-  // TODO: state and code_challenge
 
   pServer->Get(
       redirectPath,
@@ -241,29 +242,25 @@ Connection::Connection(
       _accessToken(accessToken),
       _apiUrl(apiUrl) {}
 
-template <typename T> static Response<T> createEmptyResponse() {
-  return Response<T>{
-      std::nullopt,
-      0,
-      "NoResponse",
-      "The server did not return a response."};
+namespace {
+
+template <typename T> Response<T> createEmptyResponse() {
+  return Response<T>{0, "NoResponse", "The server did not return a response."};
 }
 
 template <typename T>
-static Response<T> createErrorResponse(const IAssetResponse* pResponse) {
+Response<T> createErrorResponse(const IAssetResponse* pResponse) {
   return Response<T>{
-      std::nullopt,
       pResponse->statusCode(),
       std::to_string(pResponse->statusCode()),
       "Received response code " + std::to_string(pResponse->statusCode())};
 }
 
 template <typename T>
-static Response<T> createJsonErrorResponse(
+Response<T> createJsonErrorResponse(
     const IAssetResponse* pResponse,
     const rapidjson::Document& d) {
   return Response<T>{
-      std::nullopt,
       pResponse->statusCode(),
       "ParseError",
       std::string("Failed to parse JSON response: ") +
@@ -271,23 +268,30 @@ static Response<T> createJsonErrorResponse(
 }
 
 template <typename T>
-static Response<T> createJsonTypeResponse(
+Response<T> createJsonTypeResponse(
     const IAssetResponse* pResponse,
     const std::string& expectedType) {
   return Response<T>{
-      std::nullopt,
       pResponse->statusCode(),
       "ParseError",
       "Response is not a JSON " + expectedType + "."};
 }
 
-static bool
-parseJsonObject(const IAssetResponse* pResponse, rapidjson::Document& d) {
+template <typename T> Response<T> createNoMorePagesResponse() {
+  return Response<T>{
+      0,
+      "NoMorePages",
+      "There are no more pages after the current one."};
+}
+
+bool parseJsonObject(const IAssetResponse* pResponse, rapidjson::Document& d) {
   d.Parse(
       reinterpret_cast<const char*>(pResponse->data().data()),
       pResponse->data().size());
   return !d.HasParseError();
 }
+
+} // namespace
 
 CesiumAsync::Future<Response<Profile>> Connection::me() const {
   return this->_pAssetAccessor
@@ -343,14 +347,16 @@ CesiumAsync::Future<Response<Profile>> Connection::me() const {
             }
 
             return Response<Profile>{
-                result,
+                std::move(result),
                 pResponse->statusCode(),
                 std::string(),
                 std::string()};
           });
 }
 
-static Asset jsonToAsset(const rapidjson::Value& item) {
+namespace {
+
+Asset jsonToAsset(const rapidjson::Value& item) {
   Asset result;
   result.id = JsonHelpers::getInt64OrDefault(item, "id", -1);
   result.name = JsonHelpers::getStringOrDefault(item, "name", "");
@@ -364,6 +370,8 @@ static Asset jsonToAsset(const rapidjson::Value& item) {
       int8_t(JsonHelpers::getInt32OrDefault(item, "percentComplete", -1));
   return result;
 }
+
+} // namespace
 
 CesiumAsync::Future<Response<Assets>> Connection::assets() const {
   return this->_pAssetAccessor
@@ -408,78 +416,93 @@ CesiumAsync::Future<Response<Assets>> Connection::assets() const {
             }
 
             return Response<Assets>{
-                result,
+                std::move(result),
                 pResponse->statusCode(),
                 std::string(),
                 std::string()};
           });
 }
 
-static Token tokenFromJson(const rapidjson::Value& json) {
+namespace {
+
+Token tokenFromJson(const rapidjson::Value& json) {
 
   Token token;
-  token.jti = JsonHelpers::getStringOrDefault(json, "jti", "");
+
+  token.id = JsonHelpers::getStringOrDefault(json, "id", "");
   token.name = JsonHelpers::getStringOrDefault(json, "name", "");
   token.token = JsonHelpers::getStringOrDefault(json, "token", "");
+  token.dateAdded = JsonHelpers::getStringOrDefault(json, "dateAdded", "");
+  token.dateModified =
+      JsonHelpers::getStringOrDefault(json, "dateModified", "");
+  token.dateLastUsed =
+      JsonHelpers::getStringOrDefault(json, "dateLastUsed", "");
   token.isDefault = JsonHelpers::getBoolOrDefault(json, "isDefault", false);
-  token.lastUsed = JsonHelpers::getStringOrDefault(json, "lastUsed", "");
   token.scopes = JsonHelpers::getStrings(json, "scopes");
 
-  const auto assetsIt = json.FindMember("assets");
-  if (assetsIt != json.MemberEnd()) {
-    token.assets = JsonHelpers::getInt64s(json, "assets");
+  auto assetIdsIt = json.FindMember("assetIds");
+  if (assetIdsIt != json.MemberEnd() && !assetIdsIt->value.IsNull()) {
+    token.assetIds = JsonHelpers::getInt64s(json, "assetIds");
   } else {
-    token.assets = std::nullopt;
+    token.assetIds = std::nullopt;
+  }
+
+  auto allowedUrlsIt = json.FindMember("allowedUrls");
+  if (allowedUrlsIt != json.MemberEnd() && !allowedUrlsIt->value.IsNull()) {
+    token.allowedUrls = JsonHelpers::getStrings(json, "allowedUrls");
+  } else {
+    token.allowedUrls = std::nullopt;
   }
 
   return token;
 }
 
-CesiumAsync::Future<Response<std::vector<Token>>> Connection::tokens() const {
-  return this->_pAssetAccessor
-      ->get(
-          this->_asyncSystem,
-          CesiumUtility::Uri::resolve(this->_apiUrl, "v1/tokens"),
-          {{"Accept", "application/json"},
-           {"Authorization", "Bearer " + this->_accessToken}})
-      .thenInMainThread(
-          [](std::shared_ptr<CesiumAsync::IAssetRequest>&& pRequest) {
-            const IAssetResponse* pResponse = pRequest->response();
-            if (!pResponse) {
-              return createEmptyResponse<std::vector<Token>>();
-            }
+TokenList tokenListFromJson(const rapidjson::Value& json) {
+  TokenList result;
 
-            if (pResponse->statusCode() < 200 ||
-                pResponse->statusCode() >= 300) {
-              return createErrorResponse<std::vector<Token>>(pResponse);
-            }
+  const auto itemsIt = json.FindMember("items");
+  if (itemsIt != json.MemberEnd() || !itemsIt->value.IsArray()) {
+    const rapidjson::Value& items = itemsIt->value;
 
-            rapidjson::Document d;
-            if (!parseJsonObject(pResponse, d)) {
-              return createJsonErrorResponse<std::vector<Token>>(pResponse, d);
-            }
-            if (!d.IsArray()) {
-              return createJsonTypeResponse<std::vector<Token>>(
-                  pResponse,
-                  "array");
-            }
+    for (auto it = items.Begin(); it != items.End(); ++it) {
+      std::optional<Token> token = tokenFromJson(*it);
+      if (!token) {
+        continue;
+      }
 
-            std::vector<Token> result;
-            for (auto it = d.Begin(); it != d.End(); ++it) {
-              std::optional<Token> token = tokenFromJson(*it);
-              if (!token) {
-                continue;
-              }
+      result.items.emplace_back(std::move(token.value()));
+    }
+  }
 
-              result.emplace_back(std::move(token.value()));
-            }
+  return result;
+}
 
-            return Response<std::vector<Token>>{
-                result,
-                pResponse->statusCode(),
-                std::string(),
-                std::string()};
-          });
+} // namespace
+
+Future<Response<TokenList>>
+Connection::tokens(const ListTokensOptions& options) const {
+  std::string url = Uri::resolve(this->_apiUrl, "v2/tokens");
+
+  if (options.limit) {
+    url = Uri::addQuery(url, "limit", std::to_string(*options.limit));
+  }
+  if (options.page) {
+    url = Uri::addQuery(url, "page", std::to_string(*options.page));
+  }
+  if (options.search) {
+    url = Uri::addQuery(url, "search", *options.search);
+  }
+  if (options.sortBy) {
+    url = Uri::addQuery(url, "sortBy", *options.sortBy);
+  }
+  if (options.sortOrder) {
+    url = Uri::addQuery(
+        url,
+        "sortOrder",
+        *options.sortOrder == SortOrder::Ascending ? "ASC" : "DESC");
+  }
+
+  return this->tokens(url);
 }
 
 CesiumAsync::Future<Response<Asset>> Connection::asset(int64_t assetID) const {
@@ -520,32 +543,107 @@ CesiumAsync::Future<Response<Asset>> Connection::asset(int64_t assetID) const {
           });
 }
 
+CesiumAsync::Future<Response<Token>>
+Connection::token(const std::string& tokenID) const {
+  std::string tokensUrl =
+      CesiumUtility::Uri::resolve(this->_apiUrl, "v2/tokens/");
+
+  return this->_pAssetAccessor
+      ->get(
+          this->_asyncSystem,
+          CesiumUtility::Uri::resolve(tokensUrl, tokenID),
+          {{"Accept", "application/json"},
+           {"Authorization", "Bearer " + this->_accessToken}})
+      .thenInMainThread(
+          [](std::shared_ptr<CesiumAsync::IAssetRequest>&& pRequest) {
+            const IAssetResponse* pResponse = pRequest->response();
+            if (!pResponse) {
+              return createEmptyResponse<Token>();
+            }
+
+            if (pResponse->statusCode() < 200 ||
+                pResponse->statusCode() >= 300) {
+              return createErrorResponse<Token>(pResponse);
+            }
+
+            rapidjson::Document d;
+            if (!parseJsonObject(pResponse, d)) {
+              return createJsonErrorResponse<Token>(pResponse, d);
+            }
+            if (!d.IsObject()) {
+              return createJsonTypeResponse<Token>(pResponse, "object");
+            }
+
+            return Response<Token>{
+                tokenFromJson(d),
+                pResponse->statusCode(),
+                std::string(),
+                std::string()};
+          });
+}
+
+CesiumAsync::Future<Response<TokenList>>
+Connection::nextPage(const Response<TokenList>& currentPage) const {
+  if (!currentPage.nextPageUrl) {
+    return this->_asyncSystem.createResolvedFuture(
+        createNoMorePagesResponse<TokenList>());
+  }
+
+  return this->tokens(*currentPage.nextPageUrl);
+}
+
+CesiumAsync::Future<Response<TokenList>>
+Connection::previousPage(const Response<TokenList>& currentPage) const {
+  if (!currentPage.previousPageUrl) {
+    return this->_asyncSystem.createResolvedFuture(
+        createNoMorePagesResponse<TokenList>());
+  }
+
+  return this->tokens(*currentPage.previousPageUrl);
+}
+
 CesiumAsync::Future<Response<Token>> Connection::createToken(
     const std::string& name,
     const std::vector<std::string>& scopes,
-    const std::optional<std::vector<int64_t>>& assets) const {
+    const std::optional<std::vector<int64_t>>& assetIds,
+    const std::optional<std::vector<std::string>>& allowedUrls) const {
   rapidjson::StringBuffer tokenBuffer;
   rapidjson::Writer<rapidjson::StringBuffer> writer(tokenBuffer);
 
   writer.StartObject();
+
   writer.Key("name");
   writer.String(name.c_str(), rapidjson::SizeType(name.size()));
+
   writer.Key("scopes");
   writer.StartArray();
   for (auto& scope : scopes) {
     writer.String(scope.c_str(), rapidjson::SizeType(scope.size()));
   }
   writer.EndArray();
-  writer.Key("assets");
-  if (assets) {
+
+  writer.Key("assetIds");
+  if (assetIds) {
     writer.StartArray();
-    for (auto asset : assets.value()) {
+    for (auto asset : assetIds.value()) {
       writer.Int64(asset);
     }
     writer.EndArray();
   } else {
     writer.Null();
   }
+
+  writer.Key("allowedUrls");
+  if (allowedUrls) {
+    writer.StartArray();
+    for (auto& allowedUrl : allowedUrls.value()) {
+      writer.String(allowedUrl.c_str(), rapidjson::SizeType(allowedUrl.size()));
+    }
+    writer.EndArray();
+  } else {
+    writer.Null();
+  }
+
   writer.EndObject();
 
   const gsl::span<const std::byte> tokenBytes(
@@ -555,7 +653,7 @@ CesiumAsync::Future<Response<Token>> Connection::createToken(
       ->request(
           this->_asyncSystem,
           "POST",
-          CesiumUtility::Uri::resolve(this->_apiUrl, "v1/tokens"),
+          Uri::resolve(this->_apiUrl, "v2/tokens"),
           {{"Content-Type", "application/json"},
            {"Accept", "application/json"},
            {"Authorization", "Bearer " + this->_accessToken}},
@@ -587,6 +685,129 @@ CesiumAsync::Future<Response<Token>> Connection::createToken(
                 std::string(),
                 std::string()};
           });
+}
+
+Future<Response<NoValue>> Connection::modifyToken(
+    const std::string& tokenID,
+    const std::string& newName,
+    const std::optional<std::vector<int64_t>>& newAssetIDs,
+    const std::vector<std::string>& newScopes,
+    const std::optional<std::vector<std::string>>& newAllowedUrls) const {
+  std::string url = Uri::resolve(this->_apiUrl, "v2/tokens/");
+  url = Uri::resolve(url, tokenID);
+
+  rapidjson::StringBuffer tokenBuffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(tokenBuffer);
+
+  writer.StartObject();
+
+  writer.Key("name");
+  writer.String(newName.c_str(), rapidjson::SizeType(newName.size()));
+
+  writer.Key("assetIds");
+  if (newAssetIDs) {
+    writer.StartArray();
+    for (auto asset : newAssetIDs.value()) {
+      writer.Int64(asset);
+    }
+    writer.EndArray();
+  } else {
+    writer.Null();
+  }
+
+  writer.Key("scopes");
+  writer.StartArray();
+  for (auto& scope : newScopes) {
+    writer.String(scope.c_str(), rapidjson::SizeType(scope.size()));
+  }
+  writer.EndArray();
+
+  writer.Key("newAllowedUrls");
+  if (newAllowedUrls) {
+    writer.StartArray();
+    for (auto& allowedUrl : newAllowedUrls.value()) {
+      writer.String(allowedUrl.c_str(), rapidjson::SizeType(allowedUrl.size()));
+    }
+    writer.EndArray();
+  } else {
+    writer.Null();
+  }
+
+  writer.EndObject();
+
+  const gsl::span<const std::byte> tokenBytes(
+      reinterpret_cast<const std::byte*>(tokenBuffer.GetString()),
+      tokenBuffer.GetSize());
+
+  return this->_pAssetAccessor
+      ->request(
+          this->_asyncSystem,
+          "PATCH",
+          url,
+          {{"Content-Type", "application/json"},
+           {"Accept", "application/json"},
+           {"Authorization", "Bearer " + this->_accessToken}},
+          tokenBytes)
+      .thenInMainThread([](std::shared_ptr<IAssetRequest>&& pRequest) {
+        const IAssetResponse* pResponse = pRequest->response();
+        if (!pResponse) {
+          return createEmptyResponse<NoValue>();
+        }
+
+        if (pResponse->statusCode() < 200 || pResponse->statusCode() >= 300) {
+          return createErrorResponse<NoValue>(pResponse);
+        }
+
+        return Response<NoValue>{
+            NoValue(),
+            pResponse->statusCode(),
+            std::string(),
+            std::string()};
+      });
+}
+
+/*static*/ std::optional<std::string>
+Connection::getIdFromToken(const std::string& token) {
+  size_t startPos = token.find(".");
+  if (startPos == std::string::npos || startPos == token.size() - 1) {
+    return std::nullopt;
+  }
+
+  size_t endPos = token.find(".", startPos + 1);
+  if (endPos == std::string::npos) {
+    return std::nullopt;
+  }
+
+  size_t length = endPos - startPos - 1;
+  if (length == 0) {
+    return std::nullopt;
+  }
+
+  std::string decoded(modp_b64_decode_len(length), '\0');
+  size_t decodedLength =
+      modp_b64_decode(decoded.data(), token.data() + startPos + 1, length);
+  if (decodedLength == 0 || decodedLength == std::string::npos) {
+    return std::nullopt;
+  }
+
+  decoded.resize(decodedLength);
+
+  rapidjson::Document document;
+  document.Parse(decoded.data(), decoded.size());
+  if (document.HasParseError()) {
+    return std::nullopt;
+  }
+
+  auto jtiIt = document.FindMember("jti");
+  if (jtiIt == document.MemberEnd()) {
+    return std::nullopt;
+  }
+
+  if (!jtiIt->value.IsString()) {
+    return std::nullopt;
+  }
+
+  return jtiIt->value.GetString();
 }
 
 /*static*/ CesiumAsync::Future<Connection> Connection::completeTokenExchange(
@@ -657,4 +878,36 @@ CesiumAsync::Future<Response<Token>> Connection::createToken(
 
         return Connection(asyncSystem, pAssetAccessor, accessToken, ionApiUrl);
       });
+}
+
+CesiumAsync::Future<Response<TokenList>>
+Connection::tokens(const std::string& url) const {
+  return this->_pAssetAccessor
+      ->get(
+          this->_asyncSystem,
+          url,
+          {{"Accept", "application/json"},
+           {"Authorization", "Bearer " + this->_accessToken}})
+      .thenInMainThread(
+          [](std::shared_ptr<CesiumAsync::IAssetRequest>&& pRequest) {
+            const IAssetResponse* pResponse = pRequest->response();
+            if (!pResponse) {
+              return createEmptyResponse<TokenList>();
+            }
+
+            if (pResponse->statusCode() < 200 ||
+                pResponse->statusCode() >= 300) {
+              return createErrorResponse<TokenList>(pResponse);
+            }
+
+            rapidjson::Document d;
+            if (!parseJsonObject(pResponse, d)) {
+              return createJsonErrorResponse<TokenList>(pResponse, d);
+            }
+            if (!d.IsObject()) {
+              return createJsonTypeResponse<TokenList>(pResponse, "object");
+            }
+
+            return Response<TokenList>(pRequest, tokenListFromJson(d));
+          });
 }

--- a/CesiumIonClient/src/Response.cpp
+++ b/CesiumIonClient/src/Response.cpp
@@ -1,0 +1,81 @@
+#include "CesiumIonClient/Response.h"
+
+#include "CesiumIonClient/Assets.h"
+#include "CesiumIonClient/Profile.h"
+#include "CesiumIonClient/TokenList.h"
+#include "parseLinkHeader.h"
+
+#include <CesiumAsync/IAssetRequest.h>
+#include <CesiumAsync/IAssetResponse.h>
+#include <CesiumUtility/Uri.h>
+
+#include <cassert>
+
+using namespace CesiumAsync;
+using namespace CesiumUtility;
+
+namespace CesiumIonClient {
+
+template <typename T> Response<T>::Response() {}
+
+template <typename T>
+Response<T>::Response(
+    T&& value_,
+    uint16_t httpStatusCode_,
+    const std::string& errorCode_,
+    const std::string& errorMessage_)
+    : value(value_),
+      httpStatusCode(httpStatusCode_),
+      errorCode(errorCode_),
+      errorMessage(errorMessage_),
+      nextPageUrl(),
+      previousPageUrl() {}
+
+template <typename T>
+Response<T>::Response(
+    uint16_t httpStatusCode_,
+    const std::string& errorCode_,
+    const std::string& errorMessage_)
+    : value(),
+      httpStatusCode(httpStatusCode_),
+      errorCode(errorCode_),
+      errorMessage(errorMessage_),
+      nextPageUrl(),
+      previousPageUrl() {}
+
+template <typename T>
+Response<T>::Response(
+    const std::shared_ptr<CesiumAsync::IAssetRequest>& pRequest,
+    T&& value_)
+    : value(value_),
+      httpStatusCode(pRequest->response()->statusCode()),
+      errorCode(),
+      errorMessage(),
+      nextPageUrl(),
+      previousPageUrl() {
+  const HttpHeaders& headers = pRequest->response()->headers();
+  auto it = headers.find("link");
+  if (it == headers.end()) {
+    return;
+  }
+
+  const std::string& linkHeader = it->second;
+  std::vector<Link> links = parseLinkHeader(linkHeader);
+  for (const Link& link : links) {
+    if (link.rel == "next") {
+      this->nextPageUrl = Uri::resolve(pRequest->url(), link.url);
+    } else if (link.rel == "prev") {
+      this->previousPageUrl = Uri::resolve(pRequest->url(), link.url);
+    }
+  }
+}
+
+// Explicit instantiations
+template struct Response<Asset>;
+template struct Response<Assets>;
+template struct Response<NoValue>;
+template struct Response<Profile>;
+template struct Response<Token>;
+template struct Response<TokenList>;
+
+} // namespace CesiumIonClient

--- a/CesiumIonClient/src/parseLinkHeader.cpp
+++ b/CesiumIonClient/src/parseLinkHeader.cpp
@@ -1,0 +1,103 @@
+#include "parseLinkHeader.h"
+
+#include <optional>
+#include <regex>
+
+// This implementation is loosely based on the JavaScript implementation found
+// here:
+// https://github.com/thlorenz/parse-link-header/blob/8521bd7a1256c1c3875e13d88be9dbfa7640663e/index.js.
+//
+// The license of that implementation is as follows (MIT):
+//
+// Copyright 2013 Thorsten Lorenz.
+// All rights reserved.
+
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+namespace CesiumIonClient {
+
+namespace {
+
+std::optional<Link> parseLink(const std::string& linkText) {
+  std::regex splitLink("<?([^>]*)>(.*)", std::regex_constants::ECMAScript);
+
+  std::sregex_iterator matchIt(linkText.begin(), linkText.end(), splitLink);
+  if (matchIt == std::sregex_iterator()) {
+    return std::nullopt;
+  }
+
+  const std::smatch& match = *matchIt;
+  if (match.size() != 3) {
+    return std::nullopt;
+  }
+
+  Link result;
+
+  result.url = match[1];
+
+  std::string params = match[2];
+
+  std::regex splitParts(
+      ";\\s*(.+)\\s*=\\s*\"?([^\"]+)\"?",
+      std::regex_constants::ECMAScript);
+  std::sregex_iterator partIt(params.begin(), params.end(), splitParts);
+
+  for (; partIt != std::sregex_iterator(); ++partIt) {
+    const std::smatch& partMatch = *partIt;
+    if (partMatch.size() != 3) {
+      continue;
+    }
+
+    if (partMatch[1] == "rel") {
+      result.rel = partMatch[2];
+    } else {
+      result.otherParameters[partMatch[1]] = partMatch[2];
+    }
+  }
+
+  return result;
+}
+
+} // namespace
+
+std::vector<Link> parseLinkHeader(const std::string& linkHeader) {
+  std::vector<Link> result;
+
+  std::regex splitLinks(",\\s*<", std::regex_constants::ECMAScript);
+
+  std::sregex_token_iterator it(
+      linkHeader.begin(),
+      linkHeader.end(),
+      splitLinks,
+      -1);
+  for (; it != std::sregex_token_iterator(); ++it) {
+    std::string linkText = *it;
+    std::optional<Link> link = parseLink(linkText);
+    if (link) {
+      result.emplace_back(std::move(*link));
+    }
+  }
+
+  return result;
+}
+
+} // namespace CesiumIonClient

--- a/CesiumIonClient/src/parseLinkHeader.h
+++ b/CesiumIonClient/src/parseLinkHeader.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace CesiumIonClient {
+
+struct Link {
+  std::string url;
+  std::string rel;
+  std::map<std::string, std::string> otherParameters;
+};
+
+std::vector<Link> parseLinkHeader(const std::string& linkHeader);
+
+} // namespace CesiumIonClient

--- a/CesiumIonClient/test/TestParseLinkHeader.cpp
+++ b/CesiumIonClient/test/TestParseLinkHeader.cpp
@@ -1,0 +1,26 @@
+#include "../src/parseLinkHeader.h"
+
+#include <catch2/catch.hpp>
+
+using namespace CesiumIonClient;
+
+TEST_CASE("parseLinkHeader") {
+  std::vector<Link> result =
+      parseLinkHeader("<https://api.cesium.com/v2/"
+                      "tokens?limit=100&page=3&sortBy=NAME&search=cesium%"
+                      "20token>; rel=\"next\", "
+                      "<https://api.cesium.com/v2/"
+                      "tokens?limit=100&page=1&sortBy=NAME&search=cesium%"
+                      "20token>; rel=\"prev\"");
+  REQUIRE(result.size() == 2);
+  CHECK(
+      result[0].url ==
+      "https://api.cesium.com/v2/"
+      "tokens?limit=100&page=3&sortBy=NAME&search=cesium%20token");
+  CHECK(result[0].rel == "next");
+  CHECK(
+      result[1].url ==
+      "https://api.cesium.com/v2/"
+      "tokens?limit=100&page=1&sortBy=NAME&search=cesium%20token");
+  CHECK(result[1].rel == "prev");
+}

--- a/CesiumNativeTests/CMakeLists.txt
+++ b/CesiumNativeTests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(cesium_native_targets
     CesiumGltf
     CesiumGltfReader
     CesiumGltfWriter
+    CesiumIonClient
     CesiumUtility
 )
 


### PR DESCRIPTION
This builds on #423 so merge that first.

From CHANGES.md:

- Added new capabilities to `Connection` in `CesiumIonClient`:
  - The `tokens` method now uses the v2 service endpoint and allows a number of options to be specified.
  - Added a `token` method to allow details of a single token to be retrieved.
  - Added `nextPage` and `previousPage` methods to allow paging through tokens.
  - Added `modifyToken` method.
  - Added static `getIdFromToken` method to obtain a token ID from a given token value.
