### PR TITLE
Dynamically increase SSE based on memory limit

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/DynamicSSE.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/DynamicSSE.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "Cesium3DTilesSelection/ViewState.h"
+#include "Cesium3DTilesSelection/ViewUpdateResult.h"
+
+namespace Cesium3DTilesSelection {
+class DynamicSSE {
+public:
+  void updateScale(bool overLimit, const ViewState& frustum);
+  float getScale() const;
+
+private:
+  uint32_t _numFramesConsecutiveNoChange;
+  const uint32_t _maxNumFramesConsecutiveNoChange = 4;
+
+  glm::dvec3 _lastDirection;
+  glm::dvec3 _lastPosition;
+
+  float scale = 1.0f;
+};
+} // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "DynamicSSE.h"
 #include "ImplicitTraversal.h"
 #include "Library.h"
 #include "RasterOverlayCollection.h"
@@ -590,6 +591,8 @@ private:
   // selection.
   std::vector<std::unique_ptr<std::vector<double>>> _distancesStack;
   size_t _nextDistancesVector;
+
+  DynamicSSE _scaler;
 
   CESIUM_TRACE_DECLARE_TRACK_SET(_loadingSlots, "Tileset Loading Slot");
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetOptions.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetOptions.h
@@ -180,6 +180,8 @@ struct CESIUM3DTILESSELECTION_API TilesetOptions {
    */
   int64_t maximumCachedBytes = 512 * 1024 * 1024;
 
+  int64_t maximumBytes = std::numeric_limits<int64_t>::max();
+
   /**
    * @brief A table that maps the camera height above the ellipsoid to a fog
    * density. Tiles that are in full fog are culled. The density of the fog

--- a/Cesium3DTilesSelection/src/DynamicSSE.cpp
+++ b/Cesium3DTilesSelection/src/DynamicSSE.cpp
@@ -1,0 +1,18 @@
+#include "Cesium3DTilesSelection/DynamicSSE.h"
+
+void Cesium3DTilesSelection::DynamicSSE::updateScale(
+    bool overLimit,
+    const ViewState& frustum) {
+  if (_lastPosition != frustum.getPosition() &&
+      _lastDirection != frustum.getDirection()) {
+    _lastPosition = frustum.getPosition();
+    _lastDirection = frustum.getDirection();
+    scale = 1.0f;
+  } else if (
+      ++_numFramesConsecutiveNoChange > _maxNumFramesConsecutiveNoChange &&
+      overLimit) {
+    scale += .1f;
+  }
+}
+
+float Cesium3DTilesSelection::DynamicSSE::getScale() const { return scale; }

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -329,6 +329,10 @@ Tileset::updateView(const std::vector<ViewState>& frustums) {
 
   this->_previousFrameNumber = currentFrameNumber;
 
+  this->_scaler.updateScale(
+      this->_tileDataBytes > this->getOptions().maximumBytes,
+      frustums[0]);
+
   return result;
 }
 
@@ -878,7 +882,8 @@ bool Tileset::_meetsSse(
 
   return culled ? !this->_options.enforceCulledScreenSpaceError ||
                       largestSse < this->_options.culledScreenSpaceError
-                : largestSse < this->_options.maximumScreenSpaceError;
+                : largestSse < this->_options.maximumScreenSpaceError *
+                                   this->_scaler.getScale();
 }
 
 /**

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -1546,6 +1546,8 @@ void Tileset::processQueue(
     uint32_t maximumLoadsInProgress) {
   if (loadsInProgress >= maximumLoadsInProgress) {
     return;
+  } else if (this->_tileDataBytes > this->getOptions().maximumBytes) {
+    return;
   }
 
   std::sort(queue.begin(), queue.end());


### PR DESCRIPTION
Devices that have very little RAM, such as mobile devices, will quickly run out of memory when displaying Melbourne photogrammetry, for instance. The following graph shows the memory use for Melbourne in Cesium Native. The Y axis is the number of megabytes, and the X axis is the number of frames:
![no-limit](https://user-images.githubusercontent.com/97980867/176549134-0039d5f3-1541-4577-84e1-09f21c9af819.png)

For the iPhone, the program will exit when this memory exceeds around 400 megabytes. Preventing cesium-native to continue loading after its reached the limit will keep it from crashing. However, by pausing loading, large portions of the tileset may be missing.

So the idea here is to increase the screen space error until all the tiles for that SSE can be loaded.

![sse-over-time](https://user-images.githubusercontent.com/97980867/176549137-e4bbfe6b-36e3-4157-9b4b-3a8ac8f2436b.png)

This graph shows the SSE changing over time.

With these changes, the memory usage stays within reasonable limits:
![using-limit](https://user-images.githubusercontent.com/97980867/176549140-5cc95eab-6f66-44a6-8102-3d23244f445c.png)

Currently, the SSE will start increasing when there is no camera movement for a couple of frames and is consistently over the limit. When in motion, it reverts back to the original SSE. 
