### PR TITLE
Make sure aggregated raster overlay is saved for Ion Raster Overlay

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/IonRasterOverlay.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/IonRasterOverlay.h
@@ -50,6 +50,7 @@ public:
 private:
   uint32_t _ionAssetID;
   std::string _ionAccessToken;
+  std::unique_ptr<RasterOverlay> _pAggregatedOverlay;
 
   struct AssetEndpointAttribution {
     std::string html;

--- a/Cesium3DTilesSelection/src/IonRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/IonRasterOverlay.cpp
@@ -50,22 +50,21 @@ IonRasterOverlay::createTileProvider(
           !attribution.collapsible || this->getOptions().showCreditsOnScreen));
     }
   }
-  std::unique_ptr<RasterOverlay> pAggregatedOverlay = nullptr;
   if (endpoint.externalType == "BING") {
-    pAggregatedOverlay = std::make_unique<BingMapsRasterOverlay>(
+    _pAggregatedOverlay = std::make_unique<BingMapsRasterOverlay>(
         this->getName(),
         endpoint.url,
         endpoint.key,
         endpoint.mapStyle,
         endpoint.culture);
   } else {
-    pAggregatedOverlay = std::make_unique<TileMapServiceRasterOverlay>(
+    _pAggregatedOverlay = std::make_unique<TileMapServiceRasterOverlay>(
         this->getName(),
         endpoint.url,
         std::vector<CesiumAsync::IAssetAccessor::THeader>{
             std::make_pair("Authorization", "Bearer " + endpoint.accessToken)});
   }
-  return pAggregatedOverlay->createTileProvider(
+  return _pAggregatedOverlay->createTileProvider(
       asyncSystem,
       pAssetAccessor,
       pCreditSystem,


### PR DESCRIPTION
Ion raster overlay use TMS and Bing behind the scene, but those overlay wait for main thread to run. However, before the main thread run, they are already deleted which leads to crash