### PR TITLE
Add raster overlay back to the refactor code

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/GltfUtilities.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/GltfUtilities.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <Cesium3DTilesSelection/RasterOverlayDetails.h>
+#include <CesiumGeospatial/BoundingRegion.h>
+#include <CesiumGeospatial/GlobeRectangle.h>
 #include <CesiumGltf/Model.h>
 
 #include <glm/glm.hpp>
@@ -9,5 +12,21 @@ struct GltfUtilities {
   static glm::dmat4x4 applyRtcCenter(
       const CesiumGltf::Model& gltf,
       const glm::dmat4x4& rootTransform);
+
+  static glm::dmat4x4 applyGltfUpAxisTransform(
+      const CesiumGltf::Model& model,
+      const glm::dmat4x4& rootTransform);
+
+  static std::optional<RasterOverlayDetails>
+  createRasterOverlayTextureCoordinates(
+      CesiumGltf::Model& gltf,
+      const glm::dmat4& modelToEcefTransform,
+      int32_t firstTextureCoordinateID,
+      const std::optional<CesiumGeospatial::GlobeRectangle>& globeRectangle,
+      std::vector<CesiumGeospatial::Projection>&& projections);
+
+  static CesiumGeospatial::BoundingRegion computeBoundingRegion(
+      const CesiumGltf::Model& gltf,
+      const glm::dmat4& transform);
 };
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterMappedTo3DTile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterMappedTo3DTile.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "RasterOverlayTile.h"
+#include <Cesium3DTilesSelection/RasterOverlayTile.h>
+#include <Cesium3DTilesSelection/IPrepareRendererResources.h>
 
 #include <CesiumGeometry/Rectangle.h>
 #include <CesiumGeospatial/Projection.h>
@@ -155,12 +156,17 @@ public:
    * @param tile The owner tile.
    * @return The {@link MoreDetailAvailable} state.
    */
-  RasterOverlayTile::MoreDetailAvailable update(Tile& tile);
+  RasterOverlayTile::MoreDetailAvailable
+  update(IPrepareRendererResources& prepareRendererResources, Tile& tile);
+
+  bool isMoreDetailAvailable() const noexcept;
 
   /**
    * @brief Detach the raster from the given tile.
    */
-  void detachFromTile(Tile& tile) noexcept;
+  void detachFromTile(
+      IPrepareRendererResources& prepareRendererResources,
+      Tile& tile) noexcept;
 
   /**
    * @brief Does a throttled load of the mapped {@link RasterOverlayTile}.
@@ -199,6 +205,7 @@ public:
    * the raster overlay.
    */
   static RasterMappedTo3DTile* mapOverlayToTile(
+      double maximumScreenSpaceError,
       RasterOverlay& overlay,
       Tile& tile,
       std::vector<CesiumGeospatial::Projection>& missingProjections);

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterMappedTo3DTile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterMappedTo3DTile.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <Cesium3DTilesSelection/RasterOverlayTile.h>
 #include <Cesium3DTilesSelection/IPrepareRendererResources.h>
-
+#include <Cesium3DTilesSelection/RasterOverlayTile.h>
 #include <CesiumGeometry/Rectangle.h>
 #include <CesiumGeospatial/Projection.h>
 #include <CesiumUtility/IntrusivePointer.h>

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayCollection.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayCollection.h
@@ -33,7 +33,7 @@ public:
    */
   RasterOverlayCollection(Tileset& tileset) noexcept;
 
-  ~RasterOverlayCollection();
+  ~RasterOverlayCollection() noexcept;
 
   /**
    * @brief Adds the given {@link RasterOverlay} to this collection.

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayDetails.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayDetails.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <CesiumGeospatial/Projection.h>
+#include <CesiumGeospatial/BoundingRegion.h>
+#include <CesiumGeometry/Rectangle.h>
+#include <vector>
+
+namespace Cesium3DTilesSelection {
+struct RasterOverlayDetails {
+  std::vector<CesiumGeospatial::Projection> rasterOverlayProjections;
+
+  std::vector<CesiumGeometry::Rectangle> rasterOverlayRectangles;
+
+  CesiumGeospatial::BoundingRegion boundingRegion;
+
+  const CesiumGeometry::Rectangle* findRectangleForOverlayProjection(
+      const CesiumGeospatial::Projection& projection) const;
+};
+} // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayDetails.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayDetails.h
@@ -8,13 +8,22 @@
 
 namespace Cesium3DTilesSelection {
 struct RasterOverlayDetails {
+  RasterOverlayDetails();
+
+  RasterOverlayDetails(
+      std::vector<CesiumGeospatial::Projection>&& rasterOverlayProjections,
+      std::vector<CesiumGeometry::Rectangle>&& rasterOverlayRectangles,
+      const CesiumGeospatial::BoundingRegion& boundingRegion);
+
+  const CesiumGeometry::Rectangle* findRectangleForOverlayProjection(
+      const CesiumGeospatial::Projection& projection) const;
+
+  void merge(RasterOverlayDetails&& other);
+
   std::vector<CesiumGeospatial::Projection> rasterOverlayProjections;
 
   std::vector<CesiumGeometry::Rectangle> rasterOverlayRectangles;
 
   CesiumGeospatial::BoundingRegion boundingRegion;
-
-  const CesiumGeometry::Rectangle* findRectangleForOverlayProjection(
-      const CesiumGeospatial::Projection& projection) const;
 };
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayDetails.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayDetails.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <CesiumGeospatial/Projection.h>
-#include <CesiumGeospatial/BoundingRegion.h>
 #include <CesiumGeometry/Rectangle.h>
+#include <CesiumGeospatial/BoundingRegion.h>
+#include <CesiumGeospatial/Projection.h>
+
 #include <vector>
 
 namespace Cesium3DTilesSelection {

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
@@ -1,12 +1,13 @@
 #pragma once
 
-#include "BoundingVolume.h"
-#include "Library.h"
-#include "TileID.h"
-#include "TileRefine.h"
-#include "TileSelectionState.h"
-
 #include <Cesium3DTilesSelection/TileContent.h>
+#include <Cesium3DTilesSelection/RasterMappedTo3DTile.h>
+#include <Cesium3DTilesSelection/TileID.h>
+#include <Cesium3DTilesSelection/TileRefine.h>
+#include <Cesium3DTilesSelection/TileSelectionState.h>
+#include <Cesium3DTilesSelection/BoundingVolume.h>
+#include <Cesium3DTilesSelection/Library.h>
+
 #include <CesiumUtility/DoublyLinkedList.h>
 
 #include <glm/common.hpp>
@@ -361,6 +362,15 @@ public:
 
   TileContent& getContent() noexcept { return *_pContent; }
 
+  std::vector<RasterMappedTo3DTile>& getMappedRasterTiles() noexcept {
+    return this->_rasterTiles;
+  }
+
+  const std::vector<RasterMappedTo3DTile>&
+  getMappedRasterTiles() const noexcept {
+    return this->_rasterTiles;
+  }
+
   bool isRenderable() const noexcept;
 
   bool isRenderContent() const noexcept;
@@ -402,6 +412,9 @@ private:
   // tile content
   CesiumUtility::DoublyLinkedListPointers<Tile> _loadedTilesLinks;
   std::unique_ptr<TileContent> _pContent;
+
+  // mapped raster overlay
+  std::vector<RasterMappedTo3DTile> _rasterTiles;
 
 public:
   /**

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <Cesium3DTilesSelection/TileContent.h>
+#include <Cesium3DTilesSelection/BoundingVolume.h>
+#include <Cesium3DTilesSelection/Library.h>
 #include <Cesium3DTilesSelection/RasterMappedTo3DTile.h>
+#include <Cesium3DTilesSelection/TileContent.h>
 #include <Cesium3DTilesSelection/TileID.h>
 #include <Cesium3DTilesSelection/TileRefine.h>
 #include <Cesium3DTilesSelection/TileSelectionState.h>
-#include <Cesium3DTilesSelection/BoundingVolume.h>
-#include <Cesium3DTilesSelection/Library.h>
-
 #include <CesiumUtility/DoublyLinkedList.h>
 
 #include <glm/common.hpp>

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <CesiumGltf/Model.h>
 #include <CesiumGeospatial/Projection.h>
+#include <CesiumGltf/Model.h>
 
 #include <functional>
 #include <optional>
@@ -67,7 +67,7 @@ private:
 
   void setContentKind(const TileContentKind& contentKind);
 
-  void setProjection(const CesiumGeospatial::Projection &projection);
+  void setProjection(const CesiumGeospatial::Projection& projection);
 
   void setState(TileLoadState state) noexcept;
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CesiumGltf/Model.h>
+#include <CesiumGeospatial/Projection.h>
 
 #include <functional>
 #include <optional>
@@ -55,6 +56,8 @@ public:
 
   const TileRenderContent* getRenderContent() const noexcept;
 
+  const CesiumGeospatial::Projection* getProjection() const noexcept;
+
   TilesetContentLoader* getLoader() noexcept;
 
   void* getRenderResources() const noexcept;
@@ -63,6 +66,8 @@ private:
   void setContentKind(TileContentKind&& contentKind);
 
   void setContentKind(const TileContentKind& contentKind);
+
+  void setProjection(const CesiumGeospatial::Projection &projection);
 
   void setState(TileLoadState state) noexcept;
 
@@ -75,7 +80,8 @@ private:
   TileLoadState _state;
   TileContentKind _contentKind;
   void* _pRenderResources;
-  std::function<void(Tile&)> _deferredTileInitializer;
+  std::optional<CesiumGeospatial::Projection> _projection;
+  std::function<void(Tile&)> _tileInitializer;
   TilesetContentLoader* _pLoader;
 
   friend class TilesetContentManager;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
@@ -63,9 +63,11 @@ public:
 
   const TileRenderContent* getRenderContent() const noexcept;
 
-  const RasterOverlayDetails* getRasterOverlayDetails() const noexcept;
+  TileRenderContent* getRenderContent() noexcept;
 
-  RasterOverlayDetails* getRasterOverlayDetails() noexcept;
+  const RasterOverlayDetails& getRasterOverlayDetails() const noexcept;
+
+  RasterOverlayDetails& getRasterOverlayDetails() noexcept;
 
   TilesetContentLoader* getLoader() noexcept;
 
@@ -95,7 +97,7 @@ private:
   TileLoadState _state;
   TileContentKind _contentKind;
   void* _pRenderResources;
-  std::optional<RasterOverlayDetails> _rasterOverlayDetails;
+  RasterOverlayDetails _rasterOverlayDetails;
   std::function<void(Tile&)> _tileInitializer;
   TilesetContentLoader* _pLoader;
   bool _shouldContentContinueUpdated;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
@@ -63,8 +63,6 @@ public:
 
   const TileRenderContent* getRenderContent() const noexcept;
 
-  const CesiumGeospatial::Projection* getProjection() const noexcept;
-
   const RasterOverlayDetails* getRasterOverlayDetails() const noexcept;
 
   RasterOverlayDetails* getRasterOverlayDetails() noexcept;
@@ -77,8 +75,6 @@ private:
   void setContentKind(TileContentKind&& contentKind);
 
   void setContentKind(const TileContentKind& contentKind);
-
-  void setProjection(const CesiumGeospatial::Projection& projection);
 
   void
   setRasterOverlayDetails(const RasterOverlayDetails& rasterOverlayDetails);
@@ -99,7 +95,6 @@ private:
   TileLoadState _state;
   TileContentKind _contentKind;
   void* _pRenderResources;
-  std::optional<CesiumGeospatial::Projection> _projection;
   std::optional<RasterOverlayDetails> _rasterOverlayDetails;
   std::function<void(Tile&)> _tileInitializer;
   TilesetContentLoader* _pLoader;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Cesium3DTilesSelection/RasterOverlayDetails.h>
 #include <CesiumGeospatial/Projection.h>
 #include <CesiumGltf/Model.h>
 
@@ -58,6 +59,10 @@ public:
 
   const CesiumGeospatial::Projection* getProjection() const noexcept;
 
+  const RasterOverlayDetails* getRasterOverlayDetails() const noexcept;
+
+  RasterOverlayDetails* getRasterOverlayDetails() noexcept;
+
   TilesetContentLoader* getLoader() noexcept;
 
   void* getRenderResources() const noexcept;
@@ -68,6 +73,10 @@ private:
   void setContentKind(const TileContentKind& contentKind);
 
   void setProjection(const CesiumGeospatial::Projection& projection);
+
+  void setRasterOverlayDetails(const RasterOverlayDetails &rasterOverlayDetails);
+
+  void setRasterOverlayDetails(RasterOverlayDetails &&rasterOverlayDetails);
 
   void setState(TileLoadState state) noexcept;
 
@@ -81,6 +90,7 @@ private:
   TileContentKind _contentKind;
   void* _pRenderResources;
   std::optional<CesiumGeospatial::Projection> _projection;
+  std::optional<RasterOverlayDetails> _rasterOverlayDetails;
   std::function<void(Tile&)> _tileInitializer;
   TilesetContentLoader* _pLoader;
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
@@ -74,9 +74,10 @@ private:
 
   void setProjection(const CesiumGeospatial::Projection& projection);
 
-  void setRasterOverlayDetails(const RasterOverlayDetails &rasterOverlayDetails);
+  void
+  setRasterOverlayDetails(const RasterOverlayDetails& rasterOverlayDetails);
 
-  void setRasterOverlayDetails(RasterOverlayDetails &&rasterOverlayDetails);
+  void setRasterOverlayDetails(RasterOverlayDetails&& rasterOverlayDetails);
 
   void setState(TileLoadState state) noexcept;
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -408,7 +408,7 @@ private:
 
   CESIUM_TRACE_DECLARE_TRACK_SET(_loadingSlots, "Tileset Loading Slot");
 
-  static double addTileToLoadQueue(
+  double addTileToLoadQueue(
       std::vector<LoadRecord>& loadQueue,
       const std::vector<ViewState>& frustums,
       Tile& tile,

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -67,7 +67,7 @@ public:
    * This may block the calling thread while waiting for pending asynchronous
    * tile loads to terminate.
    */
-  ~Tileset();
+  ~Tileset() noexcept;
 
   const std::vector<Credit> getTilesetCredits() const noexcept {
     return this->_tilesetCredits;

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
@@ -347,15 +347,13 @@ CesiumAsync::Future<TileLoadResult> CesiumIonTilesetLoader::loadTileContent(
         TileUnknownContent{},
         TileLoadResultState::RetryLater,
         nullptr,
-        {},
-        std::nullopt});
+        {}});
   } else if (_refreshTokenState == TokenRefreshState::Failed) {
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileUnknownContent{},
         TileLoadResultState::Failed,
         nullptr,
-        {},
-        std::nullopt});
+        {}});
   }
 
   // TODO: the way this is structured, requests already in progress

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
@@ -345,12 +345,18 @@ CesiumAsync::Future<TileLoadResult> CesiumIonTilesetLoader::loadTileContent(
   if (_refreshTokenState == TokenRefreshState::Loading) {
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileUnknownContent{},
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
         TileLoadResultState::RetryLater,
         nullptr,
         {}});
   } else if (_refreshTokenState == TokenRefreshState::Failed) {
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileUnknownContent{},
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
         TileLoadResultState::Failed,
         nullptr,
         {}});

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
@@ -347,14 +347,12 @@ CesiumAsync::Future<TileLoadResult> CesiumIonTilesetLoader::loadTileContent(
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        std::nullopt,
         TileLoadResultState::RetryLater,
         nullptr,
         {}});
   } else if (_refreshTokenState == TokenRefreshState::Failed) {
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileUnknownContent{},
-        std::nullopt,
         std::nullopt,
         std::nullopt,
         TileLoadResultState::Failed,

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
@@ -265,13 +265,15 @@ CesiumAsync::Future<TileLoadResult> CesiumIonTilesetLoader::loadTileContent(
         TileUnknownContent{},
         TileLoadResultState::RetryLater,
         nullptr,
-        {}});
+        {},
+        std::nullopt});
   } else if (_refreshTokenState == TokenRefreshState::Failed) {
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileUnknownContent{},
         TileLoadResultState::Failed,
         nullptr,
-        {}});
+        {},
+        std::nullopt});
   }
 
   // TODO: the way this is structured, requests already in progress

