### PR TITLE
Only occlusion test tiles when they are within the frustum

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -601,6 +601,11 @@ private:
   // selection.
   std::vector<double> _distances;
 
+  // Caches frustum check results of children for the currently traversed tile.
+  // Allows for occlusion culling to reuse frustum results - occlusion queries
+  // only have to be issued for tiles that are within the frustum.
+  std::vector<bool> _childrenFrustumChecks;
+
   // Holds the occlusion proxies of the children of a tile. Store them in this
   // scratch variable so that it can allocate only when growing bigger.
   std::vector<const TileOcclusionRendererProxy*> _childOcclusionProxies;


### PR DESCRIPTION
Frustum culled tiles usually never reach _visitTile. When they do, they usually never need to refine. This means they don't need to check for occlusion. However, after #492 we use children BVs when possible to determine the visibility of a tile (both for frustum and occlusion culling). This lets us get a better hitrate on culling tiles not needed for the current view.

A tile is not considered frustum culled if only some of the children BVs are out of the frustum. This creates a situation where children BVs that are out of the frustum are still being occlusion tested. This creates two equally uncomfortable options for the renderer client:
- The client might issue a few unnecessary occlusion queries if the implementation does no independent frustum culling.
- If the client does its own frustum culling (e.g., Unreal Engine), the resulting occlusion results might come back invalid (since they may have never been issued). It will be hard then, to decide what to do in that case: do we wait because there will eventually be results, or do we just treat it as not occluded? If we treat a tile's child as unoccluded, but it turns out to just be out of the frustum, we may miss a chance to cull the tile.

Luckily, it's easy enough on our end to avoid occlusion queries for BVs out of the frustum: we can just cache the results of the frustum checks in _frustumCull and reuse them in _checkOcclusion.

