### PR TITLE
Add option to invert polygon selections

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -113,7 +113,8 @@
       "cfenv": "cpp",
       "ktxint.h": "c",
       "texture.h": "c",
-      "gl_format.h": "c"
+      "gl_format.h": "c",
+      "complex": "cpp"
     },
     "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
     "cmake.configureOnOpen": true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+### v0.16.0 - ????
+
+##### Additions :tada:
+
+- Added option to the `RasterizedPolygonsOverlay` to invert the selection, so everything outside the polygons gets rasterized instead of inside.
+- The `RasterizedPolygonsTileExcluder` excludes tiles outside the selection instead of inside when given an inverted `RasterizedPolygonsOverlay`.
+
 ### v0.15.2 - 2022-05-13
 
 ##### Fixes :wrench:

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsOverlay.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsOverlay.h
@@ -49,8 +49,8 @@ public:
 
 private:
   std::vector<CesiumGeospatial::CartographicPolygon> _polygons;
+  bool _flipSelection;
   CesiumGeospatial::Ellipsoid _ellipsoid;
   CesiumGeospatial::Projection _projection;
-  bool _flipSelection;
 };
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsOverlay.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsOverlay.h
@@ -24,7 +24,7 @@ public:
   RasterizedPolygonsOverlay(
       const std::string& name,
       const std::vector<CesiumGeospatial::CartographicPolygon>& polygons,
-      bool flipSelection,
+      bool invertSelection,
       const CesiumGeospatial::Ellipsoid& ellipsoid,
       const CesiumGeospatial::Projection& projection,
       const RasterOverlayOptions& overlayOptions = {});
@@ -45,11 +45,11 @@ public:
     return this->_polygons;
   }
 
-  bool getFlipSelection() const noexcept { return this->_flipSelection; }
+  bool getInvertSelection() const noexcept { return this->_invertSelection; }
 
 private:
   std::vector<CesiumGeospatial::CartographicPolygon> _polygons;
-  bool _flipSelection;
+  bool _invertSelection;
   CesiumGeospatial::Ellipsoid _ellipsoid;
   CesiumGeospatial::Projection _projection;
 };

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsOverlay.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsOverlay.h
@@ -24,6 +24,7 @@ public:
   RasterizedPolygonsOverlay(
       const std::string& name,
       const std::vector<CesiumGeospatial::CartographicPolygon>& polygons,
+      bool flipSelection,
       const CesiumGeospatial::Ellipsoid& ellipsoid,
       const CesiumGeospatial::Projection& projection,
       const RasterOverlayOptions& overlayOptions = {});
@@ -44,9 +45,12 @@ public:
     return this->_polygons;
   }
 
+  bool getFlipSelection() const noexcept { return this->_flipSelection; }
+
 private:
   std::vector<CesiumGeospatial::CartographicPolygon> _polygons;
   CesiumGeospatial::Ellipsoid _ellipsoid;
   CesiumGeospatial::Projection _projection;
+  bool _flipSelection;
 };
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/RasterizedPolygonsOverlay.cpp
+++ b/Cesium3DTilesSelection/src/RasterizedPolygonsOverlay.cpp
@@ -10,7 +10,6 @@
 #include <CesiumGeospatial/GlobeRectangle.h>
 #include <CesiumUtility/IntrusivePointer.h>
 
-#include <cstring>
 #include <memory>
 #include <string>
 
@@ -48,9 +47,7 @@ void rasterizePolygons(
     image.height = 1;
     image.channels = 1;
     image.bytesPerChannel = 1;
-    image.pixelData.resize(1);
-
-    image.pixelData[0] = insideColor;
+    image.pixelData.resize(1, insideColor);
     return;
   }
 
@@ -73,9 +70,7 @@ void rasterizePolygons(
     image.height = 1;
     image.channels = 1;
     image.bytesPerChannel = 1;
-    image.pixelData.resize(1);
-
-    image.pixelData[0] = outsideColor;
+    image.pixelData.resize(1, outsideColor);
     return;
   }
 
