### PR TITLE
Allow tileset loader to update tile content

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
@@ -49,6 +49,8 @@ public:
 
   TileLoadState getState() const noexcept;
 
+  bool shouldContentContinueUpdated() const noexcept;
+
   bool isEmptyContent() const noexcept;
 
   bool isExternalContent() const noexcept;
@@ -74,10 +76,14 @@ private:
 
   void setRenderResources(void* pRenderResources) noexcept;
 
+  void
+  setContentShouldContinueUpdated(bool shouldContentContinueUpdated) noexcept;
+
   TileLoadState _state;
   TileContentKind _contentKind;
   void* _pRenderResources;
   TilesetContentLoader* _pLoader;
+  bool _shouldContentContinueUpdated;
 
   friend class TilesetContentManager;
 };

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
@@ -23,7 +23,9 @@ struct TileUnknownContent {};
 
 struct TileEmptyContent {};
 
-struct TileExternalContent {};
+struct TileExternalContent {
+  std::function<void(Tile&)> createSubtree;
+};
 
 struct TileRenderContent {
   std::optional<CesiumGltf::Model> model{};
@@ -53,6 +55,10 @@ public:
 
   bool isRenderContent() const noexcept;
 
+  const TileExternalContent* getExternalContent() const noexcept;
+
+  TileExternalContent* getExternalContent() noexcept;
+
   const TileRenderContent* getRenderContent() const noexcept;
 
   TilesetContentLoader* getLoader() noexcept;
@@ -68,14 +74,9 @@ private:
 
   void setRenderResources(void* pRenderResources) noexcept;
 
-  void setTileInitializerCallback(std::function<void(Tile&)> callback);
-
-  std::function<void(Tile&)>& getTileInitializerCallback();
-
   TileLoadState _state;
   TileContentKind _contentKind;
   void* _pRenderResources;
-  std::function<void(Tile&)> _deferredTileInitializer;
   TilesetContentLoader* _pLoader;
 
   friend class TilesetContentManager;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
@@ -23,9 +23,7 @@ struct TileUnknownContent {};
 
 struct TileEmptyContent {};
 
-struct TileExternalContent {
-  std::function<void(Tile&)> createSubtree;
-};
+struct TileExternalContent {};
 
 struct TileRenderContent {
   std::optional<CesiumGltf::Model> model{};
@@ -76,6 +74,10 @@ private:
 
   void setRenderResources(void* pRenderResources) noexcept;
 
+  void setTileInitializerCallback(std::function<void(Tile&)> callback);
+
+  std::function<void(Tile&)>& getTileInitializerCallback();
+
   void
   setContentShouldContinueUpdated(bool shouldContentContinueUpdated) noexcept;
 
@@ -83,6 +85,7 @@ private:
   TileContentKind _contentKind;
   void* _pRenderResources;
   TilesetContentLoader* _pLoader;
+  std::function<void(Tile&)> _tileInitializer;
   bool _shouldContentContinueUpdated;
 
   friend class TilesetContentManager;

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
@@ -264,14 +264,12 @@ CesiumAsync::Future<TileLoadResult> CesiumIonTilesetLoader::loadTileContent(
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileUnknownContent{},
         TileLoadResultState::RetryLater,
-        nullptr,
-        {}});
+        nullptr});
   } else if (_refreshTokenState == TokenRefreshState::Failed) {
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileUnknownContent{},
         TileLoadResultState::Failed,
-        nullptr,
-        {}});
+        nullptr});
   }
 
   // TODO: the way this is structured, requests already in progress
@@ -356,6 +354,11 @@ void CesiumIonTilesetLoader::refreshTokenInMainThread(
 
             _refreshTokenState = TokenRefreshState::Failed;
           });
+}
+
+bool CesiumIonTilesetLoader::updateTileContent(Tile& tile) {
+  auto pLoader = tile.getContent().getLoader();
+  return pLoader->updateTileContent(tile);
 }
 
 CesiumAsync::Future<TilesetContentLoaderResult>

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.h
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.h
@@ -32,6 +32,8 @@ public:
       const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders)
       override;
 
+  bool updateTileContent(Tile& tile) override;
+
   static CesiumAsync::Future<TilesetContentLoaderResult> createLoader(
       const TilesetExternals& externals,
       uint32_t ionAssetID,

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
@@ -271,8 +271,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
           return TileLoadResult{
               TileUnknownContent{},
               TileLoadResultState::Failed,
-              nullptr,
-              {}};
+              nullptr};
         }
 
         uint16_t statusCode = pResponse->statusCode();
@@ -285,8 +284,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
           return TileLoadResult{
               TileUnknownContent{},
               TileLoadResultState::Failed,
-              nullptr,
-              {}};
+              nullptr};
         }
 
         // find gltf converter
@@ -309,8 +307,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
             return TileLoadResult{
                 TileRenderContent{std::nullopt},
                 TileLoadResultState::Failed,
-                std::move(pCompletedRequest),
-                {}};
+                std::move(pCompletedRequest)};
           }
 
           std::function<void(Tile&)> tileInitializer;
@@ -328,8 +325,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
         return TileLoadResult{
             TileRenderContent{std::nullopt},
             TileLoadResultState::Failed,
-            std::move(pCompletedRequest),
-            {}};
+            std::move(pCompletedRequest)};
       });
 }
 } // namespace
@@ -348,8 +344,7 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
     return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
         TileUnknownContent{},
         TileLoadResultState::Failed,
-        nullptr,
-        {}});
+        nullptr});
   }
 
   // find the subtree ID
@@ -358,8 +353,7 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
     return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
         TileUnknownContent{},
         TileLoadResultState::Failed,
-        nullptr,
-        {}});
+        nullptr});
   }
 
   uint64_t levelLeft = pOctreeID->level % _subtreeLevels;
