### PR TITLE
Update Tile from Content before calling prepareInMainThread

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - Fixed a bug that could sometimes cause tilesets to fail to show their full detail when making changes to raster overlays.
 - Fixed a bug that could cause holes even with `TilesetOptions::forbidHoles` enabled, particularly when using external tilesets.
 - Tiles will no longer be selected to render when they have no content and they have a higher "geometric error" than their parent. In previous versions, this situation could briefly lead to holes while the children of such tiles loaded.
+- Fixed a bug where `IPrepareRendererResources::prepareInMainThread` was called on a `Tile` before that `Tile` was updated with loaded content.
 
 ### v0.14.1 - 2022-04-14
 

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -502,13 +502,6 @@ void Tile::processLoadedContent() {
   const TilesetExternals& externals = this->getTileset()->getExternals();
 
   if (this->getState() == LoadState::ContentLoaded) {
-    if (externals.pPrepareRendererResources) {
-      this->_pRendererResources =
-          externals.pPrepareRendererResources->prepareInMainThread(
-              *this,
-              this->getRendererResources());
-    }
-
     if (this->_pContent) {
       // Apply children from content, but only if we don't already have
       // children.
@@ -586,6 +579,13 @@ void Tile::processLoadedContent() {
           }
         }
       }
+    }
+
+    if (externals.pPrepareRendererResources) {
+      this->_pRendererResources =
+          externals.pPrepareRendererResources->prepareInMainThread(
+              *this,
+              this->getRendererResources());
     }
 
     this->setState(LoadState::Done);


### PR DESCRIPTION
Previously, we called `IPrepareRendererResources::prepareInMainThread` _before_ we updated the `Tile` with the loaded content. Mostly this doesn't matter, but if `prepareInMainThread` used the tile's bounding volume, for example, and the loaded content included an updated bounding volume, this would result in `prepareInMainThread` using a stale bounding volume. Better to do the update first.