@@ -88,15 +83,7 @@ void rasterizePolygons(
   image.height = int32_t(glm::round(textureSize.y));
   image.channels = 1;
   image.bytesPerChannel = 1;
-  image.pixelData.resize(size_t(image.width * image.height));
-
-  // If the outside color is not 0, clear the image with the outside color.
-  if (static_cast<char>(outsideColor) != 0) {
-    std::memset(
-        image.pixelData.data(),
-        (char)outsideColor,
-        image.pixelData.size());
-  }
+  image.pixelData.resize(size_t(image.width * image.height), outsideColor);
 
   // TODO: this is naive approach, use line-triangle
   // intersections to rasterize one row at a time

--- a/Cesium3DTilesSelection/src/RasterizedPolygonsOverlay.cpp
+++ b/Cesium3DTilesSelection/src/RasterizedPolygonsOverlay.cpp
@@ -166,33 +166,6 @@ void rasterizePolygons(
     }
   }
 }
-
-Rectangle computeCoverageRectangle(
-    const Projection& projection,
-    const std::vector<CartographicPolygon>& polygons) {
-  std::optional<GlobeRectangle> result;
-
-  for (const CartographicPolygon& polygon : polygons) {
-    std::optional<GlobeRectangle> maybeRectangle =
-        polygon.getBoundingRectangle();
-    if (!maybeRectangle) {
-      continue;
-    }
-
-    if (result) {
-      result = result->computeUnion(*maybeRectangle);
-    } else {
-      result = maybeRectangle;
-    }
-  }
-
-  if (result) {
-    return projectRectangleSimple(projection, *result);
-  } else {
-    return Rectangle(0.0, 0.0, 0.0, 0.0);
-  }
-}
-
 } // namespace
 
 class CESIUM3DTILESSELECTION_API RasterizedPolygonsTileProvider final