@@ -438,8 +432,7 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
                   TileLoadResult{
                       TileUnknownContent{},
                       TileLoadResultState::Failed,
-                      nullptr,
-                      {}});
+                      nullptr});
             });
   }
 
@@ -450,8 +443,7 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileEmptyContent{},
         TileLoadResultState::Success,
-        nullptr,
-        {}});
+        nullptr});
   }
 
   std::string tileUrl = resolveUrl(_baseUrl, _contentUrlTemplate, *pOctreeID);

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
@@ -184,24 +184,6 @@ void populateSubtree(
   tile.createChildTiles(std::move(children));
 }
 
-struct SubtreeContentInitializer {
-public:
-  SubtreeContentInitializer(
-      ImplicitOctreeLoader* pImplicitLoader,
-      const CesiumGeometry::OctreeTileID& subtreeID)
-      : subtreeAvailability{std::nullopt},
-        subtreeID{subtreeID},
-        pLoader{pImplicitLoader} {}
-
-  void operator()() {
-    pLoader->addSubtreeAvailability(subtreeID, std::move(*subtreeAvailability));
-  }
-
-  std::optional<SubtreeAvailability> subtreeAvailability;
-  CesiumGeometry::OctreeTileID subtreeID;
-  ImplicitOctreeLoader* pLoader;
-};
-
 bool isTileContentAvailable(
     const CesiumGeometry::OctreeTileID& subtreeID,
     const CesiumGeometry::OctreeTileID& octreeID,
@@ -337,68 +319,28 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
     // subtree is not loaded, so load it now.
     std::string subtreeUrl =
         resolveUrl(_baseUrl, _subtreeUrlTemplate, subtreeID);
-    std::string tileUrl = resolveUrl(_baseUrl, _contentUrlTemplate, *pOctreeID);
-    CesiumGltf::Ktx2TranscodeTargets ktx2TranscodeTargets =
-        contentOptions.ktx2TranscodeTargets;
-
-    SubtreeContentInitializer subtreeInitializer{this, subtreeID};
-    return SubtreeAvailability::loadSubtree(
-               3,
-               asyncSystem,
-               pAssetAccessor,
-               pLogger,
-               subtreeUrl,
-               requestHeaders)
+    SubtreeAvailability::loadSubtree(
+        3,
+        asyncSystem,
+        pAssetAccessor,
+        pLogger,
+        subtreeUrl,
+        requestHeaders)
         .thenInWorkerThread(
-            [pLogger,
-             asyncSystem,
-             pAssetAccessor,
-             tileUrl = std::move(tileUrl),
-             subtreeID,
-             octreeID = *pOctreeID,
-             requestHeaders,
-             ktx2TranscodeTargets,
-             subtreeInitializer = std::move(subtreeInitializer)](
-                std::optional<SubtreeAvailability>&&
-                    subtreeAvailability) mutable {
+            [this, subtreeID](std::optional<SubtreeAvailability>&&
+                                  subtreeAvailability) mutable {
               if (subtreeAvailability) {
-                bool tileHasContent = isTileContentAvailable(
+                this->addSubtreeAvailability(
                     subtreeID,
-                    octreeID,
-                    *subtreeAvailability);
-
-                // send subtree back to the loader.
-                // CAUTION: do not use the subtree availability after this point
-                // as it is moved off to the main thread alread
-                subtreeInitializer.subtreeAvailability =
-                    std::move(*subtreeAvailability);
-                asyncSystem.runInMainThread(std::move(subtreeInitializer));
-
-                // subtree is available, so check if tile has content or not. If
-                // it has, then request it
-                if (!tileHasContent) {
-                  // check if tile has empty content
-                  return asyncSystem.createResolvedFuture(TileLoadResult{
-                      TileEmptyContent{},
-                      TileLoadResultState::Success,
-                      nullptr});
-                }
-
-                return requestTileContent(
-                    pLogger,
-                    asyncSystem,
-                    pAssetAccessor,
-                    tileUrl,
-                    requestHeaders,
-                    ktx2TranscodeTargets);
+                    std::move(*subtreeAvailability));
               }
-
-              return asyncSystem.createResolvedFuture<TileLoadResult>(
-                  TileLoadResult{
-                      TileUnknownContent{},
-                      TileLoadResultState::Failed,
-                      nullptr});
             });
+
+    // tell client to retry later
+    return asyncSystem.createResolvedFuture(TileLoadResult{
+        TileUnknownContent{},
+        TileLoadResultState::RetryLater,
+        nullptr});
   }
 
   // subtree is available, so check if tile has content or not. If it has, then

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
@@ -221,7 +221,8 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
           return TileLoadResult{
               TileUnknownContent{},
               TileLoadResultState::Failed,
-              nullptr};
+              nullptr,
+              {}};
         }
 
         uint16_t statusCode = pResponse->statusCode();
@@ -234,7 +235,8 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
           return TileLoadResult{
               TileUnknownContent{},
               TileLoadResultState::Failed,
-              nullptr};
+              nullptr,
+              {}};
         }
 
         // find gltf converter
@@ -257,20 +259,23 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
             return TileLoadResult{
                 TileRenderContent{std::nullopt},
                 TileLoadResultState::Failed,
-                std::move(pCompletedRequest)};
+                std::move(pCompletedRequest),
+                {}};
           }
 
           return TileLoadResult{
               TileRenderContent{std::move(result.model)},
               TileLoadResultState::Success,
-              std::move(pCompletedRequest)};
+              std::move(pCompletedRequest),
+              {}};
         }
 
         // content type is not supported
         return TileLoadResult{
             TileRenderContent{std::nullopt},
             TileLoadResultState::Failed,
-            std::move(pCompletedRequest)};
+            std::move(pCompletedRequest),
+            {}};
       });
 }
 } // namespace
@@ -289,7 +294,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
     return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
         TileUnknownContent{},
         TileLoadResultState::Failed,
-        nullptr});
+        nullptr,
+        {}});
   }
 
   // find the subtree ID
