### PR TITLE
Fix forbid holes bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
 
 - Fixed bug that could cause properties types in a B3DM Batch Table to be deduced incorrectly, leading to a crash when accessing property values.
 - Fixed a bug where implicit tiles were not receiving the root transform and so could sometimes end up in the wrong place.
+- Fixed a bug that prevented tiles from loading when "Forbid Holes" option was true.
 
 ### v0.12.0 - 2022-02-01
 

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -725,10 +725,10 @@ bool Tileset::_queueLoadOfChildrenRequiredForRefinement(
 
       // While we are waiting for the child to load, we need to push along the
       // tile and raster loading by continuing to update it.
-      if (tile.getState() == Tile::LoadState::ContentLoaded) {
-        tile.processLoadedContent();
+      if (child.getState() == Tile::LoadState::ContentLoaded) {
+        child.processLoadedContent();
         ImplicitTraversalUtilities::createImplicitChildrenIfNeeded(
-            tile,
+            child,
             childInfo);
       }
       child.update(frameState.lastFrameNumber, frameState.currentFrameNumber);


### PR DESCRIPTION
This PR fixes the bug where the Cesium CWT would not load if the Forbid Holes option was enabled.