### PR TITLE
Let loader interface to accept const reference of tile

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
@@ -74,7 +74,7 @@ public:
 
   std::vector<Credit>& getCredits() noexcept;
 
-  TilesetContentLoader* getLoader() noexcept;
+  TilesetContentLoader* getLoader() const noexcept;
 
   void* getRenderResources() const noexcept;
 

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
@@ -388,6 +388,12 @@ CesiumIonTilesetLoader::loadTileContent(const TileLoadInput& loadInput) {
       });
 }
 
+TileChildrenResult
+CesiumIonTilesetLoader::createTileChildren(const Tile& tile) {
+  auto pLoader = tile.getContent().getLoader();
+  return pLoader->createTileChildren(tile);
+}
+
 void CesiumIonTilesetLoader::refreshTokenInMainThread(
     const std::shared_ptr<spdlog::logger>& pLogger,
     const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
@@ -435,11 +441,6 @@ void CesiumIonTilesetLoader::refreshTokenInMainThread(
 
             _refreshTokenState = TokenRefreshState::Failed;
           });
-}
-
-bool CesiumIonTilesetLoader::updateTileContent(Tile& tile) {
-  auto pLoader = tile.getContent().getLoader();
-  return pLoader->updateTileContent(tile);
 }
 
 CesiumAsync::Future<TilesetContentLoaderResult>

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
@@ -336,7 +336,7 @@ CesiumIonTilesetLoader::CesiumIonTilesetLoader(
       _headerChangeListener{std::move(headerChangeListener)} {}
 
 CesiumAsync::Future<TileLoadResult> CesiumIonTilesetLoader::loadTileContent(
-    Tile& tile,
+    const Tile& tile,
     const TilesetContentOptions& contentOptions,
     const CesiumAsync::AsyncSystem& asyncSystem,
     const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
@@ -347,17 +347,19 @@ CesiumAsync::Future<TileLoadResult> CesiumIonTilesetLoader::loadTileContent(
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        TileLoadResultState::RetryLater,
+        std::nullopt,
         nullptr,
-        {}});
+        {},
+        TileLoadResultState::RetryLater});
   } else if (_refreshTokenState == TokenRefreshState::Failed) {
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        TileLoadResultState::Failed,
+        std::nullopt,
         nullptr,
-        {}});
+        {},
+        TileLoadResultState::Failed});
   }
 
   // TODO: the way this is structured, requests already in progress

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.h
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.h
@@ -24,7 +24,7 @@ public:
       AuthorizationHeaderChangeListener&& headerChangeListener);
 
   CesiumAsync::Future<TileLoadResult> loadTileContent(
-      Tile& tile,
+      const Tile& tile,
       const TilesetContentOptions& contentOptions,
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.h
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.h
@@ -26,7 +26,7 @@ public:
   CesiumAsync::Future<TileLoadResult>
   loadTileContent(const TileLoadInput& loadInput) override;
 
-  bool updateTileContent(Tile& tile) override;
+  TileChildrenResult createTileChildren(const Tile& tile) override;
 
   static CesiumAsync::Future<TilesetContentLoaderResult> createLoader(
       const TilesetExternals& externals,

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.h
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.h
@@ -23,14 +23,8 @@ public:
       std::unique_ptr<TilesetContentLoader>&& pAggregatedLoader,
       AuthorizationHeaderChangeListener&& headerChangeListener);
 
-  CesiumAsync::Future<TileLoadResult> loadTileContent(
-      const Tile& tile,
-      const TilesetContentOptions& contentOptions,
-      const CesiumAsync::AsyncSystem& asyncSystem,
-      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
-      const std::shared_ptr<spdlog::logger>& pLogger,
-      const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders)
-      override;
+  CesiumAsync::Future<TileLoadResult>
+  loadTileContent(const TileLoadInput& loadInput) override;
 
   bool updateTileContent(Tile& tile) override;
 

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
@@ -112,15 +112,15 @@ BoundingVolume subdivideBoundingVolume(
   return subdivideOrientedBoundingBox(tileID, *pOBB);
 }
 
-void populateSubtree(
+std::vector<Tile> populateSubtree(
     const SubtreeAvailability& subtreeAvailability,
     uint32_t subtreeLevels,
     uint32_t relativeTileLevel,
     uint64_t relativeTileMortonID,
-    Tile& tile,
+    const Tile& tile,
     ImplicitOctreeLoader& loader) {
   if (relativeTileLevel >= subtreeLevels) {
-    return;
+    return {};
   }
 
   const CesiumGeometry::OctreeTileID* pOctreeID =
@@ -181,7 +181,7 @@ void populateSubtree(
     }
   }
 
-  tile.createChildTiles(std::move(children));
+  return children;
 }
 
 bool isTileContentAvailable(
@@ -400,44 +400,42 @@ ImplicitOctreeLoader::loadTileContent(const TileLoadInput& loadInput) {
       contentOptions.ktx2TranscodeTargets);
 }
 
-bool ImplicitOctreeLoader::updateTileContent(Tile& tile) {
-  if (tile.getChildren().empty()) {
-    const CesiumGeometry::OctreeTileID* pOctreeID =
-        std::get_if<CesiumGeometry::OctreeTileID>(&tile.getTileID());
-    assert(pOctreeID != nullptr && "This loader only serves quadtree tile");
+TileChildrenResult ImplicitOctreeLoader::createTileChildren(const Tile& tile) {
+  const CesiumGeometry::OctreeTileID* pOctreeID =
+      std::get_if<CesiumGeometry::OctreeTileID>(&tile.getTileID());
+  assert(pOctreeID != nullptr && "This loader only serves quadtree tile");
 
-    // find the subtree ID
-    uint32_t subtreeLevelIdx = pOctreeID->level / _subtreeLevels;
-    if (subtreeLevelIdx >= _loadedSubtrees.size()) {
-      return false;
-    }
-
-    uint64_t levelLeft = pOctreeID->level % _subtreeLevels;
-    uint32_t subtreeX = pOctreeID->x >> levelLeft;
-    uint32_t subtreeY = pOctreeID->y >> levelLeft;
-    uint32_t subtreeZ = pOctreeID->z >> levelLeft;
-
-    uint64_t subtreeMortonIdx =
-        libmorton::morton3D_64_encode(subtreeX, subtreeY, subtreeZ);
-    auto subtreeIt = _loadedSubtrees[subtreeLevelIdx].find(subtreeMortonIdx);
-    if (subtreeIt != _loadedSubtrees[subtreeLevelIdx].end()) {
-      uint64_t relativeTileMortonIdx = libmorton::morton3D_64_encode(
-          pOctreeID->x - (subtreeX << levelLeft),
-          pOctreeID->y - (subtreeY << levelLeft),
-          pOctreeID->z - (subtreeZ << levelLeft));
-      populateSubtree(
-          subtreeIt->second,
-          _subtreeLevels,
-          static_cast<std::uint32_t>(levelLeft),
-          relativeTileMortonIdx,
-          tile,
-          *this);
-
-      return false;
-    }
+  // find the subtree ID
+  uint32_t subtreeLevelIdx = pOctreeID->level / _subtreeLevels;
+  if (subtreeLevelIdx >= _loadedSubtrees.size()) {
+    return {{}, TileLoadResultState::Failed};
   }
 
-  return true;
+  uint64_t levelLeft = pOctreeID->level % _subtreeLevels;
+  uint32_t subtreeX = pOctreeID->x >> levelLeft;
+  uint32_t subtreeY = pOctreeID->y >> levelLeft;
+  uint32_t subtreeZ = pOctreeID->z >> levelLeft;
+
+  uint64_t subtreeMortonIdx =
+      libmorton::morton3D_64_encode(subtreeX, subtreeY, subtreeZ);
+  auto subtreeIt = _loadedSubtrees[subtreeLevelIdx].find(subtreeMortonIdx);
+  if (subtreeIt != _loadedSubtrees[subtreeLevelIdx].end()) {
+    uint64_t relativeTileMortonIdx = libmorton::morton3D_64_encode(
+        pOctreeID->x - (subtreeX << levelLeft),
+        pOctreeID->y - (subtreeY << levelLeft),
+        pOctreeID->z - (subtreeZ << levelLeft));
+    auto children = populateSubtree(
+        subtreeIt->second,
+        _subtreeLevels,
+        static_cast<std::uint32_t>(levelLeft),
+        relativeTileMortonIdx,
+        tile,
+        *this);
+
+    return {std::move(children), TileLoadResultState::Success};
+  }
+
+  return {{}, TileLoadResultState::RetryLater};
 }
 
 uint32_t ImplicitOctreeLoader::getSubtreeLevels() const noexcept {

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
@@ -295,13 +295,15 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
 }
 } // namespace
 
-CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
-    const Tile& tile,
-    const TilesetContentOptions& contentOptions,
-    const CesiumAsync::AsyncSystem& asyncSystem,
-    const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
-    const std::shared_ptr<spdlog::logger>& pLogger,
-    const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders) {
+CesiumAsync::Future<TileLoadResult>
+ImplicitOctreeLoader::loadTileContent(const TileLoadInput& loadInput) {
+  const auto& tile = loadInput.tile;
+  const auto& asyncSystem = loadInput.asyncSystem;
+  const auto& pAssetAccessor = loadInput.pAssetAccessor;
+  const auto& pLogger = loadInput.pLogger;
+  const auto& requestHeaders = loadInput.requestHeaders;
+  const auto& contentOptions = loadInput.contentOptions;
+
   // make sure the tile is a octree tile
   const CesiumGeometry::OctreeTileID* pOctreeID =
       std::get_if<CesiumGeometry::OctreeTileID>(&tile.getTileID());

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
@@ -222,9 +222,10 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               TileUnknownContent{},
               std::nullopt,
               std::nullopt,
-              TileLoadResultState::Failed,
+              std::nullopt,
               nullptr,
-              {}};
+              {},
+              TileLoadResultState::Failed};
         }
 
         uint16_t statusCode = pResponse->statusCode();
