### PR TITLE
Remove dependency between tileset and Raster Overlay Collection

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayCollection.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayCollection.h
@@ -1,8 +1,10 @@
 #pragma once
 
-#include "Library.h"
-#include "RasterOverlay.h"
-#include "RasterOverlayTileProvider.h"
+#include <Cesium3DTilesSelection/Library.h>
+#include <Cesium3DTilesSelection/RasterOverlay.h>
+#include <Cesium3DTilesSelection/RasterOverlayTileProvider.h>
+#include <Cesium3DTilesSelection/Tile.h>
+#include <Cesium3DTilesSelection/TilesetExternals.h>
 
 #include <gsl/span>
 
@@ -10,8 +12,6 @@
 #include <vector>
 
 namespace Cesium3DTilesSelection {
-
-class Tileset;
 
 /**
  * @brief A collection of {@link RasterOverlay} instances that are associated
@@ -29,9 +29,14 @@ public:
   /**
    * @brief Creates a new instance.
    *
-   * @param tileset The tileset to which this instance belongs
+   * @param loadedTiles The list of loaded tiles. The collection does not own
+   * this list, so the list needs to be kept alive as long as the collection's
+   * lifetime
+   * @param externals A collection of loading system to load a raster overlay
    */
-  RasterOverlayCollection(Tileset& tileset) noexcept;
+  RasterOverlayCollection(
+      Tile::LoadedLinkedList& loadedTiles,
+      const TilesetExternals& externals) noexcept;
 
   ~RasterOverlayCollection() noexcept;
 
@@ -84,7 +89,8 @@ public:
   size_t size() const noexcept { return this->_overlays.size(); }
 
 private:
-  Tileset* _pTileset;
+  Tile::LoadedLinkedList* _pLoadedTiles;
+  TilesetExternals _externals;
   std::vector<std::unique_ptr<RasterOverlay>> _overlays;
   CESIUM_TRACE_DECLARE_TRACK_SET(_loadingSlots, "Raster Overlay Loading Slot");
 };

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -53,7 +53,7 @@ Tileset::Tileset(
       _options(options),
       _pRootTile(),
       _previousFrameNumber(0),
-      _overlays(*this),
+      _overlays(_loadedTiles, externals),
       _gltfUpAxis(CesiumGeometry::Axis::Y),
       _distancesStack(),
       _nextDistancesVector(0) {
@@ -83,7 +83,7 @@ Tileset::Tileset(
       _options(options),
       _pRootTile(),
       _previousFrameNumber(0),
-      _overlays(*this),
+      _overlays(_loadedTiles, externals),
       _gltfUpAxis(CesiumGeometry::Axis::Y),
       _distancesStack(),
       _nextDistancesVector(0) {


### PR DESCRIPTION
This PR is part of the refactor series #481. Raster Overlay collection now only uses `TilesetExternals` and `Tile::LoadedLinkList` to attach raster overlay to tile. This makes TilesetContentManager easier to test without involving Tileset since the manager depends on the raster overlay collection which requires tileset to be constructed in the previous implementation.

This is also the last dependency between the traversal (residing in tileset itself) and loading systems. By removing it, client can totally build their own traversal outside of Cesium Native and reuse the current loading system as they see fit