### PR TITLE
Add credit back to the refactored code

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/GltfUtilities.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/GltfUtilities.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <Cesium3DTilesSelection/CreditSystem.h>
 #include <Cesium3DTilesSelection/RasterOverlayDetails.h>
 #include <CesiumGeospatial/BoundingRegion.h>
 #include <CesiumGeospatial/GlobeRectangle.h>
 #include <CesiumGltf/Model.h>
 
 #include <glm/glm.hpp>
+
+#include <vector>
 
 namespace Cesium3DTilesSelection {
 struct GltfUtilities {
@@ -28,5 +31,10 @@ struct GltfUtilities {
   static CesiumGeospatial::BoundingRegion computeBoundingRegion(
       const CesiumGltf::Model& gltf,
       const glm::dmat4& transform);
+
+  static std::vector<Credit> parseGltfCopyright(
+      CreditSystem& creditSystems,
+      const CesiumGltf::Model& gltf,
+      bool showOnScreen);
 };
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Cesium3DTilesSelection/CreditSystem.h>
 #include <Cesium3DTilesSelection/RasterOverlayDetails.h>
 #include <CesiumGeospatial/Projection.h>
 #include <CesiumGltf/Model.h>
@@ -69,6 +70,10 @@ public:
 
   RasterOverlayDetails& getRasterOverlayDetails() noexcept;
 
+  const std::vector<Credit>& getCredits() const noexcept;
+
+  std::vector<Credit>& getCredits() noexcept;
+
   TilesetContentLoader* getLoader() noexcept;
 
   void* getRenderResources() const noexcept;
@@ -94,13 +99,16 @@ private:
   void
   setContentShouldContinueUpdated(bool shouldContentContinueUpdated) noexcept;
 
+  void setCredits(std::vector<Credit>&& credits);
+
   TileLoadState _state;
   TileContentKind _contentKind;
   void* _pRenderResources;
   RasterOverlayDetails _rasterOverlayDetails;
   std::function<void(Tile&)> _tileInitializer;
-  TilesetContentLoader* _pLoader;
   bool _shouldContentContinueUpdated;
+  std::vector<Credit> _credits;
+  TilesetContentLoader* _pLoader;
 
   friend class TilesetContentManager;
 };

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -24,6 +24,7 @@
 
 namespace Cesium3DTilesSelection {
 class TilesetContentManager;
+struct TilesetContentLoaderResult;
 
 /**
  * @brief A <a
@@ -348,6 +349,9 @@ private:
   void _processLoadQueue();
   void _unloadCachedTiles() noexcept;
   void _markTileVisited(Tile& tile) noexcept;
+
+  void
+  _propagateTilesetContentLoaderResult(TilesetContentLoaderResult&& result);
 
   TilesetExternals _externals;
   CesiumAsync::AsyncSystem _asyncSystem;

--- a/Cesium3DTilesSelection/src/GltfUtilities.cpp
+++ b/Cesium3DTilesSelection/src/GltfUtilities.cpp
@@ -384,4 +384,31 @@ GltfUtilities::computeBoundingRegion(
 
   return computedBounds.toRegion();
 }
+
+std::vector<Credit> GltfUtilities::parseGltfCopyright(
+    CreditSystem& creditSystem,
+    const CesiumGltf::Model& gltf,
+    bool showOnScreen) {
+  std::vector<Credit> result;
+  if (gltf.asset.copyright) {
+    const std::string& copyright = *gltf.asset.copyright;
+    if (copyright.size() > 0) {
+      size_t start = 0;
+      size_t end;
+      size_t ltrim;
+      size_t rtrim;
+      do {
+        ltrim = copyright.find_first_not_of(" \t", start);
+        end = copyright.find(';', ltrim);
+        rtrim = copyright.find_last_not_of(" \t", end - 1);
+        result.push_back(creditSystem.createCredit(
+            copyright.substr(ltrim, rtrim - ltrim + 1),
+            showOnScreen));
+        start = end + 1;
+      } while (end != std::string::npos);
+    }
+  }
+
+  return result;
+}
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
@@ -473,7 +473,7 @@ LayerJsonTerrainLoader::createLoader(
         // add credits
         std::vector<LoaderCreditResult> credits;
         credits.reserve(loadLayersResult.layerCredits.size());
-        for (auto &credit : loadLayersResult.layerCredits) {
+        for (auto& credit : loadLayersResult.layerCredits) {
           credits.emplace_back(LoaderCreditResult{std::move(credit), true});
         }
 

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
@@ -41,9 +41,7 @@ public:
         std::vector<std::string>&& tileTemplateUrls,
         CesiumGeometry::QuadtreeRectangleAvailability&& contentAvailability,
         uint32_t maxZooms,
-        int32_t availabilityLevels,
-        std::string&& creditString,
-        std::optional<Credit> credit);
+        int32_t availabilityLevels);
 
     std::string baseUrl;
     std::string version;
@@ -51,8 +49,6 @@ public:
     CesiumGeometry::QuadtreeRectangleAvailability contentAvailability;
     std::vector<std::unordered_set<uint64_t>> loadedSubtrees;
     int32_t availabilityLevels;
-    std::string creditString;
-    std::optional<Credit> credit;
   };
 
   LayerJsonTerrainLoader(

--- a/Cesium3DTilesSelection/src/TileContent.cpp
+++ b/Cesium3DTilesSelection/src/TileContent.cpp
@@ -7,8 +7,8 @@ TileContent::TileContent(TilesetContentLoader* pLoader)
       _pRenderResources{nullptr},
       _rasterOverlayDetails{},
       _tileInitializer{},
-      _pLoader{pLoader},
-      _shouldContentContinueUpdated{true} {}
+      _shouldContentContinueUpdated{true},
+      _pLoader{pLoader} {}
 
 TileContent::TileContent(
     TilesetContentLoader* pLoader,
@@ -18,8 +18,8 @@ TileContent::TileContent(
       _pRenderResources{nullptr},
       _rasterOverlayDetails{},
       _tileInitializer{},
-      _pLoader{pLoader},
-      _shouldContentContinueUpdated{true} {}
+      _shouldContentContinueUpdated{true},
+      _pLoader{pLoader} {}
 
 TileContent::TileContent(
     TilesetContentLoader* pLoader,
@@ -29,8 +29,8 @@ TileContent::TileContent(
       _pRenderResources{nullptr},
       _rasterOverlayDetails{},
       _tileInitializer{},
-      _pLoader{pLoader},
-      _shouldContentContinueUpdated{true} {}
+      _shouldContentContinueUpdated{true},
+      _pLoader{pLoader} {}
 
 TileLoadState TileContent::getState() const noexcept { return _state; }
 
@@ -75,6 +75,12 @@ RasterOverlayDetails& TileContent::getRasterOverlayDetails() noexcept {
   return _rasterOverlayDetails;
 }
 
+const std::vector<Credit>& TileContent::getCredits() const noexcept {
+  return _credits;
+}
+
+std::vector<Credit>& TileContent::getCredits() noexcept { return _credits; }
+
 TilesetContentLoader* TileContent::getLoader() noexcept { return _pLoader; }
 
 void TileContent::setContentKind(TileContentKind&& contentKind) {
@@ -113,6 +119,10 @@ std::function<void(Tile&)>& TileContent::getTileInitializerCallback() {
 void TileContent::setContentShouldContinueUpdated(
     bool shouldContentContinueUpdated) noexcept {
   _shouldContentContinueUpdated = shouldContentContinueUpdated;
+}
+
+void TileContent::setCredits(std::vector<Credit>&& credits) {
+  _credits = std::move(credits);
 }
 
 void* TileContent::getRenderResources() const noexcept {

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -282,6 +282,7 @@ Tileset::updateView(const std::vector<ViewState>& frustums) {
     for (Tile* pTile : result.tilesToRenderThisFrame) {
       const std::vector<RasterMappedTo3DTile>& mappedRasterTiles =
           pTile->getMappedRasterTiles();
+      // raster overlay tile credits
       for (const RasterMappedTo3DTile& mappedRasterTile : mappedRasterTiles) {
         const RasterOverlayTile* pRasterOverlayTile =
             mappedRasterTile.getReadyTile();
@@ -290,6 +291,11 @@ Tileset::updateView(const std::vector<ViewState>& frustums) {
             pCreditSystem->addCreditToFrame(credit);
           }
         }
+      }
+
+      // content credits like gltf copyrights
+      for (const Credit& credit : pTile->getContent().getCredits()) {
+        pCreditSystem->addCreditToFrame(credit);
       }
     }
   }

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -279,6 +279,19 @@ Tileset::updateView(const std::vector<ViewState>& frustums) {
     }
 
     // per-tile credits
+    for (Tile* pTile : result.tilesToRenderThisFrame) {
+      const std::vector<RasterMappedTo3DTile>& mappedRasterTiles =
+          pTile->getMappedRasterTiles();
+      for (const RasterMappedTo3DTile& mappedRasterTile : mappedRasterTiles) {
+        const RasterOverlayTile* pRasterOverlayTile =
+            mappedRasterTile.getReadyTile();
+        if (pRasterOverlayTile != nullptr) {
+          for (const Credit& credit : pRasterOverlayTile->getCredits()) {
+            pCreditSystem->addCreditToFrame(credit);
+          }
+        }
+      }
+    }
   }
 
   this->_previousFrameNumber = currentFrameNumber;
@@ -1099,7 +1112,6 @@ void Tileset::_propagateTilesetContentLoaderResult(
         std::move(result.requestHeaders),
         std::move(result.pLoader),
         this->getOverlays());
-
   }
 }
 

--- a/Cesium3DTilesSelection/src/TilesetContentManager.h
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.h
@@ -48,7 +48,8 @@ private:
       std::optional<RasterOverlayDetails>&& rasterOverlayDetails,
       void* pWorkerRenderResources);
 
-  void updateContentLoadedState(Tile& tile);
+  void
+  updateContentLoadedState(Tile& tile, const TilesetOptions& tilesetOptions);
 
   void updateDoneState(Tile& tile, const TilesetOptions& tilesetOptions);
 


### PR DESCRIPTION
This PR adds the credit code back to the refactored loader. It should handle:
- credit for Raster Overlay
- credit for Tileset and Quantized Mesh Layers
- credit for gltf
- credit for each raster overlay tiles