@@ -298,7 +304,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
     return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
         TileUnknownContent{},
         TileLoadResultState::Failed,
-        nullptr});
+        nullptr,
+        {}});
   }
 
   uint64_t levelLeft = pOctreeID->level % _subtreeLevels;
@@ -338,7 +345,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
           return TileLoadResult{
               TileUnknownContent{},
               TileLoadResultState::RetryLater,
-              nullptr};
+              nullptr,
+              {}};
         });
   }
 
@@ -349,7 +357,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileEmptyContent{},
         TileLoadResultState::Success,
-        nullptr});
+        nullptr,
+        {}});
   }
 
   std::string tileUrl = resolveUrl(_baseUrl, _contentUrlTemplate, *pOctreeID);

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.h
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.h
@@ -41,6 +41,8 @@ public:
       const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders)
       override;
 
+  bool updateTileContent(Tile& tile) override;
+
   uint32_t getSubtreeLevels() const noexcept;
 
   uint32_t getAvailableLevels() const noexcept;

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -276,8 +276,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
           return TileLoadResult{
               TileUnknownContent{},
               TileLoadResultState::Failed,
-              nullptr,
-              {}};
+              nullptr};
         }
 
         uint16_t statusCode = pResponse->statusCode();
@@ -290,8 +289,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
           return TileLoadResult{
               TileUnknownContent{},
               TileLoadResultState::Failed,
-              nullptr,
-              {}};
+              nullptr};
         }
 
         // find gltf converter
@@ -314,8 +312,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
             return TileLoadResult{
                 TileRenderContent{std::nullopt},
                 TileLoadResultState::Failed,
-                std::move(pCompletedRequest),
-                {}};
+                std::move(pCompletedRequest)};
           }
 
           std::function<void(Tile&)> tileInitializer;
@@ -371,8 +368,7 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
     return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
         TileUnknownContent{},
         TileLoadResultState::Failed,
-        nullptr,
-        {}});
+        nullptr});
   }
 
   // find the subtree ID
@@ -381,8 +377,7 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
     return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
         TileUnknownContent{},
         TileLoadResultState::Failed,
-        nullptr,
-        {}});
+        nullptr});
   }
 
   uint64_t levelLeft = pQuadtreeID->level % _subtreeLevels;
@@ -467,8 +462,7 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
                   TileLoadResult{
                       TileUnknownContent{},
                       TileLoadResultState::Failed,
-                      nullptr,
-                      {}});
+                      nullptr});
             });
   }
 
@@ -479,8 +473,7 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileEmptyContent{},
         TileLoadResultState::Success,
-        nullptr,
-        {}});
+        nullptr});
   }
 
   std::string tileUrl = resolveUrl(_baseUrl, _contentUrlTemplate, *pQuadtreeID);

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -348,27 +348,27 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
     // subtree is not loaded, so load it now.
     std::string subtreeUrl =
         resolveUrl(_baseUrl, _subtreeUrlTemplate, subtreeID);
-    SubtreeAvailability::loadSubtree(
-        2,
-        asyncSystem,
-        pAssetAccessor,
-        pLogger,
-        subtreeUrl,
-        requestHeaders)
-        .thenInWorkerThread(
-            [this, subtreeID](std::optional<SubtreeAvailability>&&
-                                  subtreeAvailability) mutable {
-              if (subtreeAvailability) {
-                this->addSubtreeAvailability(
-                    subtreeID,
-                    std::move(*subtreeAvailability));
-              }
-            });
+    return SubtreeAvailability::loadSubtree(
+               2,
+               asyncSystem,
+               pAssetAccessor,
+               pLogger,
+               subtreeUrl,
+               requestHeaders)
+        .thenInMainThread([this, subtreeID](std::optional<SubtreeAvailability>&&
+                                                subtreeAvailability) mutable {
+          if (subtreeAvailability) {
+            this->addSubtreeAvailability(
+                subtreeID,
+                std::move(*subtreeAvailability));
+          }
 
-    return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
-        TileUnknownContent{},
-        TileLoadResultState::RetryLater,
-        nullptr});
+          // tell client to retry later
+          return TileLoadResult{
+              TileUnknownContent{},
+              TileLoadResultState::RetryLater,
+              nullptr};
+        });
   }
 
   // subtree is available, so check if tile has content or not. If it has, then

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -227,7 +227,8 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
           return TileLoadResult{
               TileUnknownContent{},
               TileLoadResultState::Failed,
-              nullptr};
+              nullptr,
+              {}};
         }
 
         uint16_t statusCode = pResponse->statusCode();
@@ -240,7 +241,8 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
           return TileLoadResult{
               TileUnknownContent{},
               TileLoadResultState::Failed,
-              nullptr};
+              nullptr,
+              {}};
         }
 
         // find gltf converter
@@ -263,20 +265,23 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
             return TileLoadResult{
                 TileRenderContent{std::nullopt},
                 TileLoadResultState::Failed,
-                std::move(pCompletedRequest)};
+                std::move(pCompletedRequest),
+                {}};
           }
 
           return TileLoadResult{
               TileRenderContent{std::move(result.model)},
               TileLoadResultState::Success,
-              std::move(pCompletedRequest)};
+              std::move(pCompletedRequest),
+              {}};
         }
 
         // content type is not supported
         return TileLoadResult{
             TileRenderContent{std::nullopt},
             TileLoadResultState::Failed,
-            std::move(pCompletedRequest)};
+            std::move(pCompletedRequest),
+            {}};
       });
 }
 } // namespace
@@ -313,7 +318,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
     return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
         TileUnknownContent{},
         TileLoadResultState::Failed,
-        nullptr});
+        nullptr,
+        {}});
   }
 
   // find the subtree ID
@@ -322,7 +328,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
     return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
         TileUnknownContent{},
         TileLoadResultState::Failed,
-        nullptr});
+        nullptr,
+        {}});
   }
 
   uint64_t levelLeft = pQuadtreeID->level % _subtreeLevels;