@@ -238,9 +239,10 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               TileUnknownContent{},
               std::nullopt,
               std::nullopt,
-              TileLoadResultState::Failed,
+              std::nullopt,
               nullptr,
-              {}};
+              {},
+              TileLoadResultState::Failed};
         }
 
         // find gltf converter
@@ -264,18 +266,20 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
                 TileRenderContent{std::nullopt},
                 std::nullopt,
                 std::nullopt,
-                TileLoadResultState::Failed,
+                std::nullopt,
                 std::move(pCompletedRequest),
-                {}};
+                {},
+                TileLoadResultState::Failed};
           }
 
           return TileLoadResult{
               TileRenderContent{std::move(result.model)},
               std::nullopt,
               std::nullopt,
-              TileLoadResultState::Success,
+              std::nullopt,
               std::move(pCompletedRequest),
-              {}};
+              {},
+              TileLoadResultState::Success};
         }
 
         // content type is not supported
@@ -283,15 +287,16 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
             TileRenderContent{std::nullopt},
             std::nullopt,
             std::nullopt,
-            TileLoadResultState::Failed,
+            std::nullopt,
             std::move(pCompletedRequest),
-            {}};
+            {},
+            TileLoadResultState::Failed};
       });
 }
 } // namespace
 
 CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
-    Tile& tile,
+    const Tile& tile,
     const TilesetContentOptions& contentOptions,
     const CesiumAsync::AsyncSystem& asyncSystem,
     const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
@@ -305,9 +310,10 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        TileLoadResultState::Failed,
+        std::nullopt,
         nullptr,
-        {}});
+        {},
+        TileLoadResultState::Failed});
   }
 
   // find the subtree ID
@@ -317,9 +323,10 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        TileLoadResultState::Failed,
+        std::nullopt,
         nullptr,
-        {}});
+        {},
+        TileLoadResultState::Failed});
   }
 
   uint64_t levelLeft = pOctreeID->level % _subtreeLevels;
@@ -360,9 +367,10 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
               TileUnknownContent{},
               std::nullopt,
               std::nullopt,
-              TileLoadResultState::RetryLater,
+              std::nullopt,
               nullptr,
-              {}};
+              {},
+              TileLoadResultState::RetryLater};
         });
   }
 
@@ -374,9 +382,10 @@ CesiumAsync::Future<TileLoadResult> ImplicitOctreeLoader::loadTileContent(
         TileEmptyContent{},
         std::nullopt,
         std::nullopt,
-        TileLoadResultState::Success,
+        std::nullopt,
         nullptr,
-        {}});
+        {},
+        TileLoadResultState::Success});
   }
 
   std::string tileUrl = resolveUrl(_baseUrl, _contentUrlTemplate, *pOctreeID);

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.h
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.h
@@ -32,14 +32,8 @@ public:
             static_cast<float>(availableLevels) /
             static_cast<float>(subtreeLevels)))) {}
 
-  CesiumAsync::Future<TileLoadResult> loadTileContent(
-      const Tile& tile,
-      const TilesetContentOptions& contentOptions,
-      const CesiumAsync::AsyncSystem& asyncSystem,
-      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
-      const std::shared_ptr<spdlog::logger>& pLogger,
-      const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders)
-      override;
+  CesiumAsync::Future<TileLoadResult>
+  loadTileContent(const TileLoadInput& loadInput) override;
 
   bool updateTileContent(Tile& tile) override;
 

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.h
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.h
@@ -35,7 +35,7 @@ public:
   CesiumAsync::Future<TileLoadResult>
   loadTileContent(const TileLoadInput& loadInput) override;
 
-  bool updateTileContent(Tile& tile) override;
+  TileChildrenResult createTileChildren(const Tile& tile) override;
 
   uint32_t getSubtreeLevels() const noexcept;
 

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.h
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.h
@@ -33,7 +33,7 @@ public:
             static_cast<float>(subtreeLevels)))) {}
 
   CesiumAsync::Future<TileLoadResult> loadTileContent(
-      Tile& tile,
+      const Tile& tile,
       const TilesetContentOptions& contentOptions,
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -228,9 +228,10 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               TileUnknownContent{},
               std::nullopt,
               std::nullopt,
-              TileLoadResultState::Failed,
+              std::nullopt,
               nullptr,
-              {}};
+              {},
+              TileLoadResultState::Failed};
         }
 
         uint16_t statusCode = pResponse->statusCode();
