### PR TITLE
Add Promise::resolve(const T&)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v0.14.0 - YYYY-MM-DD
+
+##### Fixes :wrench:
+
+- Fix the issue where CesiumAsync failed to compile when passing lvalue reference to Promise::resolve()
+
 ### v0.13.0 - 2022-03-01
 
 ##### Breaking Changes :mega:

--- a/CesiumAsync/include/CesiumAsync/Promise.h
+++ b/CesiumAsync/include/CesiumAsync/Promise.h
@@ -25,6 +25,13 @@ public:
   void resolve(T&& value) const { this->_pEvent->set(std::move(value)); }
 
   /**
+   * @brief Will be called when the task completed successfully.
+   *
+   * @param value The value that was computed by the asynchronous task.
+   */
+  void resolve(const T& value) const { this->_pEvent->set(value); }
+
+  /**
    * @brief Will be called when the task failed.
    *
    * @param error The error that caused the task to fail.


### PR DESCRIPTION
Fix the issue where CesiumAsync failed to compile when passing lvalue reference to Promise::resolve()