### PR TITLE
Create Child tiles for layer json as soon as possible

### DIFF
--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
@@ -57,6 +57,9 @@ public:
 private:
   bool
   tileIsAvailableInAnyLayer(const CesiumGeometry::QuadtreeTileID& tileID) const;
+
+  void createTileChildren(Tile& tile);
+
   void createChildTile(
       const Tile& parent,
       std::vector<Tile>& children,
@@ -66,6 +69,8 @@ private:
   CesiumGeometry::QuadtreeTilingScheme _tilingScheme;
   CesiumGeospatial::Projection _projection;
   std::vector<Layer> _layers;
+
+  struct TileChildrenCreatorInMainThread;
 };
 
 } // namespace Cesium3DTilesSelection


### PR DESCRIPTION
This addresses the bouncing problem between the main thread and worker thread in the PR https://github.com/CesiumGS/cesium-native/pull/510. This also addresses the problem where child tiles can only be created when a tile content is loaded.

The algorithm is that:
+ When tile is at the end of a subtree (in other word, it's at the availability level), we don't have much choice but to wait for it to finish loaded before we can create the children for this tile. It's because after the tile is loaded, the current layer will have more available rectangles to determine if a tile has more children.

+ If the tile is in the middle of a subtree of the current layer and more background layers needs to request availability, we create a main thread task to wait for background layers requests to finish before creating the children of the tile. The actual quantized mesh content still proceed independently

+ If there is no background layers requests, we create the children of that tile right away, then request the content of the tile. For most of the cases where there is only one layer, this is the code path that should be executed.

cc @kring  