### PR TITLE
Remove supportsRasterOverlays bool

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
   - [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/tree/main/extensions/3DTILES_implicit_tiling)
   - [3DTILES_metadata](https://github.com/CesiumGS/3d-tiles/tree/main/extensions/3DTILES_metadata)
   - [3DTILES_content_gltf](https://github.com/CesiumGS/3d-tiles/tree/main/extensions/3DTILES_content_gltf)
+- Removed vestigial `supportsRasterOverlays` bool. It is no longer relevant and is always true since all tilesets now support raster overlays. 
 
 ##### Additions :tada:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
   - [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/tree/main/extensions/3DTILES_implicit_tiling)
   - [3DTILES_metadata](https://github.com/CesiumGS/3d-tiles/tree/main/extensions/3DTILES_metadata)
   - [3DTILES_content_gltf](https://github.com/CesiumGS/3d-tiles/tree/main/extensions/3DTILES_content_gltf)
-- Removed vestigial `supportsRasterOverlays` bool. It is no longer relevant and is always true since all tilesets now support raster overlays. 
+- Romoved the API `Tileset::getSupportsRasterOverlays` since the boolean `supportsRasterOverlays` is no longer relevant and is always true as all tilesets now support raster overlays. 
 
 ##### Additions :tada:
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -266,16 +266,6 @@ public:
   int64_t getTotalDataBytes() const noexcept;
 
   /**
-   * @brief Determines if this tileset supports raster overlays.
-   *
-   * Currently, raster overlays can only be draped over quantized-mesh terrain
-   * tilesets.
-   */
-  bool supportsRasterOverlays() const noexcept {
-    return this->_supportsRasterOverlays;
-  }
-
-  /**
    * @brief Returns the value indicating the glTF up-axis.
    *
    * This function is not supposed to be called by clients.
@@ -593,8 +583,6 @@ private:
   RasterOverlayCollection _overlays;
 
   int64_t _tileDataBytes;
-
-  bool _supportsRasterOverlays;
 
   /**
    * @brief The axis that was declared as the "up-axis" for glTF content.

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -852,8 +852,7 @@ void Tile::update(
     }
   }
 
-  if (this->getState() == LoadState::Done &&
-      this->getTileset()->supportsRasterOverlays() && this->getContent() &&
+  if (this->getState() == LoadState::Done && this->getContent() &&
       this->getContent()->model) {
     bool moreRasterDetailAvailable = false;
     bool skippedUnknown = false;

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -63,7 +63,6 @@ Tileset::Tileset(
       _subtreeLoadsInProgress(0),
       _overlays(*this),
       _tileDataBytes(0),
-      _supportsRasterOverlays(false),
       _gltfUpAxis(CesiumGeometry::Axis::Y),
       _distances(),
       _childOcclusionProxies() {
@@ -101,7 +100,6 @@ Tileset::Tileset(
       _subtreeLoadsInProgress(0),
       _overlays(*this),
       _tileDataBytes(0),
-      _supportsRasterOverlays(false),
       _gltfUpAxis(CesiumGeometry::Axis::Y),
       _distances(),
       _childOcclusionProxies() {
@@ -240,11 +238,6 @@ Tileset::updateView(const std::vector<ViewState>& frustums) {
   Tile* pRootTile = this->getRootTile();
   if (!pRootTile) {
     return result;
-  }
-
-  if (!this->supportsRasterOverlays() && this->_overlays.size() > 0) {
-    this->_externals.pLogger->warn(
-        "Only quantized-mesh terrain tilesets currently support overlays.");
   }
 
   this->_loadQueueHigh.clear();


### PR DESCRIPTION
- This PR addresses #489 
- Removes `supportRasterOverlays` from `Tileset`. 
- @nithinp7 