### PR TITLE
Use intrusive linked list to remove visible tile from last frame

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
@@ -649,6 +649,7 @@ private:
   std::vector<RasterMappedTo3DTile> _rasterTiles;
 
   CesiumUtility::DoublyLinkedListPointers<Tile> _loadedTilesLinks;
+  CesiumUtility::DoublyLinkedListPointers<Tile> _visibleTilesLinks;
 
 public:
   /**
@@ -656,6 +657,9 @@ public:
    */
   typedef CesiumUtility::DoublyLinkedList<Tile, &Tile::_loadedTilesLinks>
       LoadedLinkedList;
+
+  typedef CesiumUtility::DoublyLinkedList<Tile, &Tile::_visibleTilesLinks>
+      VisibleLinkedList;
 };
 
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -569,6 +569,7 @@ private:
       _subtreeLoadsInProgress; // TODO: does this need to be atomic?
 
   Tile::LoadedLinkedList _loadedTiles;
+  Tile::VisibleLinkedList _lastVisibleTiles;
 
   RasterOverlayCollection _overlays;
 


### PR DESCRIPTION
I think we are currently using `TileSelectionState::Result::Refine` to determine if the current rendered tile has any children that are rendered in the last frame. If there are, we traverse down the tile to find those children and grand children that were rendered in  the last frame to add them to the `ViewUpdateResult::tilesToNoLongerRenderInThisFrame`

This PR tries to experiment with intrusive linked list instead. Basically, after a frame is finished traversing, all the current rendered tiles will be added to this list. In the next frame, when we add a new tile to the render list, we remove this tile from the linked list that represents the list of visible tile in the last frame. After the current frame finish traversing, the linked list will contain only the list of tiles that need to be turned off. This way, we don't need to maintain the state machine of Refine

Open this as draft since I'm still unsure about the state machine for traversing