### PR TITLE
Don't kick external tileset children.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Change Log
 
+### ? - ?
+
+##### Breaking Changes :mega:
+
+##### Additions :tada:
+
+##### Fixes :wrench:
+
+- Fixed a bug that could cause tiles in external tilesets to fail to load.
+
 ### v0.15.0 - 2022-05-02
 
 ##### Additions :tada:

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -1038,6 +1038,8 @@ bool Tileset::_kickDescendantsAndRenderTile(
   // in that case, load this tile INSTEAD of loading any of the descendants, and
   // tell the up-level we're only waiting on this tile. Keep doing this until we
   // actually manage to render this tile.
+  // Make sure we don't end up waiting on a tile that will _never_ be
+  // renderable.
   const bool wasRenderedLastFrame =
       lastFrameSelectionState.getResult(frameState.lastFrameNumber) ==
       TileSelectionState::Result::Rendered;
@@ -1046,7 +1048,8 @@ bool Tileset::_kickDescendantsAndRenderTile(
 
   if (!wasReallyRenderedLastFrame &&
       traversalDetails.notYetRenderableCount >
-          this->_options.loadingDescendantLimit) {
+          this->_options.loadingDescendantLimit &&
+      !tile.isExternalTileset() && !tile.getUnconditionallyRefine()) {
     // Remove all descendants from the load queues.
     this->_loadQueueLow.erase(
         this->_loadQueueLow.begin() +


### PR DESCRIPTION
@nithinp7 and @argallegos noticed recently that the New York City Buildings tileset in level 6 of the Cesium for Unreal Samples would sometimes get stuck. Tiles would be missing, no matter how long you wait. Moving the camera arounda  bit would usually fix it.

![image](https://user-images.githubusercontent.com/924374/166406436-4a23dc40-89a1-480b-8a8c-351596664d87.png)

The problem turned out to be the tile selection's "kick" mechanism. It's usually a good idea to skip as many levels of detail as possible, and just directly load the tiles we need for the current view. But sometimes that's a very large number of tiles, and the user would have to sit there a long time waiting for them all. Our selection algorithm detects how many descendants of a given tile are waiting to load, and if it's a lot (a user-defined number), it kicks them all out of the load queue and instead loads and renders the current tile. As a result, the user sees detail sooner, even if it's lower quality. But it means the descendants won't start loading until after we finish loading and rendering the current tile. 

This works well enough, except if the "current tile" is not renderable at all. This happens when the tile represents an external tileset or has otherwise been deemed "unconditionally refine", because such tiles will never be renderable. In this scenario, we effectively end up waiting for a tile to become renderable, but that tile will _never_ become renderable, no matter how long we wait. Unless we move the camera, because that causes some of the tiles to be culled, which changes where the kick mechanism gets activated.

This PR fixes the problem by never kicking the descenants of an external tileset or unconditionally-refined tile.