--- a/Cesium3DTilesSelection/src/GltfUtilities.cpp
+++ b/Cesium3DTilesSelection/src/GltfUtilities.cpp
@@ -58,7 +58,7 @@ namespace Cesium3DTilesSelection {
 
 /*static*/ std::optional<RasterOverlayDetails>
 GltfUtilities::createRasterOverlayTextureCoordinates(
-    CesiumGltf::Model& gltf,
+    CesiumGltf::Model& model,
     const glm::dmat4& modelToEcefTransform,
     int32_t firstTextureCoordinateID,
     const std::optional<CesiumGeospatial::GlobeRectangle>& globeRectangle,
@@ -71,7 +71,7 @@ GltfUtilities::createRasterOverlayTextureCoordinates(
   CesiumGeospatial::GlobeRectangle bounds =
       globeRectangle
           ? *globeRectangle
-          : computeBoundingRegion(gltf, modelToEcefTransform).getRectangle();
+          : computeBoundingRegion(model, modelToEcefTransform).getRectangle();
 
   // Currently, a Longitude/Latitude Rectangle maps perfectly to all possible
   // projection types, because the only possible projection types are
@@ -84,11 +84,13 @@ GltfUtilities::createRasterOverlayTextureCoordinates(
   }
 
   glm::dmat4 rootTransform = modelToEcefTransform;
-  rootTransform = applyRtcCenter(gltf, rootTransform);
-  rootTransform = applyGltfUpAxisTransform(gltf, rootTransform);
+  rootTransform = applyRtcCenter(model, rootTransform);
+  rootTransform = applyGltfUpAxisTransform(model, rootTransform);
 
   std::vector<int> positionAccessorsToTextureCoordinateAccessor;
-  positionAccessorsToTextureCoordinateAccessor.resize(gltf.accessors.size(), 0);
+  positionAccessorsToTextureCoordinateAccessor.resize(
+      model.accessors.size(),
+      0);
 
   // When computing the tile's bounds, ignore tiles that are less than 1/1000th
   // of a tile width from the North or South pole. Longitudes cannot be trusted
@@ -301,7 +303,7 @@ GltfUtilities::createRasterOverlayTextureCoordinates(
         }
       };
 
-  gltf.forEachPrimitiveInScene(-1, createTextureCoordinatesForPrimitive);
+  model.forEachPrimitiveInScene(-1, createTextureCoordinatesForPrimitive);
 
   return RasterOverlayDetails{
       std::move(projections),

--- a/Cesium3DTilesSelection/src/GltfUtilities.cpp
+++ b/Cesium3DTilesSelection/src/GltfUtilities.cpp
@@ -1,5 +1,14 @@
+#include "SkirtMeshMetadata.h"
+
 #include <Cesium3DTilesSelection/GltfUtilities.h>
+#include <CesiumGeometry/Axis.h>
+#include <CesiumGeometry/AxisTransforms.h>
+#include <CesiumGeospatial/BoundingRegionBuilder.h>
+#include <CesiumGltf/AccessorView.h>
+#include <CesiumGltf/AccessorWriter.h>
 #include <CesiumGltf/ExtensionCesiumRTC.h>
+
+#include <vector>
 
 namespace Cesium3DTilesSelection {
 /*static*/ glm::dmat4x4 GltfUtilities::applyRtcCenter(
@@ -23,5 +32,354 @@ namespace Cesium3DTilesSelection {
       glm::dvec4(0.0, 0.0, 1.0, 0.0),
       glm::dvec4(x, y, z, 1.0));
   return rootTransform * rtcTransform;
+}
+
+/*static*/ glm::dmat4x4 GltfUtilities::applyGltfUpAxisTransform(
+    const CesiumGltf::Model& model,
+    const glm::dmat4x4& rootTransform) {
+  auto gltfUpAxisIt = model.extras.find("gltfUpAxis");
+  if (gltfUpAxisIt == model.extras.end()) {
+    // The default up-axis of glTF is the Y-axis, and no other
+    // up-axis was specified. Transform the Y-axis to the Z-axis,
+    // to match the 3D Tiles specification
+    return rootTransform * CesiumGeometry::AxisTransforms::Y_UP_TO_Z_UP;
+  }
+  const CesiumUtility::JsonValue& gltfUpAxis = gltfUpAxisIt->second;
+  int gltfUpAxisValue = static_cast<int>(gltfUpAxis.getSafeNumberOrDefault(1));
+  if (gltfUpAxisValue == static_cast<int>(CesiumGeometry::Axis::X)) {
+    return rootTransform * CesiumGeometry::AxisTransforms::X_UP_TO_Z_UP;
+  } else if (gltfUpAxisValue == static_cast<int>(CesiumGeometry::Axis::Y)) {
+    return rootTransform * CesiumGeometry::AxisTransforms::Y_UP_TO_Z_UP;
+  } else if (gltfUpAxisValue == static_cast<int>(CesiumGeometry::Axis::Z)) {
+    // No transform required
+  }
+  return rootTransform;
+}
+
+/*static*/ std::optional<RasterOverlayDetails>
+GltfUtilities::createRasterOverlayTextureCoordinates(
+    CesiumGltf::Model& gltf,
+    const glm::dmat4& modelToEcefTransform,
+    int32_t firstTextureCoordinateID,
+    const std::optional<CesiumGeospatial::GlobeRectangle>& globeRectangle,
+    std::vector<CesiumGeospatial::Projection>&& projections) {
+  if (projections.empty()) {
+    return std::nullopt;
+  }
+
+  // Compute the bounds of the tile if they're not provided.
+  CesiumGeospatial::GlobeRectangle bounds =
+      globeRectangle
+          ? *globeRectangle
+          : computeBoundingRegion(gltf, modelToEcefTransform).getRectangle();
+
+  // Currently, a Longitude/Latitude Rectangle maps perfectly to all possible
+  // projection types, because the only possible projection types are
+  // Geographic and Web Mercator. In the future if/when we add projections
+  // that don't have this convenient property, we'll need to compute the
+  // Rectangle for each projection directly from the vertex positions.
+  std::vector<CesiumGeometry::Rectangle> rectangles(projections.size());
+  for (size_t i = 0; i < projections.size(); ++i) {
+    rectangles[i] = projectRectangleSimple(projections[i], bounds);
+  }
+
+  glm::dmat4 rootTransform = modelToEcefTransform;
+  rootTransform = applyRtcCenter(gltf, rootTransform);
+  rootTransform = applyGltfUpAxisTransform(gltf, rootTransform);
+
+  std::vector<int> positionAccessorsToTextureCoordinateAccessor;
+  positionAccessorsToTextureCoordinateAccessor.resize(gltf.accessors.size(), 0);
+
+  // When computing the tile's bounds, ignore tiles that are less than 1/1000th
+  // of a tile width from the North or South pole. Longitudes cannot be trusted
+  // at such extreme latitudes.
+  CesiumGeospatial::BoundingRegionBuilder computedBounds;
+  computedBounds.setPoleTolerance(0.001 * bounds.computeHeight());
+
+  auto createTextureCoordinatesForPrimitive =
+      [&](CesiumGltf::Model& gltf,
+          CesiumGltf::Node& /*node*/,
+          CesiumGltf::Mesh& /*mesh*/,
+          CesiumGltf::MeshPrimitive& primitive,
+          const glm::dmat4& nodeTransform) {
+        auto positionIt = primitive.attributes.find("POSITION");
+        if (positionIt == primitive.attributes.end()) {
+          return;
+        }
+
+        const int positionAccessorIndex = positionIt->second;
+        if (positionAccessorIndex < 0 ||
+            positionAccessorIndex >= static_cast<int>(gltf.accessors.size())) {
+          return;
+        }
+
+        const int32_t firstTextureCoordinateAccessorIndex =
+            positionAccessorsToTextureCoordinateAccessor[static_cast<size_t>(
+                positionAccessorIndex)];
+        if (firstTextureCoordinateAccessorIndex > 0) {
+          // Already created texture coordinates for this projection, so use
+          // them.
+          for (size_t i = 0; i < projections.size(); ++i) {
+            std::string attributeName =
+                "_CESIUMOVERLAY_" +
+                std::to_string(firstTextureCoordinateID + int32_t(i));
+            primitive.attributes[attributeName] =
+                firstTextureCoordinateAccessorIndex + int32_t(i);
+          }
+          return;
+        }
+
+        const glm::dmat4 fullTransform = rootTransform * nodeTransform;
+
+        std::vector<CesiumGltf::Buffer>& buffers = gltf.buffers;
+        std::vector<CesiumGltf::BufferView>& bufferViews = gltf.bufferViews;
+        std::vector<CesiumGltf::Accessor>& accessors = gltf.accessors;
+
+        positionAccessorsToTextureCoordinateAccessor[size_t(
+            positionAccessorIndex)] = int32_t(gltf.accessors.size());
+
+        // Create a buffer, bufferView, accessor, and writer for each set of
+        // coordinates. Reserve space for them to avoid unnecessary
+        // reallocations and to prevent earlier buffers from becoming invalid
+        // after we've created an AccessorWriter for it and then add _another_
+        // buffer.
+        std::vector<CesiumGltf::AccessorWriter<glm::vec2>> uvWriters;
+        uvWriters.reserve(projections.size());
+        buffers.reserve(buffers.size() + projections.size());
+        bufferViews.reserve(bufferViews.size() + projections.size());
+        accessors.reserve(accessors.size() + projections.size());
+
+        const CesiumGltf::AccessorView<glm::vec3> positionView(
+            gltf,
+            positionAccessorIndex);
+        if (positionView.status() != CesiumGltf::AccessorViewStatus::Valid) {
+          return;
+        }
+
+        std::optional<SkirtMeshMetadata> skirtMeshMetadata =
+            SkirtMeshMetadata::parseFromGltfExtras(primitive.extras);
+        int64_t vertexBegin, vertexEnd;
+        if (skirtMeshMetadata.has_value()) {
+          vertexBegin = skirtMeshMetadata->noSkirtVerticesBegin;
+          vertexEnd = skirtMeshMetadata->noSkirtVerticesBegin +
+                      skirtMeshMetadata->noSkirtVerticesCount;
+        } else {
+          vertexBegin = 0;
+          vertexEnd = positionView.size();
+        }
+
+        for (size_t i = 0; i < projections.size(); ++i) {
+          const int uvBufferId = static_cast<int>(buffers.size());
+          CesiumGltf::Buffer& uvBuffer = buffers.emplace_back();
+
+          const int uvBufferViewId = static_cast<int>(bufferViews.size());
+          bufferViews.emplace_back();
+
+          const int uvAccessorId = static_cast<int>(accessors.size());
+          accessors.emplace_back();
+
+          uvBuffer.cesium.data.resize(
+              size_t(positionView.size()) * 2 * sizeof(float));
+
+          CesiumGltf::BufferView& uvBufferView =
+              gltf.bufferViews[static_cast<size_t>(uvBufferViewId)];
+          uvBufferView.buffer = uvBufferId;
+          uvBufferView.byteOffset = 0;
+          uvBufferView.byteStride = 2 * sizeof(float);
+          uvBufferView.byteLength = int64_t(uvBuffer.cesium.data.size());
+          uvBufferView.target = CesiumGltf::BufferView::Target::ARRAY_BUFFER;
+
+          CesiumGltf::Accessor& uvAccessor =
+              gltf.accessors[static_cast<size_t>(uvAccessorId)];
+          uvAccessor.bufferView = uvBufferViewId;
+          uvAccessor.byteOffset = 0;
+          uvAccessor.componentType = CesiumGltf::Accessor::ComponentType::FLOAT;
+          uvAccessor.count = int64_t(positionView.size());
+          uvAccessor.type = CesiumGltf::Accessor::Type::VEC2;
+
+          [[maybe_unused]] CesiumGltf::AccessorWriter<glm::vec2>& uvWriter =
+              uvWriters.emplace_back(gltf, uvAccessorId);
+          assert(uvWriter.status() == CesiumGltf::AccessorViewStatus::Valid);
+
+          std::string attributeName =
+              "_CESIUMOVERLAY_" +
+              std::to_string(firstTextureCoordinateID + int32_t(i));
+          primitive.attributes[attributeName] = uvAccessorId;
+        }
+
+        // Generate texture coordinates for each position.
+        for (int64_t positionIndex = 0; positionIndex < positionView.size();
+             ++positionIndex) {
+          // Get the ECEF position
+          const glm::vec3 position = positionView[positionIndex];
+          const glm::dvec3 positionEcef =
+              glm::dvec3(fullTransform * glm::dvec4(position, 1.0));
+
+          // Convert it to cartographic
+          const std::optional<CesiumGeospatial::Cartographic> cartographic =
+              CesiumGeospatial::Ellipsoid::WGS84.cartesianToCartographic(
+                  positionEcef);
+          if (!cartographic) {
+            for (CesiumGltf::AccessorWriter<glm::vec2>& uvWriter : uvWriters) {
+              uvWriter[positionIndex] = glm::dvec2(0.0, 0.0);
+            }
+            continue;
+          }
+
+          // exclude skirt vertices from bounds
+          if (positionIndex >= vertexBegin && positionIndex < vertexEnd) {
+            computedBounds.expandToIncludePosition(*cartographic);
+          }
+
+          // Generate texture coordinates at this position for each projection
+          for (size_t projectionIndex = 0; projectionIndex < projections.size();
+               ++projectionIndex) {
+            const CesiumGeospatial::Projection& projection =
+                projections[projectionIndex];
+            const CesiumGeometry::Rectangle& rectangle =
+                rectangles[projectionIndex];
+
+            // Project it with the raster overlay's projection
+            glm::dvec3 projectedPosition =
+                projectPosition(projection, cartographic.value());
+
+            double longitude = cartographic.value().longitude;
+            const double latitude = cartographic.value().latitude;
+            const double ellipsoidHeight = cartographic.value().height;
+
+            // If the position is near the anti-meridian and the projected
+            // position is outside the expected range, try using the equivalent
+            // longitude on the other side of the anti-meridian to see if that
+            // gets us closer.
+            if (glm::abs(
+                    glm::abs(cartographic.value().longitude) -
+                    CesiumUtility::Math::OnePi) <
+                    CesiumUtility::Math::Epsilon5 &&
+                (projectedPosition.x < rectangle.minimumX ||
+                 projectedPosition.x > rectangle.maximumX ||
+                 projectedPosition.y < rectangle.minimumY ||
+                 projectedPosition.y > rectangle.maximumY)) {
+              const double testLongitude = longitude + longitude < 0.0
+                                               ? CesiumUtility::Math::TwoPi
+                                               : -CesiumUtility::Math::TwoPi;
+              const glm::dvec3 projectedPosition2 = projectPosition(
+                  projection,
+                  CesiumGeospatial::Cartographic(
+                      testLongitude,
+                      latitude,
+                      ellipsoidHeight));
+
+              const double distance1 = rectangle.computeSignedDistance(
+                  glm::dvec2(projectedPosition));
+              const double distance2 = rectangle.computeSignedDistance(
+                  glm::dvec2(projectedPosition2));
+
+              if (distance2 < distance1) {
+                projectedPosition = projectedPosition2;
+                longitude = testLongitude;
+              }
+            }
+
+            // Scale to (0.0, 0.0) at the (minimumX, minimumY) corner, and
+            // (1.0, 1.0) at the (maximumX, maximumY) corner. The coordinates
+            // should stay inside these bounds if the input rectangle actually
+            // bounds the vertices, but we'll clamp to be safe.
+            glm::vec2 uv(
+                CesiumUtility::Math::clamp(
+                    (projectedPosition.x - rectangle.minimumX) /
+                        rectangle.computeWidth(),
+                    0.0,
+                    1.0),
+                CesiumUtility::Math::clamp(
+                    (projectedPosition.y - rectangle.minimumY) /
+                        rectangle.computeHeight(),
+                    0.0,
+                    1.0));
+
+            uvWriters[projectionIndex][positionIndex] = uv;
+          }
+        }
+      };
+
+  gltf.forEachPrimitiveInScene(-1, createTextureCoordinatesForPrimitive);
+
+  return RasterOverlayDetails{
+      std::move(projections),
+      std::move(rectangles),
+      computedBounds.toRegion()};
+}
+
+/*static*/ CesiumGeospatial::BoundingRegion
+GltfUtilities::computeBoundingRegion(
+    const CesiumGltf::Model& gltf,
+    const glm::dmat4& transform) {
+  glm::dmat4 rootTransform = transform;
+  rootTransform = applyRtcCenter(gltf, rootTransform);
+  rootTransform = applyGltfUpAxisTransform(gltf, rootTransform);
+
+  // When computing the tile's bounds, ignore tiles that are less than 1/1000th
+  // of a tile width from the North or South pole. Longitudes cannot be trusted
+  // at such extreme latitudes.
+  CesiumGeospatial::BoundingRegionBuilder computedBounds;
+
+  gltf.forEachPrimitiveInScene(
+      -1,
+      [&rootTransform, &computedBounds](
+          const CesiumGltf::Model& gltf_,
+          const CesiumGltf::Node& /*node*/,
+          const CesiumGltf::Mesh& /*mesh*/,
+          const CesiumGltf::MeshPrimitive& primitive,
+          const glm::dmat4& nodeTransform) {
+        auto positionIt = primitive.attributes.find("POSITION");
+        if (positionIt == primitive.attributes.end()) {
+          return;
+        }
+
+        const int positionAccessorIndex = positionIt->second;
+        if (positionAccessorIndex < 0 ||
+            positionAccessorIndex >= static_cast<int>(gltf_.accessors.size())) {
+          return;
+        }
+
+        const glm::dmat4 fullTransform = rootTransform * nodeTransform;
+
+        const CesiumGltf::AccessorView<glm::vec3> positionView(
+            gltf_,
+            positionAccessorIndex);
+        if (positionView.status() != CesiumGltf::AccessorViewStatus::Valid) {
+          return;
+        }
+
+        std::optional<SkirtMeshMetadata> skirtMeshMetadata =
+            SkirtMeshMetadata::parseFromGltfExtras(primitive.extras);
+        int64_t vertexBegin, vertexEnd;
+        if (skirtMeshMetadata.has_value()) {
+          vertexBegin = skirtMeshMetadata->noSkirtVerticesBegin;
+          vertexEnd = skirtMeshMetadata->noSkirtVerticesBegin +
+                      skirtMeshMetadata->noSkirtVerticesCount;
+        } else {
+          vertexBegin = 0;
+          vertexEnd = positionView.size();
+        }
+
+        for (int64_t i = vertexBegin; i < vertexEnd; ++i) {
+          // Get the ECEF position
+          const glm::vec3 position = positionView[i];
+          const glm::dvec3 positionEcef =
+              glm::dvec3(fullTransform * glm::dvec4(position, 1.0));
+
+          // Convert it to cartographic
+          std::optional<CesiumGeospatial::Cartographic> cartographic =
+              CesiumGeospatial::Ellipsoid::WGS84.cartesianToCartographic(
+                  positionEcef);
+          if (!cartographic) {
+            continue;
+          }
+
+          computedBounds.expandToIncludePosition(*cartographic);
+        }
+      });
+
+  return computedBounds.toRegion();
 }
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
@@ -272,7 +272,8 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               TileUnknownContent{},
               TileLoadResultState::Failed,
               nullptr,
-              {}};
+              {},
+              std::nullopt};
         }
 
         uint16_t statusCode = pResponse->statusCode();
@@ -286,7 +287,8 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               TileUnknownContent{},
               TileLoadResultState::Failed,
               nullptr,
-              {}};
+              {},
+              std::nullopt};
         }
 
         // find gltf converter
@@ -310,7 +312,8 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
                 TileRenderContent{std::nullopt},
                 TileLoadResultState::Failed,
                 std::move(pCompletedRequest),
-                {}};
+                {},
+                std::nullopt};
           }
 
           std::function<void(Tile&)> tileInitializer;
@@ -321,7 +324,8 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               TileRenderContent{std::move(result.model)},
               TileLoadResultState::Success,
               std::move(pCompletedRequest),
-              std::move(tileInitializer)};
+              std::move(tileInitializer),
+              std::nullopt};
         }
 
         // content type is not supported
@@ -329,7 +333,8 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
             TileRenderContent{std::nullopt},
             TileLoadResultState::Failed,
             std::move(pCompletedRequest),
-            {}};
+            {},
+            std::nullopt};
       });
 }
 } // namespace
@@ -349,7 +354,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
         TileUnknownContent{},
         TileLoadResultState::Failed,
         nullptr,
-        {}});
+        {},
+        std::nullopt});
   }
 
   // find the subtree ID
@@ -359,7 +365,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
         TileUnknownContent{},
         TileLoadResultState::Failed,
         nullptr,
-        {}});
+        {},
+        std::nullopt});
   }
 
   uint64_t levelLeft = pOctreeID->level % _subtreeLevels;
@@ -421,7 +428,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
                       TileEmptyContent{},
                       TileLoadResultState::Success,
                       nullptr,
-                      std::move(subtreeInitializer)});
+                      std::move(subtreeInitializer),
+                      std::nullopt});
                 }
 
                 return requestTileContent(
@@ -439,7 +447,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
                       TileUnknownContent{},
                       TileLoadResultState::Failed,
                       nullptr,
-                      {}});
+                      {},
+                      std::nullopt});
             });
   }
 
@@ -451,7 +460,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
         TileEmptyContent{},
         TileLoadResultState::Success,
         nullptr,
-        {}});
+        {},
+        std::nullopt});
   }
 
   std::string tileUrl = resolveUrl(_baseUrl, _contentUrlTemplate, *pOctreeID);

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
@@ -222,8 +222,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               TileUnknownContent{},
               TileLoadResultState::Failed,
               nullptr,
-              {},
-              std::nullopt};
+              {}};
         }
 
         uint16_t statusCode = pResponse->statusCode();
@@ -237,8 +236,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               TileUnknownContent{},
               TileLoadResultState::Failed,
               nullptr,
-              {},
-              std::nullopt};
+              {}};
         }
 
         // find gltf converter
@@ -262,8 +260,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
                 TileRenderContent{std::nullopt},
                 TileLoadResultState::Failed,
                 std::move(pCompletedRequest),
-                {},
-                std::nullopt};
+                {}};
           }
 
           return TileLoadResult{
@@ -278,8 +275,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
             TileRenderContent{std::nullopt},
             TileLoadResultState::Failed,
             std::move(pCompletedRequest),
-            {},
-            std::nullopt};
+            {}};
       });
 }
 } // namespace
@@ -299,8 +295,7 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
         TileUnknownContent{},
         TileLoadResultState::Failed,
         nullptr,
-        {},
-        std::nullopt});
+        {}});
   }
 
   // find the subtree ID
@@ -310,8 +305,7 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
         TileUnknownContent{},
         TileLoadResultState::Failed,
         nullptr,
-        {},
-        std::nullopt});
+        {}});
   }
 
   uint64_t levelLeft = pOctreeID->level % _subtreeLevels;
@@ -364,8 +358,7 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
         TileEmptyContent{},
         TileLoadResultState::Success,
         nullptr,