@@ -367,7 +374,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
           return TileLoadResult{
               TileUnknownContent{},
               TileLoadResultState::RetryLater,
-              nullptr};
+              nullptr,
+              {}};
         });
   }
 
@@ -378,7 +386,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileEmptyContent{},
         TileLoadResultState::Success,
-        nullptr});
+        nullptr,
+        {}});
   }
 
   std::string tileUrl = resolveUrl(_baseUrl, _contentUrlTemplate, *pQuadtreeID);

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -191,24 +191,6 @@ void populateSubtree(
   tile.createChildTiles(std::move(children));
 }
 
-struct SubtreeContentInitializer {
-public:
-  SubtreeContentInitializer(
-      ImplicitQuadtreeLoader* pImplicitLoader,
-      const CesiumGeometry::QuadtreeTileID& subtreeID)
-      : subtreeAvailability{std::nullopt},
-        subtreeID{subtreeID},
-        pLoader{pImplicitLoader} {}
-
-  void operator()() {
-    pLoader->addSubtreeAvailability(subtreeID, std::move(*subtreeAvailability));
-  }
-
-  std::optional<SubtreeAvailability> subtreeAvailability;
-  CesiumGeometry::QuadtreeTileID subtreeID;
-  ImplicitQuadtreeLoader* pLoader;
-};
-
 bool isTileContentAvailable(
     const CesiumGeometry::QuadtreeTileID& subtreeID,
     const CesiumGeometry::QuadtreeTileID& quadtreeID,
@@ -366,70 +348,27 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
     // subtree is not loaded, so load it now.
     std::string subtreeUrl =
         resolveUrl(_baseUrl, _subtreeUrlTemplate, subtreeID);
-    std::string tileUrl =
-        resolveUrl(_baseUrl, _contentUrlTemplate, *pQuadtreeID);
-    const CesiumGltf::Ktx2TranscodeTargets& ktx2TranscodeTargets =
-        contentOptions.ktx2TranscodeTargets;
-
-    SubtreeContentInitializer subtreeInitializer{this, subtreeID};
-
-    return SubtreeAvailability::loadSubtree(
-               2,
-               asyncSystem,
-               pAssetAccessor,
-               pLogger,
-               subtreeUrl,
-               requestHeaders)
+    SubtreeAvailability::loadSubtree(
+        2,
+        asyncSystem,
+        pAssetAccessor,
+        pLogger,
+        subtreeUrl,
+        requestHeaders)
         .thenInWorkerThread(
-            [pLogger,
-             asyncSystem,
-             pAssetAccessor,
-             tileUrl = std::move(tileUrl),
-             subtreeID,
-             quadtreeID = *pQuadtreeID,
-             requestHeaders,
-             ktx2TranscodeTargets,
-             subtreeInitializer = std::move(subtreeInitializer)](
-                std::optional<SubtreeAvailability>&&
-                    subtreeAvailability) mutable {
+            [this, subtreeID](std::optional<SubtreeAvailability>&&
+                                  subtreeAvailability) mutable {
               if (subtreeAvailability) {
-                bool tileHasContent = isTileContentAvailable(
+                this->addSubtreeAvailability(
                     subtreeID,
-                    quadtreeID,
-                    *subtreeAvailability);
-
-                // send subtree back to the loader.
-                // CAUTION: do not use the subtree availability after this point
-                // as it is moved off to the main thread alread
-                subtreeInitializer.subtreeAvailability =
-                    std::move(subtreeAvailability);
-                asyncSystem.runInMainThread(std::move(subtreeInitializer));
-
-                // subtree is available, so check if tile has content or not. If
-                // it has, then request it
-                if (!tileHasContent) {
-                  // check if tile has empty content
-                  return asyncSystem.createResolvedFuture(TileLoadResult{
-                      TileEmptyContent{},
-                      TileLoadResultState::Success,
-                      nullptr});
-                }
-
-                return requestTileContent(
-                    pLogger,
-                    asyncSystem,
-                    pAssetAccessor,
-                    tileUrl,
-                    requestHeaders,
-                    ktx2TranscodeTargets);
+                    std::move(*subtreeAvailability));
               }
-
-              return asyncSystem.createResolvedFuture<TileLoadResult>(
-                  TileLoadResult{
-                      TileUnknownContent{},
-                      TileLoadResultState::Failed,
-                      nullptr});
             });
+
+    return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
+        TileUnknownContent{},
+        TileLoadResultState::RetryLater,
+        nullptr});
   }
 
   // subtree is available, so check if tile has content or not. If it has, then

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.h
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.h
@@ -47,6 +47,8 @@ public:
       const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders)
       override;
 
+  bool updateTileContent(Tile& tile) override;
+
   uint32_t getSubtreeLevels() const noexcept;
 
   uint32_t getAvailableLevels() const noexcept;

--- a/Cesium3DTilesSelection/src/TileContent.cpp
+++ b/Cesium3DTilesSelection/src/TileContent.cpp
@@ -6,6 +6,7 @@ TileContent::TileContent(TilesetContentLoader* pLoader)
       _contentKind{TileUnknownContent{}},
       _pRenderResources{nullptr},
       _pLoader{pLoader},