--- a/Cesium3DTilesSelection/src/RasterizedPolygonsTileExcluder.cpp
+++ b/Cesium3DTilesSelection/src/RasterizedPolygonsTileExcluder.cpp
@@ -12,7 +12,7 @@ RasterizedPolygonsTileExcluder::RasterizedPolygonsTileExcluder(
 
 bool RasterizedPolygonsTileExcluder::shouldExclude(
     const Tile& tile) const noexcept {
-  if (this->_pOverlay->getFlipSelection()) {
+  if (this->_pOverlay->getInvertSelection()) {
     return Cesium3DTilesSelection::CesiumImpl::outsidePolygons(
         tile.getBoundingVolume(),
         this->_pOverlay->getPolygons());

--- a/Cesium3DTilesSelection/src/RasterizedPolygonsTileExcluder.cpp
+++ b/Cesium3DTilesSelection/src/RasterizedPolygonsTileExcluder.cpp
@@ -12,7 +12,13 @@ RasterizedPolygonsTileExcluder::RasterizedPolygonsTileExcluder(
 
 bool RasterizedPolygonsTileExcluder::shouldExclude(
     const Tile& tile) const noexcept {
-  return Cesium3DTilesSelection::CesiumImpl::withinPolygons(
-      tile.getBoundingVolume(),
-      this->_pOverlay->getPolygons());
+  if (this->_pOverlay->getFlipSelection()) {
+    return Cesium3DTilesSelection::CesiumImpl::outsidePolygons(
+        tile.getBoundingVolume(),
+        this->_pOverlay->getPolygons());
+  } else {
+    return Cesium3DTilesSelection::CesiumImpl::withinPolygons(
+        tile.getBoundingVolume(),
+        this->_pOverlay->getPolygons());
+  }
 }

--- a/Cesium3DTilesSelection/src/TileUtilities.cpp
+++ b/Cesium3DTilesSelection/src/TileUtilities.cpp
@@ -199,8 +199,23 @@ bool outsidePolygons(
       }
     }
 
-    // Check if the polygon perimeter intersects the bounding globe rectangle
-    // edges.
+    // Check if an arbitrary point on the polygon is in the globe rectangle.
+    if (withinTriangle(
+            vertices[0],
+            rectangleCorners[0],
+            rectangleCorners[1],
+            rectangleCorners[2]) ||
+        withinTriangle(
+            vertices[0],
+            rectangleCorners[0],
+            rectangleCorners[2],
+            rectangleCorners[3])) {
+      return false;
+    }
+
+    // Now we know the rectangle does not fully contain the polygon and the
+    // polygon does not fully contain the rectangle. Now check if the polygon
+    // perimeter intersects the bounding globe rectangle edges.
     for (size_t j = 0; j < vertices.size(); ++j) {
       const glm::dvec2& a = vertices[j];
       const glm::dvec2& b = vertices[(j + 1) % vertices.size()];

--- a/Cesium3DTilesSelection/src/TileUtilities.cpp
+++ b/Cesium3DTilesSelection/src/TileUtilities.cpp
@@ -11,6 +11,33 @@ using namespace CesiumGeospatial;
 namespace Cesium3DTilesSelection {
 namespace CesiumImpl {
 
+bool withinTriangle(
+    const glm::dvec2& point,
+    const glm::dvec2& triangleVertA,
+    const glm::dvec2& triangleVertB,
+    const glm::dvec2& triangleVertC) noexcept {
+
+  const glm::dvec2 ab = triangleVertB - triangleVertA;
+  const glm::dvec2 ab_perp(-ab.y, ab.x);
+  const glm::dvec2 bc = triangleVertC - triangleVertB;
+  const glm::dvec2 bc_perp(-bc.y, bc.x);
+  const glm::dvec2 ca = triangleVertA - triangleVertC;
+  const glm::dvec2 ca_perp(-ca.y, ca.x);
+
+  const glm::dvec2 av = point - triangleVertA;
+  const glm::dvec2 cv = point - triangleVertC;
+
+  const double v_proj_ab_perp = glm::dot(av, ab_perp);
+  const double v_proj_bc_perp = glm::dot(cv, bc_perp);
+  const double v_proj_ca_perp = glm::dot(cv, ca_perp);
+
+  // This will determine in or out, irrespective of winding.
+  return (v_proj_ab_perp >= 0.0 && v_proj_ca_perp >= 0.0 &&
+          v_proj_bc_perp >= 0.0) ||
+         (v_proj_ab_perp <= 0.0 && v_proj_ca_perp <= 0.0 &&
+          v_proj_bc_perp <= 0.0);
+}
+
 bool withinPolygons(
     const BoundingVolume& boundingVolume,
     const std::vector<CartographicPolygon>& cartographicPolygons) noexcept {
@@ -58,29 +85,11 @@ bool withinPolygons(
     // inside the polygon.
     bool inside = false;
     for (size_t j = 2; j < indices.size(); j += 3) {
-      const glm::dvec2& a = vertices[indices[j - 2]];
-      const glm::dvec2& b = vertices[indices[j - 1]];
-      const glm::dvec2& c = vertices[indices[j]];
-
-      const glm::dvec2 ab = b - a;
-      const glm::dvec2 ab_perp(-ab.y, ab.x);
-      const glm::dvec2 bc = c - b;
-      const glm::dvec2 bc_perp(-bc.y, bc.x);
-      const glm::dvec2 ca = a - c;
-      const glm::dvec2 ca_perp(-ca.y, ca.x);
-
-      const glm::dvec2 av = rectangleCorners[0] - a;
-      const glm::dvec2 cv = rectangleCorners[0] - c;
-
-      const double v_proj_ab_perp = glm::dot(av, ab_perp);
-      const double v_proj_bc_perp = glm::dot(cv, bc_perp);
-      const double v_proj_ca_perp = glm::dot(cv, ca_perp);
-
-      // This will determine in or out, irrespective of winding.
-      if ((v_proj_ab_perp >= 0.0 && v_proj_ca_perp >= 0.0 &&
-           v_proj_bc_perp >= 0.0) ||
-          (v_proj_ab_perp <= 0.0 && v_proj_ca_perp <= 0.0 &&
-           v_proj_bc_perp <= 0.0)) {
+      if (withinTriangle(
+              rectangleCorners[0],
+              vertices[indices[j - 2]],
+              vertices[indices[j - 1]],
+              vertices[indices[j]])) {
         inside = true;
         break;
       }
@@ -131,6 +140,92 @@ bool withinPolygons(
   }
 
   return false;
+}
+
+bool outsidePolygons(
+    const BoundingVolume& boundingVolume,
+    const std::vector<CesiumGeospatial::CartographicPolygon>&
+        cartographicPolygons) noexcept {
+
+  std::optional<GlobeRectangle> maybeRectangle =
+      estimateGlobeRectangle(boundingVolume);
+  if (!maybeRectangle) {
+    return false;
+  }
+
+  return outsidePolygons(*maybeRectangle, cartographicPolygons);
+}
+
+bool outsidePolygons(
+    const CesiumGeospatial::GlobeRectangle& rectangle,
+    const std::vector<CesiumGeospatial::CartographicPolygon>&
+        cartographicPolygons) noexcept {
+
+  glm::dvec2 rectangleCorners[] = {
+      glm::dvec2(rectangle.getWest(), rectangle.getSouth()),
+      glm::dvec2(rectangle.getWest(), rectangle.getNorth()),
+      glm::dvec2(rectangle.getEast(), rectangle.getNorth()),
+      glm::dvec2(rectangle.getEast(), rectangle.getSouth())};
+
+  glm::dvec2 rectangleEdges[] = {
+      rectangleCorners[1] - rectangleCorners[0],
+      rectangleCorners[2] - rectangleCorners[1],
+      rectangleCorners[3] - rectangleCorners[2],
+      rectangleCorners[0] - rectangleCorners[3]};
+
+  // Iterate through all polygons.
+  for (size_t i = 0; i < cartographicPolygons.size(); ++i) {
+    const CartographicPolygon& selection = cartographicPolygons[i];
+
+    const std::optional<CesiumGeospatial::GlobeRectangle>&
+        polygonBoundingRectangle = selection.getBoundingRectangle();
+    if (!polygonBoundingRectangle ||
+        !rectangle.computeIntersection(*polygonBoundingRectangle)) {
+      continue;
+    }
+
+    const std::vector<glm::dvec2>& vertices = selection.getVertices();
+    const std::vector<uint32_t>& indices = selection.getIndices();
+
+    // First check if an arbitrary point on the bounding globe rectangle is
+    // inside the polygon.
+    for (size_t j = 2; j < indices.size(); j += 3) {
+      if (withinTriangle(
+              rectangleCorners[0],
+              vertices[indices[j - 2]],
+              vertices[indices[j - 1]],
+              vertices[indices[j]])) {
+        return false;
+      }
+    }
+
+    // Check if the polygon perimeter intersects the bounding globe rectangle
+    // edges.
+    for (size_t j = 0; j < vertices.size(); ++j) {
+      const glm::dvec2& a = vertices[j];
+      const glm::dvec2& b = vertices[(j + 1) % vertices.size()];
+
+      const glm::dvec2 ba = a - b;
+
+      // Check each rectangle edge.
+      for (size_t k = 0; k < 4; ++k) {
+        const glm::dvec2& cd = rectangleEdges[k];
+        const glm::dmat2 lineSegmentMatrix(cd, ba);
+        const glm::dvec2 ca = a - rectangleCorners[k];
+
+        // s and t are calculated such that:
+        // line_intersection = a + t * ab = c + s * cd
+        const glm::dvec2 st = glm::inverse(lineSegmentMatrix) * ca;
+
+        // check that the intersection is within the line segments
+        if (st.x <= 1.0 && st.x >= 0.0 && st.y <= 1.0 && st.y >= 0.0) {
+          return false;
+        }
+      }
+    }
+  }
+
+  return true;
 }
 } // namespace CesiumImpl
 

--- a/Cesium3DTilesSelection/src/TileUtilities.cpp
+++ b/Cesium3DTilesSelection/src/TileUtilities.cpp
@@ -187,18 +187,6 @@ bool outsidePolygons(
     const std::vector<glm::dvec2>& vertices = selection.getVertices();
     const std::vector<uint32_t>& indices = selection.getIndices();
 
-    // First check if an arbitrary point on the bounding globe rectangle is
-    // inside the polygon.
-    for (size_t j = 2; j < indices.size(); j += 3) {
-      if (withinTriangle(
-              rectangleCorners[0],
-              vertices[indices[j - 2]],
-              vertices[indices[j - 1]],
-              vertices[indices[j]])) {
-        return false;
-      }
-    }
-
     // Check if an arbitrary point on the polygon is in the globe rectangle.
     if (withinTriangle(
             vertices[0],
@@ -211,6 +199,18 @@ bool outsidePolygons(
             rectangleCorners[2],
             rectangleCorners[3])) {
       return false;
+    }
+
+    // Check if an arbitrary point on the bounding globe rectangle is
+    // inside the polygon.
+    for (size_t j = 2; j < indices.size(); j += 3) {
+      if (withinTriangle(
+              rectangleCorners[0],
+              vertices[indices[j - 2]],
+              vertices[indices[j - 1]],
+              vertices[indices[j]])) {
+        return false;
+      }
     }
 
     // Now we know the rectangle does not fully contain the polygon and the

--- a/Cesium3DTilesSelection/src/TileUtilities.h
+++ b/Cesium3DTilesSelection/src/TileUtilities.h
@@ -11,6 +11,21 @@ namespace Cesium3DTilesSelection {
 namespace CesiumImpl {
 
 /**
+ * @brief Returns whether the point is completely inside the triangle.
+ *
+ * @param point The point to check.
+ * @param triangleVertA The first vertex of the triangle.
+ * @param triangleVertB The second vertex of the triangle.
+ * @param triangleVertC The third vertex of the triangle.
+ * @return Whether the point is within the triangle.
+ */
+bool withinTriangle(
+    const glm::dvec2& point,
+    const glm::dvec2& triangleVertA,
+    const glm::dvec2& triangleVertB,
+    const glm::dvec2& triangleVertC) noexcept;
+
+/**
  * @brief Returns whether the tile is completely inside a polygon.
  *
  * @param boundingVolume The {@link Cesium3DTilesSelection::BoundingVolume} of the tile.
@@ -33,5 +48,28 @@ bool withinPolygons(
     const CesiumGeospatial::GlobeRectangle& rectangle,
     const std::vector<CesiumGeospatial::CartographicPolygon>&
         cartographicPolygons) noexcept;
+
+/**
+ * @brief Returns whether the tile is completely outside all the polygons.
+ *
+ * @param boundingVolume The {@link Cesium3DTilesSelection::BoundingVolume} of the tile.
+ * @param cartographicPolygons The list of polygons to check.
+ * @return Whether the tile is completely outside all the polygons.
+ */
+bool outsidePolygons(
+    const BoundingVolume& boundingVolume,
+    const std::vector<CesiumGeospatial::CartographicPolygon>&
+        cartographicPolygons) noexcept;
+
+/**
+ * @brief Returns whether the tile is completely outside all the polygons.
+ *
+ * @param rectangle The {@link CesiumGeospatial::GlobeRectangle} of the tile.
+ * @param cartographicPolygons The list of polygons to check.
+ * @return Whether the tile is completely outside all the polygons.
+ */
+bool outsidePolygons(
+    const CesiumGeospatial::GlobeRectangle& rectangle,
+    const std::vector<CesiumGeospatial::CartographicPolygon>&) noexcept;
 } // namespace CesiumImpl
 } // namespace Cesium3DTilesSelection


### PR DESCRIPTION
Adds an option to invert a `RasterizedPolygonOverlay` so that it rasterizes outside the polygon instead of inside. The `RasterizedPolygonsTileExcluder` also takes into account whether the polygon overlay is inverted. If so, tiles outside the polygons will be excluded instead of tiles within.