### PR TITLE
Upsample using first overlay with more detail

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Added option to the `RasterizedPolygonsOverlay` to invert the selection, so everything outside the polygons gets rasterized instead of inside.
 - The `RasterizedPolygonsTileExcluder` excludes tiles outside the selection instead of inside when given an inverted `RasterizedPolygonsOverlay`.
+- Ensure that tiles are upsampled using the first raster overlay in the list with more detail.
 
 ### v0.15.2 - 2022-05-13
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterMappedTo3DTile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterMappedTo3DTile.h
@@ -157,6 +157,8 @@ public:
    */
   RasterOverlayTile::MoreDetailAvailable update(Tile& tile);
 
+  bool isMoreDetailAvailable() const noexcept;
+
   /**
    * @brief Detach the raster from the given tile.
    */

--- a/Cesium3DTilesSelection/src/GltfContent.cpp
+++ b/Cesium3DTilesSelection/src/GltfContent.cpp
@@ -153,7 +153,6 @@ GltfContent::createRasterOverlayTextureCoordinates(
   // at such extreme latitudes.
   BoundingRegionBuilder computedBounds;
   computedBounds.setPoleTolerance(0.001 * bounds.computeHeight());
-  bool boundsUpdated = false;
 
   auto createTextureCoordinatesForPrimitive =
       [&](CesiumGltf::Model& gltf,
@@ -288,7 +287,6 @@ GltfContent::createRasterOverlayTextureCoordinates(
           // exclude skirt vertices from bounds
           if (positionIndex >= vertexBegin && positionIndex < vertexEnd) {
             computedBounds.expandToIncludePosition(*cartographic);
-            boundsUpdated = true;
           }
 
           // Generate texture coordinates at this position for each projection
@@ -361,8 +359,7 @@ GltfContent::createRasterOverlayTextureCoordinates(
   return TileContentDetailsForOverlays{
       std::move(projections),
       std::move(rectangles),
-      boundsUpdated ? computedBounds.toRegion()
-                    : GltfContent::computeBoundingRegion(gltf, rootTransform)};
+      computedBounds.toRegion()};
 }
 
 /*static*/ CesiumGeospatial::BoundingRegion GltfContent::computeBoundingRegion(

--- a/Cesium3DTilesSelection/src/GltfContent.cpp
+++ b/Cesium3DTilesSelection/src/GltfContent.cpp
@@ -153,6 +153,7 @@ GltfContent::createRasterOverlayTextureCoordinates(
   // at such extreme latitudes.
   BoundingRegionBuilder computedBounds;
   computedBounds.setPoleTolerance(0.001 * bounds.computeHeight());
+  bool boundsUpdated = false;
 
   auto createTextureCoordinatesForPrimitive =
       [&](CesiumGltf::Model& gltf,
@@ -287,6 +288,7 @@ GltfContent::createRasterOverlayTextureCoordinates(
           // exclude skirt vertices from bounds
           if (positionIndex >= vertexBegin && positionIndex < vertexEnd) {
             computedBounds.expandToIncludePosition(*cartographic);
+            boundsUpdated = true;
           }
 
           // Generate texture coordinates at this position for each projection
@@ -359,7 +361,8 @@ GltfContent::createRasterOverlayTextureCoordinates(
   return TileContentDetailsForOverlays{
       std::move(projections),
       std::move(rectangles),
-      computedBounds.toRegion()};
+      boundsUpdated ? computedBounds.toRegion()
+                    : GltfContent::computeBoundingRegion(gltf, rootTransform)};
 }
 
 /*static*/ CesiumGeospatial::BoundingRegion GltfContent::computeBoundingRegion(

--- a/Cesium3DTilesSelection/src/RasterMappedTo3DTile.cpp
+++ b/Cesium3DTilesSelection/src/RasterMappedTo3DTile.cpp
@@ -173,6 +173,12 @@ RasterMappedTo3DTile::update(Tile& tile) {
   }
 }
 
+bool RasterMappedTo3DTile::isMoreDetailAvailable() const noexcept {
+  return !_pLoadingTile && !_originalFailed && _pReadyTile &&
+         _pReadyTile->isMoreDetailAvailable() ==
+             RasterOverlayTile::MoreDetailAvailable::Yes;
+}
+
 void RasterMappedTo3DTile::detachFromTile(Tile& tile) noexcept {
   if (this->getState() == AttachmentState::Unattached) {
     return;

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -665,12 +665,9 @@ getTileBoundingRegionForUpsampling(const Tile& parent) {
     // The tile will be subdivided by (0.5, 0.5) in the first overlay's
     // texture coordinates which overlay had more detail.
 
-    for (size_t i = 0; i < parent.getMappedRasterTiles().size(); ++i) {
-      RasterMappedTo3DTile* pMapped =
-          const_cast<RasterMappedTo3DTile*>(&parent.getMappedRasterTiles()[i]);
-      if (pMapped->update(*const_cast<Tile*>(&parent)) ==
-          RasterOverlayTile::MoreDetailAvailable::Yes) {
-        const Projection& projection = pMapped->getReadyTile()
+    for (const RasterMappedTo3DTile& mapped : parent.getMappedRasterTiles()) {
+      if (mapped.isMoreDetailAvailable()) {
+        const Projection& projection = mapped.getReadyTile()
                                            ->getOverlay()
                                            .getTileProvider()
                                            ->getProjection();
@@ -1044,9 +1041,8 @@ void Tile::upsampleParent(
       }
     }
   } else {
-    for (RasterMappedTo3DTile& mapped : pParent->getMappedRasterTiles()) {
-      if (mapped.update(*pParent) ==
-          RasterOverlayTile::MoreDetailAvailable::Yes) {
+    for (const RasterMappedTo3DTile& mapped : pParent->getMappedRasterTiles()) {
+      if (mapped.isMoreDetailAvailable()) {
         const Projection& projection = mapped.getReadyTile()
                                            ->getOverlay()
                                            .getTileProvider()

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -666,12 +666,22 @@ getTileBoundingRegionForUpsampling(const Tile& parent) {
     // texture coordinates (no matter which overlay(s) had more detail), at
     // least until https://github.com/CesiumGS/cesium-native/issues/385 is
     // addressed. So pick the center accordingly.
-    glm::dvec2 centerProjected = details.rasterOverlayRectangles[0].getCenter();
-    Cartographic center = unprojectPosition(
-        details.rasterOverlayProjections[0],
-        glm::dvec3(centerProjected, 0.0));
 
-    return RegionAndCenter{details.boundingRegion, center};
+    for (const RasterMappedTo3DTile& mappedRasterTile :
+         parent.getMappedRasterTiles()) {
+      const RasterOverlayTile* readyTile = mappedRasterTile.getReadyTile();
+      if (readyTile && readyTile->isMoreDetailAvailable() ==
+                           RasterOverlayTile::MoreDetailAvailable::Yes) {
+        const Projection& projection =
+            readyTile->getOverlay().getTileProvider()->getProjection();
+        glm::dvec2 centerProjected =
+            details.findRectangleForOverlayProjection(projection)->getCenter();
+        Cartographic center =
+            unprojectPosition(projection, glm::dvec3(centerProjected, 0.0));
+
+        return RegionAndCenter{details.boundingRegion, center};
+      }
+    }
   }
 
   // We shouldn't be upsampling from a tile until that tile is loaded.
@@ -984,6 +994,8 @@ void Tile::upsampleParent(
   };
 
   int32_t index = 0;
+  std::vector<Projection>& parentProjections =
+      pParentContent->overlayDetails->rasterOverlayProjections;
 
   const gsl::span<Tile> children = pParent->getChildren();
   if (std::get_if<QuadtreeTileID>(&pParent->getTileID()) &&
@@ -993,9 +1005,6 @@ void Tile::upsampleParent(
           [](const Tile& tile) noexcept {
             return std::get_if<QuadtreeTileID>(&tile.getTileID());
           })) {
-    TileContentLoadResult& content = *pParent->getContent();
-    std::vector<Projection>& parentProjections =
-        content.overlayDetails->rasterOverlayProjections;
     if (_pContext->implicitContext->projection.has_value()) {
       const Projection& projection = *_pContext->implicitContext->projection;
       auto it = std::find(
@@ -1017,13 +1026,28 @@ void Tile::upsampleParent(
                               : std::nullopt,
                 {projection});
         if (overlayDetails) {
-          content.overlayDetails->rasterOverlayRectangles.emplace_back(
+          pParentContent->overlayDetails->rasterOverlayRectangles.emplace_back(
               overlayDetails->rasterOverlayRectangles[0]);
           parentProjections.emplace_back(projection);
           index = int32_t(parentProjections.size()) - 1;
         }
       } else {
         index = int32_t(it - parentProjections.begin());
+      }
+    } else {
+      for (const RasterMappedTo3DTile& mappedRasterTile :
+           pParent->getMappedRasterTiles()) {
+        const RasterOverlayTile* readyTile = mappedRasterTile.getReadyTile();
+        if (readyTile && readyTile->isMoreDetailAvailable() ==
+                             RasterOverlayTile::MoreDetailAvailable::Yes) {
+          const Projection& projection =
+              readyTile->getOverlay().getTileProvider()->getProjection();
+          auto it = std::find(
+              parentProjections.begin(),
+              parentProjections.end(),
+              projection);
+          index = int32_t(it - parentProjections.begin());
+        }
       }
     }
   }
@@ -1054,8 +1078,9 @@ void Tile::upsampleParent(
             // We can't necessarily trust our original bounding volume, so
             // recompute it here. See:
             // https://github.com/CesiumGS/cesium-native/issues/385
-            pContent->updatedBoundingVolume =
-                GltfContent::computeBoundingRegion(*pContent->model, transform);
+            // pContent->updatedBoundingVolume =
+            //    GltfContent::computeBoundingRegion(*pContent->model,
+            //    transform);
 
             void* pRendererResources = processNewTileContent(
                 pPrepareRendererResources,

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -1010,6 +1010,13 @@ void Tile::upsampleParent(
           [](const Tile& tile) noexcept {
             return std::get_if<QuadtreeTileID>(&tile.getTileID());
           })) {
+    // We will only get here for quantized-mesh tiles where some (but not all)
+    // tiles are present in the data and the rest need to be upsampled. And in
+    // that scenario, we need to use the implicit context's projection for
+    // subdivision, no matter what the status of the overlays.
+    //
+    // For a more typical upsampling, driven by raster overlays, all child tiles
+    // will have a `UpsampledQuadtreeNode` tile ID.
     if (_pContext->implicitContext->projection.has_value()) {
       const Projection& projection = *_pContext->implicitContext->projection;
       auto it = std::find(

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -1086,13 +1086,6 @@ void Tile::upsampleParent(
                 *pSubdividedParentID,
                 textureCoordinateIndex);
 
-            // We can't necessarily trust our original bounding volume, so
-            // recompute it here. See:
-            // https://github.com/CesiumGS/cesium-native/issues/385
-            // pContent->updatedBoundingVolume =
-            //    GltfContent::computeBoundingRegion(*pContent->model,
-            //    transform);
-
             void* pRendererResources = processNewTileContent(
                 pPrepareRendererResources,
                 pLogger,

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -1082,9 +1082,8 @@ void Tile::upsampleParent(
             // We can't necessarily trust our original bounding volume, so
             // recompute it here. See:
             // https://github.com/CesiumGS/cesium-native/issues/385
-            // pContent->updatedBoundingVolume =
-            //    GltfContent::computeBoundingRegion(*pContent->model,
-            //    transform);
+            pContent->updatedBoundingVolume =
+                GltfContent::computeBoundingRegion(*pContent->model, transform);
 
             void* pRendererResources = processNewTileContent(
                 pPrepareRendererResources,

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -1082,8 +1082,9 @@ void Tile::upsampleParent(
             // We can't necessarily trust our original bounding volume, so
             // recompute it here. See:
             // https://github.com/CesiumGS/cesium-native/issues/385
-            pContent->updatedBoundingVolume =
-                GltfContent::computeBoundingRegion(*pContent->model, transform);
+            // pContent->updatedBoundingVolume =
+            //    GltfContent::computeBoundingRegion(*pContent->model,
+            //    transform);
 
             void* pRendererResources = processNewTileContent(
                 pPrepareRendererResources,

--- a/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.cpp
+++ b/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.cpp
@@ -101,7 +101,7 @@ isSouthChild(CesiumGeometry::UpsampledQuadtreeNode childID) noexcept {
 
 static void copyMetadataTables(const Model& parentModel, Model& result);
 
-Model upsampleGltfForRasterOverlays(
+std::optional<Model> upsampleGltfForRasterOverlays(
     const Model& parentModel,
     CesiumGeometry::UpsampledQuadtreeNode childID,
     int32_t textureCoordinateIndex) {
@@ -148,6 +148,8 @@ Model upsampleGltfForRasterOverlays(
     nameIt->second = name;
   }
 
+  bool containsPrimitives = false;
+
   for (Mesh& mesh : result.meshes) {
     for (size_t i = 0; i < mesh.primitives.size(); ++i) {
       MeshPrimitive& primitive = mesh.primitives[i];
@@ -166,10 +168,11 @@ Model upsampleGltfForRasterOverlays(
         mesh.primitives.erase(mesh.primitives.begin() + int64_t(i));
         --i;
       }
+      containsPrimitives |= !mesh.primitives.empty();
     }
   }
 
-  return result;
+  return containsPrimitives ? std::make_optional<Model>(result) : std::nullopt;
 }
 
 static void copyVertexAttributes(

--- a/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.cpp
+++ b/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.cpp
@@ -172,7 +172,8 @@ std::optional<Model> upsampleGltfForRasterOverlays(
     }
   }
 
-  return containsPrimitives ? std::make_optional<Model>(result) : std::nullopt;
+  return containsPrimitives ? std::make_optional<Model>(std::move(result))
+                            : std::nullopt;
 }
 
 static void copyVertexAttributes(

--- a/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.h
+++ b/Cesium3DTilesSelection/src/upsampleGltfForRasterOverlays.h
@@ -5,7 +5,7 @@
 
 namespace Cesium3DTilesSelection {
 
-CesiumGltf::Model upsampleGltfForRasterOverlays(
+std::optional<CesiumGltf::Model> upsampleGltfForRasterOverlays(
     const CesiumGltf::Model& parentModel,
     CesiumGeometry::UpsampledQuadtreeNode childID,
     int32_t textureCoordinateIndex = 0);

--- a/Cesium3DTilesSelection/test/TestUpsampleGltfForRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/test/TestUpsampleGltfForRasterOverlay.cpp
@@ -193,7 +193,7 @@ TEST_CASE("Test upsample tile without skirts") {
       CesiumGeometry::QuadtreeTileID(1, 1, 1)};
 
   SECTION("Upsample bottom left child") {
-    Model upsampledModel = upsampleGltfForRasterOverlays(model, lowerLeft);
+    Model upsampledModel = *upsampleGltfForRasterOverlays(model, lowerLeft);
 
     REQUIRE(upsampledModel.meshes.size() == 1);
     const Mesh& upsampledMesh = upsampledModel.meshes.back();
@@ -263,7 +263,7 @@ TEST_CASE("Test upsample tile without skirts") {
   }
 
   SECTION("Upsample upper left child") {
-    Model upsampledModel = upsampleGltfForRasterOverlays(model, upperLeft);
+    Model upsampledModel = *upsampleGltfForRasterOverlays(model, upperLeft);
 
     REQUIRE(upsampledModel.meshes.size() == 1);
     const Mesh& upsampledMesh = upsampledModel.meshes.back();
@@ -333,7 +333,7 @@ TEST_CASE("Test upsample tile without skirts") {
   }
 
   SECTION("Upsample upper right child") {
-    Model upsampledModel = upsampleGltfForRasterOverlays(model, upperRight);
+    Model upsampledModel = *upsampleGltfForRasterOverlays(model, upperRight);
 
     REQUIRE(upsampledModel.meshes.size() == 1);
     const Mesh& upsampledMesh = upsampledModel.meshes.back();
@@ -403,7 +403,7 @@ TEST_CASE("Test upsample tile without skirts") {
   }
 
   SECTION("Upsample bottom right child") {
-    Model upsampledModel = upsampleGltfForRasterOverlays(model, lowerRight);
+    Model upsampledModel = *upsampleGltfForRasterOverlays(model, lowerRight);
 
     REQUIRE(upsampledModel.meshes.size() == 1);
     const Mesh& upsampledMesh = upsampledModel.meshes.back();
@@ -488,7 +488,7 @@ TEST_CASE("Test upsample tile without skirts") {
     primitive.extras = SkirtMeshMetadata::createGltfExtras(skirtMeshMetadata);
 
     SECTION("Check bottom left skirt") {
-      Model upsampledModel = upsampleGltfForRasterOverlays(model, lowerLeft);
+      Model upsampledModel = *upsampleGltfForRasterOverlays(model, lowerLeft);
 
       REQUIRE(upsampledModel.meshes.size() == 1);
       const Mesh& upsampledMesh = upsampledModel.meshes.back();
@@ -589,7 +589,7 @@ TEST_CASE("Test upsample tile without skirts") {
     }
 
     SECTION("Check upper left skirt") {
-      Model upsampledModel = upsampleGltfForRasterOverlays(model, upperLeft);
+      Model upsampledModel = *upsampleGltfForRasterOverlays(model, upperLeft);
 
       REQUIRE(upsampledModel.meshes.size() == 1);
       const Mesh& upsampledMesh = upsampledModel.meshes.back();
@@ -714,7 +714,7 @@ TEST_CASE("Test upsample tile without skirts") {
     }
 
     SECTION("Check upper right skirt") {
-      Model upsampledModel = upsampleGltfForRasterOverlays(model, upperRight);
+      Model upsampledModel = *upsampleGltfForRasterOverlays(model, upperRight);
 
       REQUIRE(upsampledModel.meshes.size() == 1);
       const Mesh& upsampledMesh = upsampledModel.meshes.back();
@@ -815,7 +815,7 @@ TEST_CASE("Test upsample tile without skirts") {
     }
 
     SECTION("Check bottom right skirt") {
-      Model upsampledModel = upsampleGltfForRasterOverlays(model, lowerRight);
+      Model upsampledModel = *upsampleGltfForRasterOverlays(model, lowerRight);
 
       REQUIRE(upsampledModel.meshes.size() == 1);
       const Mesh& upsampledMesh = upsampledModel.meshes.back();


### PR DESCRIPTION
Pull request in order to fix #385. 

This creates bounding volumes for the four upsampled tiles using the first raster overlay tile that has more detail.

It will also upsample using that same projection.

To make sure that it uses the same projection, it makes sure that the previous raster overlay tiles in the list do not have more data.

Update: During upsampling, its posssible that all the primitives are clipped out. In this case, it returns a std::nullopt. 