### PR TITLE
Get ion token correctly for TMS.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,11 @@
 # Change Log
 
-### ? - ?
+### v0.14.1 - 2022-04-14
 
 ##### Fixes :wrench:
 
 - Fixed a crash caused by using an aggregated overlay of `IonRasterOverlay` after it is freed.
+- Fix a bug introduced in v0.14.0 that caused Tile Map Service (TMS) overlays from Cesium ion to fail to load.
 
 ### v0.14.0 - 2022-04-01
 

--- a/Cesium3DTilesSelection/src/IonRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/IonRasterOverlay.cpp
@@ -204,7 +204,7 @@ IonRasterOverlay::createTileProvider(
               endpoint.url =
                   JsonHelpers::getStringOrDefault(response, "url", "");
               endpoint.accessToken =
-                  JsonHelpers::getStringOrDefault(response, "accessToken");
+                  JsonHelpers::getStringOrDefault(response, "accessToken", "");
             }
             return endpoint;
           })


### PR DESCRIPTION
Fixes a bug that prevents accessing TMS layers from Cesium ion.

`JsonHelpers::getStringOrDefault(response, "accessToken")` tries to interpret `response` as a string and returns `"accessToken"` if that fails. `JsonHelpers::getStringOrDefault(response, "accessToken", "")` tries to interpret a property called `accessToken` on the response object as a string, and returns an empty string if that fails. Clearly the API could be better here.