### PR TITLE
fix distance squared to function in bounding sphere

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@
 
 - Fixes a bug where `notifyTileDoneLoading` is not called when encountering Ion responses that can't be parsed.
 - Fixed a bug that prevented a continuation attached to a `SharedFuture` from returning a `Future` itself.
+- Fixed `computeDistanceSquaredToPosition` in `BoundingSphere`
 
 ### v0.11.0 - 2022-01-03
 

--- a/CesiumGeometry/include/CesiumGeometry/BoundingSphere.h
+++ b/CesiumGeometry/include/CesiumGeometry/BoundingSphere.h
@@ -50,7 +50,7 @@ public:
 
   /**
    * @brief Computes the distance squared from a position to the closest point
-   * on this bounding sphere.
+   * on this bounding sphere. Returns 0 if the point is inside the sphere.
    *
    * @param position The position.
    * @return The distance squared from the position to the closest point on this

--- a/CesiumGeometry/src/BoundingSphere.cpp
+++ b/CesiumGeometry/src/BoundingSphere.cpp
@@ -26,8 +26,12 @@ BoundingSphere::intersectPlane(const Plane& plane) const noexcept {
 
 double BoundingSphere::computeDistanceSquaredToPosition(
     const glm::dvec3& position) const noexcept {
-  const glm::dvec3 diff = position - this->_center;
-  return glm::dot(diff, diff) - this->_radius * this->_radius;
+  const glm::dvec3 diff = this->_center - position;
+  auto distance = glm::length(diff) - this->_radius;
+  if (distance <= 0) {
+    return 0;
+  }
+  return distance * distance;
 }
 
 } // namespace CesiumGeometry

--- a/CesiumGeometry/test/TestBoundingSphere.cpp
+++ b/CesiumGeometry/test/TestBoundingSphere.cpp
@@ -1,5 +1,6 @@
 #include "CesiumGeometry/BoundingSphere.h"
 #include "CesiumGeometry/Plane.h"
+#include "CesiumUtility/Math.h"
 
 #include <catch2/catch.hpp>
 #include <glm/mat3x3.hpp>
@@ -35,11 +36,22 @@ TEST_CASE("BoundingSphere::intersectPlane") {
       testCase.expectedResult);
 }
 
-TEST_CASE("BoundingSphere::computeDistanceSquaredToPosition") {
+TEST_CASE(
+    "BoundingSphere::computeDistanceSquaredToPosition test outside sphere") {
   BoundingSphere bs(glm::dvec3(0.0), 1.0);
   glm::dvec3 position(-2.0, 1.0, 0.0);
-  double expected = glm::dot(position, position) - 1.0;
-  CHECK(bs.computeDistanceSquaredToPosition(position) == expected);
+  double expected = 1.52786405;
+  CHECK(CesiumUtility::Math::equalsEpsilon(
+      bs.computeDistanceSquaredToPosition(position),
+      expected,
+      CesiumUtility::Math::EPSILON6));
+}
+
+TEST_CASE(
+    "BoundingSphere::computeDistanceSquaredToPosition test inside sphere") {
+  BoundingSphere bs(glm::dvec3(0.0), 1.0);
+  glm::dvec3 position(-.5, 0.5, 0.0);
+  CHECK(bs.computeDistanceSquaredToPosition(position) == 0);
 }
 
 TEST_CASE("BoundingSphere::computeDistanceSquaredToPosition example") {


### PR DESCRIPTION
Fixes #288. It looks like the original function computed the estimated squared distance so possibly we could move it to a seperate function for performance. I also added that it will return zero if the point is inside the sphere.