@@ -244,9 +245,10 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               TileUnknownContent{},
               std::nullopt,
               std::nullopt,
-              TileLoadResultState::Failed,
+              std::nullopt,
               nullptr,
-              {}};
+              {},
+              TileLoadResultState::Failed};
         }
 
         // find gltf converter
@@ -270,18 +272,20 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
                 TileRenderContent{std::nullopt},
                 std::nullopt,
                 std::nullopt,
-                TileLoadResultState::Failed,
+                std::nullopt,
                 std::move(pCompletedRequest),
-                {}};
+                {},
+                TileLoadResultState::Failed};
           }
 
           return TileLoadResult{
               TileRenderContent{std::move(result.model)},
               std::nullopt,
               std::nullopt,
-              TileLoadResultState::Success,
+              std::nullopt,
               std::move(pCompletedRequest),
-              {}};
+              {},
+              TileLoadResultState::Success};
         }
 
         // content type is not supported
@@ -289,15 +293,16 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
             TileRenderContent{std::nullopt},
             std::nullopt,
             std::nullopt,
-            TileLoadResultState::Failed,
+            std::nullopt,
             std::move(pCompletedRequest),
-            {}};
+            {},
+            TileLoadResultState::Failed};
       });
 }
 } // namespace
 
 CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
-    Tile& tile,
+    const Tile& tile,
     const TilesetContentOptions& contentOptions,
     const CesiumAsync::AsyncSystem& asyncSystem,
     const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
@@ -329,9 +334,10 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        TileLoadResultState::Failed,
+        std::nullopt,
         nullptr,
-        {}});
+        {},
+        TileLoadResultState::Failed});
   }
 
   // find the subtree ID
@@ -341,9 +347,10 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        TileLoadResultState::Failed,
+        std::nullopt,
         nullptr,
-        {}});
+        {},
+        TileLoadResultState::Failed});
   }
 
   uint64_t levelLeft = pQuadtreeID->level % _subtreeLevels;
@@ -389,9 +396,10 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
               TileUnknownContent{},
               std::nullopt,
               std::nullopt,
-              TileLoadResultState::RetryLater,
+              std::nullopt,
               nullptr,
-              {}};
+              {},
+              TileLoadResultState::RetryLater};
         });
   }
 
@@ -403,9 +411,10 @@ CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
         TileEmptyContent{},
         std::nullopt,
         std::nullopt,
-        TileLoadResultState::Success,
+        std::nullopt,
         nullptr,
-        {}});
+        {},
+        TileLoadResultState::Success});
   }
 
   std::string tileUrl = resolveUrl(_baseUrl, _contentUrlTemplate, *pQuadtreeID);

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -301,13 +301,15 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
 }
 } // namespace
 
-CesiumAsync::Future<TileLoadResult> ImplicitQuadtreeLoader::loadTileContent(
-    const Tile& tile,
-    const TilesetContentOptions& contentOptions,
-    const CesiumAsync::AsyncSystem& asyncSystem,
-    const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
-    const std::shared_ptr<spdlog::logger>& pLogger,
-    const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders) {
+CesiumAsync::Future<TileLoadResult>
+ImplicitQuadtreeLoader::loadTileContent(const TileLoadInput& loadInput) {
+  const auto& tile = loadInput.tile;
+  const auto& asyncSystem = loadInput.asyncSystem;
+  const auto& pAssetAccessor = loadInput.pAssetAccessor;
+  const auto& pLogger = loadInput.pLogger;
+  const auto& requestHeaders = loadInput.requestHeaders;
+  const auto& contentOptions = loadInput.contentOptions;
+
   // Ensure CesiumGeometry::QuadtreeTileID only has 32-bit components. There are
   // solutions below if the ID has more than 32-bit components.
   static_assert(

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.h
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.h
@@ -39,7 +39,7 @@ public:
             static_cast<float>(subtreeLevels)))) {}
 
   CesiumAsync::Future<TileLoadResult> loadTileContent(
-      Tile& tile,
+      const Tile& tile,
       const TilesetContentOptions& contentOptions,
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.h
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.h
@@ -41,7 +41,7 @@ public:
   CesiumAsync::Future<TileLoadResult>
   loadTileContent(const TileLoadInput& loadInput) override;
 
-  bool updateTileContent(Tile& tile) override;
+  TileChildrenResult createTileChildren(const Tile& tile) override;
 
   uint32_t getSubtreeLevels() const noexcept;
 

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.h
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.h
@@ -38,14 +38,8 @@ public:
             static_cast<float>(availableLevels) /
             static_cast<float>(subtreeLevels)))) {}
 
