### PR TITLE
Remove explicit initPool step.

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileOcclusionRendererProxy.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileOcclusionRendererProxy.h
@@ -79,15 +79,9 @@ private:
  */
 class CESIUM3DTILESSELECTION_API TileOcclusionRendererProxyPool {
 public:
-  virtual ~TileOcclusionRendererProxyPool();
+  TileOcclusionRendererProxyPool(int32_t maximumPoolSize);
 
-  /**
-   * @brief Initialize a pool of {@link TileOcclusionRendererProxy}s of the
-   * given size.
-   *
-   * @param poolSize The pool size.
-   */
-  void initPool(uint32_t poolSize);
+  virtual ~TileOcclusionRendererProxyPool();
 
   /**
    * @brief Destroy the pool.
@@ -132,7 +126,9 @@ protected:
 
 private:
   // Singly linked list representing the free proxies in the pool
-  TileOcclusionRendererProxy* _pFreeProxiesHead = nullptr;
+  TileOcclusionRendererProxy* _pFreeProxiesHead;
+  int32_t _currentSize;
+  int32_t _maxSize;
   // The currently used proxies in the pool
   std::unordered_map<const Tile*, TileOcclusionRendererProxy*>
       _tileToOcclusionProxyMappings;

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -70,10 +70,6 @@ Tileset::Tileset(
   if (!url.empty()) {
     CESIUM_TRACE_USE_TRACK_SET(this->_loadingSlots);
     this->notifyTileStartLoading(nullptr);
-    if (this->_externals.pTileOcclusionProxyPool) {
-      this->_externals.pTileOcclusionProxyPool->initPool(
-          options.occlusionPoolSize);
-    }
     LoadTilesetDotJson::start(*this, url).thenInMainThread([this]() {
       this->notifyTileDoneLoading(nullptr);
     });
@@ -112,10 +108,6 @@ Tileset::Tileset(
   if (ionAssetID > 0) {
     CESIUM_TRACE_USE_TRACK_SET(this->_loadingSlots);
     this->notifyTileStartLoading(nullptr);
-    if (this->_externals.pTileOcclusionProxyPool) {
-      this->_externals.pTileOcclusionProxyPool->initPool(
-          options.occlusionPoolSize);
-    }
     LoadIonAssetEndpoint::start(*this).thenInMainThread(
         [this]() { this->notifyTileDoneLoading(nullptr); });
   }


### PR DESCRIPTION
@nithinp7 this is a PR into #492 showing what I had in mind for removing `initPool`. The base-class, cesium-native code still manages the pool, but the items in the pool are only created when they're needed (rather than all up front) and the derived class controls the total pool size.