### PR TITLE
Add dynamic screen space error

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -493,6 +493,8 @@ private:
 
   std::string getResolvedContentUrl(const Tile& tile) const;
 
+  double calcDynamicSSEDensity(const Tile &tile, const ViewState& frustum) const noexcept;
+
   std::vector<std::unique_ptr<TileContext>> _contexts;
   TilesetExternals _externals;
   CesiumAsync::AsyncSystem _asyncSystem;
@@ -588,6 +590,8 @@ private:
   // selection.
   std::vector<std::unique_ptr<std::vector<double>>> _distancesStack;
   size_t _nextDistancesVector;
+
+  std::vector<double> _dynamicScreenSpaceErrorDensities;
 
   CESIUM_TRACE_DECLARE_TRACK_SET(_loadingSlots, "Tileset Loading Slot");
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetOptions.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetOptions.h
@@ -74,6 +74,15 @@ struct CESIUM3DTILESSELECTION_API TilesetOptions {
    */
   bool showCreditsOnScreen = false;
 
+  bool enableDynamicScreenSpaceError = true;
+  double dynamicScreenSpaceErrorDensity = 0.00278;
+  double dynamicScreenSpaceErrorFactor = 4.0;
+  double dynamicScreenSpaceErrorHeightFallOff = 0.25;
+  double dynamicScreenSpaceErrorNearDistance = 10000.0;
+  double dynamicScreenSpaceErrorFarDistance = 40000.0;
+  double dynamicScreenSpaceErrorCloseHeight = 0.0;
+  double dynamicScreenSpaceErrorFarHeight = 8000.0;
+
   /**
    * @brief The maximum number of pixels of error when rendering this tileset.
    * This is used to select an appropriate level-of-detail.


### PR DESCRIPTION
This PR experiments with dynamic screen space error that is implemented in CesiumJS [here] (https://github.com/CesiumGS/cesium/blob/a0c6ff34dff12ffede139e8978260cd9ba5c9d15/Source/Scene/Cesium3DTileset.js#L2208)

However, this deviates from the CesiumJS implementation a little bit. In the CesiumJS, it uses fog functions to control the sse based on distance between the camera and tile. The further the tile is away from camera, the more coarse the tile is going to get compared to its original sse. But the fog function doesn't allow the user to configure the near distance at which we want to apply dynamic SSE. This PR uses the Hermite interpolation or smoothstep() to do that. Also the fog function and hermite is quite pretty similar for x > 0. e.g https://www.desmos.com/calculator/bvcofnekxw

Also in CesiumJS, it automatically tries to configure the minimum height and max height of the root to apply dynamic SSE. Outside of that range, dynamic SSE will not apply. But that doesn't work for tileset that covers the whole earth, so I opt it to be a parameter to let the user set by themselves. The CesiumJS method can be implemented by client if desired though.