### PR TITLE
Tms update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Change Log
 
+### ? - ? 
+
 ### v0.18.0 - 2022-08-01
+
+##### Fixes :wrench:
+- Support the "local" profile for TMS that when it uses geographic or mercator SRS.
+- Enable loading TMS URLs that do not have a "xmlresource.xml" file, such as from GeoServer.
 
 ##### Breaking Changes :mega:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,8 @@
 ### v0.18.0 - 2022-08-01
 
 ##### Fixes :wrench:
-- Support the "local" profile for TMS that when it uses geographic or mercator SRS.
-- Enable loading TMS URLs that do not have a "xmlresource.xml" file, such as from GeoServer.
+- Support the "local" profile when the SRS is mercator or geodetic.
+- Enable loading TMS URLs that do not have an "xmlresource.xml" file, such as from GeoServer.
 
 ##### Breaking Changes :mega:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,8 @@
 ### v0.18.0 - 2022-08-01
 
 ##### Fixes :wrench:
-- Support the "local" profile when the SRS is mercator or geodetic.
-- Enable loading TMS URLs that do not have an "xmlresource.xml" file, such as from GeoServer.
+- Enable loading Tile Map Service (TMS) URLs that do not have a file named "tilemapresource.xml", such as from GeoServer.
+- Add support for Tile Map Service documents that use the "local" profile when the SRS is mercator or geodetic.
 
 ##### Breaking Changes :mega:
 

--- a/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
@@ -144,8 +144,9 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
                   options.moreDetailAvailable};
             }
 
-            if (pResponse->statusCode() != 0 && pResponse->statusCode() < 200 ||
-                pResponse->statusCode() >= 300) {
+            if (pResponse->statusCode() != 0 &&
+                (pResponse->statusCode() < 200 ||
+                 pResponse->statusCode() >= 300)) {
               std::string message = "Image response code " +
                                     std::to_string(pResponse->statusCode()) +
                                     " for " + pRequest->url();

--- a/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
@@ -144,7 +144,7 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
                   options.moreDetailAvailable};
             }
 
