### PR TITLE
Less holes, and improvements to "forbid holes" mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,18 @@
 # Change Log
 
+### ? - ?
+
+##### Additions :tada:
+
+- Improved the load performance when `TilesetOptions::forbidHoles` is enabled by only loading child tiles when their parent does not meet the necessary screen-space error requirement.
+
+##### Fixes :wrench:
+
+- Fixed a bug that could cause the same tiles to be continually loaded and unloaded when `TilesetOptions::forbidHoles` was enabled.
+- Fixed a bug that could sometimes cause tilesets to fail to show their full detail when making changes to raster overlays.
+- Fixed a bug that could cause holes even with `TilesetOptions::forbidHoles` enabled, particularly when using external tilesets.
+- Tiles will no longer be selected to render when they have no content and they have a higher "geometric error" than their parent. In previous versions, this situation could briefly lead to holes while the children of such tiles loaded.
+
 ### v0.14.1 - 2022-04-14
 
 ##### Fixes :wrench:

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -472,10 +472,10 @@ private:
    * @param tile The tile that is potentially being refined.
    * @param implicitInfo The implicit traversal info.
    * @param distance The distance to the tile.
-   * @return true Some of the required descendents are not yet loaded, so this tile
-   * _cannot_ yet be refined.
-   * @return false All of the required descendents (if there are any) are loaded,
-   * so this tile _can_ be refined.
+   * @return true Some of the required descendents are not yet loaded, so this
+   * tile _cannot_ yet be refined.
+   * @return false All of the required descendents (if there are any) are
+   * loaded, so this tile _can_ be refined.
    */
   bool _queueLoadOfChildrenRequiredForForbidHoles(
       const FrameState& frameState,

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -461,26 +461,23 @@ private:
 
   /**
    * @brief Queues load of tiles that are _required_ to be loaded before the
-   * given tile can be refined.
+   * given tile can be refined in "Forbid Holes" mode.
    *
-   * If {@link TilesetOptions::forbidHoles} is false (the default), any tile can
-   * be refined, regardless of whether its children are loaded or not. So in
-   * that case, this method immediately returns `false`.
+   * The queued tiles may include descedents, too, if any children are set to
+   * Unconditionally Refine ({@link Tile::getUnconditionallyRefine}).
    *
-   * When `forbidHoles` is true, however, and some of this tile's children are
-   * not yet renderable, this method returns `true`. It also adds those
-   * not-yet-renderable tiles to the load queue.
+   * This method should only be called if {@link TilesetOptions::forbidHoles} is enabled.
    *
    * @param frameState The state of the current frame.
    * @param tile The tile that is potentially being refined.
    * @param implicitInfo The implicit traversal info.
    * @param distance The distance to the tile.
-   * @return true Some of the required children are not yet loaded, so this tile
+   * @return true Some of the required descendents are not yet loaded, so this tile
    * _cannot_ yet be refined.
-   * @return false All of the required children (if there are any) are loaded,
+   * @return false All of the required descendents (if there are any) are loaded,
    * so this tile _can_ be refined.
    */
-  bool _queueLoadOfChildrenRequiredForRefinement(
+  bool _queueLoadOfChildrenRequiredForForbidHoles(
       const FrameState& frameState,
       Tile& tile,
       const ImplicitTraversalInfo& implicitInfo,

--- a/Cesium3DTilesSelection/src/ExternalTilesetContent.cpp
+++ b/Cesium3DTilesSelection/src/ExternalTilesetContent.cpp
@@ -70,25 +70,6 @@ ExternalTilesetContent::load(const TileContentLoadInput& input) {
       *pContext,
       pLogger);
 
-  // Special case: if the root tile of an external tileset has no content,
-  // treat it as unrenderable rather than rendering a hole in its place.
-  // This is arguably contrary to the 3D Tiles spec (see
-  // https://github.com/CesiumGS/3d-tiles/issues/609), but it's very
-  // convenient when an external tileset conceptually has multiple roots.
-  // It also brings us closer to CesiumJS's behavior.
-  const auto rootIt = tilesetJson.FindMember("root");
-  if (rootIt != tilesetJson.MemberEnd()) {
-    const auto contentIt = rootIt->value.FindMember("content");
-    if (contentIt == rootIt->value.MemberEnd()) {
-      Tile& rootTile = pResult->childTiles.value()[0];
-
-      // A tile is unrenderable if it _does_ have content, but that content has
-      // a _nullopt_ model. Yes, this is confusing.
-      rootTile.setEmptyContent();
-      rootTile.setState(Tile::LoadState::ContentLoaded);
-    }
-  }
-
   return pResult;
 }
 

--- a/Cesium3DTilesSelection/src/ExternalTilesetContent.cpp
+++ b/Cesium3DTilesSelection/src/ExternalTilesetContent.cpp
@@ -79,7 +79,7 @@ ExternalTilesetContent::load(const TileContentLoadInput& input) {
   const auto rootIt = tilesetJson.FindMember("root");
   if (rootIt != tilesetJson.MemberEnd()) {
     const auto contentIt = rootIt->value.FindMember("content");
-    if (contentIt == tilesetJson.MemberEnd()) {
+    if (contentIt == rootIt->value.MemberEnd()) {
       Tile& rootTile = pResult->childTiles.value()[0];
 
       // A tile is unrenderable if it _does_ have content, but that content has

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -599,25 +599,6 @@ bool Tile::unloadContent() noexcept {
       return false;
     }
 
-    // Very rarely, we can end up unloading a tile that is not associated with
-    // a tileset at all. This can happen when:
-    //
-    // 1. ExternalTilesetContent creates content-less root tiles with an initial
-    //    state of ContentLoaded.
-    // 2. These tiles are initially added to TileContentLoadResult.
-    // 3. When the processLoadedContent is called on the parent tile, the child
-    //    tiles (including the one created in step 2) are copied to the parent
-    //    tile's childTiles property.
-    //
-    // If the root tile created in (1) is deleted between steps (2) and (3)
-    // because its parent content is unloaded, we'll find ourselves in this
-    // method right here with a nullptr TileContext::pTileset. Exit early
-    // because the unloading steps below are unnecessary in this case, and
-    // because we'd crash if we tried to do them.
-    if (this->getTileset() == nullptr) {
-      return true;
-    }
-
     // If a child tile is being upsampled from this one, we can't unload this
     // one yet.
     if (this->getState() == Tile::LoadState::Done &&

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -865,7 +865,6 @@ void Tile::update(
     }
   }
 
-  // TODO: if there's no model, we can actually free any existing overlays.
   if (this->getState() == LoadState::Done &&
       this->getTileset()->supportsRasterOverlays() && this->getContent() &&
       this->getContent()->model) {
@@ -923,6 +922,12 @@ void Tile::update(
     if (moreRasterDetailAvailable && this->_children.empty()) {
       createQuadtreeSubdividedChildren(*this);
     }
+  } else if (
+      this->getState() == LoadState::Done && !this->_rasterTiles.empty()) {
+    // We can't hang raster images on a tile without geometry, and their existence
+    // can prevent the tile from being deemed done loading. So clear them out
+    // here.
+    this->_rasterTiles.clear();
   }
 }
 

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -924,9 +924,9 @@ void Tile::update(
     }
   } else if (
       this->getState() == LoadState::Done && !this->_rasterTiles.empty()) {
-    // We can't hang raster images on a tile without geometry, and their existence
-    // can prevent the tile from being deemed done loading. So clear them out
-    // here.
+    // We can't hang raster images on a tile without geometry, and their
+    // existence can prevent the tile from being deemed done loading. So clear
+    // them out here.
     this->_rasterTiles.clear();
   }
 }

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -599,6 +599,25 @@ bool Tile::unloadContent() noexcept {
       return false;
     }
 
+    // Very rarely, we can end up unloading a tile that is not associated with
+    // a tileset at all. This can happen when:
+    //
+    // 1. ExternalTilesetContent creates content-less root tiles with an initial
+    //    state of ContentLoaded.
+    // 2. These tiles are initially added to TileContentLoadResult.
+    // 3. When the processLoadedContent is called on the parent tile, the child
+    //    tiles (including the one created in step 2) are copied to the parent
+    //    tile's childTiles property.
+    //
+    // If the root tile created in (1) is deleted between steps (2) and (3)
+    // because its parent content is unloaded, we'll find ourselves in this
+    // method right here with a nullptr TileContext::pTileset. Exit early
+    // because the unloading steps below are unnecessary in this case, and
+    // because we'd crash if we tried to do them.
+    if (this->getTileset() == nullptr) {
+      return true;
+    }
+
     // If a child tile is being upsampled from this one, we can't unload this
     // one yet.
     if (this->getState() == Tile::LoadState::Done &&

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -1409,7 +1409,7 @@ static bool anyRasterOverlaysNeedLoading(const Tile& tile) noexcept {
         //    hole. To have this behavior, the tile should _not_ have content at
         //    all.
         //
-        // We distinguish whether the tileset createor wanted (1) or (2) by
+        // We distinguish whether the tileset creator wanted (1) or (2) by
         // comparing this tile's geometricError to the geometricError of its
         // parent tile. If this tile's error is greater than or equal to its
         // parent, treat it as (1). If it's less, treat it was (2).

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -1412,14 +1412,20 @@ static bool anyRasterOverlaysNeedLoading(const Tile& tile) noexcept {
         // We distinguish whether the tileset creator wanted (1) or (2) by
         // comparing this tile's geometricError to the geometricError of its
         // parent tile. If this tile's error is greater than or equal to its
-        // parent, treat it as (1). If it's less, treat it was (2).
+        // parent, treat it as (1). If it's less, treat it as (2).
         //
         // For a tile with no parent there's no difference between the
         // behaviors.
         double myGeometricError = tile.getNonZeroGeometricError();
+
+        Tile* pAncestor = tile.getParent();
+        while (pAncestor && pAncestor->getUnconditionallyRefine()) {
+          pAncestor = pAncestor->getParent();
+        }
+
         double parentGeometricError =
-            tile.getParent() ? tile.getParent()->getNonZeroGeometricError()
-                             : myGeometricError * 2.0;
+            pAncestor ? pAncestor->getNonZeroGeometricError()
+                      : myGeometricError * 2.0;
         if (myGeometricError >= parentGeometricError) {
           tile.setEmptyContent();
         }

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -713,6 +713,8 @@ bool Tileset::_queueLoadOfChildrenRequiredForRefinement(
   gsl::span<Tile> children = tile.getChildren();
   bool waitingForChildren = false;
   for (Tile& child : children) {
+    this->_markTileVisited(child);
+
     if (!child.isRenderable() && !child.isExternalTileset()) {
       waitingForChildren = true;
 
@@ -727,7 +729,6 @@ bool Tileset::_queueLoadOfChildrenRequiredForRefinement(
             childInfo);
       }
       child.update(frameState.lastFrameNumber, frameState.currentFrameNumber);
-      this->_markTileVisited(child);
 
       // We're using the distance to the parent tile to compute the load
       // priority. This is fine because the relative priority of the children is

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -701,11 +701,12 @@ Tileset::TraversalDetails Tileset::_renderLeaf(
   return traversalDetails;
 }
 
-bool Tileset::_queueLoadOfChildrenRequiredForRefinement(
+bool Tileset::_queueLoadOfChildrenRequiredForForbidHoles(
     const FrameState& frameState,
     Tile& tile,
     const ImplicitTraversalInfo& implicitInfo,
     const std::vector<double>& distances) {
+  // This method should only be called in "Forbid Holes" mode.
   assert(this->_options.forbidHoles);
 
   bool waitingForChildren = false;
@@ -747,7 +748,7 @@ bool Tileset::_queueLoadOfChildrenRequiredForRefinement(
       // we don't care because all tiles must be loaded before we can render any
       // of them, so their relative priority doesn't matter.
       ImplicitTraversalInfo childInfo(&child, &implicitInfo);
-      waitingForChildren |= this->_queueLoadOfChildrenRequiredForRefinement(
+      waitingForChildren |= this->_queueLoadOfChildrenRequiredForForbidHoles(
           frameState,
           child,
           childInfo,
@@ -1022,11 +1023,12 @@ Tileset::TraversalDetails Tileset::_visitTile(
   // are loaded. But don't queue the children for load until we _want_ to
   // refine this tile.
   if (wantToRefine && this->_options.forbidHoles) {
-    const bool waitingForChildren = _queueLoadOfChildrenRequiredForRefinement(
-        frameState,
-        tile,
-        implicitInfo,
-        distances);
+    const bool waitingForChildren =
+        this->_queueLoadOfChildrenRequiredForForbidHoles(
+            frameState,
+            tile,
+            implicitInfo,
+            distances);
     wantToRefine = !waitingForChildren;
   }
 


### PR DESCRIPTION
This PR has a few significant improvements to tile selection, especially when "Forbid Holes" is enabled:

## Improved performance with "Forbid Holes"

When "Forbid Holes" is enabled, all of a parent tile's children must be loaded before the parent can be refined. This forces us to "refine down through the tree." But previously (before this PR), the algorithm _also_ loaded all children of a tile that met the SSE. That was super wasteful; in a quadtree it would end up loading 4x more tiles than necessary! "Forbid Holes" enabled is always going to be slower, but now it's much closer to peformance parity and therefore much more useable.

## Fixed ping-ping loading with "Forbid Holes"

With "Forbid Holes" enabled, the algorithm would often get stuck in a cycle of loading and unloading the same tiles repeatedly. 😱  This PR fixes it.

Essentially the problem was that already-loaded child tiles would not be marked as visited while waiting for other children to finish loading. Non-visited tiles are eligible to be unloaded. With a full cache, we'd unload one child tile while waiting for a second to load, then unload the second while waiting for the first. And so on.

## Don't get stuck

When using raster overlays and a tileset where some tiles don't have any content, the algorithm could sometimes get stuck and fail to refine tiles to their proper detail. It's easy to reproduce with such a tileset, but unfortunately I can't share the one I've been testing with here. Here's how it's done:

1. Create a tileset and enable "Forbid Holes"
2. Attach a raster overlay, such as `DebugColorizeTilesRasterOverlay`.
3. Zoom in close and let the detail load.
4. Change the maximum SSE of the tileset, even slightly.
5. All the detail disappears, and doesn't come back.

Changing the SSE back doesn't help. Recreating the Tileset (e.g. pressing Refresh Tileset in Cesium for Unreal) _does_ fix it.

Setting the SSE in Cesium for Unreal removes and re-adds the raster overlay. When we add a raster overlay, we add a placeholder for it to all tiles. In the `Tile::update`, we turn the placeholder into a real overlay tile, if necessary. But we only turn the placeholders into real overlays if the tile has geometry. For tiles without content, before this PR, the placeholders would simply block refinement forever, because they would never be deemed ready.

The solution in this PR is to remove overlays from tiles that are in the `Done` state but still do not have any geometry.

## Forbid Holes should be aware of unconditional refinement

Some tiles are marked "unconditionally refine". Such tiles should _never_ be shown, but are only used for culling and then their children are considered in their place. This PR makes the "Forbid Holes" option aware of this, so that, when waiting for children to load, if one of those children is marked "unconditionally refine", then that tile's _children_ will be waited on, too.

This fixes some holes that can appear even in forbid holes mode.

## Better handling of tiles without content

cesium-native has long treated tiles without any content exactly the same way as it does tiles that do have content. If the tile meets the SSE, it's "rendered". In a case `A -> B -> C` where a tile without content (B) appears between two tiles that do have content (A and C), this can cause a hole to briefly appear in between when A is refined but C is not yet loaded, even if B's geometric error is huge and so it immediately refines anytime A refines.

This is arguably correct according to the 3D Tiles spec, but it's inconsistent with CesiumJS, and it causes problems when a tile without content is used for structural reasons (e.g. an external tileset must have a single root tile).

So with this PR, a tile without content will now be handled differently depending on whether it's geometric error is less than its parent's geometric error. From the code:

```
        // There are two possible ways to handle a tile with no content:
        //
        // 1. Treat it as a placeholder used for more efficient culling, but
        //    never render it. Refining to this tile is equivalent to refining
        //    to its children. To have this behavior, the tile _should_ have
        //    content, but that content's model should be std::nullopt.
        // 2. Treat it as an indication that nothing need be rendered in this
        //    area at this level-of-detail. In other words, "render" it as a
        //    hole. To have this behavior, the tile should _not_ have content at
        //    all.
        //
        // We distinguish whether the tileset creator wanted (1) or (2) by
        // comparing this tile's geometricError to the geometricError of its
        // parent tile. If this tile's error is greater than or equal to its
        // parent, treat it as (1). If it's less, treat it was (2).
        //
        // For a tile with no parent there's no difference between the
        // behaviors.
```

CC https://github.com/CesiumGS/3d-tiles/issues/609