### PR TITLE
Make quantized-mesh availability tile loading part of the tile content load process

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ImplicitTraversal.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ImplicitTraversal.h
@@ -90,8 +90,6 @@ struct ImplicitTraversalInfo {
 
 namespace ImplicitTraversalUtilities {
 
-CesiumAsync::Future<void> loadAvailability(Tile& tile);
-
 void createImplicitChildrenIfNeeded(
     Tile& tile,
     const ImplicitTraversalInfo& implicitInfo);

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContext.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContext.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "BoundingVolume.h"
-#include "Cesium3DTilesSelection/CreditSystem.h"
+#include "CreditSystem.h"
 
 #include <CesiumGeometry/Availability.h>
 #include <CesiumGeometry/OctreeAvailability.h>
@@ -19,6 +19,7 @@ namespace Cesium3DTilesSelection {
 
 class Tileset;
 class TileContext;
+
 /**
  * @brief A tiling context that was created for implicit quadtree or octree
  * tiles.
@@ -105,7 +106,7 @@ public:
    * If `availabilityLevels` is `n`, then availability information is stored
    * every `n`th level in the tile tree.
    */
-  std::optional<int32_t> availabilityLevels;
+  std::optional<uint32_t> availabilityLevels;
 
   /**
    * @brief Any attribution associated with this context/layer.

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContext.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContext.h
@@ -13,7 +13,6 @@
 
 #include <optional>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 namespace Cesium3DTilesSelection {
@@ -107,12 +106,6 @@ public:
    * every `n`th level in the tile tree.
    */
   std::optional<int32_t> availabilityLevels;
-
-  /**
-   * @brief A hash set of the indices of the loaded availability tiles for this
-   * context.
-   */
-  std::unordered_set<CesiumGeometry::QuadtreeTileID> availabilityTilesLoaded;
 
   /**
    * @brief Any attribution associated with this context/layer.
@@ -245,8 +238,20 @@ public:
    * For example, custom terrain for a small area layered on top of Cesium World
    * Terrain. In this scenario, Cesium World Terrain would be the
    * underlyingContext.
+   *
+   * This property can be viewed as forming a singly-linked list of contexts.
+   * {@link pTopContext} points back to the head of list.
    */
   std::unique_ptr<TileContext> pUnderlyingContext;
+
+  /**
+   * @brief Points back to the top context, if this is an underlying context. If
+   * this context _is_ the top context, this property is nullptr.
+   *
+   * {@link pUnderlyingContext} can be viewed as forming a singly-linked list
+   * of contexts. This pointer points back to the head of list.
+   */
+  TileContext* pTopContext = nullptr;
 };
 
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -242,18 +242,6 @@ public:
   requestAvailabilitySubtree(Tile& tile);
 
   /**
-   * @brief Request to load an availability tile.
-   *
-   * This function is not supposed to be called by client.
-   *
-   * @param availabilityTileID The ID of the availability tile.
-   * @param pAvailabilityContext The tile context of the availability tile.
-   */
-  CesiumAsync::SharedFuture<int> requestAvailabilityTile(
-      const CesiumGeometry::QuadtreeTileID& availabilityTileID,
-      TileContext* pAvailabilityContext);
-
-  /**
    * @brief Add the given {@link TileContext} to this tile set.
    *
    * This function is not supposed to be called by clients.
@@ -647,6 +635,10 @@ private:
   void processSubtreeQueue();
 
   void reportError(TilesetLoadFailureDetails&& errorDetails);
+
+  CesiumAsync::Future<int> _requestQuantizedMeshAvailabilityTile(
+      const CesiumGeometry::QuadtreeTileID& availabilityTileID,
+      TileContext* pAvailabilityContext);
 
   Tileset(const Tileset& rhs) = delete;
   Tileset& operator=(const Tileset& rhs) = delete;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -557,28 +557,6 @@ private:
     }
   };
 
-  struct AvailabilityLoadRecord {
-    /**
-     * @brief The ID of the availability tile.
-     */
-    CesiumGeometry::QuadtreeTileID tileID;
-
-    /**
-     * @brief The tile context of the availability tile.
-     */
-    const TileContext* pTileContext;
-
-    /**
-     * @brief A shared future of the availability loading.
-     */
-    CesiumAsync::SharedFuture<int> future;
-
-    bool operator==(const AvailabilityLoadRecord& rhs) const noexcept {
-      return this->tileID == rhs.tileID &&
-             this->pTileContext == rhs.pTileContext;
-    }
-  };
-
   std::vector<LoadRecord> _loadQueueHigh;
   std::vector<LoadRecord> _loadQueueMedium;
   std::vector<LoadRecord> _loadQueueLow;
@@ -587,8 +565,6 @@ private:
   std::vector<SubtreeLoadRecord> _subtreeLoadQueue;
   std::atomic<uint32_t>
       _subtreeLoadsInProgress; // TODO: does this need to be atomic?
-
-  std::vector<AvailabilityLoadRecord> _availabilityLoading;
 
   Tile::LoadedLinkedList _loadedTiles;
 

--- a/Cesium3DTilesSelection/src/ImplicitTraversal.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitTraversal.cpp
@@ -455,7 +455,7 @@ void createImplicitChildrenIfNeeded(
 
         if (sw & TileAvailabilityFlags::TILE_AVAILABLE) {
           createImplicitQuadtreeTile(
-              pSW,
+              pContext,
               implicitContext,
               tile,
               children[childIndex++],
@@ -465,7 +465,7 @@ void createImplicitChildrenIfNeeded(
 
         if (se & TileAvailabilityFlags::TILE_AVAILABLE) {
           createImplicitQuadtreeTile(
-              pSE,
+              pContext,
               implicitContext,
               tile,
               children[childIndex++],
@@ -475,7 +475,7 @@ void createImplicitChildrenIfNeeded(
 
         if (nw & TileAvailabilityFlags::TILE_AVAILABLE) {
           createImplicitQuadtreeTile(
-              pNW,
+              pContext,
               implicitContext,
               tile,
               children[childIndex++],
@@ -485,7 +485,7 @@ void createImplicitChildrenIfNeeded(
 
         if (ne & TileAvailabilityFlags::TILE_AVAILABLE) {
           createImplicitQuadtreeTile(
-              pNE,
+              pContext,
               implicitContext,
               tile,
               children[childIndex],

--- a/Cesium3DTilesSelection/src/ImplicitTraversal.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitTraversal.cpp
@@ -6,12 +6,9 @@
 #include "Cesium3DTilesSelection/Tileset.h"
 #include "QuantizedMeshContent.h"
 
-#include <CesiumAsync/IAssetResponse.h>
-#include <CesiumGeometry/QuadtreeRectangleAvailability.h>
 #include <CesiumGeometry/TileAvailabilityFlags.h>
 #include <CesiumGeospatial/S2CellID.h>
 
-using namespace CesiumAsync;
 using namespace CesiumGeometry;
 using namespace CesiumGeospatial;
 
@@ -159,22 +156,6 @@ ImplicitTraversalInfo::ImplicitTraversalInfo(
             this->pCurrentNode));
   }
 }
-
-namespace {
-
-inline CesiumGeometry::QuadtreeTileID getAvailabilityTile(
-    const CesiumGeometry::QuadtreeTileID& tileID,
-    uint32_t availabilityLevels) {
-  uint32_t parentLevel =
-      tileID.level % availabilityLevels == 0
-          ? tileID.level - availabilityLevels
-          : (tileID.level / availabilityLevels) * availabilityLevels;
-
-  uint32_t divisor = 1U << (tileID.level - parentLevel);
-  return QuadtreeTileID(parentLevel, tileID.x / divisor, tileID.y / divisor);
-}
-
-} // namespace
 
 namespace ImplicitTraversalUtilities {
 

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -482,8 +482,8 @@ void Tile::loadContent() {
       .thenInMainThread([this](LoadResult&& loadResult) noexcept {
         this->_pContent = std::move(loadResult.pContent);
         this->_pRendererResources = loadResult.pRendererResources;
-        this->setState(loadResult.state);
         this->getTileset()->notifyTileDoneLoading(this);
+        this->setState(loadResult.state);
       })
       .catchInMainThread([this](const std::exception& e) {
         this->_pContent.reset();

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -574,12 +574,13 @@ void Tile::processLoadedContent() {
       }
 
       if (!this->_pContent->availableTileRectangles.empty() &&
-          this->getContext()->implicitContext &&
-          context.rectangleAvailability) {
+          this->getContext()->implicitContext) {
         ImplicitTilingContext& context = *this->getContext()->implicitContext;
-        for (const QuadtreeTileRectangularRange& range :
-             this->_pContent->availableTileRectangles) {
-          context.rectangleAvailability->addAvailableTileRange(range);
+        if (context.rectangleAvailability) {
+          for (const QuadtreeTileRectangularRange& range :
+               this->_pContent->availableTileRectangles) {
+            context.rectangleAvailability->addAvailableTileRange(range);
+          }
         }
       }
     }

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -411,7 +411,9 @@ Tileset::requestTileContent(Tile& tile) {
     while (pContext) {
       if (pContext != pTileContext && pContext->implicitContext &&
           pContext->implicitContext->availabilityLevels) {
-        if ((level % *pContext->implicitContext->availabilityLevels) == 0) {
+        uint32_t availabilityLevels =
+            uint32_t(*pContext->implicitContext->availabilityLevels);
+        if ((level % availabilityLevels) == 0) {
           // This tile has availability data, so load it.
           layerFutures.emplace_back(this->_requestQuantizedMeshAvailabilityTile(
               *pQuadtreeTileID,
@@ -465,7 +467,7 @@ Future<int> Tileset::_requestQuantizedMeshAvailabilityTile(
             return {};
           })
       .thenInMainThread(
-          [pAvailabilityContext, availabilityTileID, this](
+          [pAvailabilityContext](
               std::vector<CesiumGeometry::QuadtreeTileRectangularRange>&&
                   rectangles) {
             if (!rectangles.empty()) {

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -385,81 +385,97 @@ Tileset::requestTileContent(Tile& tile) {
 
   this->notifyTileStartLoading(&tile);
 
-  return this->getExternals().pAssetAccessor->get(
-      this->getAsyncSystem(),
-      url,
-      tile.getContext()->requestHeaders);
-}
+  Future<std::shared_ptr<IAssetRequest>> tileFuture =
+      this->getExternals().pAssetAccessor->get(
+          this->getAsyncSystem(),
+          url,
+          tile.getContext()->requestHeaders);
 
-CesiumAsync::SharedFuture<int> Tileset::requestAvailabilityTile(
-    const CesiumGeometry::QuadtreeTileID& availabilityTileID,
-    TileContext* pAvailabilityContext) {
-  AvailabilityLoadRecord record{
-      availabilityTileID,
-      pAvailabilityContext,
-      _asyncSystem.createResolvedFuture(0).share()};
-  auto recordIt = std::find(
-      _availabilityLoading.begin(),
-      _availabilityLoading.end(),
-      record);
-  if (recordIt != _availabilityLoading.end()) {
-    return recordIt->future;
+  // In addition to loading the main tile, we also need to load the same tile in
+  // any underlying contexts for which this tile is an availability level. This
+  // is necessary because, when we later create this tile's children, we need to
+  // be able to create children that are only available from an underlying
+  // layer, and we can only do that if we know they're available.
+  TileContext* pTileContext = tile.getContext();
+  TileContext* pContext =
+      pTileContext->pTopContext ? pTileContext->pTopContext : pTileContext;
+
+  const QuadtreeTileID* pQuadtreeTileID =
+      std::get_if<QuadtreeTileID>(&tile.getTileID());
+
+  if (pQuadtreeTileID && pContext->implicitContext &&
+      pContext->implicitContext->rectangleAvailability &&
+      pContext->implicitContext->availabilityLevels) {
+    uint32_t level = pQuadtreeTileID->level;
+    std::vector<Future<int>> layerFutures;
+    while (pContext) {
+      if (pContext != pTileContext && pContext->implicitContext &&
+          pContext->implicitContext->availabilityLevels) {
+        if ((level % *pContext->implicitContext->availabilityLevels) == 0) {
+          // This tile has availability data, so load it.
+          layerFutures.emplace_back(this->_requestQuantizedMeshAvailabilityTile(
+              *pQuadtreeTileID,
+              pContext));
+        }
+      }
+
+      pContext = pContext->pUnderlyingContext.get();
+    }
+
+    // If we need to load any tiles for availability, do that and then return
+    // the data for the actual tile.
+    if (!layerFutures.empty()) {
+      return this->getAsyncSystem()
+          .all(std::move(layerFutures))
+          .thenImmediately(
+              [tileFuture = std::move(tileFuture)](std::vector<int>&&) mutable {
+                return std::move(tileFuture);
+              });
+    }
   }
 
+  return tileFuture;
+}
+
+Future<int> Tileset::_requestQuantizedMeshAvailabilityTile(
+    const CesiumGeometry::QuadtreeTileID& availabilityTileID,
+    TileContext* pAvailabilityContext) {
   std::string url =
       getResolvedContentUrl(*pAvailabilityContext, availabilityTileID);
-  record.future =
-      _externals.pAssetAccessor
-          ->get(
-              _externals.asyncSystem,
-              url,
-              pAvailabilityContext->requestHeaders)
-          .thenInWorkerThread(
-              [pLogger = _externals.pLogger, url, availabilityTileID](
-                  std::shared_ptr<IAssetRequest>&& pRequest)
-                  -> std::vector<QuadtreeTileRectangularRange> {
-                const IAssetResponse* pResponse = pRequest->response();
-                if (pResponse) {
-                  uint16_t statusCode = pResponse->statusCode();
 
-                  if (!(statusCode != 0 &&
-                        (statusCode < 200 || statusCode >= 300))) {
-                    return QuantizedMeshContent::loadMetadata(
-                        pLogger,
-                        pResponse->data(),
-                        availabilityTileID);
-                  }
-                }
-                return {};
-              })
-          .thenInMainThread(
-              [pAvailabilityContext, availabilityTileID, this](
-                  std::vector<CesiumGeometry::QuadtreeTileRectangularRange>&&
-                      rectangles) {
-                pAvailabilityContext->implicitContext->availabilityTilesLoaded
-                    .insert(availabilityTileID);
-                if (!rectangles.empty()) {
-                  for (const QuadtreeTileRectangularRange& range : rectangles) {
-                    pAvailabilityContext->implicitContext->rectangleAvailability
-                        ->addAvailableTileRange(range);
-                  }
-                }
-                AvailabilityLoadRecord record{
-                    availabilityTileID,
-                    pAvailabilityContext,
-                    _asyncSystem.createResolvedFuture(0).share()};
-                auto recordIt = std::find(
-                    _availabilityLoading.begin(),
-                    _availabilityLoading.end(),
-                    record);
-                if (recordIt != _availabilityLoading.end()) {
-                  _availabilityLoading.erase(recordIt);
-                }
-                return 0;
-              })
-          .share();
-  _availabilityLoading.push_back(record);
-  return record.future;
+  return this->getExternals()
+      .pAssetAccessor
+      ->get(this->getAsyncSystem(), url, pAvailabilityContext->requestHeaders)
+      .thenInWorkerThread(
+          [pLogger = _externals.pLogger,
+           availabilityTileID](std::shared_ptr<IAssetRequest>&& pRequest)
+              -> std::vector<QuadtreeTileRectangularRange> {
+            const IAssetResponse* pResponse = pRequest->response();
+            if (pResponse) {
+              uint16_t statusCode = pResponse->statusCode();
+
+              if (!(statusCode != 0 &&
+                    (statusCode < 200 || statusCode >= 300))) {
+                return QuantizedMeshContent::loadMetadata(
+                    pLogger,
+                    pResponse->data(),
+                    availabilityTileID);
+              }
+            }
+            return {};
+          })
+      .thenInMainThread(
+          [pAvailabilityContext, availabilityTileID, this](
+              std::vector<CesiumGeometry::QuadtreeTileRectangularRange>&&
+                  rectangles) {
+            if (!rectangles.empty()) {
+              for (const QuadtreeTileRectangularRange& range : rectangles) {
+                pAvailabilityContext->implicitContext->rectangleAvailability
+                    ->addAvailableTileRange(range);
+              }
+            }
+            return 0;
+          });
 }
 
 void Tileset::addContext(std::unique_ptr<TileContext>&& pNewContext) {

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -412,7 +412,7 @@ Tileset::requestTileContent(Tile& tile) {
       if (pContext != pTileContext && pContext->implicitContext &&
           pContext->implicitContext->availabilityLevels) {
         uint32_t availabilityLevels =
-            uint32_t(*pContext->implicitContext->availabilityLevels);
+            *pContext->implicitContext->availabilityLevels;
         if ((level % availabilityLevels) == 0) {
           // This tile has availability data, so load it.
           layerFutures.emplace_back(this->_requestQuantizedMeshAvailabilityTile(

--- a/Cesium3DTilesSelection/src/TilesetLoadTileFromJson.cpp
+++ b/Cesium3DTilesSelection/src/TilesetLoadTileFromJson.cpp
@@ -324,7 +324,6 @@ void parseImplicitTileset(
           std::nullopt,
           std::nullopt,
           std::nullopt,
-          {},
           std::nullopt};
 
       TileID rootID = "";

--- a/Cesium3DTilesSelection/src/TilesetLoadTilesetDotJson.cpp
+++ b/Cesium3DTilesSelection/src/TilesetLoadTilesetDotJson.cpp
@@ -422,7 +422,6 @@ Future<void> Tileset::LoadTilesetDotJson::Private::workerThreadLoadTileContext(
       std::nullopt,
       std::nullopt,
       std::nullopt,
-      {},
       std::nullopt};
 
   std::vector<std::string> extensions =
@@ -533,6 +532,12 @@ Future<void> Tileset::LoadTilesetDotJson::Private::workerThreadLoadTileContext(
               context.pUnderlyingContext->pTileset = context.pTileset;
               context.pUnderlyingContext->requestHeaders =
                   context.requestHeaders;
+              if (context.pTopContext) {
+                context.pUnderlyingContext->pTopContext = context.pTopContext;
+              } else {
+                context.pUnderlyingContext->pTopContext = &context;
+              }
+
               return Private::workerThreadLoadTileContext(
                   parentLayerJson,
                   *context.pUnderlyingContext,

--- a/Cesium3DTilesSelection/test/TestQuantizedMeshContent.cpp
+++ b/Cesium3DTilesSelection/test/TestQuantizedMeshContent.cpp
@@ -706,7 +706,6 @@ TEST_CASE("Test converting quantized mesh to gltf with skirt") {
       std::nullopt,
       std::nullopt,
       std::nullopt,
-      {},
       std::nullopt};
 
   SECTION("Check quantized mesh that has uint16_t indices") {
@@ -1048,7 +1047,6 @@ TEST_CASE("Test converting ill-formed quantized mesh") {
       std::nullopt,
       std::nullopt,
       std::nullopt,
-      {},
       std::nullopt};
 
   // mock quantized mesh


### PR DESCRIPTION
This is a PR into #485.

In the process of writing https://github.com/CesiumGS/cesium-native/blob/main/doc/implicit-tiling.md, I realized there might be a pretty straightforward way to make sure all of the necessary availability tiles are loaded. This PR is an attempt to implement it, and I think it worked out ok. @joseph-kaile please take a look, and if you're happy you can merge both this PR and #485. Let me know if you have any concerns.

The basic idea here is that whenever we're loading a quadtree tile, consider whether that tile is also an "availability tile" in any layers. If it is, download that layer's version of the tile and add its availability data to the TileContext. And make these extra loads prerequisites for moving the tile into the `ContentLoaded` state. Because we never create implicitly-tiled children before the parent hits `ContentLoaded`, this guarantees that we won't try to create children - upsampled or otherwise - before we know whether or not they're available.

This eliminates the need to separately track availability tile loads and simplifies the code quite a bit.