-  CesiumAsync::Future<TileLoadResult> loadTileContent(
-      const Tile& tile,
-      const TilesetContentOptions& contentOptions,
-      const CesiumAsync::AsyncSystem& asyncSystem,
-      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
-      const std::shared_ptr<spdlog::logger>& pLogger,
-      const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders)
-      override;
+  CesiumAsync::Future<TileLoadResult>
+  loadTileContent(const TileLoadInput& loadInput) override;
 
   bool updateTileContent(Tile& tile) override;
 

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
@@ -24,10 +24,12 @@ TileLoadResult convertToTileLoadResult(QuantizedMeshLoadResult&& loadResult) {
       TileRenderContent{std::move(loadResult.model)},
       loadResult.updatedBoundingVolume,
       std::nullopt,
+      std::nullopt,
+      nullptr,
+      {},
       loadResult.errors.hasErrors() ? TileLoadResultState::Failed
                                     : TileLoadResultState::Success,
-      nullptr,
-      {}};
+  };
 }
 
 size_t maxSubtreeInLayer(uint32_t maxZooms, int32_t availabilityLevels) {
@@ -89,6 +91,38 @@ void addRectangleAvailabilityToLayer(
   }
 
   layer.loadedSubtrees[subtreeLevelIdx].insert(subtreeMortonIdx);
+}
+
+void generateRasterOverlayUVs(
+    const BoundingVolume& tileBoundingVolume,
+    const glm::dmat4& tileTransform,
+    const Projection& projection,
+    TileLoadResult& result) {
+  if (result.state != TileLoadResultState::Success) {
+    return;
+  }
+
+  const BoundingRegion* pParentRegion = nullptr;
+  if (result.updatedBoundingVolume) {
+    pParentRegion =
+        std::get_if<BoundingRegion>(&result.updatedBoundingVolume.value());
+  } else {
+    pParentRegion = std::get_if<BoundingRegion>(&tileBoundingVolume);
+  }
+
+  TileRenderContent& renderContent =
+      std::get<TileRenderContent>(result.contentKind);
+  if (renderContent.model) {
+    result.rasterOverlayDetails =
+        GltfUtilities::createRasterOverlayTextureCoordinates(
+            *renderContent.model,
+            tileTransform,
+            0,
+            pParentRegion ? std::make_optional<GlobeRectangle>(
+                                pParentRegion->getRectangle())
+                          : std::nullopt,
+            {projection});
+  }
 }
 
 /**
@@ -614,7 +648,7 @@ Future<int> loadTileAvailability(
 } // namespace
 
 Future<TileLoadResult> LayerJsonTerrainLoader::loadTileContent(
-    Tile& tile,
+    const Tile& tile,
     const TilesetContentOptions& contentOptions,
     const AsyncSystem& asyncSystem,
     const std::shared_ptr<IAssetAccessor>& pAssetAccessor,
@@ -635,9 +669,10 @@ Future<TileLoadResult> LayerJsonTerrainLoader::loadTileContent(
           TileUnknownContent{},
           std::nullopt,
           std::nullopt,
-          TileLoadResultState::Failed,
+          std::nullopt,
           nullptr,
-          {}});
+          {},
+          TileLoadResultState::Failed});
     }
 
     // now do upsampling
@@ -659,9 +694,11 @@ Future<TileLoadResult> LayerJsonTerrainLoader::loadTileContent(
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        TileLoadResultState::Failed,
+        std::nullopt,
         nullptr,
-        {}});
+        {},
+        TileLoadResultState::Failed,
+    });
   }
 
   // Also load the same tile in any underlying layers for which this tile
@@ -727,24 +764,69 @@ Future<TileLoadResult> LayerJsonTerrainLoader::loadTileContent(
                       });
 
     return std::move(finalFuture)
-        .thenInMainThread([&currentLayer,
-                           tileID = *pQuadtreeTileID,
+        .thenInMainThread([this,
+                           asyncSystem,
+                           &currentLayer,
+                           &tile,
                            shouldCurrLayerLoadAvailability](
                               QuantizedMeshLoadResult&& loadResult) {
           if (shouldCurrLayerLoadAvailability) {
+            const QuadtreeTileID& tileID =
+                std::get<QuadtreeTileID>(tile.getTileID());
             addRectangleAvailabilityToLayer(
                 currentLayer,
                 tileID,
                 loadResult.availableTileRectangles);
           }
 
-          return convertToTileLoadResult(std::move(loadResult));
+          // if this tile has one of the children that needs to be upsampled, we
+          // will need to generate the tile raster overlay UVs in the worker
+          // thread based on the projection of the loader since the upsampler
+          // needs this UV to do the upsampling
+          auto finalResult = convertToTileLoadResult(std::move(loadResult));
+          bool tileHasUpsampledChild = doesTileHasUpsampledChild(tile);
+          if (tileHasUpsampledChild &&
+              finalResult.state == TileLoadResultState::Success) {
+            return asyncSystem.runInWorkerThread(
+                [finalResult = std::move(finalResult),
+                 projection = _projection,
+                 tileTransform = tile.getTransform(),
+                 tileBoundingVolume = tile.getBoundingVolume()]() mutable {
+                  generateRasterOverlayUVs(
+                      tileBoundingVolume,
+                      tileTransform,
+                      projection,
+                      finalResult);
+                  return finalResult;
+                });
+          }
+
+          return asyncSystem.createResolvedFuture(std::move(finalResult));
         });
   }
 
+  bool tileHasUpsampledChild = doesTileHasUpsampledChild(tile);
   return std::move(futureQuantizedMesh)
-      .thenImmediately([](QuantizedMeshLoadResult&& loadResult) mutable {
-        return convertToTileLoadResult(std::move(loadResult));
+      .thenImmediately([tileHasUpsampledChild,
+                        projection = _projection,
+                        tileTransform = tile.getTransform(),
+                        tileBoundingVolume = tile.getBoundingVolume()](
+                           QuantizedMeshLoadResult&& loadResult) mutable {
+        // if this tile has one of the children needs to be upsampled, we will
+        // need to generate its raster overlay UVs in the worker thread based
+        // on the projection of the loader since the upsampler needs this UV
+        // to do the upsampling
+        auto result = convertToTileLoadResult(std::move(loadResult));
+        if (tileHasUpsampledChild &&
+            result.state == TileLoadResultState::Success) {
+          generateRasterOverlayUVs(
+              tileBoundingVolume,
+              tileTransform,
+              projection,
+              result);
+        }
+
+        return result;
       });
 }
 
@@ -780,6 +862,37 @@ bool LayerJsonTerrainLoader::updateTileContent(Tile& tile) {
   }
 
   return false;
+}
+
+bool LayerJsonTerrainLoader::doesTileHasUpsampledChild(const Tile& tile) const {
+  const auto& tileChildren = tile.getChildren();
+  if (tileChildren.empty()) {
+    const QuadtreeTileID* pQuadtreeTileID =
+        std::get_if<QuadtreeTileID>(&tile.getTileID());
+
+    const QuadtreeTileID swID(
+        pQuadtreeTileID->level + 1,
+        pQuadtreeTileID->x * 2,
+        pQuadtreeTileID->y * 2);
+    const QuadtreeTileID seID(swID.level, swID.x + 1, swID.y);
+    const QuadtreeTileID nwID(swID.level, swID.x, swID.y + 1);
+    const QuadtreeTileID neID(swID.level, swID.x + 1, swID.y + 1);
+
+    uint32_t totalChildren = 0;
+    totalChildren += this->tileIsAvailableInAnyLayer(swID);
+    totalChildren += this->tileIsAvailableInAnyLayer(seID);
+    totalChildren += this->tileIsAvailableInAnyLayer(nwID);
+    totalChildren += this->tileIsAvailableInAnyLayer(neID);
+    return totalChildren > 0 && totalChildren < 4;
+  } else {
+    for (const auto& child : tileChildren) {
+      if (std::holds_alternative<UpsampledQuadtreeNode>(child.getTileID())) {
+        return true;
+      }
+    }
+
+    return false;
+  }
 }
 
 void LayerJsonTerrainLoader::createTileChildren(Tile& tile) {
@@ -910,19 +1023,21 @@ void LayerJsonTerrainLoader::createChildTile(
 }
 
 CesiumAsync::Future<TileLoadResult> LayerJsonTerrainLoader::upsampleParentTile(
-    Tile& tile,
+    const Tile& tile,
     const CesiumAsync::AsyncSystem& asyncSystem) {
-  Tile* pParent = tile.getParent();
-  TileContent& parentContent = pParent->getContent();
-  TileRenderContent* pParentRenderContent = parentContent.getRenderContent();
+  const Tile* pParent = tile.getParent();
+  const TileContent& parentContent = pParent->getContent();
+  const TileRenderContent* pParentRenderContent =
+      parentContent.getRenderContent();
   if (!pParentRenderContent || !pParentRenderContent->model) {
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        TileLoadResultState::Failed,
+        std::nullopt,
         nullptr,
-        {}});
+        {},
+        TileLoadResultState::Failed});
   }
 
   const UpsampledQuadtreeNode* pUpsampledTileID =
@@ -935,33 +1050,15 @@ CesiumAsync::Future<TileLoadResult> LayerJsonTerrainLoader::upsampleParentTile(
       parentProjections.begin(),
       parentProjections.end(),
       _projection);
-  if (it != parentProjections.end()) {
-    index = int32_t(it - parentProjections.begin());
-  } else {
-    const BoundingRegion* pParentRegion =
-        std::get_if<BoundingRegion>(&pParent->getBoundingVolume());
-
-    std::optional<RasterOverlayDetails> overlayDetails =
-        GltfUtilities::createRasterOverlayTextureCoordinates(
-            *pParentRenderContent->model,
-            pParent->getTransform(),
-            int32_t(parentProjections.size()),
-            pParentRegion ? std::make_optional<GlobeRectangle>(
-                                pParentRegion->getRectangle())
-                          : std::nullopt,
-            {_projection});
-
-    if (overlayDetails) {
-      index = int32_t(parentProjections.size());
-      parentContent.getRasterOverlayDetails().merge(std::move(*overlayDetails));
-    }
-  }
 
   // Cannot find raster overlay UVs that has this projection, so we can't
   // upsample right now
   assert(
-      index != -1 && "Cannot find raster overlay UVs that has this projection. "
-                     "Should not happen");
+      it != parentProjections.end() &&
+      "Cannot find raster overlay UVs that has this projection. "
+      "Should not happen");
+
+  index = int32_t(it - parentProjections.begin());
 
   const CesiumGltf::Model& parentModel = pParentRenderContent->model.value();
   return asyncSystem.runInWorkerThread(
@@ -978,17 +1075,19 @@ CesiumAsync::Future<TileLoadResult> LayerJsonTerrainLoader::upsampleParentTile(
               TileRenderContent{std::nullopt},
               std::nullopt,
               std::nullopt,
-              TileLoadResultState::Failed,
+              std::nullopt,
               nullptr,
-              {}};
+              {},
+              TileLoadResultState::Failed};
         }
 
         return TileLoadResult{
             TileRenderContent{std::move(model)},
             std::nullopt,
             std::nullopt,
-            TileLoadResultState::Success,
+            std::nullopt,
             nullptr,
-            {}};
+            {},
+            TileLoadResultState::Success};
       });
 }

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
@@ -647,13 +647,15 @@ Future<int> loadTileAvailability(
 }
 } // namespace
 
-Future<TileLoadResult> LayerJsonTerrainLoader::loadTileContent(
-    const Tile& tile,
-    const TilesetContentOptions& contentOptions,
-    const AsyncSystem& asyncSystem,
-    const std::shared_ptr<IAssetAccessor>& pAssetAccessor,
-    const std::shared_ptr<spdlog::logger>& pLogger,
-    const std::vector<IAssetAccessor::THeader>& requestHeaders) {
+Future<TileLoadResult>
+LayerJsonTerrainLoader::loadTileContent(const TileLoadInput& loadInput) {
+  const auto& tile = loadInput.tile;
+  const auto& asyncSystem = loadInput.asyncSystem;
+  const auto& pAssetAccessor = loadInput.pAssetAccessor;
+  const auto& pLogger = loadInput.pLogger;
+  const auto& requestHeaders = loadInput.requestHeaders;
+  const auto& contentOptions = loadInput.contentOptions;
+
   // This type of loader should never have child loaders.
   assert(tile.getContent().getLoader() == this);
 

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
@@ -57,7 +57,7 @@ public:
       std::vector<Layer>&& layers);
 
   CesiumAsync::Future<TileLoadResult> loadTileContent(
-      Tile& tile,
+      const Tile& tile,
       const TilesetContentOptions& contentOptions,
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
@@ -68,6 +68,8 @@ public:
   bool updateTileContent(Tile& tile) override;
 
 private:
+  bool doesTileHasUpsampledChild(const Tile& til) const;
+
   void createTileChildren(Tile& tile);
 
   bool
@@ -83,8 +85,9 @@ private:
       const CesiumGeometry::QuadtreeTileID& childID,
       bool isAvailable);
 
-  CesiumAsync::Future<TileLoadResult>
-  upsampleParentTile(Tile& tile, const CesiumAsync::AsyncSystem& asyncSystem);
+  CesiumAsync::Future<TileLoadResult> upsampleParentTile(
+      const Tile& tile,
+      const CesiumAsync::AsyncSystem& asyncSystem);
 
   CesiumGeometry::QuadtreeTilingScheme _tilingScheme;
   CesiumGeospatial::Projection _projection;

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
@@ -56,14 +56,8 @@ public:
       const CesiumGeospatial::Projection& projection,
       std::vector<Layer>&& layers);
 
-  CesiumAsync::Future<TileLoadResult> loadTileContent(
-      const Tile& tile,
-      const TilesetContentOptions& contentOptions,
-      const CesiumAsync::AsyncSystem& asyncSystem,
-      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
-      const std::shared_ptr<spdlog::logger>& pLogger,
-      const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders)
-      override;
+  CesiumAsync::Future<TileLoadResult>
+  loadTileContent(const TileLoadInput& loadInput) override;
 
   bool updateTileContent(Tile& tile) override;
 

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
@@ -59,12 +59,12 @@ public:
   CesiumAsync::Future<TileLoadResult>
   loadTileContent(const TileLoadInput& loadInput) override;
 
-  bool updateTileContent(Tile& tile) override;
+  TileChildrenResult createTileChildren(const Tile& tile) override;
 
 private:
   bool doesTileHasUpsampledChild(const Tile& til) const;
 
-  void createTileChildren(Tile& tile);
+  std::vector<Tile> createTileChildrenImpl(const Tile& tile);
 
   bool
   tileIsAvailableInAnyLayer(const CesiumGeometry::QuadtreeTileID& tileID) const;

--- a/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
@@ -103,7 +103,8 @@ RasterOverlayUpsampler::loadTileContent(const TileLoadInput& loadInput) {
       });
 }
 
-bool RasterOverlayUpsampler::updateTileContent([[maybe_unused]] Tile& tile) {
-  return false;
+TileChildrenResult
+RasterOverlayUpsampler::createTileChildren([[maybe_unused]] const Tile& tile) {
+  return {{}, TileLoadResultState::Success};
 }
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
@@ -105,6 +105,6 @@ RasterOverlayUpsampler::loadTileContent(const TileLoadInput& loadInput) {
 
 TileChildrenResult
 RasterOverlayUpsampler::createTileChildren([[maybe_unused]] const Tile& tile) {
-  return {{}, TileLoadResultState::Success};
+  return {{}, TileLoadResultState::Failed};
 }
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
@@ -14,7 +14,7 @@
 
 namespace Cesium3DTilesSelection {
 CesiumAsync::Future<TileLoadResult> RasterOverlayUpsampler::loadTileContent(
-    Tile& tile,
+    const Tile& tile,
     [[maybe_unused]] const TilesetContentOptions& contentOptions,
     const CesiumAsync::AsyncSystem& asyncSystem,
     [[maybe_unused]] const std::shared_ptr<CesiumAsync::IAssetAccessor>&
@@ -22,15 +22,16 @@ CesiumAsync::Future<TileLoadResult> RasterOverlayUpsampler::loadTileContent(
     [[maybe_unused]] const std::shared_ptr<spdlog::logger>& pLogger,
     [[maybe_unused]] const std::vector<CesiumAsync::IAssetAccessor::THeader>&
         requestHeaders) {
-  Tile* pParent = tile.getParent();
+  const Tile* pParent = tile.getParent();
   if (pParent == nullptr) {
     return asyncSystem.createResolvedFuture(TileLoadResult{
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        TileLoadResultState::Failed,
+        std::nullopt,
         nullptr,
-        {}});
+        {},
+        TileLoadResultState::Failed});
   }
 
   const CesiumGeometry::UpsampledQuadtreeNode* pTileID =
@@ -41,9 +42,10 @@ CesiumAsync::Future<TileLoadResult> RasterOverlayUpsampler::loadTileContent(
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        TileLoadResultState::Failed,
+        std::nullopt,
         nullptr,
-        {}});
+        {},
+        TileLoadResultState::Failed});
   }
 
   // The tile content manager guarantees that the parent tile is already loaded
@@ -61,9 +63,10 @@ CesiumAsync::Future<TileLoadResult> RasterOverlayUpsampler::loadTileContent(
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        TileLoadResultState::Failed,
+        std::nullopt,
         nullptr,
-        {}});
+        {},
+        TileLoadResultState::Failed});
   }
 
   int32_t index = 0;
@@ -98,9 +101,10 @@ CesiumAsync::Future<TileLoadResult> RasterOverlayUpsampler::loadTileContent(
         TileRenderContent{std::move(model)},
         std::nullopt,
         std::nullopt,
-        TileLoadResultState::Success,
+        std::nullopt,
         nullptr,
-        {}};
+        {},
+        TileLoadResultState::Success};
   });
 }
 

--- a/Cesium3DTilesSelection/src/RasterOverlayUpsampler.h
+++ b/Cesium3DTilesSelection/src/RasterOverlayUpsampler.h
@@ -8,6 +8,6 @@ public:
   CesiumAsync::Future<TileLoadResult>
   loadTileContent(const TileLoadInput& loadInput) override;
 
-  bool updateTileContent(Tile& tile) override;
+  TileChildrenResult createTileChildren(const Tile& tile) override;
 };
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/RasterOverlayUpsampler.h
+++ b/Cesium3DTilesSelection/src/RasterOverlayUpsampler.h
@@ -5,14 +5,8 @@
 namespace Cesium3DTilesSelection {
 class RasterOverlayUpsampler : public TilesetContentLoader {
 public:
-  CesiumAsync::Future<TileLoadResult> loadTileContent(
-      const Tile& tile,
-      const TilesetContentOptions& contentOptions,
-      const CesiumAsync::AsyncSystem& asyncSystem,
-      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
-      const std::shared_ptr<spdlog::logger>& pLogger,
-      const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders)
-      override;
+  CesiumAsync::Future<TileLoadResult>
+  loadTileContent(const TileLoadInput& loadInput) override;
 
   bool updateTileContent(Tile& tile) override;
 };

--- a/Cesium3DTilesSelection/src/RasterOverlayUpsampler.h
+++ b/Cesium3DTilesSelection/src/RasterOverlayUpsampler.h
@@ -6,7 +6,7 @@ namespace Cesium3DTilesSelection {
 class RasterOverlayUpsampler : public TilesetContentLoader {
 public:
   CesiumAsync::Future<TileLoadResult> loadTileContent(
-      Tile& tile,
+      const Tile& tile,
       const TilesetContentOptions& contentOptions,
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,

--- a/Cesium3DTilesSelection/src/TileContent.cpp
+++ b/Cesium3DTilesSelection/src/TileContent.cpp
@@ -81,7 +81,9 @@ const std::vector<Credit>& TileContent::getCredits() const noexcept {
 
 std::vector<Credit>& TileContent::getCredits() noexcept { return _credits; }
 
-TilesetContentLoader* TileContent::getLoader() noexcept { return _pLoader; }
+TilesetContentLoader* TileContent::getLoader() const noexcept {
+  return _pLoader;
+}
 
 void TileContent::setContentKind(TileContentKind&& contentKind) {
   _contentKind = std::move(contentKind);

--- a/Cesium3DTilesSelection/src/TilesetContentLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentLoader.cpp
@@ -1,0 +1,17 @@
+#include "TilesetContentLoader.h"
+
+namespace Cesium3DTilesSelection {
+TileLoadInput::TileLoadInput(
+    const Tile& tile_,
+    const TilesetContentOptions& contentOptions_,
+    const CesiumAsync::AsyncSystem& asyncSystem_,
+    const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor_,
+    const std::shared_ptr<spdlog::logger>& pLogger_,
+    const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders_)
+    : tile{tile_},
+      contentOptions{contentOptions_},
+      asyncSystem{asyncSystem_},
+      pAssetAccessor{pAssetAccessor_},
+      pLogger{pLogger_},
+      requestHeaders{requestHeaders_} {}
+} // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/TilesetContentLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetContentLoader.h
@@ -47,6 +47,11 @@ struct TileLoadResult {
   TileLoadResultState state;
 };
 
+struct TileChildrenResult {
+  std::vector<Tile> children;
+  TileLoadResultState state;
+};
+
 class TilesetContentLoader {
 public:
   virtual ~TilesetContentLoader() = default;
@@ -54,6 +59,6 @@ public:
   virtual CesiumAsync::Future<TileLoadResult>
   loadTileContent(const TileLoadInput& input) = 0;
 
-  virtual bool updateTileContent(Tile& tile) = 0;
+  virtual TileChildrenResult createTileChildren(const Tile& tile) = 0;
 };
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/TilesetContentLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetContentLoader.h
@@ -24,9 +24,10 @@ struct TileLoadResult {
   TileContentKind contentKind;
   std::optional<BoundingVolume> updatedBoundingVolume;
   std::optional<BoundingVolume> updatedContentBoundingVolume;
-  TileLoadResultState state;
+  std::optional<RasterOverlayDetails> rasterOverlayDetails;
   std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest;
   std::function<void(Tile&)> tileInitializer;
+  TileLoadResultState state;
 };
 
 class TilesetContentLoader {
@@ -34,7 +35,7 @@ public:
   virtual ~TilesetContentLoader() = default;
 
   virtual CesiumAsync::Future<TileLoadResult> loadTileContent(
-      Tile& tile,
+      const Tile& tile,
       const TilesetContentOptions& contentOptions,
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,

--- a/Cesium3DTilesSelection/src/TilesetContentLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetContentLoader.h
@@ -20,6 +20,23 @@ class Tile;
 
 enum class TileLoadResultState { Success, Failed, RetryLater };
 
+struct TileLoadInput {
+  TileLoadInput(
+      const Tile& tile,
+      const TilesetContentOptions& contentOptions,
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+      const std::shared_ptr<spdlog::logger>& pLogger,
+      const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders);
+
+  const Tile& tile;
+  const TilesetContentOptions& contentOptions;
+  const CesiumAsync::AsyncSystem& asyncSystem;
+  const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor;
+  const std::shared_ptr<spdlog::logger>& pLogger;
+  const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders;
+};
+
 struct TileLoadResult {
   TileContentKind contentKind;
   std::optional<BoundingVolume> updatedBoundingVolume;
@@ -34,14 +51,8 @@ class TilesetContentLoader {
 public:
   virtual ~TilesetContentLoader() = default;
 
-  virtual CesiumAsync::Future<TileLoadResult> loadTileContent(
-      const Tile& tile,
-      const TilesetContentOptions& contentOptions,
-      const CesiumAsync::AsyncSystem& asyncSystem,
-      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
-      const std::shared_ptr<spdlog::logger>& pLogger,
-      const std::vector<CesiumAsync::IAssetAccessor::THeader>&
-          requestHeaders) = 0;
+  virtual CesiumAsync::Future<TileLoadResult>
+  loadTileContent(const TileLoadInput& input) = 0;
 
   virtual bool updateTileContent(Tile& tile) = 0;
 };

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -316,6 +316,8 @@ void calcRasterOverlayDetailsInWorkerThread(
     }
   }
 
+  // generate the overlay details from the rest of projections and merge it with
+  // the existing one
   auto overlayDetails = GltfUtilities::createRasterOverlayTextureCoordinates(
       *renderContent.model,
       tileLoadInfo.tileTransform,

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -689,8 +689,15 @@ void TilesetContentManager::updateTileContent(
     break;
   }
 
-  if (content.shouldContentContinueUpdated()) {
-    content.setContentShouldContinueUpdated(_pLoader->updateTileContent(tile));
+  if (content.shouldContentContinueUpdated() && tile.getChildren().empty()) {
+    TileChildrenResult childrenResult = _pLoader->createTileChildren(tile);
+    if (childrenResult.state == TileLoadResultState::Success) {
+      tile.createChildTiles(std::move(childrenResult.children));
+    }
+
+    bool shouldTileContinueUpdated =
+        childrenResult.state == TileLoadResultState::RetryLater;
+    content.setContentShouldContinueUpdated(shouldTileContinueUpdated);
   }
 }
 

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -617,14 +617,15 @@ void TilesetContentManager::loadTileContent(
     pLoader = _pLoader.get();
   }
 
-  pLoader
-      ->loadTileContent(
-          tile,
-          tilesetOptions.contentOptions,
-          _externals.asyncSystem,
-          _externals.pAssetAccessor,
-          _externals.pLogger,
-          _requestHeaders)
+  TileLoadInput loadInput{
+      tile,
+      tilesetOptions.contentOptions,
+      _externals.asyncSystem,
+      _externals.pAssetAccessor,
+      _externals.pLogger,
+      _requestHeaders};
+
+  pLoader->loadTileContent(loadInput)
       .thenImmediately([tileLoadInfo = std::move(tileLoadInfo),
                         projections = std::move(projections)](
                            TileLoadResult&& result) mutable {

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -17,7 +17,6 @@ namespace Cesium3DTilesSelection {
 namespace {
 struct TileLoadResultAndRenderResources {
   TileLoadResult result;
-  std::optional<RasterOverlayDetails> rasterOverlayDetails;
   void* pRenderResources{nullptr};
 };
 
@@ -274,7 +273,7 @@ const BoundingVolume& getEffectiveContentBoundingVolume(
   return tileBoundingVolume;
 }
 
-std::optional<RasterOverlayDetails> calcRasterOverlayDetailsInWorkerThread(
+void calcRasterOverlayDetailsInWorkerThread(
     TileLoadResult& result,
     std::vector<CesiumGeospatial::Projection>&& projections,
     const TileContentLoadInfo& tileLoadInfo) {
@@ -295,12 +294,40 @@ std::optional<RasterOverlayDetails> calcRasterOverlayDetailsInWorkerThread(
   const CesiumGeospatial::BoundingRegion* pRegion =
       getBoundingRegionFromBoundingVolume(contentBoundingVolume);
 
+  // remove any projections that are already used to generated UV
+  int32_t firstRasterOverlayTexCoord = 0;
+  if (result.rasterOverlayDetails) {
+    const auto& existingProjections =
+        result.rasterOverlayDetails->rasterOverlayProjections;
+    firstRasterOverlayTexCoord =
+        static_cast<int32_t>(existingProjections.size());
+    for (size_t i = 0; i < projections.size(); ++i) {
+      for (const auto& existingProjection : existingProjections) {
+        if (projections[i] == existingProjection) {
+          if (i != projections.size() - 1) {
+            std::swap(projections[i], projections.back());
+          }
+
+          projections.pop_back();
+          --i;
+          break;
+        }
+      }
+    }
+  }
+
   auto overlayDetails = GltfUtilities::createRasterOverlayTextureCoordinates(
       *renderContent.model,
       tileLoadInfo.tileTransform,
-      0,
+      firstRasterOverlayTexCoord,
       pRegion ? std::make_optional(pRegion->getRectangle()) : std::nullopt,
       std::move(projections));
+
+  if (result.rasterOverlayDetails && overlayDetails) {
+    result.rasterOverlayDetails->merge(std::move(*overlayDetails));
+  } else if (overlayDetails) {
+    result.rasterOverlayDetails = std::move(*overlayDetails);
+  }
 
   if (pRegion && overlayDetails) {
     // If the original bounding region was wrong, report it.
@@ -339,13 +366,10 @@ std::optional<RasterOverlayDetails> calcRasterOverlayDetailsInWorkerThread(
           url);
     }
   }
-
-  return overlayDetails;
 }
 
 void calcFittestBoundingRegionForLooseTile(
     TileLoadResult& result,
-    const std::optional<RasterOverlayDetails>& rasterOverlayDetails,
     const TileContentLoadInfo& tileLoadInfo) {
   TileRenderContent& renderContent =
       std::get<TileRenderContent>(result.contentKind);
@@ -356,9 +380,10 @@ void calcFittestBoundingRegionForLooseTile(
       result.updatedContentBoundingVolume);
   if (std::get_if<CesiumGeospatial::BoundingRegionWithLooseFittingHeights>(
           &boundingVolume) != nullptr) {
-    if (rasterOverlayDetails) {
+    if (result.rasterOverlayDetails) {
       // We already computed the bounding region for overlays, so use it.
-      result.updatedBoundingVolume = rasterOverlayDetails->boundingRegion;
+      result.updatedBoundingVolume =
+          result.rasterOverlayDetails->boundingRegion;
     } else {
       // We need to compute an accurate bounding region
       result.updatedBoundingVolume = GltfUtilities::computeBoundingRegion(
@@ -381,16 +406,13 @@ TileLoadResultAndRenderResources postProcessGltfInWorkerThread(
   }
 
   // calculate raster overlay details
-  auto rasterOverlayDetails = calcRasterOverlayDetailsInWorkerThread(
+  calcRasterOverlayDetailsInWorkerThread(
       result,
       std::move(projections),
       tileLoadInfo);
 
   // If our tile bounding region has loose fitting heights, find the real ones.
-  calcFittestBoundingRegionForLooseTile(
-      result,
-      rasterOverlayDetails,
-      tileLoadInfo);
+  calcFittestBoundingRegionForLooseTile(result, tileLoadInfo);
 
   // generate missing smooth normal
   if (tileLoadInfo.contentOptions.generateMissingNormalsSmooth) {
@@ -403,10 +425,7 @@ TileLoadResultAndRenderResources postProcessGltfInWorkerThread(
           *renderContent.model,
           tileLoadInfo.tileTransform);
 
-  return TileLoadResultAndRenderResources{
-      std::move(result),
-      std::move(rasterOverlayDetails),
-      pRenderResources};
+  return TileLoadResultAndRenderResources{std::move(result), pRenderResources};
 }
 
 CesiumAsync::Future<TileLoadResultAndRenderResources>
@@ -633,14 +652,10 @@ void TilesetContentManager::loadTileContent(
 
         return tileLoadInfo.asyncSystem
             .createResolvedFuture<TileLoadResultAndRenderResources>(
-                {std::move(result), std::nullopt, nullptr});
+                {std::move(result), nullptr});
       })
       .thenInMainThread([&tile, this](TileLoadResultAndRenderResources&& pair) {
-        setTileContent(
-            tile,
-            std::move(pair.result),
-            std::move(pair.rasterOverlayDetails),
-            pair.pRenderResources);
+        setTileContent(tile, std::move(pair.result), pair.pRenderResources);
 
         notifyTileDoneLoading(tile);
       })
@@ -762,7 +777,6 @@ bool TilesetContentManager::doesTileNeedLoading(
 void TilesetContentManager::setTileContent(
     Tile& tile,
     TileLoadResult&& result,
-    std::optional<RasterOverlayDetails>&& rasterOverlayDetails,
     void* pWorkerRenderResources) {
   // update bounding volume
   if (result.updatedBoundingVolume) {
@@ -791,8 +805,8 @@ void TilesetContentManager::setTileContent(
   }
 
   content.setContentKind(std::move(result.contentKind));
-  if (rasterOverlayDetails) {
-    content.setRasterOverlayDetails(std::move(*rasterOverlayDetails));
+  if (result.rasterOverlayDetails) {
+    content.setRasterOverlayDetails(std::move(*result.rasterOverlayDetails));
   }
   content.setRenderResources(pWorkerRenderResources);
   content.setTileInitializerCallback(std::move(result.tileInitializer));

--- a/Cesium3DTilesSelection/src/TilesetContentManager.h
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.h
@@ -45,7 +45,6 @@ private:
   static void setTileContent(
       Tile& tile,
       TileLoadResult&& result,
-      std::optional<RasterOverlayDetails>&& rasterOverlayDetails,
       void* pWorkerRenderResources);
 
   void

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -683,9 +683,10 @@ TileLoadResult parseExternalTilesetInWorkerThread(
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        TileLoadResultState::Failed,
+        std::nullopt,
         std::move(pCompletedRequest),
-        {}};
+        {},
+        TileLoadResultState::Failed};
   }
 
   externalContentInitializer.pExternalTilesetLoaders =
@@ -697,9 +698,10 @@ TileLoadResult parseExternalTilesetInWorkerThread(
       TileExternalContent{},
       std::nullopt,
       std::nullopt,
-      TileLoadResultState::Success,
+      std::nullopt,
       std::move(pCompletedRequest),
-      std::move(externalContentInitializer)};
+      std::move(externalContentInitializer),
+      TileLoadResultState::Success};
 }
 } // namespace
 
@@ -746,7 +748,7 @@ CesiumAsync::Future<TilesetContentLoaderResult> TilesetJsonLoader::createLoader(
 }
 
 CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
-    Tile& tile,
+    const Tile& tile,
     const TilesetContentOptions& contentOptions,
     const CesiumAsync::AsyncSystem& asyncSystem,
     const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
@@ -771,9 +773,10 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
         TileUnknownContent{},
         std::nullopt,
         std::nullopt,
-        TileLoadResultState::Failed,
+        std::nullopt,
         nullptr,
-        {}});
+        {},
+        TileLoadResultState::Failed});
   }
 
   const glm::dmat4& tileTransform = tile.getTransform();
@@ -802,9 +805,10 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
                   TileUnknownContent{},
                   std::nullopt,
                   std::nullopt,
-                  TileLoadResultState::Failed,
+                  std::nullopt,
                   std::move(pCompletedRequest),
-                  {}};
+                  {},
+                  TileLoadResultState::Failed};
             }
 
             uint16_t statusCode = pResponse->statusCode();
@@ -818,9 +822,10 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
                   TileUnknownContent{},
                   std::nullopt,
                   std::nullopt,
-                  TileLoadResultState::Failed,
+                  std::nullopt,
                   std::move(pCompletedRequest),
-                  {}};
+                  {},
+                  TileLoadResultState::Failed};
             }
 
             // find gltf converter
@@ -844,18 +849,20 @@ CesiumAsync::Future<TileLoadResult> TilesetJsonLoader::loadTileContent(
                     TileRenderContent{std::nullopt},
                     std::nullopt,
                     std::nullopt,
-                    TileLoadResultState::Failed,
+                    std::nullopt,
                     std::move(pCompletedRequest),
-                    {}};
+                    {},
+                    TileLoadResultState::Failed};
               }
 
               return TileLoadResult{
                   TileRenderContent{std::move(result.model)},
                   std::nullopt,
                   std::nullopt,
-                  TileLoadResultState::Success,
+                  std::nullopt,
                   std::move(pCompletedRequest),
-                  {}};
+                  {},
+                  TileLoadResultState::Success};
             } else {
               // not a renderable content, then it must be external tileset
               return parseExternalTilesetInWorkerThread(

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -877,7 +877,7 @@ TileChildrenResult TilesetJsonLoader::createTileChildren(const Tile& tile) {
     return pLoader->createTileChildren(tile);
   }
 
-  return {{}, TileLoadResultState::Success};
+  return {{}, TileLoadResultState::Failed};
 }
 
 const std::string& TilesetJsonLoader::getBaseUrl() const noexcept {

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -871,13 +871,13 @@ TilesetJsonLoader::loadTileContent(const TileLoadInput& loadInput) {
           });
 }
 
-bool TilesetJsonLoader::updateTileContent(Tile& tile) {
+TileChildrenResult TilesetJsonLoader::createTileChildren(const Tile& tile) {
   auto pLoader = tile.getContent().getLoader();
   if (pLoader != this) {
-    return pLoader->updateTileContent(tile);
+    return pLoader->createTileChildren(tile);
   }
 
-  return false;
+  return {{}, TileLoadResultState::Success};
 }
 
 const std::string& TilesetJsonLoader::getBaseUrl() const noexcept {

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.h
@@ -16,14 +16,8 @@ class TilesetJsonLoader : public TilesetContentLoader {
 public:
   TilesetJsonLoader(const std::string& baseUrl);
 
-  CesiumAsync::Future<TileLoadResult> loadTileContent(
-      const Tile& tile,
-      const TilesetContentOptions& contentOptions,
-      const CesiumAsync::AsyncSystem& asyncSystem,
-      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
-      const std::shared_ptr<spdlog::logger>& pLogger,
-      const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders)
-      override;
+  CesiumAsync::Future<TileLoadResult>
+  loadTileContent(const TileLoadInput& loadInput) override;
 
   bool updateTileContent(Tile& tile) override;
 

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.h
@@ -19,7 +19,7 @@ public:
   CesiumAsync::Future<TileLoadResult>
   loadTileContent(const TileLoadInput& loadInput) override;
 
-  bool updateTileContent(Tile& tile) override;
+  TileChildrenResult createTileChildren(const Tile& tile) override;
 
   const std::string& getBaseUrl() const noexcept;
 

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.h
@@ -17,7 +17,7 @@ public:
   TilesetJsonLoader(const std::string& baseUrl);
 
   CesiumAsync::Future<TileLoadResult> loadTileContent(
-      Tile& tile,
+      const Tile& tile,
       const TilesetContentOptions& contentOptions,
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,


### PR DESCRIPTION
This is part of the refactor series #481. The loader now only accepts the const reference of tile in `TilesetContentLoader::loadTileContent()`. `TilesetContentLoader::updateTileContent()` is changed to `TilesetContentLoader::createTileChildren()` and accepts the const ref for tile as well