### PR TITLE
Experiment with unloading cache strategy

### DIFF
--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -1186,12 +1186,34 @@ void Tileset::_processLoadQueue() {
 }
 
 void Tileset::_unloadCachedTiles() noexcept {
+  // const int64_t maxBytes = this->getOptions().maximumCachedBytes;
+
+  // Tile* pTile = this->_loadedTiles.head();
+
+  // while (this->getTotalDataBytes() > maxBytes) {
+  //  if (pTile == nullptr || pTile == this->_pRootTile.get()) {
+  //    // We've either removed all tiles or the next tile is the root.
+  //    // The root tile marks the beginning of the tiles that were used
+  //    // for rendering last frame.
+  //    break;
+  //  }
+
+  //  Tile* pNext = this->_loadedTiles.next(*pTile);
+
+  //  const bool removed = pTile->unloadContent();
+  //  if (removed) {
+  //    this->_loadedTiles.remove(*pTile);
+  //  }
+
+  //  pTile = pNext;
+  //}
+
   const int64_t maxBytes = this->getOptions().maximumCachedBytes;
 
   Tile* pTile = this->_loadedTiles.head();
 
   while (this->getTotalDataBytes() > maxBytes) {
-    if (pTile == nullptr || pTile == this->_pRootTile.get()) {
+    if (pTile == nullptr) {
       // We've either removed all tiles or the next tile is the root.
       // The root tile marks the beginning of the tiles that were used
       // for rendering last frame.
@@ -1199,10 +1221,13 @@ void Tileset::_unloadCachedTiles() noexcept {
     }
 
     Tile* pNext = this->_loadedTiles.next(*pTile);
-
-    const bool removed = pTile->unloadContent();
-    if (removed) {
-      this->_loadedTiles.remove(*pTile);
+    if (pTile->getLastSelectionState().getOriginalResult(
+            this->_previousFrameNumber + 1) !=
+        TileSelectionState::Result::Rendered) {
+      const bool removed = pTile->unloadContent();
+      if (removed) {
+        this->_loadedTiles.remove(*pTile);
+      }
     }
 
     pTile = pNext;


### PR DESCRIPTION
Open this PR as draft to compare different approaches for unloading tiles.

when the tileset unloads its cache, it will unload all loaded tiles up to the root since the root marks the beginning of recently used tiles in the current frame (https://github.com/CesiumGS/cesium-native/blob/cc754d439e9d43b2f3566386d5e92caafdb383a5/Cesium3DTilesSelection/src/Tileset.cpp#L1194). But is it too conservative?

for example, if a root is level 0 and a tile at level 11 is currently rendered in the current frame, that means all tiles from the root -> 11 in some tileset branches are never released. My understanding is that they are only released when the camera is zoomed out. Not sure if I understand correctly. Assume the example tileset above is using replace refinement

When loading Nearmap tileset for Manhattan and setting local cache size to 0, the unloadCachedTiles reduces the number of tiles from 279 -> 261 tiles, the number of tiles that should be rendered in this frame is 79 tiles

A different approach for unloading the cache is that we loop through loaded tiles to the end and eagerly remove tiles that are not selected to be rendered in the current frame

so for this approach, I see unloadCachedTiles reduces the number of tiles from 278 -> 78 tiles, and the number of tiles that should be rendered in this frame is also 78 tiles

The disadvantage I can see for the second approach is that since tiles are removed more eagerly compared to the original method, you can see more tiles disappear and re-appear again when moving camera around when cache size is small 

but I think it works best for the first person shooter's use case where camera tends to be quite close to the detailed tiles

I'm not sure which one is good though.