### PR TITLE
Ignore layer.json "bounds" property.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@
 - Added option to the `RasterizedPolygonsOverlay` to invert the selection, so everything outside the polygons gets rasterized instead of inside.
 - The `RasterizedPolygonsTileExcluder` excludes tiles outside the selection instead of inside when given an inverted `RasterizedPolygonsOverlay`.
 
+##### Fixes :wrench:
+
+- For consistency with CesiumJS and compatibility with third-party terrain tilers widely used in the community, the `bounds` property the `layer.json` file of a quantized-mesh terrain tileset is now ignored, and the terrain is assumed to cover the entire globe.
+
 ### v0.15.2 - 2022-05-13
 
 ##### Fixes :wrench:


### PR DESCRIPTION
Some third-party terrain tiling tools generate an incorrect "bounds" property in layer.json, and these tilesets still work in CesiumJS because it ignores this property. This PR makes cesium-native match the CesiumJS behavior.

I could argue that CesiumJS is wrong and should change, but because quantized-mesh / layer.json is basically a legacy format at this point (and had a rather informal specification to begin with), compatibility is more important than correctness.

See https://community.cesium.com/t/cesium-terrain-for-unreal/17940/18.