-        {},
-        std::nullopt});
+        {}});
   }
 
   std::string tileUrl = resolveUrl(_baseUrl, _contentUrlTemplate, *pOctreeID);

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
@@ -220,6 +220,9 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               tileUrl);
           return TileLoadResult{
               TileUnknownContent{},
+              std::nullopt,
+              std::nullopt,
+              std::nullopt,
               TileLoadResultState::Failed,
               nullptr,
               {}};
@@ -234,6 +237,9 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               tileUrl);
           return TileLoadResult{
               TileUnknownContent{},
+              std::nullopt,
+              std::nullopt,
+              std::nullopt,
               TileLoadResultState::Failed,
               nullptr,
               {}};
@@ -258,6 +264,9 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
           if (result.errors) {
             return TileLoadResult{
                 TileRenderContent{std::nullopt},
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
                 TileLoadResultState::Failed,
                 std::move(pCompletedRequest),
                 {}};
@@ -265,6 +274,9 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
 
           return TileLoadResult{
               TileRenderContent{std::move(result.model)},
+              std::nullopt,
+              std::nullopt,
+              std::nullopt,
               TileLoadResultState::Success,
               std::move(pCompletedRequest),
               {}};
@@ -273,6 +285,9 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
         // content type is not supported
         return TileLoadResult{
             TileRenderContent{std::nullopt},
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
             TileLoadResultState::Failed,
             std::move(pCompletedRequest),
             {}};
@@ -293,6 +308,9 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
   if (!pOctreeID) {
     return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
         TileUnknownContent{},
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
         TileLoadResultState::Failed,
         nullptr,
         {}});
@@ -303,6 +321,9 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
   if (subtreeLevelIdx >= _loadedSubtrees.size()) {
     return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
         TileUnknownContent{},
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
         TileLoadResultState::Failed,
         nullptr,
         {}});
@@ -344,6 +365,9 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
           // tell client to retry later
           return TileLoadResult{
               TileUnknownContent{},
+              std::nullopt,
+              std::nullopt,
+              std::nullopt,
               TileLoadResultState::RetryLater,
               nullptr,
               {}};
@@ -356,6 +380,9 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
     // check if tile has empty content
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileEmptyContent{},
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
         TileLoadResultState::Success,
         nullptr,
         {}});

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
@@ -222,7 +222,6 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               TileUnknownContent{},
               std::nullopt,
               std::nullopt,
-              std::nullopt,
               TileLoadResultState::Failed,
               nullptr,
               {}};
@@ -237,7 +236,6 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               tileUrl);
           return TileLoadResult{
               TileUnknownContent{},
-              std::nullopt,
               std::nullopt,
               std::nullopt,
               TileLoadResultState::Failed,
@@ -266,7 +264,6 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
                 TileRenderContent{std::nullopt},
                 std::nullopt,
                 std::nullopt,
-                std::nullopt,
                 TileLoadResultState::Failed,
                 std::move(pCompletedRequest),
                 {}};
@@ -274,7 +271,6 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
 
           return TileLoadResult{
               TileRenderContent{std::move(result.model)},
-              std::nullopt,
               std::nullopt,
               std::nullopt,
               TileLoadResultState::Success,
@@ -285,7 +281,6 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
         // content type is not supported
         return TileLoadResult{
             TileRenderContent{std::nullopt},
-            std::nullopt,
             std::nullopt,
             std::nullopt,
             TileLoadResultState::Failed,
@@ -310,7 +305,6 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        std::nullopt,
         TileLoadResultState::Failed,
         nullptr,
         {}});
@@ -321,7 +315,6 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
   if (subtreeLevelIdx >= _loadedSubtrees.size()) {
     return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
         TileUnknownContent{},
-        std::nullopt,
         std::nullopt,
         std::nullopt,
         TileLoadResultState::Failed,
@@ -367,7 +360,6 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
               TileUnknownContent{},
               std::nullopt,
               std::nullopt,
-              std::nullopt,
               TileLoadResultState::RetryLater,
               nullptr,
               {}};
@@ -380,7 +372,6 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
     // check if tile has empty content
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileEmptyContent{},
-        std::nullopt,
         std::nullopt,
         std::nullopt,
         TileLoadResultState::Success,

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -228,7 +228,6 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               TileUnknownContent{},
               std::nullopt,
               std::nullopt,
-              std::nullopt,
               TileLoadResultState::Failed,
               nullptr,
               {}};
@@ -243,7 +242,6 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               tileUrl);
           return TileLoadResult{
               TileUnknownContent{},
-              std::nullopt,
               std::nullopt,
               std::nullopt,
               TileLoadResultState::Failed,
@@ -272,7 +270,6 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
                 TileRenderContent{std::nullopt},
                 std::nullopt,
                 std::nullopt,
-                std::nullopt,
                 TileLoadResultState::Failed,
                 std::move(pCompletedRequest),
                 {}};
@@ -280,7 +277,6 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
 
           return TileLoadResult{
               TileRenderContent{std::move(result.model)},
-              std::nullopt,
               std::nullopt,
               std::nullopt,
               TileLoadResultState::Success,
@@ -291,7 +287,6 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
         // content type is not supported
         return TileLoadResult{
             TileRenderContent{std::nullopt},
-            std::nullopt,
             std::nullopt,
             std::nullopt,
             TileLoadResultState::Failed,
@@ -334,7 +329,6 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        std::nullopt,
         TileLoadResultState::Failed,
         nullptr,
         {}});
@@ -345,7 +339,6 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
   if (subtreeLevelIdx >= _loadedSubtrees.size()) {
     return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
         TileUnknownContent{},
-        std::nullopt,
         std::nullopt,
         std::nullopt,
         TileLoadResultState::Failed,
@@ -396,7 +389,6 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
               TileUnknownContent{},
               std::nullopt,
               std::nullopt,
-              std::nullopt,
               TileLoadResultState::RetryLater,
               nullptr,
               {}};
@@ -409,7 +401,6 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
     // check if tile has empty content
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileEmptyContent{},
-        std::nullopt,
         std::nullopt,
         std::nullopt,
         TileLoadResultState::Success,

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -277,7 +277,8 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               TileUnknownContent{},
               TileLoadResultState::Failed,
               nullptr,
-              {}};
+              {},
+              std::nullopt};
         }
 
         uint16_t statusCode = pResponse->statusCode();
@@ -291,7 +292,8 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               TileUnknownContent{},
               TileLoadResultState::Failed,
               nullptr,
-              {}};
+              {},
+              std::nullopt};
         }
 
         // find gltf converter
@@ -315,7 +317,8 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
                 TileRenderContent{std::nullopt},
                 TileLoadResultState::Failed,
                 std::move(pCompletedRequest),
-                {}};
+                {},
+                std::nullopt};
           }
 
           std::function<void(Tile&)> tileInitializer;
@@ -326,7 +329,8 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               TileRenderContent{std::move(result.model)},
               TileLoadResultState::Success,
               std::move(pCompletedRequest),
-              std::move(tileInitializer)};
+              std::move(tileInitializer),
+              std::nullopt};
         }
 
         // content type is not supported
@@ -334,7 +338,8 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
             TileRenderContent{std::nullopt},
             TileLoadResultState::Failed,
             std::move(pCompletedRequest),
-            {}};
+            {},
+            std::nullopt};
       });
 }
 } // namespace
@@ -372,7 +377,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
         TileUnknownContent{},
         TileLoadResultState::Failed,
         nullptr,
-        {}});
+        {},
+        std::nullopt});
   }
 
   // find the subtree ID
@@ -382,7 +388,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
         TileUnknownContent{},
         TileLoadResultState::Failed,
         nullptr,
-        {}});
+        {},
+        std::nullopt});
   }
 
   uint64_t levelLeft = pQuadtreeID->level % _subtreeLevels;
@@ -450,7 +457,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
                       TileEmptyContent{},
                       TileLoadResultState::Success,
                       nullptr,
-                      std::move(subtreeInitializer)});
+                      std::move(subtreeInitializer),
+                      std::nullopt});
                 }
 
                 return requestTileContent(
@@ -468,7 +476,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
                       TileUnknownContent{},
                       TileLoadResultState::Failed,
                       nullptr,
-                      {}});
+                      {},
+                      std::nullopt});
             });
   }
 
@@ -480,7 +489,8 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
         TileEmptyContent{},
         TileLoadResultState::Success,
         nullptr,
-        {}});
+        {},
+        std::nullopt});
   }
 
   std::string tileUrl = resolveUrl(_baseUrl, _contentUrlTemplate, *pQuadtreeID);

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -228,8 +228,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               TileUnknownContent{},
               TileLoadResultState::Failed,
               nullptr,
-              {},
-              std::nullopt};
+              {}};
         }
 
         uint16_t statusCode = pResponse->statusCode();
@@ -243,8 +242,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               TileUnknownContent{},
               TileLoadResultState::Failed,
               nullptr,
-              {},
-              std::nullopt};
+              {}};
         }
 
         // find gltf converter
@@ -268,16 +266,14 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
                 TileRenderContent{std::nullopt},
                 TileLoadResultState::Failed,
                 std::move(pCompletedRequest),
-                {},
-                std::nullopt};
+                {}};
           }
 
           return TileLoadResult{
               TileRenderContent{std::move(result.model)},
               TileLoadResultState::Success,
               std::move(pCompletedRequest),
-              {},
-              std::nullopt};
+              {}};
         }
 
         // content type is not supported
@@ -285,8 +281,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
             TileRenderContent{std::nullopt},
             TileLoadResultState::Failed,
             std::move(pCompletedRequest),
-            {},
-            std::nullopt};
+            {}};
       });
 }
 } // namespace
@@ -324,8 +319,7 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
         TileUnknownContent{},
         TileLoadResultState::Failed,
         nullptr,
-        {},
-        std::nullopt});
+        {}});
   }
 
   // find the subtree ID
@@ -335,8 +329,7 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
         TileUnknownContent{},
         TileLoadResultState::Failed,
         nullptr,
-        {},
-        std::nullopt});
+        {}});
   }
 
   uint64_t levelLeft = pQuadtreeID->level % _subtreeLevels;
@@ -382,8 +375,7 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
               TileUnknownContent{},
               TileLoadResultState::RetryLater,
               nullptr,
-              {},
-              std::nullopt};
+              {}};
         });
   }
 
@@ -395,8 +387,7 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
         TileEmptyContent{},
         TileLoadResultState::Success,
         nullptr,
-        {},
-        std::nullopt});
+        {}});
   }
 
   std::string tileUrl = resolveUrl(_baseUrl, _contentUrlTemplate, *pQuadtreeID);

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -226,6 +226,9 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               tileUrl);
           return TileLoadResult{
               TileUnknownContent{},
+              std::nullopt,
+              std::nullopt,
+              std::nullopt,
               TileLoadResultState::Failed,
               nullptr,
               {}};
@@ -240,6 +243,9 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               tileUrl);
           return TileLoadResult{
               TileUnknownContent{},
+              std::nullopt,
+              std::nullopt,
+              std::nullopt,
               TileLoadResultState::Failed,
               nullptr,
               {}};
@@ -264,6 +270,9 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
           if (result.errors) {
             return TileLoadResult{
                 TileRenderContent{std::nullopt},
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
                 TileLoadResultState::Failed,
                 std::move(pCompletedRequest),
                 {}};
@@ -271,6 +280,9 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
 
           return TileLoadResult{
               TileRenderContent{std::move(result.model)},
+              std::nullopt,
+              std::nullopt,
+              std::nullopt,
               TileLoadResultState::Success,
               std::move(pCompletedRequest),
               {}};
@@ -279,6 +291,9 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
         // content type is not supported
         return TileLoadResult{
             TileRenderContent{std::nullopt},
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
             TileLoadResultState::Failed,
             std::move(pCompletedRequest),
             {}};
@@ -317,6 +332,9 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
   if (!pQuadtreeID) {
     return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
         TileUnknownContent{},
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
         TileLoadResultState::Failed,
         nullptr,
         {}});
@@ -327,6 +345,9 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
   if (subtreeLevelIdx >= _loadedSubtrees.size()) {
     return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
         TileUnknownContent{},
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
         TileLoadResultState::Failed,
         nullptr,
         {}});
@@ -373,6 +394,9 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
           // tell client to retry later
           return TileLoadResult{
               TileUnknownContent{},
+              std::nullopt,
+              std::nullopt,
+              std::nullopt,
               TileLoadResultState::RetryLater,
               nullptr,
               {}};
@@ -385,6 +409,9 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
     // check if tile has empty content
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileEmptyContent{},
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
         TileLoadResultState::Success,
         nullptr,
         {}});

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
@@ -615,6 +615,9 @@ Future<TileLoadResult> LayerJsonTerrainLoader::loadTileContent(
     // This loader only handles QuadtreeTileIDs.
     return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
         TileUnknownContent{},
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
         TileLoadResultState::Failed,
         nullptr,
         {}});
@@ -633,6 +636,9 @@ Future<TileLoadResult> LayerJsonTerrainLoader::loadTileContent(
     // No layer has this tile available.
     return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
         TileUnknownContent{},
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
         TileLoadResultState::Failed,
         nullptr,
         {}});
@@ -714,14 +720,13 @@ Future<TileLoadResult> LayerJsonTerrainLoader::loadTileContent(
 
           return TileLoadResult{
               TileRenderContent{std::move(loadResult.model)},
+              std::nullopt,
+              loadResult.updatedBoundingVolume,
+              std::nullopt,
               loadResult.errors.hasErrors() ? TileLoadResultState::Failed
                                             : TileLoadResultState::Success,
               nullptr,
-              [boundingVolume = loadResult.updatedBoundingVolume](Tile& tile) {
-                if (boundingVolume) {
-                  tile.setBoundingVolume(*boundingVolume);
-                }
-              }};
+              {}};
         });
   }
 
@@ -729,14 +734,13 @@ Future<TileLoadResult> LayerJsonTerrainLoader::loadTileContent(
       .thenImmediately([](QuantizedMeshLoadResult&& loadResult) mutable {
         return TileLoadResult{
             TileRenderContent{std::move(loadResult.model)},
+            std::nullopt,
+            loadResult.updatedBoundingVolume,
+            std::nullopt,
             loadResult.errors.hasErrors() ? TileLoadResultState::Failed
                                           : TileLoadResultState::Success,
             nullptr,
-            [boundingVolume = loadResult.updatedBoundingVolume](Tile& tile) {
-              if (boundingVolume) {
-                tile.setBoundingVolume(*boundingVolume);
-              }
-            }};
+            {}};
       });
 }
 

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
@@ -617,8 +617,7 @@ Future<TileLoadResult> LayerJsonTerrainLoader::loadTileContent(
         TileUnknownContent{},
         TileLoadResultState::Failed,
         nullptr,
-        {},
-        std::nullopt});
+        {}});
   }
 
   // Always request the tile from the first layer in which this tile ID is
@@ -636,8 +635,7 @@ Future<TileLoadResult> LayerJsonTerrainLoader::loadTileContent(
         TileUnknownContent{},
         TileLoadResultState::Failed,
         nullptr,
-        {},
-        std::nullopt});
+        {}});
   }
 
   // Also load the same tile in any underlying layers for which this tile
@@ -723,8 +721,7 @@ Future<TileLoadResult> LayerJsonTerrainLoader::loadTileContent(
                 if (boundingVolume) {
                   tile.setBoundingVolume(*boundingVolume);
                 }
-              },
-              std::nullopt};
+              }};
         });
   }
 
@@ -739,8 +736,7 @@ Future<TileLoadResult> LayerJsonTerrainLoader::loadTileContent(
               if (boundingVolume) {
                 tile.setBoundingVolume(*boundingVolume);
               }
-            },
-            std::nullopt};
+            }};
       });
 }
 

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
@@ -1,11 +1,10 @@
 #include "LayerJsonTerrainLoader.h"
 
-#include <Cesium3DTilesSelection/GltfUtilities.h>
-
 #include "QuantizedMeshLoader.h"
 #include "calcQuadtreeMaxGeometricError.h"
 #include "upsampleGltfForRasterOverlays.h"
 
