### PR TITLE
Update SqliteCache last access time correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug in `SqliteCache` where the last access time of resources was not updated correctly, sometimes causing more recently used resources to be evicted from the cache before less recently used ones.
+
 ### v0.18.0 - 2022-08-01
 
 ##### Breaking Changes :mega:

--- a/CesiumAsync/src/SqliteCache.cpp
+++ b/CesiumAsync/src/SqliteCache.cpp
@@ -61,7 +61,7 @@ const std::string GET_ENTRY_SQL =
 
 const std::string UPDATE_LAST_ACCESSED_TIME_SQL =
     "UPDATE " + CACHE_TABLE + " SET " + CACHE_TABLE_LAST_ACCESSED_TIME_COLUMN +
-    " = strftime('%s','now') WHERE " + CACHE_TABLE_KEY_COLUMN + " =?";
+    " = strftime('%s','now') WHERE rowid =?";
 
 // Sql commands for storing response
 const std::string STORE_RESPONSE_SQL =


### PR DESCRIPTION
Because of an error in a SQL statement, the last access time in the request cache was not updated on cache hit. This could lead to the wrong requests being evicted from the cache.