### PR TITLE
Change tileset load percentage to float

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -193,7 +193,7 @@ public:
    */
   void notifyTileUnloading(Tile* pTile) noexcept;
 
-  uint32_t computeLoadProgress() noexcept;
+  float computeLoadProgress() noexcept;
 
   /**
    * @brief Loads a tile tree from a tileset.json file.

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -367,7 +367,7 @@ void Tileset::notifyTileUnloading(Tile* pTile) noexcept {
   }
 }
 
-uint32_t Tileset::computeLoadProgress() noexcept {
+float_t Tileset::computeLoadProgress() noexcept {
   uint32_t queueSizeSum = (uint32_t)(this->_loadQueueLow.size() +
                                 this->_loadQueueMedium.size() +
                                 this->_loadQueueHigh.size());
@@ -376,7 +376,7 @@ uint32_t Tileset::computeLoadProgress() noexcept {
   uint32_t totalNum = this->_loadedTilesCount + inProgressSum;
   float_t percentage = static_cast<float>(this->_loadedTilesCount) /
                        static_cast<float>(totalNum);
-  return (uint32_t)(percentage * 100);
+  return (percentage * 100.f);
 }
 
 void Tileset::loadTilesFromJson(

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -374,7 +374,7 @@ float Tileset::computeLoadProgress() noexcept {
   // we ignore _subtreeLoadsInProgress for now
   uint32_t inProgressSum = (this->_loadsInProgress + queueSizeSum);
   uint32_t totalNum = this->_loadedTilesCount + inProgressSum;
-  float_t percentage = static_cast<float>(this->_loadedTilesCount) /
+  float percentage = static_cast<float>(this->_loadedTilesCount) /
                        static_cast<float>(totalNum);
   return (percentage * 100.f);
 }

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -367,7 +367,7 @@ void Tileset::notifyTileUnloading(Tile* pTile) noexcept {
   }
 }
 
-float_t Tileset::computeLoadProgress() noexcept {
+float Tileset::computeLoadProgress() noexcept {
   uint32_t queueSizeSum = (uint32_t)(this->_loadQueueLow.size() +
                                 this->_loadQueueMedium.size() +
                                 this->_loadQueueHigh.size());

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -375,7 +375,7 @@ float Tileset::computeLoadProgress() noexcept {
   uint32_t inProgressSum = (this->_loadsInProgress + queueSizeSum);
   uint32_t totalNum = this->_loadedTilesCount + inProgressSum;
   float percentage = static_cast<float>(this->_loadedTilesCount) /
-                       static_cast<float>(totalNum);
+                     static_cast<float>(totalNum);
   return (percentage * 100.f);
 }
 


### PR DESCRIPTION
- A follow up update for https://github.com/CesiumGS/cesium-unreal/issues/774 
- Update the API for getting the current loaded percentage from returning an unsigned int to a float. 