### PR TITLE
Add API call for current tileset load progress

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -193,7 +193,7 @@ public:
    */
   void notifyTileUnloading(Tile* pTile) noexcept;
 
-  const uint32_t computeLoadProgress() noexcept;
+  uint32_t computeLoadProgress() noexcept;
 
   /**
    * @brief Loads a tile tree from a tileset.json file.

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -193,6 +193,8 @@ public:
    */
   void notifyTileUnloading(Tile* pTile) noexcept;
 
+  bool getLoadingStatus();
+
   /**
    * @brief Loads a tile tree from a tileset.json file.
    *

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -193,7 +193,7 @@ public:
    */
   void notifyTileUnloading(Tile* pTile) noexcept;
 
-  const size_t getTilesetLoadingStatus() noexcept;
+  const uint32_t computeLoadProgress() noexcept;
 
   /**
    * @brief Loads a tile tree from a tileset.json file.
@@ -588,6 +588,7 @@ private:
       _subtreeLoadsInProgress; // TODO: does this need to be atomic?
 
   Tile::LoadedLinkedList _loadedTiles;
+  std::atomic<uint32_t> _loadedTilesCount;
 
   RasterOverlayCollection _overlays;
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -153,6 +153,7 @@ public:
     return this->_overlays;
   }
 
+
   /**
    * @brief Updates this view but waits for all tiles that meet sse to finish
    * loading and ready to be rendered before returning the function. This method
@@ -193,7 +194,7 @@ public:
    */
   void notifyTileUnloading(Tile* pTile) noexcept;
 
-  bool getLoadingStatus();
+  const uint32_t getTilesetLoadingStatus() noexcept;
 
   /**
    * @brief Loads a tile tree from a tileset.json file.

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -153,7 +153,6 @@ public:
     return this->_overlays;
   }
 
-
   /**
    * @brief Updates this view but waits for all tiles that meet sse to finish
    * loading and ready to be rendered before returning the function. This method
@@ -194,7 +193,7 @@ public:
    */
   void notifyTileUnloading(Tile* pTile) noexcept;
 
-  const uint32_t getTilesetLoadingStatus() noexcept;
+  const size_t getTilesetLoadingStatus() noexcept;
 
   /**
    * @brief Loads a tile tree from a tileset.json file.

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -378,10 +378,11 @@ const uint32_t Tileset::computeLoadProgress() noexcept {
   const uint32_t queueSizeSum = (uint32_t)(this->_loadQueueLow.size() +
                                 this->_loadQueueMedium.size() +
                                 this->_loadQueueHigh.size());
-  // we ignore _subtreeLoadsInProgress for now 
+  // we ignore _subtreeLoadsInProgress for now
   const uint32_t inProgressSum = (this->_loadsInProgress + queueSizeSum);
   const uint32_t totalNum = this->_loadedTilesCount + inProgressSum;
-  const float_t percentage = static_cast<float>(this->_loadedTilesCount) / totalNum;
+  const float_t percentage =
+      static_cast<float>(this->_loadedTilesCount) / totalNum;
   return (uint32_t)(percentage * 100);
 }
 

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -372,6 +372,12 @@ void Tileset::notifyTileUnloading(Tile* pTile) noexcept {
   }
 }
 
+const uint32_t Tileset::getTilesetLoadingStatus() noexcept { 
+  // bool loaded = this->_loadsInProgress == 0 && this->_subtreeLoadsInProgress > 0;
+  const uint32_t isLoading = this->_loadsInProgress + this->_subtreeLoadsInProgress;
+  return isLoading;
+}
+
 void Tileset::loadTilesFromJson(
     Tile& rootTile,
     std::vector<std::unique_ptr<TileContext>>& newContexts,
@@ -390,10 +396,6 @@ void Tileset::loadTilesFromJson(
       pLogger);
 }
 
-bool Tileset::getLoadingStatus() { 
-  bool loaded = this->_loadsInProgress > 0 && this->_subtreeLoadsInProgress > 0;
-  return loaded;
-}
 
 CesiumAsync::Future<std::shared_ptr<CesiumAsync::IAssetRequest>>
 Tileset::requestTileContent(Tile& tile) {

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -374,15 +374,15 @@ void Tileset::notifyTileUnloading(Tile* pTile) noexcept {
   }
 }
 
-const uint32_t Tileset::computeLoadProgress() noexcept {
-  const uint32_t queueSizeSum = (uint32_t)(this->_loadQueueLow.size() +
+uint32_t Tileset::computeLoadProgress() noexcept {
+  uint32_t queueSizeSum = (uint32_t)(this->_loadQueueLow.size() +
                                 this->_loadQueueMedium.size() +
                                 this->_loadQueueHigh.size());
   // we ignore _subtreeLoadsInProgress for now
-  const uint32_t inProgressSum = (this->_loadsInProgress + queueSizeSum);
-  const uint32_t totalNum = this->_loadedTilesCount + inProgressSum;
-  const float_t percentage =
-      static_cast<float>(this->_loadedTilesCount) / totalNum;
+  uint32_t inProgressSum = (this->_loadsInProgress + queueSizeSum);
+  uint32_t totalNum = this->_loadedTilesCount + inProgressSum;
+  float_t percentage = static_cast<float>(this->_loadedTilesCount) /
+                       static_cast<float>(totalNum);
   return (uint32_t)(percentage * 100);
 }
 

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -390,6 +390,11 @@ void Tileset::loadTilesFromJson(
       pLogger);
 }
 
+bool Tileset::getLoadingStatus() { 
+  bool loaded = this->_loadsInProgress > 0 && this->_subtreeLoadsInProgress > 0;
+  return loaded;
+}
+
 CesiumAsync::Future<std::shared_ptr<CesiumAsync::IAssetRequest>>
 Tileset::requestTileContent(Tile& tile) {
   std::string url =

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -372,10 +372,12 @@ void Tileset::notifyTileUnloading(Tile* pTile) noexcept {
   }
 }
 
-const uint32_t Tileset::getTilesetLoadingStatus() noexcept { 
-  // bool loaded = this->_loadsInProgress == 0 && this->_subtreeLoadsInProgress > 0;
-  const uint32_t isLoading = this->_loadsInProgress + this->_subtreeLoadsInProgress;
-  return isLoading;
+const size_t Tileset::getTilesetLoadingStatus() noexcept {
+  const size_t queueSizeSum = this->_loadQueueLow.size() +
+                                this->_loadQueueMedium.size() +
+                                this->_loadQueueHigh.size();
+  const size_t inProgressSum = (size_t)(this->_loadsInProgress + this->_subtreeLoadsInProgress);
+  return queueSizeSum + inProgressSum;
 }
 
 void Tileset::loadTilesFromJson(
@@ -395,7 +397,6 @@ void Tileset::loadTilesFromJson(
       context,
       pLogger);
 }
-
 
 CesiumAsync::Future<std::shared_ptr<CesiumAsync::IAssetRequest>>
 Tileset::requestTileContent(Tile& tile) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium-native",
-  "version": "0.13.0",
+  "version": "0.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
- This PR contains adding a new API `computeLoadProgress` to the `Tileset` class.
- We added a counter keeping track of the current number of loaded tiles in the tileset to avoid counting the doubly linked list of loaded tiles every frame. 
- The load progress computation currently takes into account the three loading queues (`low`, `medium`, `high`), current `loadsInProgress`.