+      _tileInitializer{},
       _shouldContentContinueUpdated{true} {}
 
 TileContent::TileContent(
@@ -15,6 +16,7 @@ TileContent::TileContent(
       _contentKind{emptyContent},
       _pRenderResources{nullptr},
       _pLoader{pLoader},
+      _tileInitializer{},
       _shouldContentContinueUpdated{true} {}
 
 TileContent::TileContent(
@@ -24,6 +26,7 @@ TileContent::TileContent(
       _contentKind{externalContent},
       _pRenderResources{nullptr},
       _pLoader{pLoader},
+      _tileInitializer{},
       _shouldContentContinueUpdated{true} {}
 
 TileLoadState TileContent::getState() const noexcept { return _state; }
@@ -70,6 +73,15 @@ void TileContent::setState(TileLoadState state) noexcept { _state = state; }
 
 void TileContent::setRenderResources(void* pRenderResources) noexcept {
   _pRenderResources = pRenderResources;
+}
+
+void TileContent::setTileInitializerCallback(
+    std::function<void(Tile&)> callback) {
+  _tileInitializer = std::move(callback);
+}
+
+std::function<void(Tile&)>& TileContent::getTileInitializerCallback() {
+  return _tileInitializer;
 }
 
 void TileContent::setContentShouldContinueUpdated(

--- a/Cesium3DTilesSelection/src/TileContent.cpp
+++ b/Cesium3DTilesSelection/src/TileContent.cpp
@@ -5,7 +5,8 @@ TileContent::TileContent(TilesetContentLoader* pLoader)
     : _state{TileLoadState::Unloaded},
       _contentKind{TileUnknownContent{}},
       _pRenderResources{nullptr},
-      _pLoader{pLoader} {}
+      _pLoader{pLoader},
+      _shouldContentContinueUpdated{true} {}
 
 TileContent::TileContent(
     TilesetContentLoader* pLoader,
@@ -13,7 +14,8 @@ TileContent::TileContent(
     : _state{TileLoadState::ContentLoaded},
       _contentKind{emptyContent},
       _pRenderResources{nullptr},
-      _pLoader{pLoader} {}
+      _pLoader{pLoader},
+      _shouldContentContinueUpdated{true} {}
 
 TileContent::TileContent(
     TilesetContentLoader* pLoader,
@@ -21,9 +23,14 @@ TileContent::TileContent(
     : _state{TileLoadState::ContentLoaded},
       _contentKind{externalContent},
       _pRenderResources{nullptr},
-      _pLoader{pLoader} {}
+      _pLoader{pLoader},
+      _shouldContentContinueUpdated{true} {}
 
 TileLoadState TileContent::getState() const noexcept { return _state; }
+
+bool TileContent::shouldContentContinueUpdated() const noexcept {
+  return _shouldContentContinueUpdated;
+}
 
 bool TileContent::isEmptyContent() const noexcept {
   return std::holds_alternative<TileEmptyContent>(_contentKind);
@@ -63,6 +70,11 @@ void TileContent::setState(TileLoadState state) noexcept { _state = state; }
 
 void TileContent::setRenderResources(void* pRenderResources) noexcept {
   _pRenderResources = pRenderResources;
+}
+
+void TileContent::setContentShouldContinueUpdated(
+    bool shouldContentContinueUpdated) noexcept {
+  _shouldContentContinueUpdated = shouldContentContinueUpdated;
 }
 
 void* TileContent::getRenderResources() const noexcept {

--- a/Cesium3DTilesSelection/src/TileContent.cpp
+++ b/Cesium3DTilesSelection/src/TileContent.cpp
@@ -5,7 +5,6 @@ TileContent::TileContent(TilesetContentLoader* pLoader)
     : _state{TileLoadState::Unloaded},
       _contentKind{TileUnknownContent{}},
       _pRenderResources{nullptr},
-      _deferredTileInitializer{},
       _pLoader{pLoader} {}
 
 TileContent::TileContent(
@@ -14,7 +13,6 @@ TileContent::TileContent(
     : _state{TileLoadState::ContentLoaded},
       _contentKind{emptyContent},
       _pRenderResources{nullptr},
-      _deferredTileInitializer{},
       _pLoader{pLoader} {}
 
 TileContent::TileContent(
@@ -23,7 +21,6 @@ TileContent::TileContent(
     : _state{TileLoadState::ContentLoaded},
       _contentKind{externalContent},
       _pRenderResources{nullptr},
-      _deferredTileInitializer{},
       _pLoader{pLoader} {}
 
 TileLoadState TileContent::getState() const noexcept { return _state; }
@@ -38,6 +35,14 @@ bool TileContent::isExternalContent() const noexcept {
 
 bool TileContent::isRenderContent() const noexcept {
   return std::holds_alternative<TileRenderContent>(_contentKind);
+}
+
+const TileExternalContent* TileContent::getExternalContent() const noexcept {
+  return std::get_if<TileExternalContent>(&_contentKind);
+}
+
+TileExternalContent* TileContent::getExternalContent() noexcept {
+  return std::get_if<TileExternalContent>(&_contentKind);
 }
 
 const TileRenderContent* TileContent::getRenderContent() const noexcept {
@@ -62,14 +67,5 @@ void TileContent::setRenderResources(void* pRenderResources) noexcept {
 
 void* TileContent::getRenderResources() const noexcept {
   return _pRenderResources;
-}
-
-void TileContent::setTileInitializerCallback(
-    std::function<void(Tile&)> callback) {
-  _deferredTileInitializer = std::move(callback);
-}
-
-std::function<void(Tile&)>& TileContent::getTileInitializerCallback() {
-  return _deferredTileInitializer;
 }
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/TilesetContentLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetContentLoader.h
@@ -21,7 +21,7 @@ struct TileLoadResult {
   TileContentKind contentKind;
   TileLoadResultState state;
   std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest;
-  std::function<void(Tile&)> tileInitializer;
+  std::function<void(Tile&)> tileInitializer; // TODO: remove
 };
 
 class TilesetContentLoader {

--- a/Cesium3DTilesSelection/src/TilesetContentLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetContentLoader.h
@@ -21,7 +21,6 @@ struct TileLoadResult {
   TileContentKind contentKind;
   TileLoadResultState state;
   std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest;
-  std::function<void(Tile&)> tileInitializer; // TODO: remove
 };
 
 class TilesetContentLoader {
@@ -36,5 +35,7 @@ public:
       const std::shared_ptr<spdlog::logger>& pLogger,
       const std::vector<CesiumAsync::IAssetAccessor::THeader>&
           requestHeaders) = 0;
+
+  virtual bool updateTileContent(Tile& tile) = 0;
 };
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/TilesetContentLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetContentLoader.h
@@ -21,6 +21,7 @@ struct TileLoadResult {
   TileContentKind contentKind;
   TileLoadResultState state;
   std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest;
+  std::function<void(Tile&)> tileInitializer;
 };
 
 class TilesetContentLoader {

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -209,7 +209,7 @@ void TilesetContentManager::loadTileContent(
 }
 
 void TilesetContentManager::updateTileContent(Tile& tile) {
-  const TileContent& content = tile.getContent();
+  TileContent& content = tile.getContent();
 
   TileLoadState state = content.getState();
   switch (state) {
@@ -218,6 +218,10 @@ void TilesetContentManager::updateTileContent(Tile& tile) {
     break;
   default:
     break;
+  }
+
+  if (content.shouldContentContinueUpdated()) {
+    content.setContentShouldContinueUpdated(_pLoader->updateTileContent(tile));
   }
 }
 
@@ -300,8 +304,10 @@ void TilesetContentManager::updateContentLoadedState(Tile& tile) {
   TileContent& content = tile.getContent();
   if (content.isExternalContent()) {
     auto externalContent = content.getExternalContent();
-    externalContent->createSubtree(tile);
-    externalContent->createSubtree = {};
+    if (externalContent->createSubtree) {
+      externalContent->createSubtree(tile);
+      externalContent->createSubtree = {};
+    }
 
     // if tile is external tileset, then it will be refined no matter what
     tile.setUnconditionallyRefine();

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -48,87 +48,86 @@ CesiumAsync::Future<TileLoadResultAndRenderResources> postProcessContent(
     std::shared_ptr<IPrepareRendererResources>&& pPrepareRendererResources,
     const TilesetContentOptions& contentOptions,
     const glm::dmat4& tileTransform) {
-  void* pRenderResources = nullptr;
-  if (result.state == TileLoadResultState::Success) {
-    TileRenderContent* pRenderContent =
-        std::get_if<TileRenderContent>(&result.contentKind);
-    if (pRenderContent && pRenderContent->model) {
-      // Download any external image or buffer urls in the gltf if there are any
-      CesiumGltfReader::GltfReaderResult gltfResult{
-          std::move(*pRenderContent->model),
-          {},
-          {}};
+  assert(
+      result.state == TileLoadResultState::Success &&
+      "This function requires result to be success");
 
-      CesiumAsync::HttpHeaders requestHeaders;
-      std::string baseUrl;
-      if (result.pCompletedRequest) {
-        requestHeaders = result.pCompletedRequest->headers();
-        baseUrl = result.pCompletedRequest->url();
-      }
+  TileRenderContent* pRenderContent =
+      std::get_if<TileRenderContent>(&result.contentKind);
+  assert(
+      (pRenderContent && pRenderContent->model != std::nullopt) &&
+      "This function only processes render content");
 
-      CesiumGltfReader::GltfReaderOptions gltfOptions;
-      gltfOptions.ktx2TranscodeTargets = contentOptions.ktx2TranscodeTargets;
+  // Download any external image or buffer urls in the gltf if there are any
+  CesiumGltfReader::GltfReaderResult gltfResult{
+      std::move(*pRenderContent->model),
+      {},
+      {}};
 
-      return CesiumGltfReader::GltfReader::resolveExternalData(
-                 asyncSystem,
-                 baseUrl,
-                 requestHeaders,
-                 pAssetAccessor,
-                 gltfOptions,
-                 std::move(gltfResult))
-          .thenInWorkerThread(
-              [pLogger,
-               tileTransform,
-               contentOptions,
-               result = std::move(result),
-               pPrepareRendererResources =
-                   std::move(pPrepareRendererResources)](
-                  CesiumGltfReader::GltfReaderResult&& gltfResult) mutable {
-                if (!gltfResult.errors.empty()) {
-                  if (result.pCompletedRequest) {
-                    SPDLOG_LOGGER_ERROR(
-                        pLogger,
-                        "Failed resolving external glTF buffers from {}:\n- {}",
-                        result.pCompletedRequest->url(),
-                        CesiumUtility::joinToString(gltfResult.errors, "\n- "));
-                  } else {
-                    SPDLOG_LOGGER_ERROR(
-                        pLogger,
-                        "Failed resolving external glTF buffers:\n- {}",
-                        CesiumUtility::joinToString(gltfResult.errors, "\n- "));
-                  }
-                }
-
-                if (!gltfResult.warnings.empty()) {
-                  if (result.pCompletedRequest) {
-                    SPDLOG_LOGGER_WARN(
-                        pLogger,
-                        "Warning when resolving external gltf buffers from "
-                        "{}:\n- {}",
-                        result.pCompletedRequest->url(),
-                        CesiumUtility::joinToString(gltfResult.errors, "\n- "));
-                  } else {
-                    SPDLOG_LOGGER_ERROR(
-                        pLogger,
-                        "Warning resolving external glTF buffers:\n- {}",
-                        CesiumUtility::joinToString(gltfResult.errors, "\n- "));
-                  }
-                }
-
-                TileRenderContent& renderContent =
-                    std::get<TileRenderContent>(result.contentKind);
-                renderContent.model = std::move(gltfResult.model);
-                return postProcessGltf(
-                    std::move(result),
-                    tileTransform,
-                    contentOptions,
-                    pPrepareRendererResources);
-              });
-    }
+  CesiumAsync::HttpHeaders requestHeaders;
+  std::string baseUrl;
+  if (result.pCompletedRequest) {
+    requestHeaders = result.pCompletedRequest->headers();
+    baseUrl = result.pCompletedRequest->url();
   }
 
-  return asyncSystem.createResolvedFuture(
-      TileLoadResultAndRenderResources{std::move(result), pRenderResources});
+  CesiumGltfReader::GltfReaderOptions gltfOptions;
+  gltfOptions.ktx2TranscodeTargets = contentOptions.ktx2TranscodeTargets;
+
+  return CesiumGltfReader::GltfReader::resolveExternalData(
+             asyncSystem,
+             baseUrl,
+             requestHeaders,
+             pAssetAccessor,
+             gltfOptions,
+             std::move(gltfResult))
+      .thenInWorkerThread(
+          [pLogger,
+           tileTransform,
+           contentOptions,
+           result = std::move(result),
+           pPrepareRendererResources = std::move(pPrepareRendererResources)](
+              CesiumGltfReader::GltfReaderResult&& gltfResult) mutable {
+            if (!gltfResult.errors.empty()) {
+              if (result.pCompletedRequest) {
+                SPDLOG_LOGGER_ERROR(
+                    pLogger,
+                    "Failed resolving external glTF buffers from {}:\n- {}",
+                    result.pCompletedRequest->url(),
+                    CesiumUtility::joinToString(gltfResult.errors, "\n- "));
+              } else {
+                SPDLOG_LOGGER_ERROR(
+                    pLogger,
+                    "Failed resolving external glTF buffers:\n- {}",
+                    CesiumUtility::joinToString(gltfResult.errors, "\n- "));
+              }
+            }
+
+            if (!gltfResult.warnings.empty()) {
+              if (result.pCompletedRequest) {
+                SPDLOG_LOGGER_WARN(
+                    pLogger,
+                    "Warning when resolving external gltf buffers from "
+                    "{}:\n- {}",
+                    result.pCompletedRequest->url(),
+                    CesiumUtility::joinToString(gltfResult.errors, "\n- "));
+              } else {
+                SPDLOG_LOGGER_ERROR(
+                    pLogger,
+                    "Warning resolving external glTF buffers:\n- {}",
+                    CesiumUtility::joinToString(gltfResult.errors, "\n- "));
+              }
+            }
+
+            TileRenderContent& renderContent =
+                std::get<TileRenderContent>(result.contentKind);
+            renderContent.model = std::move(gltfResult.model);
+            return postProcessGltf(
+                std::move(result),
+                tileTransform,
+                contentOptions,
+                pPrepareRendererResources);
+          });
 }
 } // namespace
 
@@ -174,21 +173,48 @@ void TilesetContentManager::loadTileContent(
           _externals.pAssetAccessor,
           _externals.pLogger,
           _requestHeaders)
-      .thenInWorkerThread(
+      .thenImmediately(
           [pPrepareRendererResources = _externals.pPrepareRendererResources,
            asyncSystem = _externals.asyncSystem,
            pAssetAccessor = _externals.pAssetAccessor,
            pLogger = _externals.pLogger,
            contentOptions,
            tileTransform](TileLoadResult&& result) mutable {
-            return postProcessContent(
-                std::move(result),
-                std::move(asyncSystem),
-                std::move(pAssetAccessor),
-                std::move(pLogger),
-                std::move(pPrepareRendererResources),
-                contentOptions,
-                tileTransform);
+            // the reason we run immediate continuation, instead of in the
+            // worker thread, is that the loader may run the task in the main
+            // thread. And most often than not, those main thread task is very
+            // light weight. So when those tasks return, there is no need to
+            // spawn another worker thread if the result of the task isn't
+            // related to render content. We only ever spawn a new task in the
+            // worker thread if the content is a render content
+            if (result.state == TileLoadResultState::Success) {
+              auto pRenderContent =
+                  std::get_if<TileRenderContent>(&result.contentKind);
+              if (pRenderContent && pRenderContent->model) {
+                return asyncSystem.runInWorkerThread(
+                    [result = std::move(result),
+                     asyncSystem,
+                     pAssetAccessor = std::move(pAssetAccessor),
+                     pLogger = std::move(pLogger),
+                     pPrepareRendererResources =
+                         std::move(pPrepareRendererResources),
+                     contentOptions,
+                     tileTransform]() mutable {
+                      return postProcessContent(
+                          std::move(result),
+                          std::move(asyncSystem),
+                          std::move(pAssetAccessor),
+                          std::move(pLogger),
+                          std::move(pPrepareRendererResources),
+                          contentOptions,
+                          tileTransform);
+                    });
+              }
+            }
+
+            return asyncSystem
+                .createResolvedFuture<TileLoadResultAndRenderResources>(
+                    {std::move(result), nullptr});
           })
       .thenInMainThread([&tile, this](TileLoadResultAndRenderResources&& pair) {
         TilesetContentManager::setTileContent(

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -676,8 +676,7 @@ TileLoadResult parseExternalTilesetInWorkerThread(
     return TileLoadResult{
         TileUnknownContent{},
         TileLoadResultState::Failed,
-        std::move(pCompletedRequest),
-        {}};
+        std::move(pCompletedRequest)};
   }
 
   externalContentInitializer.pExternalTilesetLoaders =
@@ -686,10 +685,9 @@ TileLoadResult parseExternalTilesetInWorkerThread(
 
   // mark this tile has external content
   return TileLoadResult{
-      TileExternalContent{},
+      TileExternalContent{std::move(externalContentInitializer)},
       TileLoadResultState::Success,
-      std::move(pCompletedRequest),
-      std::move(externalContentInitializer)};
+      std::move(pCompletedRequest)};
 }
 } // namespace
 
@@ -756,11 +754,8 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
   // this loader only handles Url ID
   const std::string* url = std::get_if<std::string>(&tile.getTileID());
   if (!url) {
-    return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
-        TileUnknownContent{},
-        TileLoadResultState::Failed,
-        0,
-        {}});
+    return asyncSystem.createResolvedFuture<TileLoadResult>(
+        TileLoadResult{TileUnknownContent{}, TileLoadResultState::Failed, 0});
   }
 
   const glm::dmat4& tileTransform = tile.getTransform();
@@ -786,8 +781,7 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
               return TileLoadResult{
                   TileUnknownContent{},
                   TileLoadResultState::Failed,
-                  std::move(pCompletedRequest),
-                  {}};
+                  std::move(pCompletedRequest)};
             }
 
             uint16_t statusCode = pResponse->statusCode();
@@ -800,8 +794,7 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
               return TileLoadResult{
                   TileUnknownContent{},
                   TileLoadResultState::Failed,
-                  std::move(pCompletedRequest),
-                  {}};
+                  std::move(pCompletedRequest)};
             }
 
             // find gltf converter
@@ -824,15 +817,13 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
                 return TileLoadResult{
                     TileRenderContent{std::nullopt},
                     TileLoadResultState::Failed,
-                    std::move(pCompletedRequest),
-                    {}};
+                    std::move(pCompletedRequest)};
               }
 
               return TileLoadResult{
                   TileRenderContent{std::move(result.model)},
                   TileLoadResultState::Success,
-                  std::move(pCompletedRequest),
-                  {}};
+                  std::move(pCompletedRequest)};
             } else {
               // not a renderable content, then it must be external tileset
               return parseExternalTilesetInWorkerThread(

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -835,6 +835,15 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
           });
 }
 
+bool TilesetJsonLoader::updateTileContent(Tile& tile) {
+  auto pLoader = tile.getContent().getLoader();
+  if (pLoader != this) {
+    return pLoader->updateTileContent(tile);
+  }
+
+  return false;
+}
+
 const std::string& TilesetJsonLoader::getBaseUrl() const noexcept {
   return _baseUrl;
 }

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -676,7 +676,8 @@ TileLoadResult parseExternalTilesetInWorkerThread(
     return TileLoadResult{
         TileUnknownContent{},
         TileLoadResultState::Failed,
-        std::move(pCompletedRequest)};
+        std::move(pCompletedRequest),
+        {}};
   }
 
   externalContentInitializer.pExternalTilesetLoaders =
@@ -685,9 +686,10 @@ TileLoadResult parseExternalTilesetInWorkerThread(
 
   // mark this tile has external content
   return TileLoadResult{
-      TileExternalContent{std::move(externalContentInitializer)},
+      TileExternalContent{},
       TileLoadResultState::Success,
-      std::move(pCompletedRequest)};
+      std::move(pCompletedRequest),
+      std::move(externalContentInitializer)};
 }
 } // namespace
 
@@ -754,8 +756,11 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
   // this loader only handles Url ID
   const std::string* url = std::get_if<std::string>(&tile.getTileID());
   if (!url) {
-    return asyncSystem.createResolvedFuture<TileLoadResult>(
-        TileLoadResult{TileUnknownContent{}, TileLoadResultState::Failed, 0});
+    return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
+        TileUnknownContent{},
+        TileLoadResultState::Failed,
+        nullptr,
+        {}});
   }
 
   const glm::dmat4& tileTransform = tile.getTransform();
@@ -781,7 +786,8 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
               return TileLoadResult{
                   TileUnknownContent{},
                   TileLoadResultState::Failed,
-                  std::move(pCompletedRequest)};
+                  std::move(pCompletedRequest),
+                  {}};
             }
 
             uint16_t statusCode = pResponse->statusCode();
@@ -794,7 +800,8 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
               return TileLoadResult{
                   TileUnknownContent{},
                   TileLoadResultState::Failed,
-                  std::move(pCompletedRequest)};
+                  std::move(pCompletedRequest),
+                  {}};
             }
 
             // find gltf converter
@@ -817,13 +824,15 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
                 return TileLoadResult{
                     TileRenderContent{std::nullopt},
                     TileLoadResultState::Failed,
-                    std::move(pCompletedRequest)};
+                    std::move(pCompletedRequest),
+                    {}};
               }
 
               return TileLoadResult{
                   TileRenderContent{std::move(result.model)},
                   TileLoadResultState::Success,
-                  std::move(pCompletedRequest)};
+                  std::move(pCompletedRequest),
+                  {}};
             } else {
               // not a renderable content, then it must be external tileset
               return parseExternalTilesetInWorkerThread(

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.h
@@ -25,6 +25,8 @@ public:
       const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders)
       override;
 
+  bool updateTileContent(Tile& tile) override;
+
   const std::string& getBaseUrl() const noexcept;
 
   void addChildLoader(std::unique_ptr<TilesetContentLoader> pLoader);


### PR DESCRIPTION
This PR addresses the feedback for [the refactor PR comment](https://github.com/CesiumGS/cesium-native/pull/508#discussion_r889857003)

The PR adds `TilesetContentLoader::updateTileContent(Tile &tile)` to allow loader to update the tile content piece by piece if needed. The function allows the implicit tileset to create the children of tile if needed, instead of creating all children in the subtree. The function returns a boolean to indicate if the tile should be continue updated in the next frame. For the implicit tileset, once it creates the children for the tile, it will return false to indicate that the `updateTileContent()` should no longer be called on this tile in the future.

Along with this PR, I move `std::function<Tile &> tileInitializer` to `TileExternalContent`. The original idea in the original PR is that the loader can pass some custom info to the initializer (e.g maybe updated bounding volume) during loading. However, the only current use for it is to create children for a tile. Using it to pass custom data from a loader to a tile maybe best suited for `std::any` and use the new `updateTileContent(Tile &tile)` to process that `std::any`, but that is a feature for the future. 

Using `TileExternalContent` and `std::function<Tile &>` to create a subtree can be even optimized further (not implemented in this PR). Since `TileExternalContent` is stored in the std::variant along with `CesiumGltf::Model` and `CesiumGltf::Model` has more than 512 bytes memory footprint, it would be nice if any functor that is passed to TileExternalContent is created in that memory. Currently `std::function<Tile &>` has way too small inlined buffer, so it will very likely allocate for any functor passed into it. We will need to create a custom one only for TileExternalContent to take advantage of this optimization

cc @kring 