### PR TITLE
Use int64_t instead of uint32_t for Cesium ion asset IDs.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 ##### Breaking Changes :mega:
 
-- Added a parameter to `prepareRasterInLoadThread`
+- Added a parameter to `prepareRasterInLoadThread`.
+- Changed the type of Cesium ion asset IDs from `uint32_t` to `int64_t`.
 
 ##### Fixes :wrench:
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/IonRasterOverlay.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/IonRasterOverlay.h
@@ -32,7 +32,7 @@ public:
    */
   IonRasterOverlay(
       const std::string& name,
-      uint32_t ionAssetID,
+      int64_t ionAssetID,
       const std::string& ionAccessToken,
       const RasterOverlayOptions& overlayOptions = {});
   virtual ~IonRasterOverlay() override;
@@ -48,7 +48,7 @@ public:
       RasterOverlay* pOwner) override;
 
 private:
-  uint32_t _ionAssetID;
+  int64_t _ionAssetID;
   std::string _ionAccessToken;
 
   struct AssetEndpointAttribution {

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -58,7 +58,7 @@ public:
    */
   Tileset(
       const TilesetExternals& externals,
-      uint32_t ionAssetID,
+      int64_t ionAssetID,
       const std::string& ionAccessToken,
       const TilesetOptions& options = TilesetOptions(),
       const std::string& ionAssetEndpointUrl = "https://api.cesium.com/");
@@ -82,7 +82,7 @@ public:
    * If the tileset references a URL, this property
    * will not have a value.
    */
-  std::optional<uint32_t> getIonAssetID() const noexcept {
+  std::optional<int64_t> getIonAssetID() const noexcept {
     return this->_ionAssetID;
   }
 
@@ -508,7 +508,7 @@ private:
   std::vector<Credit> _tilesetCredits;
 
   std::optional<std::string> _url;
-  std::optional<uint32_t> _ionAssetID;
+  std::optional<int64_t> _ionAssetID;
   std::optional<std::string> _ionAccessToken;
   bool _isRefreshingIonToken;
   std::optional<std::string> _ionAssetEndpointUrl;

--- a/Cesium3DTilesSelection/src/IonRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/IonRasterOverlay.cpp
@@ -22,7 +22,7 @@ namespace Cesium3DTilesSelection {
 
 IonRasterOverlay::IonRasterOverlay(
     const std::string& name,
-    uint32_t ionAssetID,
+    int64_t ionAssetID,
     const std::string& ionAccessToken,
     const RasterOverlayOptions& overlayOptions)
     : RasterOverlay(name, overlayOptions),

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -75,7 +75,7 @@ Tileset::Tileset(
 
 Tileset::Tileset(
     const TilesetExternals& externals,
-    uint32_t ionAssetID,
+    int64_t ionAssetID,
     const std::string& ionAccessToken,
     const TilesetOptions& options,
     const std::string& ionAssetEndpointUrl)


### PR DESCRIPTION
Because we should mostly avoid unsigned types, and because 32-bits for Cesium ion asset IDs might someday be insufficient.