### PR TITLE
Fix sqlite crash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - Fixed a bug that could sometimes cause tilesets to fail to show their full detail when making changes to raster overlays.
 - Fixed a bug that could cause holes even with `TilesetOptions::forbidHoles` enabled, particularly when using external tilesets.
 - Tiles will no longer be selected to render when they have no content and they have a higher "geometric error" than their parent. In previous versions, this situation could briefly lead to holes while the children of such tiles loaded.
+- Fixed a bug where getting bad data from sqlite cache could cause a crash.
 
 ### v0.14.1 - 2022-04-14
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 - Fixed a bug that could sometimes cause tilesets to fail to show their full detail when making changes to raster overlays.
 - Fixed a bug that could cause holes even with `TilesetOptions::forbidHoles` enabled, particularly when using external tilesets.
 - Tiles will no longer be selected to render when they have no content and they have a higher "geometric error" than their parent. In previous versions, this situation could briefly lead to holes while the children of such tiles loaded.
-- Fixed a bug where getting bad data from sqlite cache could cause a crash.
+- Fixed a bug where getting bad data from sqlite cache could cause a crash. If the sqlite database is corrupt, it will be deleted and recreated.
 
 ### v0.14.1 - 2022-04-14
 

--- a/CesiumAsync/include/CesiumAsync/SqliteCache.h
+++ b/CesiumAsync/include/CesiumAsync/SqliteCache.h
@@ -58,5 +58,7 @@ public:
 private:
   struct Impl;
   std::unique_ptr<Impl> _pImpl;
+  void createConnection() const;
+  void destroyDatabase();
 };
 } // namespace CesiumAsync

--- a/CesiumAsync/src/SqliteCache.cpp
+++ b/CesiumAsync/src/SqliteCache.cpp
@@ -792,7 +792,6 @@ void SqliteCache::destroyDatabase() {
     SPDLOG_LOGGER_ERROR(
         this->_pImpl->_pLogger,
         "Unable to delete database file.");
-    return;
   }
   createConnection();
 }


### PR DESCRIPTION
In my case, when reading from `requestHeader`, the JSON string was empty, which caused the json document to have a parse error, and then the program would crash.

Now, it does not crash, it will query from the network instead, and attempt to store the value again. In my case, the value cannot be stored because the sqlite database became corrupt.


If SQL_STATUS is ever SQL_CORRUPT after a SQL_Step command, then it will attempt to delete the file, and then create the database again.

I was unable to call `destroyDatabase` during the `getEntry` because it is marked `const`.