### PR TITLE
Fix array of string parsing in JsonObjectJsonHandler

### DIFF
--- a/CesiumJsonReader/src/JsonObjectJsonHandler.cpp
+++ b/CesiumJsonReader/src/JsonObjectJsonHandler.cpp
@@ -62,7 +62,15 @@ IJsonHandler* JsonObjectJsonHandler::readDouble(double d) {
 }
 
 IJsonHandler* JsonObjectJsonHandler::readString(const std::string_view& str) {
-  *this->_stack.back() = std::string(str);
+  CesiumUtility::JsonValue& current = *this->_stack.back();
+  CesiumUtility::JsonValue::Array* pArray =
+      std::get_if<CesiumUtility::JsonValue::Array>(&current.value);
+  if (pArray) {
+    pArray->emplace_back(std::string(str));
+  } else {
+    current = std::string(str);
+  }
+
   return this->doneElement();
 }
 


### PR DESCRIPTION
Example tileset.json snippet that was failing:

```json
{
  "asset": {
    "version": "1.0"
  },
  "extensions": {
    "3DTILES_metadata": {
      "tileset": {
        "properties": {
          "propertyA": "stuff",
          "propertyB": ["a", "b", "c"], // crashes here
          "propertyC": [0, 1, 2, 3]
        }
      }
    }
  }
}
```