+#include <Cesium3DTilesSelection/GltfUtilities.h>
 #include <CesiumAsync/IAssetResponse.h>
 #include <CesiumUtility/JsonHelpers.h>
 #include <CesiumUtility/Uri.h>

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
@@ -956,6 +956,7 @@ CesiumAsync::Future<TileLoadResult> LayerJsonTerrainLoader::upsampleParentTile(
             {_projection});
 
     if (overlayDetails) {
+      index = int32_t(parentProjections.size());
       parentContent.getRasterOverlayDetails().merge(std::move(*overlayDetails));
     }
   }

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
@@ -968,9 +968,7 @@ CesiumAsync::Future<TileLoadResult> LayerJsonTerrainLoader::upsampleParentTile(
   const CesiumGltf::Model& parentModel = pParentRenderContent->model.value();
   return asyncSystem.runInWorkerThread(
       [&parentModel,
-       tileTransform = tile.getTransform(),
        boundingVolume = tile.getBoundingVolume(),
-       projection = _projection,
        textureCoordinateIndex = index,
        tileID = *pUpsampledTileID]() mutable {
         auto model = upsampleGltfForRasterOverlays(

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
@@ -980,6 +980,10 @@ CesiumAsync::Future<TileLoadResult> LayerJsonTerrainLoader::upsampleParentTile(
       parentProjections.begin(),
       parentProjections.end(),
       _projection);
+  assert(
+      it != parentProjections.end() &&
+      "Cannot find projection of parent tile. This should not happen as "
+      "parent's projection UV is already computed by this loader");
   index = int32_t(it - parentProjections.begin());
 
   const CesiumGltf::Model& parentModel = pParentRenderContent->model.value();

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
@@ -955,15 +955,9 @@ CesiumAsync::Future<TileLoadResult> LayerJsonTerrainLoader::upsampleParentTile(
 
   // Cannot find raster overlay UVs that has this projection, so we can't
   // upsample right now
-  if (index == -1) {
-    return asyncSystem.createResolvedFuture(TileLoadResult{
-        TileUnknownContent{},
-        std::nullopt,
-        std::nullopt,
-        TileLoadResultState::Failed,
-        nullptr,
-        {}});
-  }
+  assert(
+      index != -1 && "Cannot find raster overlay UVs that has this projection. "
+                     "Should not happen");
 
   const CesiumGltf::Model& parentModel = pParentRenderContent->model.value();
   return asyncSystem.runInWorkerThread(

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
@@ -87,6 +87,9 @@ private:
       const CesiumGeometry::QuadtreeTileID& childID,
       bool isAvailable);
 
+  CesiumAsync::Future<TileLoadResult>
+  upsampleParentTile(Tile& tile, const CesiumAsync::AsyncSystem& asyncSystem);
+
   CesiumGeometry::QuadtreeTilingScheme _tilingScheme;
   CesiumGeospatial::Projection _projection;
   std::vector<Layer> _layers;

--- a/Cesium3DTilesSelection/src/RasterMappedTo3DTile.cpp
+++ b/Cesium3DTilesSelection/src/RasterMappedTo3DTile.cpp
@@ -1,13 +1,13 @@
+#include "TileUtilities.h"
+
 #include <Cesium3DTilesSelection/IPrepareRendererResources.h>
+#include <Cesium3DTilesSelection/RasterMappedTo3DTile.h>
 #include <Cesium3DTilesSelection/RasterOverlayCollection.h>
 #include <Cesium3DTilesSelection/RasterOverlayTileProvider.h>
 #include <Cesium3DTilesSelection/Tile.h>
 #include <Cesium3DTilesSelection/TileContent.h>
 #include <Cesium3DTilesSelection/Tileset.h>
 #include <Cesium3DTilesSelection/TilesetExternals.h>
-#include "TileUtilities.h"
-
-#include <Cesium3DTilesSelection/RasterMappedTo3DTile.h>
 
 using namespace CesiumGeometry;
 using namespace CesiumGeospatial;
@@ -47,8 +47,7 @@ namespace Cesium3DTilesSelection {
 RasterMappedTo3DTile::RasterMappedTo3DTile(
     const CesiumUtility::IntrusivePointer<RasterOverlayTile>& pRasterTile,
     int32_t textureCoordinateIndex)
-    : 
-      _pLoadingTile(pRasterTile),
+    : _pLoadingTile(pRasterTile),
       _pReadyTile(nullptr),
       _textureCoordinateID(textureCoordinateIndex),
       _translation(0.0, 0.0),
@@ -56,8 +55,9 @@ RasterMappedTo3DTile::RasterMappedTo3DTile(
       _state(AttachmentState::Unattached),
       _originalFailed(false) {}
 
-RasterOverlayTile::MoreDetailAvailable
-RasterMappedTo3DTile::update(IPrepareRendererResources& prepareRendererResources, Tile& tile) {
+RasterOverlayTile::MoreDetailAvailable RasterMappedTo3DTile::update(
+    IPrepareRendererResources& prepareRendererResources,
+    Tile& tile) {
   if (this->getState() == AttachmentState::Attached) {
     return !this->_originalFailed && this->_pReadyTile &&
                    this->_pReadyTile->isMoreDetailAvailable() !=
@@ -177,7 +177,9 @@ bool RasterMappedTo3DTile::isMoreDetailAvailable() const noexcept {
              RasterOverlayTile::MoreDetailAvailable::Yes;
 }
 
-void RasterMappedTo3DTile::detachFromTile(IPrepareRendererResources& prepareRendererResources, Tile& tile) noexcept {
+void RasterMappedTo3DTile::detachFromTile(
+    IPrepareRendererResources& prepareRendererResources,
+    Tile& tile) noexcept {
   if (this->getState() == AttachmentState::Unattached) {
     return;
   }
@@ -293,9 +295,8 @@ RasterMappedTo3DTile* addRealTile(
   if (!pTile) {
     return nullptr;
   } else {
-    return &tile.getMappedRasterTiles().emplace_back(RasterMappedTo3DTile(
-        pTile,
-        textureCoordinateIndex));
+    return &tile.getMappedRasterTiles().emplace_back(
+        RasterMappedTo3DTile(pTile, textureCoordinateIndex));
   }
 }
 
@@ -309,9 +310,8 @@ RasterMappedTo3DTile* addRealTile(
   RasterOverlayTileProvider* pProvider = overlay.getTileProvider();
   if (pProvider->isPlaceholder()) {
     // Provider not created yet, so add a placeholder tile.
-    return &tile.getMappedRasterTiles().emplace_back(RasterMappedTo3DTile(
-        getPlaceholderTile(overlay),
-        -1));
+    return &tile.getMappedRasterTiles().emplace_back(
+        RasterMappedTo3DTile(getPlaceholderTile(overlay), -1));
   }
 
   // We can get a more accurate estimate of the real-world size of the projected

--- a/Cesium3DTilesSelection/src/RasterMappedTo3DTile.cpp
+++ b/Cesium3DTilesSelection/src/RasterMappedTo3DTile.cpp
@@ -329,16 +329,14 @@ RasterMappedTo3DTile* addRealTile(
   // If the tile is loaded, use the precise rectangle computed from the content.
   const TileContent& content = tile.getContent();
   if (content.getState() >= TileLoadState::ContentLoaded) {
-    const RasterOverlayDetails* pOverlayDetails =
+    const RasterOverlayDetails& overlayDetails =
         content.getRasterOverlayDetails();
     const Rectangle* pRectangle =
-        pOverlayDetails
-            ? pOverlayDetails->findRectangleForOverlayProjection(projection)
-            : nullptr;
+        overlayDetails.findRectangleForOverlayProjection(projection);
     if (pRectangle) {
       // We have a rectangle and texture coordinates for this projection.
       int32_t index =
-          int32_t(pRectangle - &pOverlayDetails->rasterOverlayRectangles[0]);
+          int32_t(pRectangle - &overlayDetails.rasterOverlayRectangles[0]);
       const glm::dvec2 screenPixels = computeDesiredScreenPixels(
           tile,
           projection,
@@ -352,9 +350,7 @@ RasterMappedTo3DTile* addRealTile(
       // tile was loaded before we knew we needed this projection. We'll need to
       // reload the tile (later).
       int32_t existingIndex =
-          pOverlayDetails
-              ? int32_t(pOverlayDetails->rasterOverlayProjections.size())
-              : 0;
+          int32_t(overlayDetails.rasterOverlayProjections.size());
       int32_t textureCoordinateIndex =
           existingIndex + addProjectionToList(missingProjections, projection);
       return &tile.getMappedRasterTiles().emplace_back(RasterMappedTo3DTile(
@@ -393,22 +389,22 @@ RasterMappedTo3DTile* addRealTile(
 }
 
 void RasterMappedTo3DTile::computeTranslationAndScale(const Tile& tile) {
-  const RasterOverlayDetails* pOverlayDetails =
-      tile.getContent().getRasterOverlayDetails();
-  if (!this->_pReadyTile || !pOverlayDetails) {
+  if (!this->_pReadyTile) {
     // This shouldn't happen
     assert(false);
     return;
   }
 
+  const RasterOverlayDetails& overlayDetails =
+      tile.getContent().getRasterOverlayDetails();
   const RasterOverlayTileProvider& tileProvider =
       *this->_pReadyTile->getOverlay().getTileProvider();
 
   const Projection& projection = tileProvider.getProjection();
   const std::vector<Projection>& projections =
-      pOverlayDetails->rasterOverlayProjections;
+      overlayDetails.rasterOverlayProjections;
   const std::vector<Rectangle>& rectangles =
-      pOverlayDetails->rasterOverlayRectangles;
+      overlayDetails.rasterOverlayRectangles;
 
   auto projectionIt =
       std::find(projections.begin(), projections.end(), projection);

--- a/Cesium3DTilesSelection/src/RasterMappedTo3DTile.cpp
+++ b/Cesium3DTilesSelection/src/RasterMappedTo3DTile.cpp
@@ -1,9 +1,10 @@
-#include "Cesium3DTilesSelection/IPrepareRendererResources.h"
-#include "Cesium3DTilesSelection/RasterOverlayCollection.h"
-#include "Cesium3DTilesSelection/RasterOverlayTileProvider.h"
-#include "Cesium3DTilesSelection/Tile.h"
-#include "Cesium3DTilesSelection/Tileset.h"
-#include "Cesium3DTilesSelection/TilesetExternals.h"
+#include <Cesium3DTilesSelection/IPrepareRendererResources.h>
+#include <Cesium3DTilesSelection/RasterOverlayCollection.h>
+#include <Cesium3DTilesSelection/RasterOverlayTileProvider.h>
+#include <Cesium3DTilesSelection/Tile.h>
+#include <Cesium3DTilesSelection/TileContent.h>
+#include <Cesium3DTilesSelection/Tileset.h>
+#include <Cesium3DTilesSelection/TilesetExternals.h>
 #include "TileUtilities.h"
 
 #include <Cesium3DTilesSelection/RasterMappedTo3DTile.h>
@@ -14,432 +15,428 @@ using namespace Cesium3DTilesSelection;
 using namespace CesiumUtility;
 
 namespace {
-//
-//// Find the given overlay in the given tile.
-// RasterOverlayTile* findTileOverlay(Tile& tile, const RasterOverlay& overlay)
-// {
-//   std::vector<RasterMappedTo3DTile>& tiles = tile.getMappedRasterTiles();
-//   auto parentTileIt = std::find_if(
-//       tiles.begin(),
-//       tiles.end(),
-//       [&overlay](RasterMappedTo3DTile& raster) noexcept {
-//         return raster.getReadyTile() &&
-//                &raster.getReadyTile()->getOverlay() == &overlay;
-//       });
-//   if (parentTileIt != tiles.end()) {
-//     RasterMappedTo3DTile& mapped = *parentTileIt;
-//
-//     // Prefer the loading tile if there is one.
-//     if (mapped.getLoadingTile()) {
-//       return mapped.getLoadingTile();
-//     } else {
-//       return mapped.getReadyTile();
-//     }
-//   }
-//
-//   return nullptr;
-// }
+
+// Find the given overlay in the given tile.
+RasterOverlayTile* findTileOverlay(Tile& tile, const RasterOverlay& overlay) {
+  std::vector<RasterMappedTo3DTile>& tiles = tile.getMappedRasterTiles();
+  auto parentTileIt = std::find_if(
+      tiles.begin(),
+      tiles.end(),
+      [&overlay](RasterMappedTo3DTile& raster) noexcept {
+        return raster.getReadyTile() &&
+               &raster.getReadyTile()->getOverlay() == &overlay;
+      });
+  if (parentTileIt != tiles.end()) {
+    RasterMappedTo3DTile& mapped = *parentTileIt;
+
+    // Prefer the loading tile if there is one.
+    if (mapped.getLoadingTile()) {
+      return mapped.getLoadingTile();
+    } else {
+      return mapped.getReadyTile();
+    }
+  }
+
+  return nullptr;
+}
 
 } // namespace
 
 namespace Cesium3DTilesSelection {
-//
-// RasterMappedTo3DTile::RasterMappedTo3DTile(
-//    const CesiumUtility::IntrusivePointer<RasterOverlayTile>& pRasterTile,
-//    int32_t textureCoordinateIndex)
-//    : _pLoadingTile(pRasterTile),
-//      _pReadyTile(nullptr),
-//      _textureCoordinateID(textureCoordinateIndex),
-//      _translation(0.0, 0.0),
-//      _scale(1.0, 1.0),
-//      _state(AttachmentState::Unattached),
-//      _originalFailed(false) {}
-//
-// RasterOverlayTile::MoreDetailAvailable
-// RasterMappedTo3DTile::update(Tile& tile) {
-//  if (this->getState() == AttachmentState::Attached) {
-//    return !this->_originalFailed && this->_pReadyTile &&
-//                   this->_pReadyTile->isMoreDetailAvailable() !=
-//                       RasterOverlayTile::MoreDetailAvailable::No
-//               ? RasterOverlayTile::MoreDetailAvailable::Yes
-//               : RasterOverlayTile::MoreDetailAvailable::No;
-//  }
-//
-//  // If the loading tile has failed, try its parent's loading tile.
-//  Tile* pTile = &tile;
-//  while (this->_pLoadingTile &&
-//         this->_pLoadingTile->getState() ==
-//             RasterOverlayTile::LoadState::Failed &&
-//         pTile) {
-//    // Note when our original tile fails to load so that we don't report more
-//    // data available. This means - by design - we won't refine past a failed
-//    // tile.
-//    this->_originalFailed = true;
-//
-//    pTile = pTile->getParent();
-//    if (pTile) {
-//      RasterOverlayTile* pOverlayTile =
-//          findTileOverlay(*pTile, this->_pLoadingTile->getOverlay());
-//      if (pOverlayTile) {
-//        this->_pLoadingTile = pOverlayTile;
-//      }
-//    }
-//  }
-//
-//  // If the loading tile is now ready, make it the ready tile.
-//  if (this->_pLoadingTile &&
-//      this->_pLoadingTile->getState() >= RasterOverlayTile::LoadState::Loaded)
-//      {
-//    // Unattach the old tile
-//    if (this->_pReadyTile && this->getState() != AttachmentState::Unattached)
-//    {
-//      const TilesetExternals& externals = tile.getTileset()->getExternals();
-//      externals.pPrepareRendererResources->detachRasterInMainThread(
-//          tile,
-//          this->getTextureCoordinateID(),
-//          *this->_pReadyTile,
-//          this->_pReadyTile->getRendererResources());
-//      this->_state = AttachmentState::Unattached;
-//    }
-//
-//    // Mark the loading tile ready.
-//    this->_pReadyTile = this->_pLoadingTile;
-//    this->_pLoadingTile = nullptr;
-//
-//    // Compute the translation and scale for the new tile.
-//    this->computeTranslationAndScale(tile);
-//  }
-//
-//  // Find the closest ready ancestor tile.
-//  if (this->_pLoadingTile) {
-//    CesiumUtility::IntrusivePointer<RasterOverlayTile> pCandidate;
-//
-//    pTile = tile.getParent();
-//    while (pTile) {
-//      pCandidate = findTileOverlay(*pTile, this->_pLoadingTile->getOverlay());
-//      if (pCandidate &&
-//          pCandidate->getState() >= RasterOverlayTile::LoadState::Loaded) {
-//        break;
-//      }
-//      pTile = pTile->getParent();
-//    }
-//
-//    if (pCandidate &&
-//        pCandidate->getState() >= RasterOverlayTile::LoadState::Loaded &&
-//        this->_pReadyTile != pCandidate) {
-//      if (this->getState() != AttachmentState::Unattached) {
-//        const TilesetExternals& externals = tile.getTileset()->getExternals();
-//        externals.pPrepareRendererResources->detachRasterInMainThread(
-//            tile,
-//            this->getTextureCoordinateID(),
-//            *this->_pReadyTile,
-//            this->_pReadyTile->getRendererResources());
-//        this->_state = AttachmentState::Unattached;
-//      }
-//
-//      this->_pReadyTile = pCandidate;
-//
-//      // Compute the translation and scale for the new tile.
-//      this->computeTranslationAndScale(tile);
-//    }
-//  }
-//
-//  // Attach the ready tile if it's not already attached.
-//  if (this->_pReadyTile &&
-//      this->getState() == RasterMappedTo3DTile::AttachmentState::Unattached) {
-//    this->_pReadyTile->loadInMainThread();
-//
-//    const TilesetExternals& externals = tile.getTileset()->getExternals();
-//    externals.pPrepareRendererResources->attachRasterInMainThread(
-//        tile,
-//        this->getTextureCoordinateID(),
-//        *this->_pReadyTile,
-//        this->_pReadyTile->getRendererResources(),
-//        this->getTranslation(),
-//        this->getScale());
-//
-//    this->_state = this->_pLoadingTile ? AttachmentState::TemporarilyAttached
-//                                       : AttachmentState::Attached;
-//  }
-//
-//  // TODO: check more precise raster overlay tile availability, rather than
-//  just
-//  // max level?
-//  if (this->_pLoadingTile) {
-//    return RasterOverlayTile::MoreDetailAvailable::Unknown;
-//  }
-//
-//  if (!this->_originalFailed && this->_pReadyTile) {
-//    return this->_pReadyTile->isMoreDetailAvailable();
-//  } else {
-//    return RasterOverlayTile::MoreDetailAvailable::No;
-//  }
-//}
-//
-// void RasterMappedTo3DTile::detachFromTile(Tile& tile) noexcept {
-//  if (this->getState() == AttachmentState::Unattached) {
-//    return;
-//  }
-//
-//  if (!this->_pReadyTile) {
-//    return;
-//  }
-//
-//  const TilesetExternals& externals = tile.getTileset()->getExternals();
-//  externals.pPrepareRendererResources->detachRasterInMainThread(
-//      tile,
-//      this->getTextureCoordinateID(),
-//      *this->_pReadyTile,
-//      this->_pReadyTile->getRendererResources());
-//
-//  this->_state = AttachmentState::Unattached;
-//}
-//
-// bool RasterMappedTo3DTile::loadThrottled() noexcept {
-//  RasterOverlayTile* pLoading = this->getLoadingTile();
-//  if (!pLoading) {
-//    return true;
-//  }
-//
-//  RasterOverlayTileProvider* pProvider =
-//      pLoading->getOverlay().getTileProvider();
-//  if (!pProvider) {
-//    // This should not be possible.
-//    assert(pProvider);
-//    return false;
-//  }
-//
-//  return pProvider->loadTileThrottled(*pLoading);
-//}
-//
-// namespace {
-//
-// IntrusivePointer<RasterOverlayTile> getPlaceholderTile(RasterOverlay&
-// overlay) {
-//  // Rectangle and geometric error don't matter for a placeholder.
-//  return overlay.getPlaceholder()->getTile(Rectangle(), glm::dvec2(0.0));
-//}
-//
-// std::optional<Rectangle> getPreciseRectangleFromBoundingVolume(
-//    const Projection& projection,
-//    const BoundingVolume& boundingVolume) {
-//  const BoundingRegion* pRegion =
-//      getBoundingRegionFromBoundingVolume(boundingVolume);
-//  if (!pRegion) {
-//    return std::nullopt;
-//  }
-//
-//  // Currently _all_ supported projections can have a rectangle precisely
-//  // determined from a bounding region. This may not be true, however, for
-//  // projections we add in the future where X is not purely a function of
-//  // longitude or Y is not purely a function of latitude.
-//  return projectRectangleSimple(projection, pRegion->getRectangle());
-//}
-//
-// int32_t addProjectionToList(
-//    std::vector<Projection>& projections,
-//    const Projection& projection) {
-//  auto it = std::find(projections.begin(), projections.end(), projection);
-//  if (it == projections.end()) {
-//    projections.emplace_back(projection);
-//    return int32_t(projections.size()) - 1;
-//  } else {
-//    return int32_t(it - projections.begin());
-//  }
-//}
-//
-// glm::dvec2 computeDesiredScreenPixels(
-//    const Tile& tile,
-//    const Projection& projection,
-//    const Rectangle& rectangle,
-//    double maxHeight,
-//    const Ellipsoid& ellipsoid = Ellipsoid::WGS84) {
-//  // We're aiming to estimate the maximum number of pixels (in each projected
-//  // direction) the tile will occupy on the screen. The will be determined by
-//  // the tile's geometric error, because when less error is needed (i.e. the
-//  // viewer moved closer), the LOD will switch to show the tile's children
-//  // instead of this tile.
-//  //
-//  // It works like this:
-//  // * Estimate the size of the projected rectangle in world coordinates.
-//  // * Compute the distance at which tile will switch to its children, based
-//  on
-//  // its geometric error and the tileset SSE.
-//  // * Compute the on-screen size of the projected rectangle at that distance.
-//  //
-//  // For the two compute steps, we use the usual perspective projection SSE
-//  // equation:
-//  // screenSize = (realSize * viewportHeight) / (distance * 2 * tan(0.5 *
-//  fovY))
-//  //
-//  // Conveniently a bunch of terms cancel out, so the screen pixel size at the
-//  // switch distance is not actually dependent on the screen dimensions or
-//  // field-of-view angle.
-//  double geometryError = tile.getNonZeroGeometricError();
-//  double geometrySSE =
-//  tile.getTileset()->getOptions().maximumScreenSpaceError; glm::dvec2
-//  diameters = computeProjectedRectangleSize(
-//      projection,
-//      rectangle,
-//      maxHeight,
-//      ellipsoid);
-//  return diameters * geometrySSE / geometryError;
-//}
-//
-// RasterMappedTo3DTile* addRealTile(
-//    Tile& tile,
-//    RasterOverlayTileProvider& provider,
-//    const Rectangle& rectangle,
-//    const glm::dvec2& screenPixels,
-//    int32_t textureCoordinateIndex) {
-//  IntrusivePointer<RasterOverlayTile> pTile =
-//      provider.getTile(rectangle, screenPixels);
-//  if (!pTile) {
-//    return nullptr;
-//  } else {
-//    return &tile.getMappedRasterTiles().emplace_back(
-//        RasterMappedTo3DTile(pTile, textureCoordinateIndex));
-//  }
-//}
-//
-//} // namespace
-//
-///*static*/ RasterMappedTo3DTile* RasterMappedTo3DTile::mapOverlayToTile(
-//    RasterOverlay& overlay,
-//    Tile& tile,
-//    std::vector<Projection>& missingProjections) {
-//  RasterOverlayTileProvider* pProvider = overlay.getTileProvider();
-//  if (pProvider->isPlaceholder()) {
-//    // Provider not created yet, so add a placeholder tile.
-//    return &tile.getMappedRasterTiles().emplace_back(
-//        RasterMappedTo3DTile(getPlaceholderTile(overlay), -1));
-//  }
-//
-//  // We can get a more accurate estimate of the real-world size of the
-//  projected
-//  // rectangle if we consider the rectangle at the true height of the geometry
-//  // rather than assuming it's on the ellipsoid. This will make basically no
-//  // difference for small tiles (because surface normals on opposite ends of
-//  // tiles are effectively identical), and only a small difference for large
-//  // ones (because heights will be small compared to the total size of a large
-//  // tile). So we're skipping this complexity for now and estimating geometry
-//  // width/height as if it's on the ellipsoid surface.
-//  const double heightForSizeEstimation = 0.0;
-//
-//  const Projection& projection = pProvider->getProjection();
-//
-//  // If the tile is loaded, use the precise rectangle computed from the
-//  content. const TileContentLoadResult* pContent = tile.getContent(); if
-//  (pContent) {
-//    const Rectangle* pRectangle =
-//        pContent->overlayDetails
-//            ? pContent->overlayDetails->findRectangleForOverlayProjection(
-//                  projection)
-//            : nullptr;
-//    if (pRectangle) {
-//      // We have a rectangle and texture coordinates for this projection.
-//      int32_t index = int32_t(
-//          pRectangle - &pContent->overlayDetails->rasterOverlayRectangles[0]);
-//      const glm::dvec2 screenPixels = computeDesiredScreenPixels(
-//          tile,
-//          projection,
-//          *pRectangle,
-//          heightForSizeEstimation,
-//          Ellipsoid::WGS84);
-//      return addRealTile(tile, *pProvider, *pRectangle, screenPixels, index);
-//    } else {
-//      // We don't have a precise rectangle for this projection, which means
-//      the
-//      // tile was loaded before we knew we needed this projection. We'll need
-//      to
-//      // reload the tile (later).
-//      int32_t existingIndex =
-//          pContent->overlayDetails
-//              ? int32_t(
-//                    pContent->overlayDetails->rasterOverlayProjections.size())
-//              : 0;
-//      int32_t textureCoordinateIndex =
-//          existingIndex + addProjectionToList(missingProjections, projection);
-//      return &tile.getMappedRasterTiles().emplace_back(RasterMappedTo3DTile(
-//          getPlaceholderTile(overlay),
-//          textureCoordinateIndex));
-//    }
-//  }
-//
-//  // Maybe we can derive a precise rectangle from the bounding volume.
-//  int32_t textureCoordinateIndex =
-//      addProjectionToList(missingProjections, projection);
-//  std::optional<Rectangle> maybeRectangle =
-//      getPreciseRectangleFromBoundingVolume(
-//          pProvider->getProjection(),
-//          tile.getBoundingVolume());
-//  if (maybeRectangle) {
-//    const glm::dvec2 screenPixels = computeDesiredScreenPixels(
-//        tile,
-//        projection,
-//        *maybeRectangle,
-//        heightForSizeEstimation,
-//        Ellipsoid::WGS84);
-//    return addRealTile(
-//        tile,
-//        *pProvider,
-//        *maybeRectangle,
-//        screenPixels,
-//        textureCoordinateIndex);
-//  } else {
-//    // No precise rectangle yet, so return a placeholder for now.
-//    return &tile.getMappedRasterTiles().emplace_back(RasterMappedTo3DTile(
-//        getPlaceholderTile(overlay),
-//        textureCoordinateIndex));
-//  }
-//}
-//
-// void RasterMappedTo3DTile::computeTranslationAndScale(const Tile& tile) {
-//  if (!this->_pReadyTile || !tile.getContent() ||
-//      !tile.getContent()->overlayDetails) {
-//    // This shouldn't happen
-//    assert(false);
-//    return;
-//  }
-//
-//  const RasterOverlayTileProvider& tileProvider =
-//      *this->_pReadyTile->getOverlay().getTileProvider();
-//
-//  const TileContentDetailsForOverlays& overlayDetails =
-//      *tile.getContent()->overlayDetails;
-//  const Projection& projection = tileProvider.getProjection();
-//  const std::vector<Projection>& projections =
-//      overlayDetails.rasterOverlayProjections;
-//  const std::vector<Rectangle>& rectangles =
-//      overlayDetails.rasterOverlayRectangles;
-//
-//  auto projectionIt =
-//      std::find(projections.begin(), projections.end(), projection);
-//  if (projectionIt == projections.end()) {
-//    return;
-//  }
-//
-//  int32_t projectionIndex = int32_t(projectionIt - projections.begin());
-//  if (projectionIndex < 0 || size_t(projectionIndex) >= rectangles.size()) {
-//    return;
-//  }
-//
-//  const Rectangle& geometryRectangle = rectangles[size_t(projectionIndex)];
-//
-//  const CesiumGeometry::Rectangle imageryRectangle =
-//      this->_pReadyTile->getRectangle();
-//
-//  const double terrainWidth = geometryRectangle.computeWidth();
-//  const double terrainHeight = geometryRectangle.computeHeight();
-//
-//  const double scaleX = terrainWidth / imageryRectangle.computeWidth();
-//  const double scaleY = terrainHeight / imageryRectangle.computeHeight();
-//  this->_translation = glm::dvec2(
-//      (scaleX * (geometryRectangle.minimumX - imageryRectangle.minimumX)) /
-//          terrainWidth,
-//      (scaleY * (geometryRectangle.minimumY - imageryRectangle.minimumY)) /
-//          terrainHeight);
-//  this->_scale = glm::dvec2(scaleX, scaleY);
-//}
+
+RasterMappedTo3DTile::RasterMappedTo3DTile(
+    const CesiumUtility::IntrusivePointer<RasterOverlayTile>& pRasterTile,
+    int32_t textureCoordinateIndex)
+    : 
+      _pLoadingTile(pRasterTile),
+      _pReadyTile(nullptr),
+      _textureCoordinateID(textureCoordinateIndex),
+      _translation(0.0, 0.0),
+      _scale(1.0, 1.0),
+      _state(AttachmentState::Unattached),
+      _originalFailed(false) {}
+
+RasterOverlayTile::MoreDetailAvailable
+RasterMappedTo3DTile::update(IPrepareRendererResources& prepareRendererResources, Tile& tile) {
+  if (this->getState() == AttachmentState::Attached) {
+    return !this->_originalFailed && this->_pReadyTile &&
+                   this->_pReadyTile->isMoreDetailAvailable() !=
+                       RasterOverlayTile::MoreDetailAvailable::No
+               ? RasterOverlayTile::MoreDetailAvailable::Yes
+               : RasterOverlayTile::MoreDetailAvailable::No;
+  }
+
+  // If the loading tile has failed, try its parent's loading tile.
+  Tile* pTile = &tile;
+  while (this->_pLoadingTile &&
+         this->_pLoadingTile->getState() ==
+             RasterOverlayTile::LoadState::Failed &&
+         pTile) {
+    // Note when our original tile fails to load so that we don't report more
+    // data available. This means - by design - we won't refine past a failed
+    // tile.
+    this->_originalFailed = true;
+
+    pTile = pTile->getParent();
+    if (pTile) {
+      RasterOverlayTile* pOverlayTile =
+          findTileOverlay(*pTile, this->_pLoadingTile->getOverlay());
+      if (pOverlayTile) {
+        this->_pLoadingTile = pOverlayTile;
+      }
+    }
+  }
+
+  // If the loading tile is now ready, make it the ready tile.
+  if (this->_pLoadingTile &&
+      this->_pLoadingTile->getState() >= RasterOverlayTile::LoadState::Loaded) {
+    // Unattach the old tile
+    if (this->_pReadyTile && this->getState() != AttachmentState::Unattached) {
+      prepareRendererResources.detachRasterInMainThread(
+          tile,
+          this->getTextureCoordinateID(),
+          *this->_pReadyTile,
+          this->_pReadyTile->getRendererResources());
+      this->_state = AttachmentState::Unattached;
+    }
+
+    // Mark the loading tile ready.
+    this->_pReadyTile = this->_pLoadingTile;
+    this->_pLoadingTile = nullptr;
+
+    // Compute the translation and scale for the new tile.
+    this->computeTranslationAndScale(tile);
+  }
+
+  // Find the closest ready ancestor tile.
+  if (this->_pLoadingTile) {
+    CesiumUtility::IntrusivePointer<RasterOverlayTile> pCandidate;
+
+    pTile = tile.getParent();
+    while (pTile) {
+      pCandidate = findTileOverlay(*pTile, this->_pLoadingTile->getOverlay());
+      if (pCandidate &&
+          pCandidate->getState() >= RasterOverlayTile::LoadState::Loaded) {
+        break;
+      }
+      pTile = pTile->getParent();
+    }
+
+    if (pCandidate &&
+        pCandidate->getState() >= RasterOverlayTile::LoadState::Loaded &&
+        this->_pReadyTile != pCandidate) {
+      if (this->getState() != AttachmentState::Unattached) {
+        prepareRendererResources.detachRasterInMainThread(
+            tile,
+            this->getTextureCoordinateID(),
+            *this->_pReadyTile,
+            this->_pReadyTile->getRendererResources());
+        this->_state = AttachmentState::Unattached;
+      }
+
+      this->_pReadyTile = pCandidate;
+
+      // Compute the translation and scale for the new tile.
+      this->computeTranslationAndScale(tile);
+    }
+  }
+
+  // Attach the ready tile if it's not already attached.
+  if (this->_pReadyTile &&
+      this->getState() == RasterMappedTo3DTile::AttachmentState::Unattached) {
+    this->_pReadyTile->loadInMainThread();
+
+    prepareRendererResources.attachRasterInMainThread(
+        tile,
+        this->getTextureCoordinateID(),
+        *this->_pReadyTile,
+        this->_pReadyTile->getRendererResources(),
+        this->getTranslation(),
+        this->getScale());
+
+    this->_state = this->_pLoadingTile ? AttachmentState::TemporarilyAttached
+                                       : AttachmentState::Attached;
+  }
+
+  // TODO: check more precise raster overlay tile availability, rather than just
+  // max level?
+  if (this->_pLoadingTile) {
+    return RasterOverlayTile::MoreDetailAvailable::Unknown;
+  }
+
+  if (!this->_originalFailed && this->_pReadyTile) {
+    return this->_pReadyTile->isMoreDetailAvailable();
+  } else {
+    return RasterOverlayTile::MoreDetailAvailable::No;
+  }
+}
+
+bool RasterMappedTo3DTile::isMoreDetailAvailable() const noexcept {
+  return !_pLoadingTile && !_originalFailed && _pReadyTile &&
+         _pReadyTile->isMoreDetailAvailable() ==
+             RasterOverlayTile::MoreDetailAvailable::Yes;
+}
+
+void RasterMappedTo3DTile::detachFromTile(IPrepareRendererResources& prepareRendererResources, Tile& tile) noexcept {
+  if (this->getState() == AttachmentState::Unattached) {
+    return;
+  }
+
+  if (!this->_pReadyTile) {
+    return;
+  }
+
+  prepareRendererResources.detachRasterInMainThread(
+      tile,
+      this->getTextureCoordinateID(),
+      *this->_pReadyTile,
+      this->_pReadyTile->getRendererResources());
+
+  this->_state = AttachmentState::Unattached;
+}
+
+bool RasterMappedTo3DTile::loadThrottled() noexcept {
+  RasterOverlayTile* pLoading = this->getLoadingTile();
+  if (!pLoading) {
+    return true;
+  }
+
+  RasterOverlayTileProvider* pProvider =
+      pLoading->getOverlay().getTileProvider();
+  if (!pProvider) {
+    // This should not be possible.
+    assert(pProvider);
+    return false;
+  }
+
+  return pProvider->loadTileThrottled(*pLoading);
+}
+
+namespace {
+
+IntrusivePointer<RasterOverlayTile> getPlaceholderTile(RasterOverlay& overlay) {
+  // Rectangle and geometric error don't matter for a placeholder.
+  return overlay.getPlaceholder()->getTile(Rectangle(), glm::dvec2(0.0));
+}
+
+std::optional<Rectangle> getPreciseRectangleFromBoundingVolume(
+    const Projection& projection,
+    const BoundingVolume& boundingVolume) {
+  const BoundingRegion* pRegion =
+      getBoundingRegionFromBoundingVolume(boundingVolume);
+  if (!pRegion) {
+    return std::nullopt;
+  }
+
+  // Currently _all_ supported projections can have a rectangle precisely
+  // determined from a bounding region. This may not be true, however, for
+  // projections we add in the future where X is not purely a function of
+  // longitude or Y is not purely a function of latitude.
+  return projectRectangleSimple(projection, pRegion->getRectangle());
+}
+
+int32_t addProjectionToList(
+    std::vector<Projection>& projections,
+    const Projection& projection) {
+  auto it = std::find(projections.begin(), projections.end(), projection);
+  if (it == projections.end()) {
+    projections.emplace_back(projection);
+    return int32_t(projections.size()) - 1;
+  } else {
+    return int32_t(it - projections.begin());
+  }
+}
+
+glm::dvec2 computeDesiredScreenPixels(
+    const Tile& tile,
+    const Projection& projection,
+    const Rectangle& rectangle,
+    double maxHeight,
+    double maximumScreenSpaceError,
+    const Ellipsoid& ellipsoid = Ellipsoid::WGS84) {
+  // We're aiming to estimate the maximum number of pixels (in each projected
+  // direction) the tile will occupy on the screen. The will be determined by
+  // the tile's geometric error, because when less error is needed (i.e. the
+  // viewer moved closer), the LOD will switch to show the tile's children
+  // instead of this tile.
+  //
+  // It works like this:
+  // * Estimate the size of the projected rectangle in world coordinates.
+  // * Compute the distance at which tile will switch to its children, based on
+  // its geometric error and the tileset SSE.
+  // * Compute the on-screen size of the projected rectangle at that distance.
+  //
+  // For the two compute steps, we use the usual perspective projection SSE
+  // equation:
+  // screenSize = (realSize * viewportHeight) / (distance * 2 * tan(0.5 * fovY))
+  //
+  // Conveniently a bunch of terms cancel out, so the screen pixel size at the
+  // switch distance is not actually dependent on the screen dimensions or
+  // field-of-view angle.
+  double geometryError = tile.getNonZeroGeometricError();
+  glm::dvec2 diameters = computeProjectedRectangleSize(
+      projection,
+      rectangle,
+      maxHeight,
+      ellipsoid);
+  return diameters * maximumScreenSpaceError / geometryError;
+}
+
+RasterMappedTo3DTile* addRealTile(
+    Tile& tile,
+    RasterOverlayTileProvider& provider,
+    const Rectangle& rectangle,
+    const glm::dvec2& screenPixels,
+    int32_t textureCoordinateIndex) {
+  IntrusivePointer<RasterOverlayTile> pTile =
+      provider.getTile(rectangle, screenPixels);
+  if (!pTile) {
+    return nullptr;
+  } else {
+    return &tile.getMappedRasterTiles().emplace_back(RasterMappedTo3DTile(
+        pTile,
+        textureCoordinateIndex));
+  }
+}
+
+} // namespace
+
+/*static*/ RasterMappedTo3DTile* RasterMappedTo3DTile::mapOverlayToTile(
+    double maximumScreenSpaceError,
+    RasterOverlay& overlay,
+    Tile& tile,
+    std::vector<Projection>& missingProjections) {
+  RasterOverlayTileProvider* pProvider = overlay.getTileProvider();
+  if (pProvider->isPlaceholder()) {
+    // Provider not created yet, so add a placeholder tile.
+    return &tile.getMappedRasterTiles().emplace_back(RasterMappedTo3DTile(
+        getPlaceholderTile(overlay),
+        -1));
+  }
+
+  // We can get a more accurate estimate of the real-world size of the projected
+  // rectangle if we consider the rectangle at the true height of the geometry
+  // rather than assuming it's on the ellipsoid. This will make basically no
+  // difference for small tiles (because surface normals on opposite ends of
+  // tiles are effectively identical), and only a small difference for large
+  // ones (because heights will be small compared to the total size of a large
+  // tile). So we're skipping this complexity for now and estimating geometry
+  // width/height as if it's on the ellipsoid surface.
+  const double heightForSizeEstimation = 0.0;
+
+  const Projection& projection = pProvider->getProjection();
+
+  // If the tile is loaded, use the precise rectangle computed from the content.
+  const TileContent& content = tile.getContent();
+  if (content.getState() >= TileLoadState::ContentLoaded) {
+    const RasterOverlayDetails* pOverlayDetails =
+        content.getRasterOverlayDetails();
+    const Rectangle* pRectangle =
+        pOverlayDetails
+            ? pOverlayDetails->findRectangleForOverlayProjection(projection)
+            : nullptr;
+    if (pRectangle) {
+      // We have a rectangle and texture coordinates for this projection.
+      int32_t index =
+          int32_t(pRectangle - &pOverlayDetails->rasterOverlayRectangles[0]);
+      const glm::dvec2 screenPixels = computeDesiredScreenPixels(
+          tile,
+          projection,
+          *pRectangle,
+          heightForSizeEstimation,
+          maximumScreenSpaceError,
+          Ellipsoid::WGS84);
+      return addRealTile(tile, *pProvider, *pRectangle, screenPixels, index);
+    } else {
+      // We don't have a precise rectangle for this projection, which means the
+      // tile was loaded before we knew we needed this projection. We'll need to
+      // reload the tile (later).
+      int32_t existingIndex =
+          pOverlayDetails
+              ? int32_t(pOverlayDetails->rasterOverlayProjections.size())
+              : 0;
+      int32_t textureCoordinateIndex =
+          existingIndex + addProjectionToList(missingProjections, projection);
+      return &tile.getMappedRasterTiles().emplace_back(RasterMappedTo3DTile(
+          getPlaceholderTile(overlay),
+          textureCoordinateIndex));
+    }
+  }
+
+  // Maybe we can derive a precise rectangle from the bounding volume.
+  int32_t textureCoordinateIndex =
+      addProjectionToList(missingProjections, projection);
+  std::optional<Rectangle> maybeRectangle =
+      getPreciseRectangleFromBoundingVolume(
+          pProvider->getProjection(),
+          tile.getBoundingVolume());
+  if (maybeRectangle) {
+    const glm::dvec2 screenPixels = computeDesiredScreenPixels(
+        tile,
+        projection,
+        *maybeRectangle,
+        heightForSizeEstimation,
+        maximumScreenSpaceError,
+        Ellipsoid::WGS84);
+    return addRealTile(
+        tile,
+        *pProvider,
+        *maybeRectangle,
+        screenPixels,
+        textureCoordinateIndex);
+  } else {
+    // No precise rectangle yet, so return a placeholder for now.
+    return &tile.getMappedRasterTiles().emplace_back(RasterMappedTo3DTile(
+        getPlaceholderTile(overlay),
+        textureCoordinateIndex));
+  }
+}
+
+void RasterMappedTo3DTile::computeTranslationAndScale(const Tile& tile) {
+  const RasterOverlayDetails* pOverlayDetails =
+      tile.getContent().getRasterOverlayDetails();
+  if (!this->_pReadyTile || !pOverlayDetails) {
+    // This shouldn't happen
+    assert(false);
+    return;
+  }
+
+  const RasterOverlayTileProvider& tileProvider =
+      *this->_pReadyTile->getOverlay().getTileProvider();
+
+  const Projection& projection = tileProvider.getProjection();
+  const std::vector<Projection>& projections =
+      pOverlayDetails->rasterOverlayProjections;
+  const std::vector<Rectangle>& rectangles =
+      pOverlayDetails->rasterOverlayRectangles;
+
+  auto projectionIt =
+      std::find(projections.begin(), projections.end(), projection);
+  if (projectionIt == projections.end()) {
+    return;
+  }
+
+  int32_t projectionIndex = int32_t(projectionIt - projections.begin());
+  if (projectionIndex < 0 || size_t(projectionIndex) >= rectangles.size()) {
+    return;
+  }
+
+  const Rectangle& geometryRectangle = rectangles[size_t(projectionIndex)];
+
+  const CesiumGeometry::Rectangle imageryRectangle =
+      this->_pReadyTile->getRectangle();
+
+  const double terrainWidth = geometryRectangle.computeWidth();
+  const double terrainHeight = geometryRectangle.computeHeight();
+
+  const double scaleX = terrainWidth / imageryRectangle.computeWidth();
+  const double scaleY = terrainHeight / imageryRectangle.computeHeight();
+  this->_translation = glm::dvec2(
+      (scaleX * (geometryRectangle.minimumX - imageryRectangle.minimumX)) /
+          terrainWidth,
+      (scaleY * (geometryRectangle.minimumY - imageryRectangle.minimumY)) /
+          terrainHeight);
+  this->_scale = glm::dvec2(scaleX, scaleY);
+}
 
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
@@ -12,7 +12,7 @@ namespace Cesium3DTilesSelection {
 RasterOverlayCollection::RasterOverlayCollection(Tileset& tileset) noexcept
     : _pTileset(&tileset) {}
 
-RasterOverlayCollection::~RasterOverlayCollection() {
+RasterOverlayCollection::~RasterOverlayCollection() noexcept {
   if (!this->_overlays.empty()) {
     for (int64_t i = static_cast<int64_t>(this->_overlays.size() - 1); i >= 0;
          --i) {

--- a/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
@@ -22,71 +22,72 @@ RasterOverlayCollection::~RasterOverlayCollection() {
 }
 
 void RasterOverlayCollection::add(std::unique_ptr<RasterOverlay>&& pOverlay) {
-  (void)(pOverlay);
-  // CESIUM_TRACE_USE_TRACK_SET(this->_loadingSlots);
+  CESIUM_TRACE_USE_TRACK_SET(this->_loadingSlots);
 
-  // RasterOverlay* pOverlayRaw = pOverlay.get();
-  // this->_overlays.push_back(std::move(pOverlay));
+  RasterOverlay* pOverlayRaw = pOverlay.get();
+  this->_overlays.push_back(std::move(pOverlay));
 
-  // pOverlayRaw->loadTileProvider(
-  //     this->_pTileset->getAsyncSystem(),
-  //     this->_pTileset->getExternals().pAssetAccessor,
-  //     this->_pTileset->getExternals().pCreditSystem,
-  //     this->_pTileset->getExternals().pPrepareRendererResources,
-  //     this->_pTileset->getExternals().pLogger);
+  pOverlayRaw->loadTileProvider(
+      this->_pTileset->getAsyncSystem(),
+      this->_pTileset->getExternals().pAssetAccessor,
+      this->_pTileset->getExternals().pCreditSystem,
+      this->_pTileset->getExternals().pPrepareRendererResources,
+      this->_pTileset->getExternals().pLogger);
 
-  //// Add this overlay to existing geometry tiles.
-  // this->_pTileset->forEachLoadedTile([pOverlayRaw](Tile& tile) {
-  //   // The tile rectangle and geometric error don't matter for a placeholder.
-  //   if (tile.getState() != TileLoadState::Unloaded) {
-  //     tile.getMappedRasterTiles().push_back(RasterMappedTo3DTile(
-  //         pOverlayRaw->getPlaceholder()->getTile(Rectangle(),
-  //         glm::dvec2(0.0)), -1));
-  //   }
-  // });
+  // Add this overlay to existing geometry tiles.
+  this->_pTileset->forEachLoadedTile([pOverlayRaw](Tile& tile) {
+    // The tile rectangle and geometric error don't matter for a placeholder.
+    if (tile.getState() != TileLoadState::Unloaded) {
+      tile.getMappedRasterTiles().push_back(RasterMappedTo3DTile(
+          pOverlayRaw->getPlaceholder()->getTile(Rectangle(), glm::dvec2(0.0)),
+          -1));
+    }
+  });
 }
 
 void RasterOverlayCollection::remove(RasterOverlay* pOverlay) noexcept {
-  (void)(pOverlay);
-  //// Remove all mappings of this overlay to geometry tiles.
-  // auto removeCondition =
-  //     [pOverlay](const RasterMappedTo3DTile& mapped) noexcept {
-  //       return (
-  //           (mapped.getLoadingTile() &&
-  //            &mapped.getLoadingTile()->getOverlay() == pOverlay) ||
-  //           (mapped.getReadyTile() &&
-  //            &mapped.getReadyTile()->getOverlay() == pOverlay));
-  //     };
+  // Remove all mappings of this overlay to geometry tiles.
+  auto removeCondition =
+      [pOverlay](const RasterMappedTo3DTile& mapped) noexcept {
+        return (
+            (mapped.getLoadingTile() &&
+             &mapped.getLoadingTile()->getOverlay() == pOverlay) ||
+            (mapped.getReadyTile() &&
+             &mapped.getReadyTile()->getOverlay() == pOverlay));
+      };
 
-  // this->_pTileset->forEachLoadedTile([&removeCondition](Tile& tile) {
-  //   std::vector<RasterMappedTo3DTile>& mapped = tile.getMappedRasterTiles();
+  auto pPrepareRenderResources =
+      _pTileset->getExternals().pPrepareRendererResources.get();
+  this->_pTileset->forEachLoadedTile(
+      [&removeCondition, pPrepareRenderResources](Tile& tile) {
+        std::vector<RasterMappedTo3DTile>& mapped = tile.getMappedRasterTiles();
 
-  //  for (RasterMappedTo3DTile& rasterTile : mapped) {
-  //    if (removeCondition(rasterTile)) {
-  //      rasterTile.detachFromTile(tile);
-  //    }
-  //  }
+        for (RasterMappedTo3DTile& rasterTile : mapped) {
+          if (removeCondition(rasterTile)) {
+            rasterTile.detachFromTile(*pPrepareRenderResources, tile);
+          }
+        }
 
-  //  auto firstToRemove =
-  //      std::remove_if(mapped.begin(), mapped.end(), removeCondition);
-  //  mapped.erase(firstToRemove, mapped.end());
-  //});
+        auto firstToRemove =
+            std::remove_if(mapped.begin(), mapped.end(), removeCondition);
+        mapped.erase(firstToRemove, mapped.end());
+      });
 
-  // auto it = std::find_if(
-  //     this->_overlays.begin(),
-  //     this->_overlays.end(),
-  //     [pOverlay](std::unique_ptr<RasterOverlay>& pCheck) noexcept {
-  //       return pCheck.get() == pOverlay;
-  //     });
-  // if (it == this->_overlays.end()) {
-  //   return;
-  // }
+  auto it = std::find_if(
+      this->_overlays.begin(),
+      this->_overlays.end(),
+      [pOverlay](std::unique_ptr<RasterOverlay>& pCheck) noexcept {
+        return pCheck.get() == pOverlay;
+      });
+  if (it == this->_overlays.end()) {
+    return;
+  }
 
-  //// Tell the overlay provider to destroy itself, which effectively transfers
-  //// ownership _of_ itself, _to_ itself. It will delete itself when all
-  //// in-progress loads are complete, which may be immediately.
-  //(*it)->destroySafely(std::move(*it));
-  // this->_overlays.erase(it);
+  // Tell the overlay provider to destroy itself, which effectively transfers
+  // ownership _of_ itself, _to_ itself. It will delete itself when all
+  // in-progress loads are complete, which may be immediately.
+  (*it)->destroySafely(std::move(*it));
+  this->_overlays.erase(it);
 }
 
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/RasterOverlayDetails.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayDetails.cpp
@@ -1,0 +1,22 @@
+#include <Cesium3DTilesSelection/RasterOverlayDetails.h>
+
+namespace Cesium3DTilesSelection {
+const CesiumGeometry::Rectangle*
+RasterOverlayDetails::findRectangleForOverlayProjection(
+    const CesiumGeospatial::Projection& projection) const {
+  const std::vector<CesiumGeospatial::Projection>& projections = this->rasterOverlayProjections;
+  const std::vector<CesiumGeometry::Rectangle>& rectangles = this->rasterOverlayRectangles;
+
+  assert(projections.size() == rectangles.size());
+
+  auto it = std::find(projections.begin(), projections.end(), projection);
+  if (it != projections.end()) {
+    int32_t index = int32_t(it - projections.begin());
+    if (index >= 0 && size_t(index) < rectangles.size()) {
+      return &rectangles[size_t(index)];
+    }
+  }
+
+  return nullptr;
+}
+} // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/RasterOverlayDetails.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayDetails.cpp
@@ -1,8 +1,23 @@
 #include <Cesium3DTilesSelection/RasterOverlayDetails.h>
 
 #include <algorithm>
+#include <limits>
 
 namespace Cesium3DTilesSelection {
+RasterOverlayDetails::RasterOverlayDetails()
+    : boundingRegion{
+          CesiumGeospatial::GlobeRectangle::EMPTY,
+          std::numeric_limits<double>::max(),
+          std::numeric_limits<double>::lowest()} {}
+
+RasterOverlayDetails::RasterOverlayDetails(
+    std::vector<CesiumGeospatial::Projection>&& rasterOverlayProjections_,
+    std::vector<CesiumGeometry::Rectangle>&& rasterOverlayRectangles_,
+    const CesiumGeospatial::BoundingRegion& boundingRegion_)
+    : rasterOverlayProjections{std::move(rasterOverlayProjections_)},
+      rasterOverlayRectangles{std::move(rasterOverlayRectangles_)},
+      boundingRegion{boundingRegion_} {}
+
 const CesiumGeometry::Rectangle*
 RasterOverlayDetails::findRectangleForOverlayProjection(
     const CesiumGeospatial::Projection& projection) const {
@@ -22,5 +37,19 @@ RasterOverlayDetails::findRectangleForOverlayProjection(
   }
 
   return nullptr;
+}
+
+void RasterOverlayDetails::merge(RasterOverlayDetails&& other) {
+  rasterOverlayProjections.insert(
+      rasterOverlayProjections.end(),
+      other.rasterOverlayProjections.begin(),
+      other.rasterOverlayProjections.end());
+
+  rasterOverlayRectangles.insert(
+      rasterOverlayRectangles.end(),
+      other.rasterOverlayRectangles.begin(),
+      other.rasterOverlayRectangles.end());
+
+  boundingRegion.computeUnion(other.boundingRegion);
 }
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/RasterOverlayDetails.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayDetails.cpp
@@ -1,5 +1,7 @@
 #include <Cesium3DTilesSelection/RasterOverlayDetails.h>
 
+#include <algorithm>
+
 namespace Cesium3DTilesSelection {
 const CesiumGeometry::Rectangle*
 RasterOverlayDetails::findRectangleForOverlayProjection(

--- a/Cesium3DTilesSelection/src/RasterOverlayDetails.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayDetails.cpp
@@ -4,8 +4,10 @@ namespace Cesium3DTilesSelection {
 const CesiumGeometry::Rectangle*
 RasterOverlayDetails::findRectangleForOverlayProjection(
     const CesiumGeospatial::Projection& projection) const {
-  const std::vector<CesiumGeospatial::Projection>& projections = this->rasterOverlayProjections;
-  const std::vector<CesiumGeometry::Rectangle>& rectangles = this->rasterOverlayRectangles;
+  const std::vector<CesiumGeospatial::Projection>& projections =
+      this->rasterOverlayProjections;
+  const std::vector<CesiumGeometry::Rectangle>& rectangles =
+      this->rasterOverlayRectangles;
 
   assert(projections.size() == rectangles.size());
 

--- a/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
@@ -1,4 +1,5 @@
 #include "RasterOverlayUpsampler.h"
+#include <Cesium3DTilesSelection/Tile.h>
 
 namespace Cesium3DTilesSelection {
 CesiumAsync::Future<TileLoadResult> RasterOverlayUpsampler::loadTileContent(
@@ -7,9 +8,147 @@ CesiumAsync::Future<TileLoadResult> RasterOverlayUpsampler::loadTileContent(
     const CesiumAsync::AsyncSystem& asyncSystem,
     const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
     const std::shared_ptr<spdlog::logger>& pLogger,
-    const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders)
-{
+    const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders) {
+  Tile* pParent = tile.getParent();
+  const UpsampledQuadtreeNode* pSubdividedParentID =
+      std::get_if<UpsampledQuadtreeNode>(&this->getTileID());
 
+  assert(pParent != nullptr);
+  assert(pParent->getState() == LoadState::Done);
+  assert(pSubdividedParentID != nullptr);
+
+  TileContentLoadResult* pParentContent = pParent->getContent();
+  if (!pParentContent || !pParentContent->model) {
+    this->setState(LoadState::ContentLoaded);
+    return;
+  }
+
+  CesiumGltf::Model& parentModel = pParentContent->model.value();
+
+  Tileset* pTileset = this->getTileset();
+  pTileset->notifyTileStartLoading(this);
+
+  struct LoadResult {
+    LoadState state;
+    std::unique_ptr<TileContentLoadResult> pContent;
+    void* pRendererResources;
+  };
+
+  int32_t index = 0;
+  std::vector<Projection>& parentProjections =
+      pParentContent->overlayDetails->rasterOverlayProjections;
+  const gsl::span<Tile> children = pParent->getChildren();
+  if (std::get_if<QuadtreeTileID>(&pParent->getTileID()) &&
+      std::any_of(
+          children.begin(),
+          children.end(),
+          [](const Tile& tile) noexcept {
+            return std::get_if<QuadtreeTileID>(&tile.getTileID());
+          })) {
+    // We will only get here for quantized-mesh tiles where some (but not all)
+    // tiles are present in the data and the rest need to be upsampled. And in
+    // that scenario, we need to use the implicit context's projection for
+    // subdivision, no matter what the status of the overlays.
+    //
+    // For a more typical upsampling, driven by raster overlays, all child tiles
+    // will have a `UpsampledQuadtreeNode` tile ID.
+    if (_pContext->implicitContext->projection.has_value()) {
+      const Projection& projection = *_pContext->implicitContext->projection;
+      auto it = std::find(
+          parentProjections.begin(),
+          parentProjections.end(),
+          projection);
+
+      if (it == parentProjections.end()) {
+        const BoundingRegion* pParentRegion =
+            std::get_if<BoundingRegion>(&pParent->getBoundingVolume());
+
+        std::optional<TileContentDetailsForOverlays> overlayDetails =
+            GltfContent::createRasterOverlayTextureCoordinates(
+                parentModel,
+                pParent->getTransform(),
+                int32_t(parentProjections.size()),
+                pParentRegion ? std::make_optional<GlobeRectangle>(
+                                    pParentRegion->getRectangle())
+                              : std::nullopt,
+                {projection});
+        if (overlayDetails) {
+          pParentContent->overlayDetails->rasterOverlayRectangles.emplace_back(
+              overlayDetails->rasterOverlayRectangles[0]);
+          parentProjections.emplace_back(projection);
+          index = int32_t(parentProjections.size()) - 1;
+        }
+      } else {
+        index = int32_t(it - parentProjections.begin());
+      }
+    }
+  } else {
+    for (const RasterMappedTo3DTile& mapped : pParent->getMappedRasterTiles()) {
+      if (mapped.isMoreDetailAvailable()) {
+        const Projection& projection = mapped.getReadyTile()
+                                           ->getOverlay()
+                                           .getTileProvider()
+                                           ->getProjection();
+        auto it = std::find(
+            parentProjections.begin(),
+            parentProjections.end(),
+            projection);
+        index = int32_t(it - parentProjections.begin());
+      }
+    }
+  }
+
+  pTileset->getAsyncSystem()
+      .runInWorkerThread(
+          [&parentModel,
+           transform = this->getTransform(),
+           textureCoordinateIndex = index,
+           projections = std::move(projections),
+           pSubdividedParentID,
+           tileBoundingVolume = this->getBoundingVolume(),
+           tileContentBoundingVolume = this->getContentBoundingVolume(),
+           gltfUpAxis = pTileset->getGltfUpAxis(),
+           generateMissingNormalsSmooth =
+               pTileset->getOptions()
+                   .contentOptions.generateMissingNormalsSmooth,
+           pLogger = pTileset->getExternals().pLogger,
+           pPrepareRendererResources =
+               pTileset->getExternals().pPrepareRendererResources]() mutable {
+            std::unique_ptr<TileContentLoadResult> pContent =
+                std::make_unique<TileContentLoadResult>();
+            pContent->model = upsampleGltfForRasterOverlays(
+                parentModel,
+                *pSubdividedParentID,
+                textureCoordinateIndex);
+
+            void* pRendererResources = processNewTileContent(
+                pPrepareRendererResources,
+                pLogger,
+                *pContent,
+                generateMissingNormalsSmooth,
+                gltfUpAxis,
+                transform,
+                tileContentBoundingVolume,
+                tileBoundingVolume,
+                std::move(projections));
+
+            return LoadResult{
+                LoadState::ContentLoaded,
+                std::move(pContent),
+                pRendererResources};
+          })
+      .thenInMainThread([this](LoadResult&& loadResult) noexcept {
+        this->_pContent = std::move(loadResult.pContent);
+        this->_pRendererResources = loadResult.pRendererResources;
+        this->getTileset()->notifyTileDoneLoading(this);
+        this->setState(loadResult.state);
+      })
+      .catchInMainThread([this](const std::exception& /*e*/) noexcept {
+        this->_pContent.reset();
+        this->_pRendererResources = nullptr;
+        this->getTileset()->notifyTileDoneLoading(this);
+        this->setState(LoadState::Failed);
+      });
 }
 
 bool RasterOverlayUpsampler::updateTileContent([[maybe_unused]] Tile& tile) {

--- a/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
@@ -57,7 +57,8 @@ CesiumAsync::Future<TileLoadResult> RasterOverlayUpsampler::loadTileContent(
   const TileContent& parentContent = pParent->getContent();
   const TileRenderContent* pParentRenderContent =
       parentContent.getRenderContent();
-  if (!pParentRenderContent || !pParentRenderContent->model) {
+  if (!pParentRenderContent || !pParentRenderContent->model ||
+      !parentContent.getRasterOverlayDetails()) {
     // parent doesn't have mesh, so it's not possible to upsample
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileUnknownContent{},

--- a/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
@@ -1,0 +1,3 @@
+#include "RasterOverlayUpsampler.h"
+
+namespace Cesium3DTilesSelection {}

--- a/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
@@ -1,3 +1,18 @@
 #include "RasterOverlayUpsampler.h"
 
-namespace Cesium3DTilesSelection {}
+namespace Cesium3DTilesSelection {
+CesiumAsync::Future<TileLoadResult> RasterOverlayUpsampler::loadTileContent(
+    Tile& tile,
+    const TilesetContentOptions& contentOptions,
+    const CesiumAsync::AsyncSystem& asyncSystem,
+    const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+    const std::shared_ptr<spdlog::logger>& pLogger,
+    const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders)
+{
+
+}
+
+bool RasterOverlayUpsampler::updateTileContent([[maybe_unused]] Tile& tile) {
+  return false;
+}
+} // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
@@ -28,7 +28,6 @@ CesiumAsync::Future<TileLoadResult> RasterOverlayUpsampler::loadTileContent(
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        std::nullopt,
         TileLoadResultState::Failed,
         nullptr,
         {}});
@@ -40,7 +39,6 @@ CesiumAsync::Future<TileLoadResult> RasterOverlayUpsampler::loadTileContent(
     // this tile is not marked to be upsampled, so just fail it
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileUnknownContent{},
-        std::nullopt,
         std::nullopt,
         std::nullopt,
         TileLoadResultState::Failed,
@@ -57,12 +55,10 @@ CesiumAsync::Future<TileLoadResult> RasterOverlayUpsampler::loadTileContent(
   const TileContent& parentContent = pParent->getContent();
   const TileRenderContent* pParentRenderContent =
       parentContent.getRenderContent();
-  if (!pParentRenderContent || !pParentRenderContent->model ||
-      !parentContent.getRasterOverlayDetails()) {
+  if (!pParentRenderContent || !pParentRenderContent->model) {
     // parent doesn't have mesh, so it's not possible to upsample
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileUnknownContent{},
-        std::nullopt,
         std::nullopt,
         std::nullopt,
         TileLoadResultState::Failed,
@@ -72,7 +68,7 @@ CesiumAsync::Future<TileLoadResult> RasterOverlayUpsampler::loadTileContent(
 
   int32_t index = 0;
   const std::vector<CesiumGeospatial::Projection>& parentProjections =
-      parentContent.getRasterOverlayDetails()->rasterOverlayProjections;
+      parentContent.getRasterOverlayDetails().rasterOverlayProjections;
   for (const RasterMappedTo3DTile& mapped : pParent->getMappedRasterTiles()) {
     if (mapped.isMoreDetailAvailable()) {
       const CesiumGeospatial::Projection& projection = mapped.getReadyTile()
@@ -100,7 +96,6 @@ CesiumAsync::Future<TileLoadResult> RasterOverlayUpsampler::loadTileContent(
 
     return TileLoadResult{
         TileRenderContent{std::move(model)},
-        std::nullopt,
         std::nullopt,
         std::nullopt,
         TileLoadResultState::Success,

--- a/Cesium3DTilesSelection/src/RasterOverlayUpsampler.h
+++ b/Cesium3DTilesSelection/src/RasterOverlayUpsampler.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "TilesetContentLoader.h"
+
+namespace Cesium3DTilesSelection {
+class RasterOverlayUpsampler : public TilesetContentLoader {
+public:
+  CesiumAsync::Future<TileLoadResult> loadTileContent(
+      Tile& tile,
+      const TilesetContentOptions& contentOptions,
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+      const std::shared_ptr<spdlog::logger>& pLogger,
+      const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders)
+      override;
+
+  bool updateTileContent(Tile& tile) override;
+};
+} // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -170,7 +170,7 @@ bool Tile::isRenderable() const noexcept {
             return rasterTile.getReadyTile() != nullptr;
           });
     }
-  } 
+  }
 
   return false;
 }

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -163,7 +163,12 @@ int64_t Tile::computeByteSize() const noexcept {
 bool Tile::isRenderable() const noexcept {
   if (getState() >= TileLoadState::ContentLoaded) {
     if (!isExternalContent()) {
-      return true;
+      return std::all_of(
+          this->_rasterTiles.begin(),
+          this->_rasterTiles.end(),
+          [](const RasterMappedTo3DTile& rasterTile) noexcept {
+            return rasterTile.getReadyTile() != nullptr;
+          });
     }
   }
 

--- a/Cesium3DTilesSelection/src/TileContent.cpp
+++ b/Cesium3DTilesSelection/src/TileContent.cpp
@@ -5,7 +5,6 @@ TileContent::TileContent(TilesetContentLoader* pLoader)
     : _state{TileLoadState::Unloaded},
       _contentKind{TileUnknownContent{}},
       _pRenderResources{nullptr},
-      _projection{std::nullopt},
       _rasterOverlayDetails{std::nullopt},
       _tileInitializer{},
       _pLoader{pLoader},
@@ -17,7 +16,6 @@ TileContent::TileContent(
     : _state{TileLoadState::ContentLoaded},
       _contentKind{emptyContent},
       _pRenderResources{nullptr},
-      _projection{std::nullopt},
       _rasterOverlayDetails{std::nullopt},
       _tileInitializer{},
       _pLoader{pLoader},
@@ -29,7 +27,6 @@ TileContent::TileContent(
     : _state{TileLoadState::ContentLoaded},
       _contentKind{externalContent},
       _pRenderResources{nullptr},
-      _projection{std::nullopt},
       _rasterOverlayDetails{std::nullopt},
       _tileInitializer{},
       _pLoader{pLoader},
@@ -65,11 +62,6 @@ const TileRenderContent* TileContent::getRenderContent() const noexcept {
   return std::get_if<TileRenderContent>(&_contentKind);
 }
 
-const CesiumGeospatial::Projection*
-TileContent::getProjection() const noexcept {
-  return _projection ? &*_projection : nullptr;
-}
-
 const RasterOverlayDetails*
 TileContent::getRasterOverlayDetails() const noexcept {
   if (_rasterOverlayDetails) {
@@ -95,11 +87,6 @@ void TileContent::setContentKind(TileContentKind&& contentKind) {
 
 void TileContent::setContentKind(const TileContentKind& contentKind) {
   _contentKind = contentKind;
-}
-
-void TileContent::setProjection(
-    const CesiumGeospatial::Projection& projection) {
-  _projection = projection;
 }
 
 void TileContent::setRasterOverlayDetails(

--- a/Cesium3DTilesSelection/src/TileContent.cpp
+++ b/Cesium3DTilesSelection/src/TileContent.cpp
@@ -5,7 +5,7 @@ TileContent::TileContent(TilesetContentLoader* pLoader)
     : _state{TileLoadState::Unloaded},
       _contentKind{TileUnknownContent{}},
       _pRenderResources{nullptr},
-      _rasterOverlayDetails{std::nullopt},
+      _rasterOverlayDetails{},
       _tileInitializer{},
       _pLoader{pLoader},
       _shouldContentContinueUpdated{true} {}
@@ -16,7 +16,7 @@ TileContent::TileContent(
     : _state{TileLoadState::ContentLoaded},
       _contentKind{emptyContent},
       _pRenderResources{nullptr},
-      _rasterOverlayDetails{std::nullopt},
+      _rasterOverlayDetails{},
       _tileInitializer{},
       _pLoader{pLoader},
       _shouldContentContinueUpdated{true} {}
@@ -27,7 +27,7 @@ TileContent::TileContent(
     : _state{TileLoadState::ContentLoaded},
       _contentKind{externalContent},
       _pRenderResources{nullptr},
-      _rasterOverlayDetails{std::nullopt},
+      _rasterOverlayDetails{},
       _tileInitializer{},
       _pLoader{pLoader},
       _shouldContentContinueUpdated{true} {}
@@ -62,21 +62,17 @@ const TileRenderContent* TileContent::getRenderContent() const noexcept {
   return std::get_if<TileRenderContent>(&_contentKind);
 }
 
-const RasterOverlayDetails*
-TileContent::getRasterOverlayDetails() const noexcept {
-  if (_rasterOverlayDetails) {
-    return &*_rasterOverlayDetails;
-  }
-
-  return nullptr;
+TileRenderContent* TileContent::getRenderContent() noexcept {
+  return std::get_if<TileRenderContent>(&_contentKind);
 }
 
-RasterOverlayDetails* TileContent::getRasterOverlayDetails() noexcept {
-  if (_rasterOverlayDetails) {
-    return &*_rasterOverlayDetails;
-  }
+const RasterOverlayDetails&
+TileContent::getRasterOverlayDetails() const noexcept {
+  return _rasterOverlayDetails;
+}
 
-  return nullptr;
+RasterOverlayDetails& TileContent::getRasterOverlayDetails() noexcept {
+  return _rasterOverlayDetails;
 }
 
 TilesetContentLoader* TileContent::getLoader() noexcept { return _pLoader; }

--- a/Cesium3DTilesSelection/src/TileContent.cpp
+++ b/Cesium3DTilesSelection/src/TileContent.cpp
@@ -5,6 +5,8 @@ TileContent::TileContent(TilesetContentLoader* pLoader)
     : _state{TileLoadState::Unloaded},
       _contentKind{TileUnknownContent{}},
       _pRenderResources{nullptr},
+      _projection{std::nullopt},
+      _rasterOverlayDetails{std::nullopt},
       _tileInitializer{},
       _pLoader{pLoader} {}
 
@@ -14,6 +16,8 @@ TileContent::TileContent(
     : _state{TileLoadState::ContentLoaded},
       _contentKind{emptyContent},
       _pRenderResources{nullptr},
+      _projection{std::nullopt},
+      _rasterOverlayDetails{std::nullopt},
       _tileInitializer{},
       _pLoader{pLoader} {}
 
@@ -23,6 +27,8 @@ TileContent::TileContent(
     : _state{TileLoadState::ContentLoaded},
       _contentKind{externalContent},
       _pRenderResources{nullptr},
+      _projection{std::nullopt},
+      _rasterOverlayDetails{std::nullopt},
       _tileInitializer{},
       _pLoader{pLoader} {}
 
@@ -49,6 +55,23 @@ TileContent::getProjection() const noexcept {
   return _projection ? &*_projection : nullptr;
 }
 
+const RasterOverlayDetails*
+TileContent::getRasterOverlayDetails() const noexcept {
+  if (_rasterOverlayDetails) {
+    return &*_rasterOverlayDetails;
+  }
+
+  return nullptr;
+}
+
+RasterOverlayDetails* TileContent::getRasterOverlayDetails() noexcept {
+  if (_rasterOverlayDetails) {
+    return &*_rasterOverlayDetails;
+  }
+
+  return nullptr;
+}
+
 TilesetContentLoader* TileContent::getLoader() noexcept { return _pLoader; }
 
 void TileContent::setContentKind(TileContentKind&& contentKind) {
@@ -62,6 +85,16 @@ void TileContent::setContentKind(const TileContentKind& contentKind) {
 void TileContent::setProjection(
     const CesiumGeospatial::Projection& projection) {
   _projection = projection;
+}
+
+void TileContent::setRasterOverlayDetails(
+    const RasterOverlayDetails& rasterOverlayDetails) {
+  _rasterOverlayDetails = rasterOverlayDetails;
+}
+
+void TileContent::setRasterOverlayDetails(
+    RasterOverlayDetails&& rasterOverlayDetails) {
+  _rasterOverlayDetails = std::move(rasterOverlayDetails);
 }
 
 void TileContent::setState(TileLoadState state) noexcept { _state = state; }

--- a/Cesium3DTilesSelection/src/TileContent.cpp
+++ b/Cesium3DTilesSelection/src/TileContent.cpp
@@ -5,7 +5,7 @@ TileContent::TileContent(TilesetContentLoader* pLoader)
     : _state{TileLoadState::Unloaded},
       _contentKind{TileUnknownContent{}},
       _pRenderResources{nullptr},
-      _deferredTileInitializer{},
+      _tileInitializer{},
       _pLoader{pLoader} {}
 
 TileContent::TileContent(
@@ -14,7 +14,7 @@ TileContent::TileContent(
     : _state{TileLoadState::ContentLoaded},
       _contentKind{emptyContent},
       _pRenderResources{nullptr},
-      _deferredTileInitializer{},
+      _tileInitializer{},
       _pLoader{pLoader} {}
 
 TileContent::TileContent(
@@ -23,7 +23,7 @@ TileContent::TileContent(
     : _state{TileLoadState::ContentLoaded},
       _contentKind{externalContent},
       _pRenderResources{nullptr},
-      _deferredTileInitializer{},
+      _tileInitializer{},
       _pLoader{pLoader} {}
 
 TileLoadState TileContent::getState() const noexcept { return _state; }
@@ -44,6 +44,11 @@ const TileRenderContent* TileContent::getRenderContent() const noexcept {
   return std::get_if<TileRenderContent>(&_contentKind);
 }
 
+const CesiumGeospatial::Projection*
+TileContent::getProjection() const noexcept {
+  return _projection ? &*_projection : nullptr;
+}
+
 TilesetContentLoader* TileContent::getLoader() noexcept { return _pLoader; }
 
 void TileContent::setContentKind(TileContentKind&& contentKind) {
@@ -52,6 +57,11 @@ void TileContent::setContentKind(TileContentKind&& contentKind) {
 
 void TileContent::setContentKind(const TileContentKind& contentKind) {
   _contentKind = contentKind;
+}
+
+void TileContent::setProjection(
+    const CesiumGeospatial::Projection& projection) {
+  _projection = projection;
 }
 
 void TileContent::setState(TileLoadState state) noexcept { _state = state; }
@@ -66,10 +76,10 @@ void* TileContent::getRenderResources() const noexcept {
 
 void TileContent::setTileInitializerCallback(
     std::function<void(Tile&)> callback) {
-  _deferredTileInitializer = std::move(callback);
+  _tileInitializer = std::move(callback);
 }
 
 std::function<void(Tile&)>& TileContent::getTileInitializerCallback() {
-  return _deferredTileInitializer;
+  return _tileInitializer;
 }
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/TileContentLoadInfo.cpp
+++ b/Cesium3DTilesSelection/src/TileContentLoadInfo.cpp
@@ -11,8 +11,8 @@ TileContentLoadInfo::TileContentLoadInfo(
     const Tile& tile)
     : asyncSystem(asyncSystem_),
       pAssetAccessor(pAssetAccessor_),
-      pPrepareRendererResources{pPrepareRendererResources_},
       pLogger(pLogger_),
+      pPrepareRendererResources{pPrepareRendererResources_},
       tileID(tile.getTileID()),
       tileBoundingVolume(tile.getBoundingVolume()),
       tileContentBoundingVolume(tile.getContentBoundingVolume()),

--- a/Cesium3DTilesSelection/src/TileContentLoadInfo.cpp
+++ b/Cesium3DTilesSelection/src/TileContentLoadInfo.cpp
@@ -1,0 +1,23 @@
+#include "TileContentLoadInfo.h"
+
+namespace Cesium3DTilesSelection {
+TileContentLoadInfo::TileContentLoadInfo(
+    const CesiumAsync::AsyncSystem& asyncSystem_,
+    const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor_,
+    const std::shared_ptr<IPrepareRendererResources>&
+        pPrepareRendererResources_,
+    const std::shared_ptr<spdlog::logger>& pLogger_,
+    const TilesetContentOptions& contentOptions_,
+    const Tile& tile)
+    : asyncSystem(asyncSystem_),
+      pAssetAccessor(pAssetAccessor_),
+      pPrepareRendererResources{pPrepareRendererResources_},
+      pLogger(pLogger_),
+      tileID(tile.getTileID()),
+      tileBoundingVolume(tile.getBoundingVolume()),
+      tileContentBoundingVolume(tile.getContentBoundingVolume()),
+      tileRefine(tile.getRefine()),
+      tileGeometricError(tile.getGeometricError()),
+      tileTransform(tile.getTransform()),
+      contentOptions(contentOptions_) {}
+} // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/TileContentLoadInfo.h
+++ b/Cesium3DTilesSelection/src/TileContentLoadInfo.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <Cesium3DTilesSelection/IPrepareRendererResources.h>
+#include <Cesium3DTilesSelection/BoundingVolume.h>
+#include <Cesium3DTilesSelection/Tile.h>
+#include <Cesium3DTilesSelection/TileID.h>
+#include <Cesium3DTilesSelection/TileRefine.h>
+#include <Cesium3DTilesSelection/TilesetOptions.h>
+
+#include <CesiumAsync/AsyncSystem.h>
+#include <CesiumAsync/IAssetAccessor.h>
+
+#include <gsl/span>
+#include <spdlog/fwd.h>
+
+#include <cstddef>
+#include <memory>
+
+namespace Cesium3DTilesSelection {
+struct TileContentLoadInfo {
+  TileContentLoadInfo(
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+      const std::shared_ptr<IPrepareRendererResources>&
+          pPrepareRendererResources,
+      const std::shared_ptr<spdlog::logger>& pLogger,
+      const TilesetContentOptions& contentOptions,
+      const Tile& tile);
+
+  CesiumAsync::AsyncSystem asyncSystem;
+
+  std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor;
+
+  std::shared_ptr<spdlog::logger> pLogger;
+
+  std::shared_ptr<IPrepareRendererResources> pPrepareRendererResources;
+
+  TileID tileID;
+
+  BoundingVolume tileBoundingVolume;
+
+  std::optional<BoundingVolume> tileContentBoundingVolume;
+
+  TileRefine tileRefine;
+
+  double tileGeometricError;
+
+  glm::dmat4 tileTransform;
+
+  TilesetContentOptions contentOptions;
+};
+} // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/TileContentLoadInfo.h
+++ b/Cesium3DTilesSelection/src/TileContentLoadInfo.h
@@ -1,12 +1,11 @@
 #pragma once
 
-#include <Cesium3DTilesSelection/IPrepareRendererResources.h>
 #include <Cesium3DTilesSelection/BoundingVolume.h>
+#include <Cesium3DTilesSelection/IPrepareRendererResources.h>
 #include <Cesium3DTilesSelection/Tile.h>
 #include <Cesium3DTilesSelection/TileID.h>
 #include <Cesium3DTilesSelection/TileRefine.h>
 #include <Cesium3DTilesSelection/TilesetOptions.h>
-
 #include <CesiumAsync/AsyncSystem.h>
 #include <CesiumAsync/IAssetAccessor.h>
 

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -459,7 +459,7 @@ Tileset::TraversalDetails Tileset::_visitTileIfNeeded(
     bool ancestorMeetsSse,
     Tile& tile,
     ViewUpdateResult& result) {
-  _pTilesetContentManager->updateTileContent(tile);
+  _pTilesetContentManager->updateTileContent(tile, _options);
   this->_markTileVisited(tile);
 
   // whether we should visit this tile
@@ -630,7 +630,7 @@ bool Tileset::_queueLoadOfChildrenRequiredForForbidHoles(
 
       // While we are waiting for the child to load, we need to push along the
       // tile and raster loading by continuing to update it.
-      _pTilesetContentManager->updateTileContent(child);
+      _pTilesetContentManager->updateTileContent(child, _options);
 
       // We're using the distance to the parent tile to compute the load
       // priority. This is fine because the relative priority of the children is
@@ -1170,9 +1170,7 @@ void Tileset::processQueue(
 
   for (LoadRecord& record : queue) {
     CESIUM_TRACE_USE_TRACK_SET(this->_loadingSlots);
-    _pTilesetContentManager->loadTileContent(
-        *record.pTile,
-        _options.contentOptions);
+    _pTilesetContentManager->loadTileContent(*record.pTile, _options);
     if (this->_pTilesetContentManager->getNumOfTilesLoading() >=
         maximumLoadsInProgress) {
       break;

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -1111,7 +1111,8 @@ void Tileset::_markTileVisited(Tile& tile) noexcept {
     const std::vector<double>& distances) {
   double highestLoadPriority = std::numeric_limits<double>::max();
 
-  if (tile.getState() == TileLoadState::Unloaded) {
+  if (tile.getState() == TileLoadState::Unloaded ||
+      tile.getState() == TileLoadState::FailedTemporarily) {
 
     const glm::dvec3 boundingVolumeCenter =
         getBoundingVolumeCenter(tile.getBoundingVolume());

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -1104,15 +1104,14 @@ void Tileset::_markTileVisited(Tile& tile) noexcept {
 // addTileToLoadQueue(queue, tile, priorityFor(tile, viewState, distance))
 // (or at least, this function could delegate to such a call...)
 
-/*static*/ double Tileset::addTileToLoadQueue(
+double Tileset::addTileToLoadQueue(
     std::vector<Tileset::LoadRecord>& loadQueue,
     const std::vector<ViewState>& frustums,
     Tile& tile,
     const std::vector<double>& distances) {
   double highestLoadPriority = std::numeric_limits<double>::max();
 
-  if (tile.getState() == TileLoadState::Unloaded ||
-      tile.getState() == TileLoadState::FailedTemporarily) {
+  if (_pTilesetContentManager->doesTileNeedLoading(tile)) {
 
     const glm::dvec3 boundingVolumeCenter =
         getBoundingVolumeCenter(tile.getBoundingVolume());

--- a/Cesium3DTilesSelection/src/TilesetContentLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetContentLoader.h
@@ -22,7 +22,6 @@ struct TileLoadResult {
   TileLoadResultState state;
   std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest;
   std::function<void(Tile&)> tileInitializer;
-  std::optional<CesiumGeospatial::Projection> tileProjection;
 };
 
 class TilesetContentLoader {

--- a/Cesium3DTilesSelection/src/TilesetContentLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetContentLoader.h
@@ -22,7 +22,6 @@ enum class TileLoadResultState { Success, Failed, RetryLater };
 
 struct TileLoadResult {
   TileContentKind contentKind;
-  std::optional<RasterOverlayDetails> overlayDetails;
   std::optional<BoundingVolume> updatedBoundingVolume;
   std::optional<BoundingVolume> updatedContentBoundingVolume;
   TileLoadResultState state;

--- a/Cesium3DTilesSelection/src/TilesetContentLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetContentLoader.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Cesium3DTilesSelection/BoundingVolume.h>
+#include <Cesium3DTilesSelection/RasterOverlayDetails.h>
 #include <Cesium3DTilesSelection/TileContent.h>
 #include <Cesium3DTilesSelection/TilesetOptions.h>
 #include <CesiumAsync/AsyncSystem.h>
@@ -10,6 +12,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace Cesium3DTilesSelection {
@@ -19,6 +22,9 @@ enum class TileLoadResultState { Success, Failed, RetryLater };
 
 struct TileLoadResult {
   TileContentKind contentKind;
+  std::optional<RasterOverlayDetails> overlayDetails;
+  std::optional<BoundingVolume> updatedBoundingVolume;
+  std::optional<BoundingVolume> updatedContentBoundingVolume;
   TileLoadResultState state;
   std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest;
   std::function<void(Tile&)> tileInitializer;

--- a/Cesium3DTilesSelection/src/TilesetContentLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetContentLoader.h
@@ -22,6 +22,7 @@ struct TileLoadResult {
   TileLoadResultState state;
   std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest;
   std::function<void(Tile&)> tileInitializer;
+  std::optional<CesiumGeospatial::Projection> tileProjection;
 };
 
 class TilesetContentLoader {

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -82,7 +82,7 @@ getTileBoundingRegionForUpsampling(const Tile& parent) {
   return std::nullopt;
 }
 
-void createQuadtreeSubdividedChildren(Tile& parent) {
+void createQuadtreeSubdividedChildren(Tile& parent, RasterOverlayUpsampler &upsampler) {
   std::optional<RegionAndCenter> maybeRegionAndCenter =
       getTileBoundingRegionForUpsampling(parent);
   if (!maybeRegionAndCenter) {
@@ -123,7 +123,7 @@ void createQuadtreeSubdividedChildren(Tile& parent) {
   std::vector<Tile> children;
   children.reserve(4);
   for (std::size_t i = 0; i < 4; ++i) {
-    children.emplace_back(parent.getContent().getLoader());
+    children.emplace_back(&upsampler);
   }
   parent.createChildTiles(std::move(children));
 
@@ -651,7 +651,7 @@ bool TilesetContentManager::unloadTileContent(Tile& tile) {
 
   // don't unload tile if any of its children are upsampled tile and
   // currently loading. Loader can safely capture the parent tile to upsample
-  // the current tile as the manager guarentee that the parent tile will be
+  // the current tile as the manager guarantee that the parent tile will be
   // alive
   for (const Tile& child : tile.getChildren()) {
     if (child.getState() == TileLoadState::ContentLoading &&
@@ -855,7 +855,7 @@ void TilesetContentManager::updateDoneState(
     // children to hang more detailed rasters on by subdividing this tile.
     if (!skippedUnknown && moreRasterDetailAvailable &&
         tile.getChildren().empty()) {
-      createQuadtreeSubdividedChildren(tile);
+      createQuadtreeSubdividedChildren(tile, _upsampler);
     }
   }
 }

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -718,6 +718,7 @@ bool TilesetContentManager::unloadTileContent(Tile& tile) {
   }
 
   tile.getMappedRasterTiles().clear();
+  content.setRasterOverlayDetails(RasterOverlayDetails{});
   content.setContentKind(TileUnknownContent{});
   content.setState(TileLoadState::Unloaded);
   return true;
@@ -834,7 +835,7 @@ void TilesetContentManager::updateDoneState(
   }
 
   // update raster overlay
-  const TileContent& content = tile.getContent();
+  TileContent& content = tile.getContent();
   const TileRenderContent* pRenderContent = content.getRenderContent();
   if (pRenderContent && pRenderContent->model) {
     bool moreRasterDetailAvailable = false;
@@ -901,6 +902,12 @@ void TilesetContentManager::updateDoneState(
         tile.getChildren().empty()) {
       createQuadtreeSubdividedChildren(tile, _upsampler);
     }
+  } else {
+    // We can't hang raster images on a tile without geometry, and their
+    // existence can prevent the tile from being deemed done loading. So clear
+    // them out here.
+    tile.getMappedRasterTiles().clear();
+    content.setRasterOverlayDetails(RasterOverlayDetails{});
   }
 }
 

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -295,6 +295,9 @@ void TilesetContentManager::setTileContent(
   content.setContentKind(std::move(result.contentKind));
   content.setTileInitializerCallback(std::move(result.tileInitializer));
   content.setRenderResources(pWorkerRenderResources);
+  if (result.tileProjection) {
+    content.setProjection(*result.tileProjection);
+  }
 }
 
 void TilesetContentManager::updateContentLoadedState(Tile& tile) {

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -82,7 +82,9 @@ getTileBoundingRegionForUpsampling(const Tile& parent) {
   return std::nullopt;
 }
 
-void createQuadtreeSubdividedChildren(Tile& parent, RasterOverlayUpsampler &upsampler) {
+void createQuadtreeSubdividedChildren(
+    Tile& parent,
+    RasterOverlayUpsampler& upsampler) {
   std::optional<RegionAndCenter> maybeRegionAndCenter =
       getTileBoundingRegionForUpsampling(parent);
   if (!maybeRegionAndCenter) {

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -554,7 +554,14 @@ void TilesetContentManager::loadTileContent(
       tilesetOptions.contentOptions,
       tile};
 
-  _pLoader
+  TilesetContentLoader* pLoader;
+  if (content.getLoader() == &_upsampler) {
+    pLoader = &_upsampler;
+  } else {
+    pLoader = _pLoader.get();
+  }
+
+  pLoader
       ->loadTileContent(
           tile,
           tilesetOptions.contentOptions,

--- a/Cesium3DTilesSelection/src/TilesetContentManager.h
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.h
@@ -44,6 +44,8 @@ private:
 
   void updateContentLoadedState(Tile& tile);
 
+  void updateDoneState(Tile& tile);
+
   void unloadContentLoadedState(Tile& tile);
 
   void unloadDoneState(Tile& tile);

--- a/Cesium3DTilesSelection/src/TilesetContentManager.h
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "RasterOverlayUpsampler.h"
 #include "TilesetContentLoader.h"
 
 #include <Cesium3DTilesSelection/RasterOverlayCollection.h>
@@ -63,6 +64,7 @@ private:
   TilesetExternals _externals;
   std::vector<CesiumAsync::IAssetAccessor::THeader> _requestHeaders;
   std::unique_ptr<TilesetContentLoader> _pLoader;
+  RasterOverlayUpsampler _upsampler;
   RasterOverlayCollection* _pOverlayCollection;
   int32_t _tilesLoadOnProgress;
   int64_t _tilesDataUsed;

--- a/Cesium3DTilesSelection/src/TilesetContentManager.h
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.h
@@ -38,6 +38,8 @@ public:
 
   int64_t getTotalDataUsed() const noexcept;
 
+  bool doesTileNeedLoading(const Tile& tile) const noexcept;
+
 private:
   static void setTileContent(
       Tile& tile,

--- a/Cesium3DTilesSelection/src/TilesetContentManager.h
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.h
@@ -20,9 +20,9 @@ public:
 
   ~TilesetContentManager() noexcept;
 
-  void loadTileContent(Tile& tile, const TilesetContentOptions& contentOptions);
+  void loadTileContent(Tile& tile, const TilesetOptions& tilesetOptions);
 
-  void updateTileContent(Tile& tile);
+  void updateTileContent(Tile& tile, const TilesetOptions& tilesetOptions);
 
   bool unloadTileContent(Tile& tile);
 
@@ -44,7 +44,7 @@ private:
 
   void updateContentLoadedState(Tile& tile);
 
-  void updateDoneState(Tile& tile);
+  void updateDoneState(Tile& tile, const TilesetOptions& tilesetOptions);
 
   void unloadContentLoadedState(Tile& tile);
 

--- a/Cesium3DTilesSelection/src/TilesetContentManager.h
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.h
@@ -2,6 +2,7 @@
 
 #include "TilesetContentLoader.h"
 
+#include <Cesium3DTilesSelection/RasterOverlayCollection.h>
 #include <Cesium3DTilesSelection/Tile.h>
 #include <Cesium3DTilesSelection/TileContent.h>
 #include <Cesium3DTilesSelection/TilesetExternals.h>
@@ -16,7 +17,8 @@ public:
   TilesetContentManager(
       const TilesetExternals& externals,
       std::vector<CesiumAsync::IAssetAccessor::THeader>&& requestHeaders,
-      std::unique_ptr<TilesetContentLoader> pLoader);
+      std::unique_ptr<TilesetContentLoader>&& pLoader,
+      RasterOverlayCollection& overlayCollection);
 
   ~TilesetContentManager() noexcept;
 
@@ -34,7 +36,7 @@ public:
 
   int32_t getNumOfTilesLoading() const noexcept;
 
-  int64_t getTilesDataUsed() const noexcept;
+  int64_t getTotalDataUsed() const noexcept;
 
 private:
   static void setTileContent(
@@ -59,6 +61,7 @@ private:
   TilesetExternals _externals;
   std::vector<CesiumAsync::IAssetAccessor::THeader> _requestHeaders;
   std::unique_ptr<TilesetContentLoader> _pLoader;
+  RasterOverlayCollection* _pOverlayCollection;
   int32_t _tilesLoadOnProgress;
   int64_t _tilesDataUsed;
 };

--- a/Cesium3DTilesSelection/src/TilesetContentManager.h
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.h
@@ -40,7 +40,7 @@ public:
 
 private:
   static void setTileContent(
-      TileContent& content,
+      Tile& tile,
       TileLoadResult&& result,
       void* pWorkerRenderResources);
 

--- a/Cesium3DTilesSelection/src/TilesetContentManager.h
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.h
@@ -45,6 +45,7 @@ private:
   static void setTileContent(
       Tile& tile,
       TileLoadResult&& result,
+      std::optional<RasterOverlayDetails>&& rasterOverlayDetails,
       void* pWorkerRenderResources);
 
   void updateContentLoadedState(Tile& tile);

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -683,7 +683,6 @@ TileLoadResult parseExternalTilesetInWorkerThread(
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        std::nullopt,
         TileLoadResultState::Failed,
         std::move(pCompletedRequest),
         {}};
@@ -696,7 +695,6 @@ TileLoadResult parseExternalTilesetInWorkerThread(
   // mark this tile has external content
   return TileLoadResult{
       TileExternalContent{},
-      std::nullopt,
       std::nullopt,
       std::nullopt,
       TileLoadResultState::Success,
@@ -773,7 +771,6 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        std::nullopt,
         TileLoadResultState::Failed,
         nullptr,
         {}});
@@ -805,7 +802,6 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
                   TileUnknownContent{},
                   std::nullopt,
                   std::nullopt,
-                  std::nullopt,
                   TileLoadResultState::Failed,
                   std::move(pCompletedRequest),
                   {}};
@@ -820,7 +816,6 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
                   tileUrl);
               return TileLoadResult{
                   TileUnknownContent{},
-                  std::nullopt,
                   std::nullopt,
                   std::nullopt,
                   TileLoadResultState::Failed,
@@ -849,7 +844,6 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
                     TileRenderContent{std::nullopt},
                     std::nullopt,
                     std::nullopt,
-                    std::nullopt,
                     TileLoadResultState::Failed,
                     std::move(pCompletedRequest),
                     {}};
@@ -857,7 +851,6 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
 
               return TileLoadResult{
                   TileRenderContent{std::move(result.model)},
-                  std::nullopt,
                   std::nullopt,
                   std::nullopt,
                   TileLoadResultState::Success,

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -677,8 +677,7 @@ TileLoadResult parseExternalTilesetInWorkerThread(
         TileUnknownContent{},
         TileLoadResultState::Failed,
         std::move(pCompletedRequest),
-        {},
-        std::nullopt};
+        {}};
   }
 
   externalContentInitializer.pExternalTilesetLoaders =
@@ -690,8 +689,7 @@ TileLoadResult parseExternalTilesetInWorkerThread(
       TileExternalContent{},
       TileLoadResultState::Success,
       std::move(pCompletedRequest),
-      std::move(externalContentInitializer),
-      std::nullopt};
+      std::move(externalContentInitializer)};
 }
 } // namespace
 
@@ -762,8 +760,7 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
         TileUnknownContent{},
         TileLoadResultState::Failed,
         nullptr,
-        {},
-        std::nullopt});
+        {}});
   }
 
   const glm::dmat4& tileTransform = tile.getTransform();
@@ -790,8 +787,7 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
                   TileUnknownContent{},
                   TileLoadResultState::Failed,
                   std::move(pCompletedRequest),
-                  {},
-                  std::nullopt};
+                  {}};
             }
 
             uint16_t statusCode = pResponse->statusCode();
@@ -805,8 +801,7 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
                   TileUnknownContent{},
                   TileLoadResultState::Failed,
                   std::move(pCompletedRequest),
-                  {},
-                  std::nullopt};
+                  {}};
             }
 
             // find gltf converter
@@ -830,16 +825,14 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
                     TileRenderContent{std::nullopt},
                     TileLoadResultState::Failed,
                     std::move(pCompletedRequest),
-                    {},
-                    std::nullopt};
+                    {}};
               }
 
               return TileLoadResult{
                   TileRenderContent{std::move(result.model)},
                   TileLoadResultState::Success,
                   std::move(pCompletedRequest),
-                  {},
-                  std::nullopt};
+                  {}};
             } else {
               // not a renderable content, then it must be external tileset
               return parseExternalTilesetInWorkerThread(

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -677,7 +677,8 @@ TileLoadResult parseExternalTilesetInWorkerThread(
         TileUnknownContent{},
         TileLoadResultState::Failed,
         std::move(pCompletedRequest),
-        {}};
+        {},
+        std::nullopt};
   }
 
   externalContentInitializer.pExternalTilesetLoaders =
@@ -689,7 +690,8 @@ TileLoadResult parseExternalTilesetInWorkerThread(
       TileExternalContent{},
       TileLoadResultState::Success,
       std::move(pCompletedRequest),
-      std::move(externalContentInitializer)};
+      std::move(externalContentInitializer),
+      std::nullopt};
 }
 } // namespace
 
@@ -760,7 +762,8 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
         TileUnknownContent{},
         TileLoadResultState::Failed,
         0,
-        {}});
+        {},
+        std::nullopt});
   }
 
   const glm::dmat4& tileTransform = tile.getTransform();
@@ -787,7 +790,8 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
                   TileUnknownContent{},
                   TileLoadResultState::Failed,
                   std::move(pCompletedRequest),
-                  {}};
+                  {},
+                  std::nullopt};
             }
 
             uint16_t statusCode = pResponse->statusCode();
@@ -801,7 +805,8 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
                   TileUnknownContent{},
                   TileLoadResultState::Failed,
                   std::move(pCompletedRequest),
-                  {}};
+                  {},
+                  std::nullopt};
             }
 
             // find gltf converter
@@ -825,14 +830,16 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
                     TileRenderContent{std::nullopt},
                     TileLoadResultState::Failed,
                     std::move(pCompletedRequest),
-                    {}};
+                    {},
+                    std::nullopt};
               }
 
               return TileLoadResult{
                   TileRenderContent{std::move(result.model)},
                   TileLoadResultState::Success,
                   std::move(pCompletedRequest),
-                  {}};
+                  {},
+                  std::nullopt};
             } else {
               // not a renderable content, then it must be external tileset
               return parseExternalTilesetInWorkerThread(

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -675,6 +675,9 @@ TileLoadResult parseExternalTilesetInWorkerThread(
     // since the json cannot be parsed, we don't know the content of this tile
     return TileLoadResult{
         TileUnknownContent{},
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
         TileLoadResultState::Failed,
         std::move(pCompletedRequest),
         {}};
@@ -687,6 +690,9 @@ TileLoadResult parseExternalTilesetInWorkerThread(
   // mark this tile has external content
   return TileLoadResult{
       TileExternalContent{},
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
       TileLoadResultState::Success,
       std::move(pCompletedRequest),
       std::move(externalContentInitializer)};
@@ -758,6 +764,9 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
   if (!url) {
     return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
         TileUnknownContent{},
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
         TileLoadResultState::Failed,
         nullptr,
         {}});
@@ -785,6 +794,9 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
                   tileUrl);
               return TileLoadResult{
                   TileUnknownContent{},
+                  std::nullopt,
+                  std::nullopt,
+                  std::nullopt,
                   TileLoadResultState::Failed,
                   std::move(pCompletedRequest),
                   {}};
@@ -799,6 +811,9 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
                   tileUrl);
               return TileLoadResult{
                   TileUnknownContent{},
+                  std::nullopt,
+                  std::nullopt,
+                  std::nullopt,
                   TileLoadResultState::Failed,
                   std::move(pCompletedRequest),
                   {}};
@@ -823,6 +838,9 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
               if (result.errors) {
                 return TileLoadResult{
                     TileRenderContent{std::nullopt},
+                    std::nullopt,
+                    std::nullopt,
+                    std::nullopt,
                     TileLoadResultState::Failed,
                     std::move(pCompletedRequest),
                     {}};
@@ -830,6 +848,9 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
 
               return TileLoadResult{
                   TileRenderContent{std::move(result.model)},
+                  std::nullopt,
+                  std::nullopt,
+                  std::nullopt,
                   TileLoadResultState::Success,
                   std::move(pCompletedRequest),
                   {}};


### PR DESCRIPTION
This PR adds back raster overlay code to the refactored loader:

- Since Tile no longer stores the tileset, `IPrepareRendererResources` is passed to `MappedRasterToTile` directly to create render resources for raster
- In the main branch, upsampling code is used to handle both quantized mesh and raster overlay. In this branch, if the loader produced upsampled tile ID, it will be responsible for upsampling that tile. So in this case, layerjson will handle upsampling its own tile, and there is a RasterOverlayUpsampler which will handle the upsampling for raster overlay tiles
- TilesetContentManager will check if a tile has an upsampled tile ID or not. If it's an upsampled tile, it will check if the parent is loaded before loading this tile. This condition is for any generic loaders where it's required to upsample tiles (e.g voxel loader may requires upsampling), and not just for raster overlay upsampler, or quantized mesh. 
- `TileLoadResult` will have updated bounding volumes field as this information is needed to calculate Raster Overlay UVs