-            if (pResponse->statusCode() < 200 ||
+            if (pResponse->statusCode() != 0 && pResponse->statusCode() < 200 ||
                 pResponse->statusCode() >= 300) {
               std::string message = "Image response code " +
                                     std::to_string(pResponse->statusCode()) +

--- a/Cesium3DTilesSelection/src/TileMapServiceRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/TileMapServiceRasterOverlay.cpp
@@ -221,6 +221,9 @@ TileMapServiceRasterOverlay::createTileProvider(
     const std::shared_ptr<spdlog::logger>& pLogger,
     RasterOverlay* pOwner) {
   std::string xmlUrl = this->_url;
+  if (xmlUrl[xmlUrl.size() - 1] != '/') {
+    xmlUrl += "/";
+  }
 
   pOwner = pOwner ? pOwner : this;
 
@@ -242,7 +245,6 @@ TileMapServiceRasterOverlay::createTileProvider(
             pRequest,
             message});
   };
-  std::string errorMessage;
   return getXmlDocument(
              asyncSystem,
              pAssetAccessor,
@@ -347,12 +349,7 @@ TileMapServiceRasterOverlay::createTileProvider(
                 tinyxml2::XMLElement* srs = pRoot->FirstChildElement("SRS");
                 if (srs) {
                   std::string srsText = srs->GetText();
-                  if (srsText.find("3857") != std::string::npos) {
-                    projection = CesiumGeospatial::WebMercatorProjection();
-                    tilingSchemeRectangle = CesiumGeospatial::
-                        WebMercatorProjection::MAXIMUM_GLOBE_RECTANGLE;
-                    isRectangleInDegrees = true;
-                  } else if (srsText.find("4326") != std::string::npos) {
+                  if (srsText.find("4326") != std::string::npos) {
                     projection = CesiumGeospatial::GeographicProjection();
                     tilingSchemeRectangle = CesiumGeospatial::
                         GeographicProjection::MAXIMUM_GLOBE_RECTANGLE;

--- a/Cesium3DTilesSelection/src/TileMapServiceRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/TileMapServiceRasterOverlay.cpp
@@ -221,9 +221,6 @@ TileMapServiceRasterOverlay::createTileProvider(
     const std::shared_ptr<spdlog::logger>& pLogger,
     RasterOverlay* pOwner) {
   std::string xmlUrl = this->_url;
-  if (xmlUrl[xmlUrl.size() - 1] != '/') {
-    xmlUrl += "/";
-  }
 
   pOwner = pOwner ? pOwner : this;
 

--- a/Cesium3DTilesSelection/src/TileMapServiceRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/TileMapServiceRasterOverlay.cpp
@@ -200,6 +200,23 @@ Future<std::unique_ptr<tinyxml2::XMLDocument>> getXmlDocument(
                   .wait();
             } else {
               tinyxml2::XMLElement* pRoot = pDoc->RootElement();
+
+              tinyxml2::XMLElement* pTilesets =
+                  pRoot->FirstChildElement("TileSets");
+
+              if (!pTilesets &&
+                  url.find("tilemapresource.xml") == std::string::npos) {
+                return getXmlDocument(
+                           asyncSystem,
+                           pAssetAccessor,
+                           CesiumUtility::Uri::resolve(
+                               url,
+                               "tilemapresource.xml"),
+                           headers,
+                           reportError)
+                    .wait();
+              }
+
               if (!pRoot) {
                 reportError(
                     pRequest,

--- a/Cesium3DTilesSelection/src/TileMapServiceRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/TileMapServiceRasterOverlay.cpp
@@ -352,6 +352,11 @@ TileMapServiceRasterOverlay::createTileProvider(
                         GeographicProjection::MAXIMUM_GLOBE_RECTANGLE;
                     rootTilesX = 2;
                     isRectangleInDegrees = true;
+                  } else if (srsText.find("900913") != std::string::npos) {
+                    projection = CesiumGeospatial::WebMercatorProjection();
+                    tilingSchemeRectangle = CesiumGeospatial::
+                        WebMercatorProjection::MAXIMUM_GLOBE_RECTANGLE;
+                    isRectangleInDegrees = true;
                   }
                 }
               }


### PR DESCRIPTION
Fixes #469 and #468.

Currently works with all the geoserver examples, gdal2tiles.py using mercator profile, but not gdal2tiles.py with geodetic profile

File 0/0/0.png of gdal2tiles.py: 
![0](https://user-images.githubusercontent.com/97980867/179853425-b5486cf1-d8e4-471a-bc76-252751c6ce04.png)

File 0/0/0.png of geoserver: 
![0-gs](https://user-images.githubusercontent.com/97980867/179853427-61d3a0ba-a27a-4bff-b1ee-2c54877e2309.png)

the tileresource.xml document from geoserver:
```
<TileMap version="1.0.0" tilemapservice="http://localhost:8080/geoserver/gwc/service/tms/1.0.0">
<Title>BlueMarbleNG-TB_2004-12-01_rgb_3600x1800</Title>
<Abstract/>
<SRS>EPSG:4326</SRS>
<BoundingBox minx="-180.0" miny="-90.0" maxx="180.0" maxy="90.0"/>
<Origin x="-180.0" y="-90.0"/>
<TileFormat width="256" height="256" mime-type="image/png" extension="png"/>
<TileSets profile="local">
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/0" units-per-pixel="0.703125" order="0"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/1" units-per-pixel="0.3515625" order="1"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/2" units-per-pixel="0.17578125" order="2"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/3" units-per-pixel="0.087890625" order="3"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/4" units-per-pixel="0.0439453125" order="4"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/5" units-per-pixel="0.02197265625" order="5"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/6" units-per-pixel="0.010986328125" order="6"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/7" units-per-pixel="0.0054931640625" order="7"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/8" units-per-pixel="0.00274658203125" order="8"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/9" units-per-pixel="0.001373291015625" order="9"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/10" units-per-pixel="6.866455078125E-4" order="10"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/11" units-per-pixel="3.4332275390625E-4" order="11"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/12" units-per-pixel="1.71661376953125E-4" order="12"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/13" units-per-pixel="8.58306884765625E-5" order="13"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/14" units-per-pixel="4.291534423828125E-5" order="14"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/15" units-per-pixel="2.1457672119140625E-5" order="15"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/16" units-per-pixel="1.0728836059570312E-5" order="16"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/17" units-per-pixel="5.364418029785156E-6" order="17"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/18" units-per-pixel="2.682209014892578E-6" order="18"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/19" units-per-pixel="1.341104507446289E-6" order="19"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/20" units-per-pixel="6.705522537231445E-7" order="20"/>
<TileSet href="http://localhost:8080/geoserver/gwc/service/tms/1.0.0/cite%3ABlueMarbleNG-TB_2004-12-01_rgb_3600x1800@EPSG%3A4326@png/21" units-per-pixel="3.3527612686157227E-7" order="21"/>
</TileSets>
</TileMap>
```
The tileresource.xml from gdal:
```
<?xml version="1.0" encoding="utf-8"?>
    <TileMap version="1.0.0" tilemapservice="http://tms.osgeo.org/1.0.0">
      <Title>BlueMarbleNG-TB_2004-12-01_rgb_3600x1800.TIFF</Title>
      <Abstract></Abstract>
      <SRS>EPSG:4326</SRS>
      <BoundingBox minx="-180.00000000000000" miny="-90.00000000000000" maxx="180.00000000000000" maxy="90.00000000000000"/>
      <Origin x="-180.00000000000000" y="-90.00000000000000"/>
      <TileFormat width="256" height="256" mime-type="image/png" extension="png"/>
      <TileSets profile="geodetic">
        <TileSet href="0" units-per-pixel="0.70312500000000" order="0"/>
        <TileSet href="1" units-per-pixel="0.35156250000000" order="1"/>
        <TileSet href="2" units-per-pixel="0.17578125000000" order="2"/>
        <TileSet href="3" units-per-pixel="0.08789062500000" order="3"/>
      </TileSets>
    </TileMap>
    
```