### PR TITLE
Replace std::unordered_map and std::map with Parallel Hashmap

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,3 +50,6 @@
 	path = extern/KTX-Software
 	url = https://github.com/CesiumGS/KTX-Software.git
 	branch = cesium-native
+[submodule "extern/parallel-hashmap"]
+	path = extern/parallel-hashmap
+	url = https://github.com/greg7mdp/parallel-hashmap

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+
+### ? - ?
+
+##### Additions :tada:
+
+- Replaced std::unordered\_map with [Parallel Hashmap](https://github.com/greg7mdp/parallel-hashmap) for better performance.
+
 ### v0.18.1 - 2022-08-04
 
 ##### Fixes :wrench:

--- a/Cesium3DTiles/generated/include/Cesium3DTiles/Class.h
+++ b/Cesium3DTiles/generated/include/Cesium3DTiles/Class.h
@@ -7,9 +7,10 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 namespace Cesium3DTiles {
 /**
@@ -33,6 +34,6 @@ struct CESIUM3DTILES_API Class final : public CesiumUtility::ExtensibleObject {
    * object defining the property. Property IDs shall be alphanumeric
    * identifiers matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
    */
-  std::unordered_map<std::string, Cesium3DTiles::ClassProperty> properties;
+  phmap::flat_hash_map<std::string, Cesium3DTiles::ClassProperty> properties;
 };
 } // namespace Cesium3DTiles

--- a/Cesium3DTiles/generated/include/Cesium3DTiles/ClassStatistics.h
+++ b/Cesium3DTiles/generated/include/Cesium3DTiles/ClassStatistics.h
@@ -7,9 +7,10 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <cstdint>
 #include <optional>
-#include <unordered_map>
 
 namespace Cesium3DTiles {
 /**
@@ -29,6 +30,7 @@ struct CESIUM3DTILES_API ClassStatistics final
    * class' `properties` dictionary and each value is an object containing
    * statistics about property values.
    */
-  std::unordered_map<std::string, Cesium3DTiles::PropertyStatistics> properties;
+  phmap::flat_hash_map<std::string, Cesium3DTiles::PropertyStatistics>
+      properties;
 };
 } // namespace Cesium3DTiles

--- a/Cesium3DTiles/generated/include/Cesium3DTiles/MetadataEntity.h
+++ b/Cesium3DTiles/generated/include/Cesium3DTiles/MetadataEntity.h
@@ -7,8 +7,9 @@
 #include <CesiumUtility/ExtensibleObject.h>
 #include <CesiumUtility/JsonValue.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <string>
-#include <unordered_map>
 
 namespace Cesium3DTiles {
 /**
@@ -35,6 +36,6 @@ struct CESIUM3DTILES_API MetadataEntity
    * values matching the `componentType`. Required properties shall be included
    * in this dictionary.
    */
-  std::unordered_map<std::string, CesiumUtility::JsonValue> properties;
+  phmap::flat_hash_map<std::string, CesiumUtility::JsonValue> properties;
 };
 } // namespace Cesium3DTiles

--- a/Cesium3DTiles/generated/include/Cesium3DTiles/PropertyStatistics.h
+++ b/Cesium3DTiles/generated/include/Cesium3DTiles/PropertyStatistics.h
@@ -7,8 +7,9 @@
 #include <CesiumUtility/ExtensibleObject.h>
 #include <CesiumUtility/JsonValue.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <optional>
-#include <unordered_map>
 
 namespace Cesium3DTiles {
 /**
@@ -80,6 +81,6 @@ struct CESIUM3DTILES_API PropertyStatistics final
    * `type` is `ENUM`. For fixed-length arrays, this is an array of
    * component-wise occurrences.
    */
-  std::unordered_map<std::string, CesiumUtility::JsonValue> occurrences;
+  phmap::flat_hash_map<std::string, CesiumUtility::JsonValue> occurrences;
 };
 } // namespace Cesium3DTiles

--- a/Cesium3DTiles/generated/include/Cesium3DTiles/PropertyTable.h
+++ b/Cesium3DTiles/generated/include/Cesium3DTiles/PropertyTable.h
@@ -7,10 +7,11 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <cstdint>
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 namespace Cesium3DTiles {
 /**
@@ -43,7 +44,7 @@ struct CESIUM3DTILES_API PropertyTable final
    * property values are stored. Required properties shall be included in this
    * dictionary.
    */
-  std::unordered_map<std::string, Cesium3DTiles::PropertyTableProperty>
+  phmap::flat_hash_map<std::string, Cesium3DTiles::PropertyTableProperty>
       properties;
 };
 } // namespace Cesium3DTiles

--- a/Cesium3DTiles/generated/include/Cesium3DTiles/Schema.h
+++ b/Cesium3DTiles/generated/include/Cesium3DTiles/Schema.h
@@ -8,9 +8,10 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 namespace Cesium3DTiles {
 /**
@@ -45,13 +46,13 @@ struct CESIUM3DTILES_API Schema final : public CesiumUtility::ExtensibleObject {
    * object defining the class. Class IDs shall be alphanumeric identifiers
    * matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
    */
-  std::unordered_map<std::string, Cesium3DTiles::Class> classes;
+  phmap::flat_hash_map<std::string, Cesium3DTiles::Class> classes;
 
   /**
    * @brief A dictionary, where each key is an enum ID and each value is an
    * object defining the values for the enum. Enum IDs shall be alphanumeric
    * identifiers matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
    */
-  std::unordered_map<std::string, Cesium3DTiles::Enum> enums;
+  phmap::flat_hash_map<std::string, Cesium3DTiles::Enum> enums;
 };
 } // namespace Cesium3DTiles

--- a/Cesium3DTiles/generated/include/Cesium3DTiles/Statistics.h
+++ b/Cesium3DTiles/generated/include/Cesium3DTiles/Statistics.h
@@ -7,7 +7,7 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
-#include <unordered_map>
+#include <parallel_hashmap/phmap.h>
 
 namespace Cesium3DTiles {
 /**
@@ -22,6 +22,6 @@ struct CESIUM3DTILES_API Statistics final
    * `classes` dictionary and each value is an object containing statistics
    * about entities that conform to the class.
    */
-  std::unordered_map<std::string, Cesium3DTiles::ClassStatistics> classes;
+  phmap::flat_hash_map<std::string, Cesium3DTiles::ClassStatistics> classes;
 };
 } // namespace Cesium3DTiles

--- a/Cesium3DTiles/generated/include/Cesium3DTiles/Tileset.h
+++ b/Cesium3DTiles/generated/include/Cesium3DTiles/Tileset.h
@@ -13,9 +13,10 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -34,7 +35,7 @@ struct CESIUM3DTILES_API Tileset final
   /**
    * @brief A dictionary object of metadata about per-feature properties.
    */
-  std::unordered_map<std::string, Cesium3DTiles::Properties> properties;
+  phmap::flat_hash_map<std::string, Cesium3DTiles::Properties> properties;
 
   /**
    * @brief An object defining the structure of metadata classes and enums. When

--- a/Cesium3DTilesReader/CMakeLists.txt
+++ b/Cesium3DTilesReader/CMakeLists.txt
@@ -56,7 +56,7 @@ target_link_libraries(Cesium3DTilesReader
         Cesium3DTiles
         CesiumJsonReader
         GSL
-	phmap
+        phmap
 )
 
 install(TARGETS Cesium3DTilesReader

--- a/Cesium3DTilesReader/CMakeLists.txt
+++ b/Cesium3DTilesReader/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(Cesium3DTilesReader
         Cesium3DTiles
         CesiumJsonReader
         GSL
+	phmap
 )
 
 install(TARGETS Cesium3DTilesReader

--- a/Cesium3DTilesReader/generated/src/GeneratedJsonHandlers.cpp
+++ b/Cesium3DTilesReader/generated/src/GeneratedJsonHandlers.cpp
@@ -34,6 +34,23 @@ Extension3dTilesBoundingVolumeS2JsonHandler::readObjectKey(
       *this->_pObject);
 }
 
+#if __GNUC__
+void Extension3dTilesBoundingVolumeS2JsonHandler::reset(
+    CesiumJsonReader::IJsonHandler* pParentHandler,
+    CesiumUtility::ExtensibleObject& o,
+    const std::string_view& extensionName) {
+  std::experimental::any& value =
+      o.extensions
+          .emplace(
+              extensionName,
+              Cesium3DTiles::Extension3dTilesBoundingVolumeS2())
+          .first->second;
+  this->reset(
+      pParentHandler,
+      &std::experimental::any_cast<
+          Cesium3DTiles::Extension3dTilesBoundingVolumeS2&>(value));
+}
+#else
 void Extension3dTilesBoundingVolumeS2JsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -47,6 +64,7 @@ void Extension3dTilesBoundingVolumeS2JsonHandler::reset(
       pParentHandler,
       &std::any_cast<Cesium3DTiles::Extension3dTilesBoundingVolumeS2&>(value));
 }
+#endif
 
 CesiumJsonReader::IJsonHandler* Extension3dTilesBoundingVolumeS2JsonHandler::
     readObjectKeyExtension3dTilesBoundingVolumeS2(

--- a/Cesium3DTilesReader/generated/src/GeneratedJsonHandlers.cpp
+++ b/Cesium3DTilesReader/generated/src/GeneratedJsonHandlers.cpp
@@ -34,7 +34,7 @@ Extension3dTilesBoundingVolumeS2JsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void Extension3dTilesBoundingVolumeS2JsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,

--- a/Cesium3DTilesReader/generated/src/GeneratedJsonHandlers.cpp
+++ b/Cesium3DTilesReader/generated/src/GeneratedJsonHandlers.cpp
@@ -34,7 +34,7 @@ Extension3dTilesBoundingVolumeS2JsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void Extension3dTilesBoundingVolumeS2JsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,

--- a/Cesium3DTilesReader/include/Cesium3DTilesReader/SchemaReader.h
+++ b/Cesium3DTilesReader/include/Cesium3DTilesReader/SchemaReader.h
@@ -11,7 +11,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace Cesium3DTilesReader {

--- a/Cesium3DTilesReader/include/Cesium3DTilesReader/SubtreeReader.h
+++ b/Cesium3DTilesReader/include/Cesium3DTilesReader/SubtreeReader.h
@@ -11,7 +11,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace Cesium3DTilesReader {

--- a/Cesium3DTilesReader/include/Cesium3DTilesReader/TilesetReader.h
+++ b/Cesium3DTilesReader/include/Cesium3DTilesReader/TilesetReader.h
@@ -11,7 +11,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace Cesium3DTilesReader {

--- a/Cesium3DTilesSelection/CMakeLists.txt
+++ b/Cesium3DTilesSelection/CMakeLists.txt
@@ -52,7 +52,7 @@ target_link_libraries(Cesium3DTilesSelection
     # PRIVATE
         tinyxml2
         uriparser
-	phmap
+        phmap
 )
 
 install(TARGETS Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/CMakeLists.txt
+++ b/Cesium3DTilesSelection/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(Cesium3DTilesSelection
     # PRIVATE
         tinyxml2
         uriparser
+	phmap
 )
 
 install(TARGETS Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/test/TestUpgradeBatchTableToExtFeatureMetadata.cpp
+++ b/Cesium3DTilesSelection/test/TestUpgradeBatchTableToExtFeatureMetadata.cpp
@@ -155,11 +155,11 @@ static void createTestForScalarJson(
   std::optional<Schema> schema = metadata->schema;
   REQUIRE(schema != std::nullopt);
 
-  const std::unordered_map<std::string, Class>& classes = schema->classes;
+  const phmap::flat_hash_map<std::string, Class>& classes = schema->classes;
   REQUIRE(classes.size() == 1);
 
   const Class& defaultClass = classes.at("default");
-  const std::unordered_map<std::string, ClassProperty>& properties =
+  const phmap::flat_hash_map<std::string, ClassProperty>& properties =
       defaultClass.properties;
   REQUIRE(properties.size() == 1);
 
@@ -232,11 +232,11 @@ static void createTestForArrayJson(
   std::optional<Schema> schema = metadata->schema;
   REQUIRE(schema != std::nullopt);
 
-  const std::unordered_map<std::string, Class>& classes = schema->classes;
+  const phmap::flat_hash_map<std::string, Class>& classes = schema->classes;
   REQUIRE(classes.size() == 1);
 
   const Class& defaultClass = classes.at("default");
-  const std::unordered_map<std::string, ClassProperty>& properties =
+  const phmap::flat_hash_map<std::string, ClassProperty>& properties =
       defaultClass.properties;
   REQUIRE(properties.size() == 1);
 
@@ -485,11 +485,11 @@ TEST_CASE("Convert binary batch table to EXT_feature_metadata") {
   std::optional<Schema> schema = metadata->schema;
   REQUIRE(schema != std::nullopt);
 
-  const std::unordered_map<std::string, Class>& classes = schema->classes;
+  const phmap::flat_hash_map<std::string, Class>& classes = schema->classes;
   REQUIRE(classes.size() == 1);
 
   const Class& defaultClass = classes.at("default");
-  const std::unordered_map<std::string, ClassProperty>& properties =
+  const phmap::flat_hash_map<std::string, ClassProperty>& properties =
       defaultClass.properties;
   REQUIRE(properties.size() == 6);
 
@@ -629,11 +629,11 @@ TEST_CASE("Upgrade json nested json metadata to string") {
   std::optional<Schema> schema = metadata->schema;
   REQUIRE(schema != std::nullopt);
 
-  const std::unordered_map<std::string, Class>& classes = schema->classes;
+  const phmap::flat_hash_map<std::string, Class>& classes = schema->classes;
   REQUIRE(classes.size() == 1);
 
   const Class& defaultClass = classes.at("default");
-  const std::unordered_map<std::string, ClassProperty>& properties =
+  const phmap::flat_hash_map<std::string, ClassProperty>& properties =
       defaultClass.properties;
   REQUIRE(properties.size() == 6);
 
@@ -719,11 +719,11 @@ TEST_CASE("Upgrade bool json to boolean binary") {
   std::optional<Schema> schema = metadata->schema;
   REQUIRE(schema != std::nullopt);
 
-  const std::unordered_map<std::string, Class>& classes = schema->classes;
+  const phmap::flat_hash_map<std::string, Class>& classes = schema->classes;
   REQUIRE(classes.size() == 1);
 
   const Class& defaultClass = classes.at("default");
-  const std::unordered_map<std::string, ClassProperty>& properties =
+  const phmap::flat_hash_map<std::string, ClassProperty>& properties =
       defaultClass.properties;
   REQUIRE(properties.size() == 1);
 

--- a/Cesium3DTilesWriter/CMakeLists.txt
+++ b/Cesium3DTilesWriter/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(Cesium3DTilesWriter
         Cesium3DTiles
         CesiumJsonWriter
         GSL
+	phmap
 )
 
 install(TARGETS Cesium3DTilesWriter

--- a/Cesium3DTilesWriter/CMakeLists.txt
+++ b/Cesium3DTilesWriter/CMakeLists.txt
@@ -56,7 +56,7 @@ target_link_libraries(Cesium3DTilesWriter
         Cesium3DTiles
         CesiumJsonWriter
         GSL
-	phmap
+        phmap
 )
 
 install(TARGETS Cesium3DTilesWriter

--- a/Cesium3DTilesWriter/generated/src/TilesetJsonWriter.cpp
+++ b/Cesium3DTilesWriter/generated/src/TilesetJsonWriter.cpp
@@ -227,7 +227,7 @@ template <typename T>
 
 template <typename T>
 [[maybe_unused]] void writeJson(
-    const std::unordered_map<std::string, T>& obj,
+    const phmap::flat_hash_map<std::string, T>& obj,
     CesiumJsonWriter::JsonWriter& jsonWriter,
     const CesiumJsonWriter::ExtensionWriterContext& context) {
   jsonWriter.StartObject();

--- a/CesiumAsync/include/CesiumAsync/Impl/RemoveFuture.h
+++ b/CesiumAsync/include/CesiumAsync/Impl/RemoveFuture.h
@@ -11,14 +11,24 @@ namespace CesiumImpl {
 // Begin omitting doxgen warnings for Impl namespace
 //! @cond Doxygen_Suppress
 
-template <typename T> struct RemoveFuture { typedef T type; };
-template <typename T> struct RemoveFuture<Future<T>> { typedef T type; };
-template <typename T> struct RemoveFuture<const Future<T>> { typedef T type; };
-template <typename T> struct RemoveFuture<SharedFuture<T>> { typedef T type; };
+template <typename T> struct RemoveFuture {
+  typedef T type;
+};
+template <typename T> struct RemoveFuture<Future<T>> {
+  typedef T type;
+};
+template <typename T> struct RemoveFuture<const Future<T>> {
+  typedef T type;
+};
+template <typename T> struct RemoveFuture<SharedFuture<T>> {
+  typedef T type;
+};
 template <typename T> struct RemoveFuture<const SharedFuture<T>> {
   typedef T type;
 };
-template <typename T> struct RemoveFuture<async::task<T>> { typedef T type; };
+template <typename T> struct RemoveFuture<async::task<T>> {
+  typedef T type;
+};
 template <typename T> struct RemoveFuture<const async::task<T>> {
   typedef T type;
 };

--- a/CesiumGltf/CMakeLists.txt
+++ b/CesiumGltf/CMakeLists.txt
@@ -55,7 +55,7 @@ target_link_libraries(CesiumGltf
     PUBLIC
         CesiumUtility
         GSL
-	phmap
+        phmap
 )
 
 install(TARGETS CesiumGltf

--- a/CesiumGltf/CMakeLists.txt
+++ b/CesiumGltf/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(CesiumGltf
     PUBLIC
         CesiumUtility
         GSL
+	phmap
 )
 
 install(TARGETS CesiumGltf

--- a/CesiumGltf/generated/include/CesiumGltf/Class.h
+++ b/CesiumGltf/generated/include/CesiumGltf/Class.h
@@ -7,9 +7,10 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 namespace CesiumGltf {
 /**
@@ -32,6 +33,6 @@ struct CESIUMGLTF_API Class final : public CesiumUtility::ExtensibleObject {
    * @brief A dictionary, where each key is a property ID and each value is an
    * object defining the property.
    */
-  std::unordered_map<std::string, CesiumGltf::ClassProperty> properties;
+  phmap::flat_hash_map<std::string, CesiumGltf::ClassProperty> properties;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/generated/include/CesiumGltf/ClassStatistics.h
+++ b/CesiumGltf/generated/include/CesiumGltf/ClassStatistics.h
@@ -7,9 +7,10 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <cstdint>
 #include <optional>
-#include <unordered_map>
 
 namespace CesiumGltf {
 /**
@@ -29,6 +30,6 @@ struct CESIUMGLTF_API ClassStatistics final
    * class' `properties` dictionary and each value is an object containing
    * statistics about property values.
    */
-  std::unordered_map<std::string, CesiumGltf::PropertyStatistics> properties;
+  phmap::flat_hash_map<std::string, CesiumGltf::PropertyStatistics> properties;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/generated/include/CesiumGltf/ExtensionExtMeshGpuInstancing.h
+++ b/CesiumGltf/generated/include/CesiumGltf/ExtensionExtMeshGpuInstancing.h
@@ -6,8 +6,9 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <cstdint>
-#include <unordered_map>
 
 namespace CesiumGltf {
 /**
@@ -30,6 +31,6 @@ struct CESIUMGLTF_API ExtensionExtMeshGpuInstancing final
    * "SCALE" the values are FLOAT_VEC3's specifying scaling factors along the x,
    * y, and z axes.
    */
-  std::unordered_map<std::string, int32_t> attributes;
+  phmap::flat_hash_map<std::string, int32_t> attributes;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/generated/include/CesiumGltf/ExtensionExtStructuralMetadataClass.h
+++ b/CesiumGltf/generated/include/CesiumGltf/ExtensionExtStructuralMetadataClass.h
@@ -7,9 +7,10 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 namespace CesiumGltf {
 /**
@@ -35,7 +36,7 @@ struct CESIUMGLTF_API ExtensionExtStructuralMetadataClass final
    * object defining the property. Property IDs must be alphanumeric identifiers
    * matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
    */
-  std::unordered_map<
+  phmap::flat_hash_map<
       std::string,
       CesiumGltf::ExtensionExtStructuralMetadataClassProperty>
       properties;

--- a/CesiumGltf/generated/include/CesiumGltf/ExtensionExtStructuralMetadataPropertyAttribute.h
+++ b/CesiumGltf/generated/include/CesiumGltf/ExtensionExtStructuralMetadataPropertyAttribute.h
@@ -7,9 +7,10 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 namespace CesiumGltf {
 /**
@@ -38,7 +39,7 @@ struct CESIUMGLTF_API ExtensionExtStructuralMetadataPropertyAttribute final
    * property values are stored. Required properties must be included in this
    * dictionary.
    */
-  std::unordered_map<
+  phmap::flat_hash_map<
       std::string,
       CesiumGltf::ExtensionExtStructuralMetadataPropertyAttributeProperty>
       properties;

--- a/CesiumGltf/generated/include/CesiumGltf/ExtensionExtStructuralMetadataPropertyTable.h
+++ b/CesiumGltf/generated/include/CesiumGltf/ExtensionExtStructuralMetadataPropertyTable.h
@@ -7,10 +7,11 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <cstdint>
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 namespace CesiumGltf {
 /**
@@ -44,7 +45,7 @@ struct CESIUMGLTF_API ExtensionExtStructuralMetadataPropertyTable final
    * property values are stored. Required properties must be included in this
    * dictionary.
    */
-  std::unordered_map<
+  phmap::flat_hash_map<
       std::string,
       CesiumGltf::ExtensionExtStructuralMetadataPropertyTableProperty>
       properties;

--- a/CesiumGltf/generated/include/CesiumGltf/ExtensionExtStructuralMetadataPropertyTexture.h
+++ b/CesiumGltf/generated/include/CesiumGltf/ExtensionExtStructuralMetadataPropertyTexture.h
@@ -7,9 +7,10 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 namespace CesiumGltf {
 /**
@@ -38,7 +39,7 @@ struct CESIUMGLTF_API ExtensionExtStructuralMetadataPropertyTexture final
    * property values are stored. Required properties must be included in this
    * dictionary.
    */
-  std::unordered_map<
+  phmap::flat_hash_map<
       std::string,
       CesiumGltf::ExtensionExtStructuralMetadataPropertyTextureProperty>
       properties;

--- a/CesiumGltf/generated/include/CesiumGltf/ExtensionExtStructuralMetadataSchema.h
+++ b/CesiumGltf/generated/include/CesiumGltf/ExtensionExtStructuralMetadataSchema.h
@@ -8,9 +8,10 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 namespace CesiumGltf {
 /**
@@ -47,7 +48,7 @@ struct CESIUMGLTF_API ExtensionExtStructuralMetadataSchema final
    * object defining the class. Class IDs must be alphanumeric identifiers
    * matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
    */
-  std::unordered_map<
+  phmap::flat_hash_map<
       std::string,
       CesiumGltf::ExtensionExtStructuralMetadataClass>
       classes;
@@ -57,8 +58,8 @@ struct CESIUMGLTF_API ExtensionExtStructuralMetadataSchema final
    * object defining the values for the enum. Enum IDs must be alphanumeric
    * identifiers matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
    */
-  std::
-      unordered_map<std::string, CesiumGltf::ExtensionExtStructuralMetadataEnum>
+  phmap::
+      flat_hash_map<std::string, CesiumGltf::ExtensionExtStructuralMetadataEnum>
           enums;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/generated/include/CesiumGltf/ExtensionKhrDracoMeshCompression.h
+++ b/CesiumGltf/generated/include/CesiumGltf/ExtensionKhrDracoMeshCompression.h
@@ -6,8 +6,9 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <cstdint>
-#include <unordered_map>
 
 namespace CesiumGltf {
 /**
@@ -29,6 +30,6 @@ struct CESIUMGLTF_API ExtensionKhrDracoMeshCompression final
    * @brief A dictionary object, where each key corresponds to an attribute and
    * its unique attribute id stored in the compressed geometry.
    */
-  std::unordered_map<std::string, int32_t> attributes;
+  phmap::flat_hash_map<std::string, int32_t> attributes;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/generated/include/CesiumGltf/ExtensionModelExtFeatureMetadata.h
+++ b/CesiumGltf/generated/include/CesiumGltf/ExtensionModelExtFeatureMetadata.h
@@ -10,9 +10,10 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 namespace CesiumGltf {
 /**
@@ -43,12 +44,12 @@ struct CESIUMGLTF_API ExtensionModelExtFeatureMetadata final
    * @brief A dictionary, where each key is a feature table ID and each value is
    * an object defining the feature table.
    */
-  std::unordered_map<std::string, CesiumGltf::FeatureTable> featureTables;
+  phmap::flat_hash_map<std::string, CesiumGltf::FeatureTable> featureTables;
 
   /**
    * @brief A dictionary, where each key is a feature texture ID and each value
    * is an object defining the feature texture.
    */
-  std::unordered_map<std::string, CesiumGltf::FeatureTexture> featureTextures;
+  phmap::flat_hash_map<std::string, CesiumGltf::FeatureTexture> featureTextures;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/generated/include/CesiumGltf/FeatureTable.h
+++ b/CesiumGltf/generated/include/CesiumGltf/FeatureTable.h
@@ -7,10 +7,11 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <cstdint>
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 namespace CesiumGltf {
 /**
@@ -39,6 +40,7 @@ struct CESIUMGLTF_API FeatureTable final
    * property values are stored. Optional properties may be excluded from this
    * dictionary.
    */
-  std::unordered_map<std::string, CesiumGltf::FeatureTableProperty> properties;
+  phmap::flat_hash_map<std::string, CesiumGltf::FeatureTableProperty>
+      properties;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/generated/include/CesiumGltf/FeatureTexture.h
+++ b/CesiumGltf/generated/include/CesiumGltf/FeatureTexture.h
@@ -7,8 +7,9 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <string>
-#include <unordered_map>
 
 namespace CesiumGltf {
 /**
@@ -31,6 +32,6 @@ struct CESIUMGLTF_API FeatureTexture final
    * class' `properties` dictionary and each value describes the texture
    * channels containing property values.
    */
-  std::unordered_map<std::string, CesiumGltf::TextureAccessor> properties;
+  phmap::flat_hash_map<std::string, CesiumGltf::TextureAccessor> properties;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/generated/include/CesiumGltf/MeshPrimitive.h
+++ b/CesiumGltf/generated/include/CesiumGltf/MeshPrimitive.h
@@ -6,8 +6,9 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <cstdint>
-#include <unordered_map>
 #include <vector>
 
 namespace CesiumGltf {
@@ -42,7 +43,7 @@ struct CESIUMGLTF_API MeshPrimitive final
    * semantic and each value is the index of the accessor containing attribute's
    * data.
    */
-  std::unordered_map<std::string, int32_t> attributes;
+  phmap::flat_hash_map<std::string, int32_t> attributes;
 
   /**
    * @brief The index of the accessor that contains the vertex indices.
@@ -69,6 +70,6 @@ struct CESIUMGLTF_API MeshPrimitive final
   /**
    * @brief An array of morph targets.
    */
-  std::vector<std::unordered_map<std::string, int32_t>> targets;
+  std::vector<phmap::flat_hash_map<std::string, int32_t>> targets;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/generated/include/CesiumGltf/PropertyStatistics.h
+++ b/CesiumGltf/generated/include/CesiumGltf/PropertyStatistics.h
@@ -7,8 +7,9 @@
 #include <CesiumUtility/ExtensibleObject.h>
 #include <CesiumUtility/JsonValue.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <optional>
-#include <unordered_map>
 
 namespace CesiumGltf {
 /**
@@ -87,6 +88,6 @@ struct CESIUMGLTF_API PropertyStatistics final
    * `type` or `componentType` is `ENUM`. For fixed-length arrays, this is an
    * array with `componentCount` number of elements.
    */
-  std::unordered_map<std::string, CesiumUtility::JsonValue> occurrences;
+  phmap::flat_hash_map<std::string, CesiumUtility::JsonValue> occurrences;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/generated/include/CesiumGltf/Schema.h
+++ b/CesiumGltf/generated/include/CesiumGltf/Schema.h
@@ -8,9 +8,10 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
+#include <parallel_hashmap/phmap.h>
+
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 namespace CesiumGltf {
 /**
@@ -38,12 +39,12 @@ struct CESIUMGLTF_API Schema final : public CesiumUtility::ExtensibleObject {
    * @brief A dictionary, where each key is a class ID and each value is an
    * object defining the class.
    */
-  std::unordered_map<std::string, CesiumGltf::Class> classes;
+  phmap::flat_hash_map<std::string, CesiumGltf::Class> classes;
 
   /**
    * @brief A dictionary, where each key is an enum ID and each value is an
    * object defining the values for the enum.
    */
-  std::unordered_map<std::string, CesiumGltf::Enum> enums;
+  phmap::flat_hash_map<std::string, CesiumGltf::Enum> enums;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/generated/include/CesiumGltf/Statistics.h
+++ b/CesiumGltf/generated/include/CesiumGltf/Statistics.h
@@ -7,7 +7,7 @@
 
 #include <CesiumUtility/ExtensibleObject.h>
 
-#include <unordered_map>
+#include <parallel_hashmap/phmap.h>
 
 namespace CesiumGltf {
 /**
@@ -22,6 +22,6 @@ struct CESIUMGLTF_API Statistics final
    * dictionary and each value is an object containing statistics about features
    * that conform to the class.
    */
-  std::unordered_map<std::string, CesiumGltf::ClassStatistics> classes;
+  phmap::flat_hash_map<std::string, CesiumGltf::ClassStatistics> classes;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/include/CesiumGltf/FeatureTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/FeatureTexturePropertyView.h
@@ -94,7 +94,9 @@ struct FeatureTexturePropertyChannelOffsets {
  * @tparam T The component type, must correspond to a valid
  * {@link FeatureTexturePropertyComponentType}.
  */
-template <typename T> struct FeatureTexturePropertyValue { T components[4]; };
+template <typename T> struct FeatureTexturePropertyValue {
+  T components[4];
+};
 
 /**
  * @brief A view of the data specified by a property from a

--- a/CesiumGltf/include/CesiumGltf/FeatureTextureView.h
+++ b/CesiumGltf/include/CesiumGltf/FeatureTextureView.h
@@ -11,6 +11,8 @@
 #include "ImageCesium.h"
 #include "Model.h"
 
+#include <unordered_map>
+
 namespace CesiumGltf {
 
 /**

--- a/CesiumGltfReader/generated/src/GeneratedJsonHandlers.cpp
+++ b/CesiumGltfReader/generated/src/GeneratedJsonHandlers.cpp
@@ -29,7 +29,7 @@ ExtensionCesiumRTCJsonHandler::readObjectKey(const std::string_view& str) {
       *this->_pObject);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void ExtensionCesiumRTCJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -105,7 +105,7 @@ ExtensionCesiumTileEdgesJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void ExtensionCesiumTileEdgesJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -192,7 +192,7 @@ ExtensionModelExtFeatureMetadataJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void ExtensionModelExtFeatureMetadataJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -285,7 +285,7 @@ ExtensionMeshPrimitiveExtFeatureMetadataJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void ExtensionMeshPrimitiveExtFeatureMetadataJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -381,7 +381,7 @@ ExtensionExtInstanceFeaturesJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void ExtensionExtInstanceFeaturesJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -457,7 +457,7 @@ ExtensionExtMeshFeaturesJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void ExtensionExtMeshFeaturesJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -533,7 +533,7 @@ ExtensionExtMeshGpuInstancingJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void ExtensionExtMeshGpuInstancingJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -609,7 +609,7 @@ ExtensionBufferExtMeshoptCompressionJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void ExtensionBufferExtMeshoptCompressionJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -696,7 +696,7 @@ ExtensionBufferViewExtMeshoptCompressionJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void ExtensionBufferViewExtMeshoptCompressionJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -795,7 +795,7 @@ ExtensionModelExtStructuralMetadataJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void ExtensionModelExtStructuralMetadataJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -890,7 +890,7 @@ ExtensionMeshPrimitiveExtStructuralMetadataJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void ExtensionMeshPrimitiveExtStructuralMetadataJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -982,7 +982,7 @@ ExtensionKhrDracoMeshCompressionJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void ExtensionKhrDracoMeshCompressionJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -1062,7 +1062,7 @@ ExtensionKhrMaterialsUnlitJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void ExtensionKhrMaterialsUnlitJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -1136,7 +1136,7 @@ ExtensionKhrTextureBasisuJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void ExtensionKhrTextureBasisuJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -1214,7 +1214,7 @@ ExtensionModelMaxarMeshVariantsJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void ExtensionModelMaxarMeshVariantsJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -1293,7 +1293,7 @@ ExtensionNodeMaxarMeshVariantsJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void ExtensionNodeMaxarMeshVariantsJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,

--- a/CesiumGltfReader/generated/src/GeneratedJsonHandlers.cpp
+++ b/CesiumGltfReader/generated/src/GeneratedJsonHandlers.cpp
@@ -29,6 +29,19 @@ ExtensionCesiumRTCJsonHandler::readObjectKey(const std::string_view& str) {
       *this->_pObject);
 }
 
+#if __GNUC__
+void ExtensionCesiumRTCJsonHandler::reset(
+    CesiumJsonReader::IJsonHandler* pParentHandler,
+    CesiumUtility::ExtensibleObject& o,
+    const std::string_view& extensionName) {
+  std::experimental::any& value =
+      o.extensions.emplace(extensionName, CesiumGltf::ExtensionCesiumRTC())
+          .first->second;
+  this->reset(
+      pParentHandler,
+      &std::experimental::any_cast<CesiumGltf::ExtensionCesiumRTC&>(value));
+}
+#else
 void ExtensionCesiumRTCJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -40,6 +53,7 @@ void ExtensionCesiumRTCJsonHandler::reset(
       pParentHandler,
       &std::any_cast<CesiumGltf::ExtensionCesiumRTC&>(value));
 }
+#endif
 
 CesiumJsonReader::IJsonHandler*
 ExtensionCesiumRTCJsonHandler::readObjectKeyExtensionCesiumRTC(
@@ -91,6 +105,21 @@ ExtensionCesiumTileEdgesJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
+#if __GNUC__
+void ExtensionCesiumTileEdgesJsonHandler::reset(
+    CesiumJsonReader::IJsonHandler* pParentHandler,
+    CesiumUtility::ExtensibleObject& o,
+    const std::string_view& extensionName) {
+  std::experimental::any& value =
+      o.extensions
+          .emplace(extensionName, CesiumGltf::ExtensionCesiumTileEdges())
+          .first->second;
+  this->reset(
+      pParentHandler,
+      &std::experimental::any_cast<CesiumGltf::ExtensionCesiumTileEdges&>(
+          value));
+}
+#else
 void ExtensionCesiumTileEdgesJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -103,6 +132,7 @@ void ExtensionCesiumTileEdgesJsonHandler::reset(
       pParentHandler,
       &std::any_cast<CesiumGltf::ExtensionCesiumTileEdges&>(value));
 }
+#endif
 
 CesiumJsonReader::IJsonHandler*
 ExtensionCesiumTileEdgesJsonHandler::readObjectKeyExtensionCesiumTileEdges(
@@ -162,6 +192,23 @@ ExtensionModelExtFeatureMetadataJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
+#if __GNUC__
+void ExtensionModelExtFeatureMetadataJsonHandler::reset(
+    CesiumJsonReader::IJsonHandler* pParentHandler,
+    CesiumUtility::ExtensibleObject& o,
+    const std::string_view& extensionName) {
+  std::experimental::any& value =
+      o.extensions
+          .emplace(
+              extensionName,
+              CesiumGltf::ExtensionModelExtFeatureMetadata())
+          .first->second;
+  this->reset(
+      pParentHandler,
+      &std::experimental::any_cast<
+          CesiumGltf::ExtensionModelExtFeatureMetadata&>(value));
+}
+#else
 void ExtensionModelExtFeatureMetadataJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -175,6 +222,7 @@ void ExtensionModelExtFeatureMetadataJsonHandler::reset(
       pParentHandler,
       &std::any_cast<CesiumGltf::ExtensionModelExtFeatureMetadata&>(value));
 }
+#endif
 
 CesiumJsonReader::IJsonHandler* ExtensionModelExtFeatureMetadataJsonHandler::
     readObjectKeyExtensionModelExtFeatureMetadata(
@@ -237,6 +285,23 @@ ExtensionMeshPrimitiveExtFeatureMetadataJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
+#if __GNUC__
+void ExtensionMeshPrimitiveExtFeatureMetadataJsonHandler::reset(
+    CesiumJsonReader::IJsonHandler* pParentHandler,
+    CesiumUtility::ExtensibleObject& o,
+    const std::string_view& extensionName) {
+  std::experimental::any& value =
+      o.extensions
+          .emplace(
+              extensionName,
+              CesiumGltf::ExtensionMeshPrimitiveExtFeatureMetadata())
+          .first->second;
+  this->reset(
+      pParentHandler,
+      &std::experimental::any_cast<
+          CesiumGltf::ExtensionMeshPrimitiveExtFeatureMetadata&>(value));
+}
+#else
 void ExtensionMeshPrimitiveExtFeatureMetadataJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -252,6 +317,7 @@ void ExtensionMeshPrimitiveExtFeatureMetadataJsonHandler::reset(
       &std::any_cast<CesiumGltf::ExtensionMeshPrimitiveExtFeatureMetadata&>(
           value));
 }
+#endif
 
 CesiumJsonReader::IJsonHandler*
 ExtensionMeshPrimitiveExtFeatureMetadataJsonHandler::
@@ -315,6 +381,21 @@ ExtensionExtInstanceFeaturesJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
+#if __GNUC__
+void ExtensionExtInstanceFeaturesJsonHandler::reset(
+    CesiumJsonReader::IJsonHandler* pParentHandler,
+    CesiumUtility::ExtensibleObject& o,
+    const std::string_view& extensionName) {
+  std::experimental::any& value =
+      o.extensions
+          .emplace(extensionName, CesiumGltf::ExtensionExtInstanceFeatures())
+          .first->second;
+  this->reset(
+      pParentHandler,
+      &std::experimental::any_cast<CesiumGltf::ExtensionExtInstanceFeatures&>(
+          value));
+}
+#else
 void ExtensionExtInstanceFeaturesJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -327,6 +408,7 @@ void ExtensionExtInstanceFeaturesJsonHandler::reset(
       pParentHandler,
       &std::any_cast<CesiumGltf::ExtensionExtInstanceFeatures&>(value));
 }
+#endif
 
 CesiumJsonReader::IJsonHandler* ExtensionExtInstanceFeaturesJsonHandler::
     readObjectKeyExtensionExtInstanceFeatures(
@@ -375,6 +457,21 @@ ExtensionExtMeshFeaturesJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
+#if __GNUC__
+void ExtensionExtMeshFeaturesJsonHandler::reset(
+    CesiumJsonReader::IJsonHandler* pParentHandler,
+    CesiumUtility::ExtensibleObject& o,
+    const std::string_view& extensionName) {
+  std::experimental::any& value =
+      o.extensions
+          .emplace(extensionName, CesiumGltf::ExtensionExtMeshFeatures())
+          .first->second;
+  this->reset(
+      pParentHandler,
+      &std::experimental::any_cast<CesiumGltf::ExtensionExtMeshFeatures&>(
+          value));
+}
+#else
 void ExtensionExtMeshFeaturesJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -387,6 +484,7 @@ void ExtensionExtMeshFeaturesJsonHandler::reset(
       pParentHandler,
       &std::any_cast<CesiumGltf::ExtensionExtMeshFeatures&>(value));
 }
+#endif
 
 CesiumJsonReader::IJsonHandler*
 ExtensionExtMeshFeaturesJsonHandler::readObjectKeyExtensionExtMeshFeatures(
@@ -435,6 +533,21 @@ ExtensionExtMeshGpuInstancingJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
+#if __GNUC__
+void ExtensionExtMeshGpuInstancingJsonHandler::reset(
+    CesiumJsonReader::IJsonHandler* pParentHandler,
+    CesiumUtility::ExtensibleObject& o,
+    const std::string_view& extensionName) {
+  std::experimental::any& value =
+      o.extensions
+          .emplace(extensionName, CesiumGltf::ExtensionExtMeshGpuInstancing())
+          .first->second;
+  this->reset(
+      pParentHandler,
+      &std::experimental::any_cast<CesiumGltf::ExtensionExtMeshGpuInstancing&>(
+          value));
+}
+#else
 void ExtensionExtMeshGpuInstancingJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -447,6 +560,7 @@ void ExtensionExtMeshGpuInstancingJsonHandler::reset(
       pParentHandler,
       &std::any_cast<CesiumGltf::ExtensionExtMeshGpuInstancing&>(value));
 }
+#endif
 
 CesiumJsonReader::IJsonHandler* ExtensionExtMeshGpuInstancingJsonHandler::
     readObjectKeyExtensionExtMeshGpuInstancing(
@@ -495,6 +609,23 @@ ExtensionBufferExtMeshoptCompressionJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
+#if __GNUC__
+void ExtensionBufferExtMeshoptCompressionJsonHandler::reset(
+    CesiumJsonReader::IJsonHandler* pParentHandler,
+    CesiumUtility::ExtensibleObject& o,
+    const std::string_view& extensionName) {
+  std::experimental::any& value =
+      o.extensions
+          .emplace(
+              extensionName,
+              CesiumGltf::ExtensionBufferExtMeshoptCompression())
+          .first->second;
+  this->reset(
+      pParentHandler,
+      &std::experimental::any_cast<
+          CesiumGltf::ExtensionBufferExtMeshoptCompression&>(value));
+}
+#else
 void ExtensionBufferExtMeshoptCompressionJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -508,6 +639,7 @@ void ExtensionBufferExtMeshoptCompressionJsonHandler::reset(
       pParentHandler,
       &std::any_cast<CesiumGltf::ExtensionBufferExtMeshoptCompression&>(value));
 }
+#endif
 
 CesiumJsonReader::IJsonHandler*
 ExtensionBufferExtMeshoptCompressionJsonHandler::
@@ -564,6 +696,23 @@ ExtensionBufferViewExtMeshoptCompressionJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
+#if __GNUC__
+void ExtensionBufferViewExtMeshoptCompressionJsonHandler::reset(
+    CesiumJsonReader::IJsonHandler* pParentHandler,
+    CesiumUtility::ExtensibleObject& o,
+    const std::string_view& extensionName) {
+  std::experimental::any& value =
+      o.extensions
+          .emplace(
+              extensionName,
+              CesiumGltf::ExtensionBufferViewExtMeshoptCompression())
+          .first->second;
+  this->reset(
+      pParentHandler,
+      &std::experimental::any_cast<
+          CesiumGltf::ExtensionBufferViewExtMeshoptCompression&>(value));
+}
+#else
 void ExtensionBufferViewExtMeshoptCompressionJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -579,6 +728,7 @@ void ExtensionBufferViewExtMeshoptCompressionJsonHandler::reset(
       &std::any_cast<CesiumGltf::ExtensionBufferViewExtMeshoptCompression&>(
           value));
 }
+#endif
 
 CesiumJsonReader::IJsonHandler*
 ExtensionBufferViewExtMeshoptCompressionJsonHandler::
@@ -645,6 +795,23 @@ ExtensionModelExtStructuralMetadataJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
+#if __GNUC__
+void ExtensionModelExtStructuralMetadataJsonHandler::reset(
+    CesiumJsonReader::IJsonHandler* pParentHandler,
+    CesiumUtility::ExtensibleObject& o,
+    const std::string_view& extensionName) {
+  std::experimental::any& value =
+      o.extensions
+          .emplace(
+              extensionName,
+              CesiumGltf::ExtensionModelExtStructuralMetadata())
+          .first->second;
+  this->reset(
+      pParentHandler,
+      &std::experimental::any_cast<
+          CesiumGltf::ExtensionModelExtStructuralMetadata&>(value));
+}
+#else
 void ExtensionModelExtStructuralMetadataJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -658,6 +825,7 @@ void ExtensionModelExtStructuralMetadataJsonHandler::reset(
       pParentHandler,
       &std::any_cast<CesiumGltf::ExtensionModelExtStructuralMetadata&>(value));
 }
+#endif
 
 CesiumJsonReader::IJsonHandler* ExtensionModelExtStructuralMetadataJsonHandler::
     readObjectKeyExtensionModelExtStructuralMetadata(
@@ -722,6 +890,23 @@ ExtensionMeshPrimitiveExtStructuralMetadataJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
+#if __GNUC__
+void ExtensionMeshPrimitiveExtStructuralMetadataJsonHandler::reset(
+    CesiumJsonReader::IJsonHandler* pParentHandler,
+    CesiumUtility::ExtensibleObject& o,
+    const std::string_view& extensionName) {
+  std::experimental::any& value =
+      o.extensions
+          .emplace(
+              extensionName,
+              CesiumGltf::ExtensionMeshPrimitiveExtStructuralMetadata())
+          .first->second;
+  this->reset(
+      pParentHandler,
+      &std::experimental::any_cast<
+          CesiumGltf::ExtensionMeshPrimitiveExtStructuralMetadata&>(value));
+}
+#else
 void ExtensionMeshPrimitiveExtStructuralMetadataJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -737,6 +922,7 @@ void ExtensionMeshPrimitiveExtStructuralMetadataJsonHandler::reset(
       &std::any_cast<CesiumGltf::ExtensionMeshPrimitiveExtStructuralMetadata&>(
           value));
 }
+#endif
 
 CesiumJsonReader::IJsonHandler*
 ExtensionMeshPrimitiveExtStructuralMetadataJsonHandler::
@@ -796,6 +982,23 @@ ExtensionKhrDracoMeshCompressionJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
+#if __GNUC__
+void ExtensionKhrDracoMeshCompressionJsonHandler::reset(
+    CesiumJsonReader::IJsonHandler* pParentHandler,
+    CesiumUtility::ExtensibleObject& o,
+    const std::string_view& extensionName) {
+  std::experimental::any& value =
+      o.extensions
+          .emplace(
+              extensionName,
+              CesiumGltf::ExtensionKhrDracoMeshCompression())
+          .first->second;
+  this->reset(
+      pParentHandler,
+      &std::experimental::any_cast<
+          CesiumGltf::ExtensionKhrDracoMeshCompression&>(value));
+}
+#else
 void ExtensionKhrDracoMeshCompressionJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -809,6 +1012,7 @@ void ExtensionKhrDracoMeshCompressionJsonHandler::reset(
       pParentHandler,
       &std::any_cast<CesiumGltf::ExtensionKhrDracoMeshCompression&>(value));
 }
+#endif
 
 CesiumJsonReader::IJsonHandler* ExtensionKhrDracoMeshCompressionJsonHandler::
     readObjectKeyExtensionKhrDracoMeshCompression(
@@ -858,6 +1062,21 @@ ExtensionKhrMaterialsUnlitJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
+#if __GNUC__
+void ExtensionKhrMaterialsUnlitJsonHandler::reset(
+    CesiumJsonReader::IJsonHandler* pParentHandler,
+    CesiumUtility::ExtensibleObject& o,
+    const std::string_view& extensionName) {
+  std::experimental::any& value =
+      o.extensions
+          .emplace(extensionName, CesiumGltf::ExtensionKhrMaterialsUnlit())
+          .first->second;
+  this->reset(
+      pParentHandler,
+      &std::experimental::any_cast<CesiumGltf::ExtensionKhrMaterialsUnlit&>(
+          value));
+}
+#else
 void ExtensionKhrMaterialsUnlitJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -870,6 +1089,7 @@ void ExtensionKhrMaterialsUnlitJsonHandler::reset(
       pParentHandler,
       &std::any_cast<CesiumGltf::ExtensionKhrMaterialsUnlit&>(value));
 }
+#endif
 
 CesiumJsonReader::IJsonHandler*
 ExtensionKhrMaterialsUnlitJsonHandler::readObjectKeyExtensionKhrMaterialsUnlit(
@@ -916,6 +1136,21 @@ ExtensionKhrTextureBasisuJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
+#if __GNUC__
+void ExtensionKhrTextureBasisuJsonHandler::reset(
+    CesiumJsonReader::IJsonHandler* pParentHandler,
+    CesiumUtility::ExtensibleObject& o,
+    const std::string_view& extensionName) {
+  std::experimental::any& value =
+      o.extensions
+          .emplace(extensionName, CesiumGltf::ExtensionKhrTextureBasisu())
+          .first->second;
+  this->reset(
+      pParentHandler,
+      &std::experimental::any_cast<CesiumGltf::ExtensionKhrTextureBasisu&>(
+          value));
+}
+#else
 void ExtensionKhrTextureBasisuJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -928,6 +1163,7 @@ void ExtensionKhrTextureBasisuJsonHandler::reset(
       pParentHandler,
       &std::any_cast<CesiumGltf::ExtensionKhrTextureBasisu&>(value));
 }
+#endif
 
 CesiumJsonReader::IJsonHandler*
 ExtensionKhrTextureBasisuJsonHandler::readObjectKeyExtensionKhrTextureBasisu(
@@ -978,6 +1214,21 @@ ExtensionModelMaxarMeshVariantsJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
+#if __GNUC__
+void ExtensionModelMaxarMeshVariantsJsonHandler::reset(
+    CesiumJsonReader::IJsonHandler* pParentHandler,
+    CesiumUtility::ExtensibleObject& o,
+    const std::string_view& extensionName) {
+  std::experimental::any& value =
+      o.extensions
+          .emplace(extensionName, CesiumGltf::ExtensionModelMaxarMeshVariants())
+          .first->second;
+  this->reset(
+      pParentHandler,
+      &std::experimental::any_cast<
+          CesiumGltf::ExtensionModelMaxarMeshVariants&>(value));
+}
+#else
 void ExtensionModelMaxarMeshVariantsJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -990,6 +1241,7 @@ void ExtensionModelMaxarMeshVariantsJsonHandler::reset(
       pParentHandler,
       &std::any_cast<CesiumGltf::ExtensionModelMaxarMeshVariants&>(value));
 }
+#endif
 
 CesiumJsonReader::IJsonHandler* ExtensionModelMaxarMeshVariantsJsonHandler::
     readObjectKeyExtensionModelMaxarMeshVariants(
@@ -1041,6 +1293,21 @@ ExtensionNodeMaxarMeshVariantsJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
+#if __GNUC__
+void ExtensionNodeMaxarMeshVariantsJsonHandler::reset(
+    CesiumJsonReader::IJsonHandler* pParentHandler,
+    CesiumUtility::ExtensibleObject& o,
+    const std::string_view& extensionName) {
+  std::experimental::any& value =
+      o.extensions
+          .emplace(extensionName, CesiumGltf::ExtensionNodeMaxarMeshVariants())
+          .first->second;
+  this->reset(
+      pParentHandler,
+      &std::experimental::any_cast<CesiumGltf::ExtensionNodeMaxarMeshVariants&>(
+          value));
+}
+#else
 void ExtensionNodeMaxarMeshVariantsJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -1053,6 +1320,7 @@ void ExtensionNodeMaxarMeshVariantsJsonHandler::reset(
       pParentHandler,
       &std::any_cast<CesiumGltf::ExtensionNodeMaxarMeshVariants&>(value));
 }
+#endif
 
 CesiumJsonReader::IJsonHandler* ExtensionNodeMaxarMeshVariantsJsonHandler::
     readObjectKeyExtensionNodeMaxarMeshVariants(

--- a/CesiumGltfReader/generated/src/GeneratedJsonHandlers.cpp
+++ b/CesiumGltfReader/generated/src/GeneratedJsonHandlers.cpp
@@ -29,7 +29,7 @@ ExtensionCesiumRTCJsonHandler::readObjectKey(const std::string_view& str) {
       *this->_pObject);
 }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void ExtensionCesiumRTCJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -105,7 +105,7 @@ ExtensionCesiumTileEdgesJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void ExtensionCesiumTileEdgesJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -192,7 +192,7 @@ ExtensionModelExtFeatureMetadataJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void ExtensionModelExtFeatureMetadataJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -285,7 +285,7 @@ ExtensionMeshPrimitiveExtFeatureMetadataJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void ExtensionMeshPrimitiveExtFeatureMetadataJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -381,7 +381,7 @@ ExtensionExtInstanceFeaturesJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void ExtensionExtInstanceFeaturesJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -457,7 +457,7 @@ ExtensionExtMeshFeaturesJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void ExtensionExtMeshFeaturesJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -533,7 +533,7 @@ ExtensionExtMeshGpuInstancingJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void ExtensionExtMeshGpuInstancingJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -609,7 +609,7 @@ ExtensionBufferExtMeshoptCompressionJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void ExtensionBufferExtMeshoptCompressionJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -696,7 +696,7 @@ ExtensionBufferViewExtMeshoptCompressionJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void ExtensionBufferViewExtMeshoptCompressionJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -795,7 +795,7 @@ ExtensionModelExtStructuralMetadataJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void ExtensionModelExtStructuralMetadataJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -890,7 +890,7 @@ ExtensionMeshPrimitiveExtStructuralMetadataJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void ExtensionMeshPrimitiveExtStructuralMetadataJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -982,7 +982,7 @@ ExtensionKhrDracoMeshCompressionJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void ExtensionKhrDracoMeshCompressionJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -1062,7 +1062,7 @@ ExtensionKhrMaterialsUnlitJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void ExtensionKhrMaterialsUnlitJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -1136,7 +1136,7 @@ ExtensionKhrTextureBasisuJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void ExtensionKhrTextureBasisuJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -1214,7 +1214,7 @@ ExtensionModelMaxarMeshVariantsJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void ExtensionModelMaxarMeshVariantsJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,
@@ -1293,7 +1293,7 @@ ExtensionNodeMaxarMeshVariantsJsonHandler::readObjectKey(
       *this->_pObject);
 }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void ExtensionNodeMaxarMeshVariantsJsonHandler::reset(
     CesiumJsonReader::IJsonHandler* pParentHandler,
     CesiumUtility::ExtensibleObject& o,

--- a/CesiumGltfReader/generated/src/MeshPrimitiveJsonHandler.h
+++ b/CesiumGltfReader/generated/src/MeshPrimitiveJsonHandler.h
@@ -40,7 +40,7 @@ private:
   CesiumJsonReader::IntegerJsonHandler<int32_t> _material;
   CesiumJsonReader::IntegerJsonHandler<int32_t> _mode;
   CesiumJsonReader::ArrayJsonHandler<
-      std::unordered_map<std::string, int32_t>,
+      phmap::flat_hash_map<std::string, int32_t>,
       CesiumJsonReader::DictionaryJsonHandler<
           int32_t,
           CesiumJsonReader::IntegerJsonHandler<int32_t>>>

--- a/CesiumGltfReader/test/TestGltfReader.cpp
+++ b/CesiumGltfReader/test/TestGltfReader.cpp
@@ -12,7 +12,6 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
-#include <type_traits>
 
 using namespace CesiumGltf;
 using namespace CesiumGltfReader;
@@ -32,10 +31,6 @@ std::vector<std::byte> readFile(const std::filesystem::path& fileName) {
   return buffer;
 }
 } // namespace
-
-TEST_CASE("CesiumGltf::Model move constructor is noexcept") {
-  CHECK(std::is_nothrow_move_constructible<CesiumGltf::Model>::value);
-}
 
 TEST_CASE("CesiumGltfReader::GltfReader") {
   using namespace std::string_literals;

--- a/CesiumGltfReader/test/TestGltfReader.cpp
+++ b/CesiumGltfReader/test/TestGltfReader.cpp
@@ -9,12 +9,9 @@
 #include <gsl/span>
 #include <rapidjson/reader.h>
 
-#include <chrono>
 #include <filesystem>
 #include <fstream>
-#include <iostream>
 #include <string>
-using namespace std::chrono;
 
 using namespace CesiumGltf;
 using namespace CesiumGltfReader;
@@ -34,74 +31,6 @@ std::vector<std::byte> readFile(const std::filesystem::path& fileName) {
   return buffer;
 }
 } // namespace
-
-namespace fs = std::filesystem;
-
-TEST_CASE("Read GLTF samples") {
-  std::string path("C:/dev-base/glTF-Sample-Models/2.0/");
-  std::string ext(".gltf");
-
-  std::vector<CesiumGltf::Model> models;
-
-  std::vector<std::vector<std::byte>> files;
-
-  for (auto& p : fs::recursive_directory_iterator(path)) {
-    if (p.path().extension() == ext) {
-      std::string filename = p.path().string();
-      files.push_back(readFile(filename));
-    }
-  }
-
-  // for (int i = 0; i < 10; i++) {
-  for (const auto& bytes : files) {
-    GltfReader reader;
-    GltfReaderResult result = reader.readGltf(
-        gsl::span(reinterpret_cast<const std::byte*>(&bytes[0]), bytes.size()));
-    if (result.model) {
-      models.emplace_back(std::move(*result.model));
-    }
-  }
-  // }
-
-  auto start = high_resolution_clock::now();
-
-  std::vector<CesiumGltf::Model> modelCopies = models;
-  for (int i = 0; i < 40; i++) {
-    modelCopies.insert(modelCopies.end(), models.begin(), models.end());
-  }
-
-  auto stop = high_resolution_clock::now();
-
-  auto duration = duration_cast<seconds>(stop - start);
-
-  std::cout << duration.count() << std::endl;
-}
-
-// TEST_CASE("Test speed improvement") {
-//    auto bytes = readFile(
-//        "c:\\users\\josep\\downloads\\translucent\\2cylinderengine.gltf");
-//
-//    GltfReader reader;
-//    GltfReaderResult result = reader.readGltf(
-//        gsl::span(reinterpret_cast<const std::byte*>(&bytes[0]),
-//        bytes.size()));
-//
-//    Model& model = result.model.value();
-//
-//    std::vector<Model> copies;
-//
-//
-//   auto start = high_resolution_clock::now();
-//    for (int i = 0; i < 5000; i++) {
-//     copies.push_back(model);
-//   }
-//
-//    auto stop = high_resolution_clock::now();
-//
-//    auto duration = duration_cast<seconds>(stop - start);
-//
-//    std::cout << duration.count() << std::endl;
-// }
 
 TEST_CASE("CesiumGltfReader::GltfReader") {
   using namespace std::string_literals;

--- a/CesiumGltfReader/test/TestGltfReader.cpp
+++ b/CesiumGltfReader/test/TestGltfReader.cpp
@@ -12,6 +12,7 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <type_traits>
 
 using namespace CesiumGltf;
 using namespace CesiumGltfReader;
@@ -31,6 +32,10 @@ std::vector<std::byte> readFile(const std::filesystem::path& fileName) {
   return buffer;
 }
 } // namespace
+
+TEST_CASE("CesiumGltf::Model move constructor is noexcept") {
+  CHECK(std::is_nothrow_move_constructible<CesiumGltf::Model>::value);
+}
 
 TEST_CASE("CesiumGltfReader::GltfReader") {
   using namespace std::string_literals;

--- a/CesiumGltfWriter/generated/src/ModelJsonWriter.cpp
+++ b/CesiumGltfWriter/generated/src/ModelJsonWriter.cpp
@@ -529,7 +529,7 @@ template <typename T>
 
 template <typename T>
 [[maybe_unused]] void writeJson(
-    const std::unordered_map<std::string, T>& obj,
+    const phmap::flat_hash_map<std::string, T>& obj,
     CesiumJsonWriter::JsonWriter& jsonWriter,
     const CesiumJsonWriter::ExtensionWriterContext& context) {
   jsonWriter.StartObject();

--- a/CesiumJsonReader/include/CesiumJsonReader/DictionaryJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/DictionaryJsonHandler.h
@@ -4,8 +4,9 @@
 #include "Library.h"
 #include "ObjectJsonHandler.h"
 
+#include <parallel_hashmap/phmap.h>
+
 #include <map>
-#include <unordered_map>
 
 namespace CesiumJsonReader {
 template <typename T, typename THandler>
@@ -17,14 +18,9 @@ public:
 
   void reset(
       IJsonHandler* pParent,
-      std::unordered_map<std::string, T>* pDictionary) {
+      phmap::flat_hash_map<std::string, T>* pDictionary) {
     ObjectJsonHandler::reset(pParent);
     this->_pDictionary1 = pDictionary;
-  }
-
-  void reset(IJsonHandler* pParent, std::map<std::string, T>* pDictionary) {
-    ObjectJsonHandler::reset(pParent);
-    this->_pDictionary2 = pDictionary;
   }
 
   virtual IJsonHandler* readObjectKey(const std::string_view& str) override {
@@ -42,8 +38,8 @@ public:
   }
 
 private:
-  std::unordered_map<std::string, T>* _pDictionary1 = nullptr;
-  std::map<std::string, T>* _pDictionary2 = nullptr;
+  phmap::flat_hash_map<std::string, T>* _pDictionary1 = nullptr;
+  phmap::flat_hash_map<std::string, T>* _pDictionary2 = nullptr;
   THandler _item;
 };
 } // namespace CesiumJsonReader

--- a/CesiumJsonReader/include/CesiumJsonReader/ExtensionReaderContext.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/ExtensionReaderContext.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace CesiumJsonReader {

--- a/CesiumJsonReader/include/CesiumJsonReader/IExtensionJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/IExtensionJsonHandler.h
@@ -3,7 +3,7 @@
 #include "IJsonHandler.h"
 
 #include <CesiumUtility/ExtensibleObject.h>
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 #include <experimental/any>
 #else
 #include <any>

--- a/CesiumJsonReader/include/CesiumJsonReader/IExtensionJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/IExtensionJsonHandler.h
@@ -3,8 +3,11 @@
 #include "IJsonHandler.h"
 
 #include <CesiumUtility/ExtensibleObject.h>
-
+#if __GNUC__
+#include <experimental/any>
+#else
 #include <any>
+#endif
 #include <string_view>
 
 namespace CesiumJsonReader {

--- a/CesiumJsonReader/include/CesiumJsonReader/IExtensionJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/IExtensionJsonHandler.h
@@ -3,7 +3,7 @@
 #include "IJsonHandler.h"
 
 #include <CesiumUtility/ExtensibleObject.h>
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #include <experimental/any>
 #else
 #include <any>

--- a/CesiumJsonReader/src/ExtensionReaderContext.cpp
+++ b/CesiumJsonReader/src/ExtensionReaderContext.cpp
@@ -14,7 +14,7 @@ public:
       IJsonHandler* pParentHandler,
       CesiumUtility::ExtensibleObject& o,
       const std::string_view& extensionName) override {
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
     std::experimental::any& value =
         o.extensions
             .emplace(

--- a/CesiumJsonReader/src/ExtensionReaderContext.cpp
+++ b/CesiumJsonReader/src/ExtensionReaderContext.cpp
@@ -14,7 +14,7 @@ public:
       IJsonHandler* pParentHandler,
       CesiumUtility::ExtensibleObject& o,
       const std::string_view& extensionName) override {
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
     std::experimental::any& value =
         o.extensions
             .emplace(

--- a/CesiumJsonReader/src/ExtensionReaderContext.cpp
+++ b/CesiumJsonReader/src/ExtensionReaderContext.cpp
@@ -14,6 +14,17 @@ public:
       IJsonHandler* pParentHandler,
       CesiumUtility::ExtensibleObject& o,
       const std::string_view& extensionName) override {
+#if __GNUC__
+    std::experimental::any& value =
+        o.extensions
+            .emplace(
+                extensionName,
+                CesiumUtility::JsonValue(CesiumUtility::JsonValue::Object()))
+            .first->second;
+    JsonObjectJsonHandler::reset(
+        pParentHandler,
+        &std::experimental::any_cast<CesiumUtility::JsonValue&>(value));
+#else
     std::any& value =
         o.extensions
             .emplace(
@@ -23,6 +34,7 @@ public:
     JsonObjectJsonHandler::reset(
         pParentHandler,
         &std::any_cast<CesiumUtility::JsonValue&>(value));
+#endif
   }
 
   virtual IJsonHandler* readNull() override {

--- a/CesiumJsonWriter/include/CesiumJsonWriter/ExtensionWriterContext.h
+++ b/CesiumJsonWriter/include/CesiumJsonWriter/ExtensionWriterContext.h
@@ -2,7 +2,7 @@
 
 #include "CesiumJsonWriter/JsonWriter.h"
 #include "CesiumJsonWriter/Library.h"
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #include <experimental/any>
 #else
 #include <any>
@@ -65,7 +65,7 @@ public:
 
     auto it =
         this->_extensions.emplace(extensionName, ObjectTypeToHandler()).first;
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
     it->second.insert_or_assign(
         TExtended::TypeName,
         [](const std::experimental::any& obj,
@@ -125,7 +125,7 @@ public:
    */
   void
   setExtensionState(const std::string& extensionName, ExtensionState newState);
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
   ExtensionHandler<std::experimental::any> createExtensionHandler(
       const std::string_view& extensionName,
       const std::string& extendedObjectType) const;
@@ -135,7 +135,7 @@ public:
       const std::string& extendedObjectType) const;
 #endif
 private:
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
   using ObjectTypeToHandler =
       std::unordered_map<std::string, ExtensionHandler<std::experimental::any>>;
 #else

--- a/CesiumJsonWriter/include/CesiumJsonWriter/ExtensionWriterContext.h
+++ b/CesiumJsonWriter/include/CesiumJsonWriter/ExtensionWriterContext.h
@@ -2,7 +2,7 @@
 
 #include "CesiumJsonWriter/JsonWriter.h"
 #include "CesiumJsonWriter/Library.h"
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 #include <experimental/any>
 #else
 #include <any>
@@ -65,7 +65,7 @@ public:
 
     auto it =
         this->_extensions.emplace(extensionName, ObjectTypeToHandler()).first;
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
     it->second.insert_or_assign(
         TExtended::TypeName,
         [](const std::experimental::any& obj,
@@ -125,7 +125,7 @@ public:
    */
   void
   setExtensionState(const std::string& extensionName, ExtensionState newState);
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
   ExtensionHandler<std::experimental::any> createExtensionHandler(
       const std::string_view& extensionName,
       const std::string& extendedObjectType) const;
@@ -135,7 +135,7 @@ public:
       const std::string& extendedObjectType) const;
 #endif
 private:
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
   using ObjectTypeToHandler =
       std::unordered_map<std::string, ExtensionHandler<std::experimental::any>>;
 #else

--- a/CesiumJsonWriter/src/ExtensionWriterContext.cpp
+++ b/CesiumJsonWriter/src/ExtensionWriterContext.cpp
@@ -7,6 +7,15 @@
 
 namespace CesiumJsonWriter {
 namespace {
+#if __GNUC__
+void objWriter(
+    const std::experimental::any& obj,
+    JsonWriter& jsonWriter,
+    const ExtensionWriterContext& /* context */) {
+  writeJsonValue(
+      std::experimental::any_cast<const CesiumUtility::JsonValue&>(obj),
+      jsonWriter);
+#else
 void objWriter(
     const std::any& obj,
     JsonWriter& jsonWriter,
@@ -14,10 +23,15 @@ void objWriter(
   writeJsonValue(
       std::any_cast<const CesiumUtility::JsonValue&>(obj),
       jsonWriter);
+#endif
 }
 } // namespace
 
+#if __GNUC__
+ExtensionWriterContext::ExtensionHandler<std::experimental::any>
+#else
 ExtensionWriterContext::ExtensionHandler<std::any>
+#endif
 ExtensionWriterContext::createExtensionHandler(
     const std::string_view& extensionName,
     const std::string& extendedObjectType) const {

--- a/CesiumJsonWriter/src/ExtensionWriterContext.cpp
+++ b/CesiumJsonWriter/src/ExtensionWriterContext.cpp
@@ -7,7 +7,7 @@
 
 namespace CesiumJsonWriter {
 namespace {
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 void objWriter(
     const std::experimental::any& obj,
     JsonWriter& jsonWriter,
@@ -27,7 +27,7 @@ void objWriter(
 }
 } // namespace
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 ExtensionWriterContext::ExtensionHandler<std::experimental::any>
 #else
 ExtensionWriterContext::ExtensionHandler<std::any>

--- a/CesiumJsonWriter/src/ExtensionWriterContext.cpp
+++ b/CesiumJsonWriter/src/ExtensionWriterContext.cpp
@@ -7,7 +7,7 @@
 
 namespace CesiumJsonWriter {
 namespace {
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 void objWriter(
     const std::experimental::any& obj,
     JsonWriter& jsonWriter,
@@ -27,7 +27,7 @@ void objWriter(
 }
 } // namespace
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 ExtensionWriterContext::ExtensionHandler<std::experimental::any>
 #else
 ExtensionWriterContext::ExtensionHandler<std::any>

--- a/CesiumUtility/CMakeLists.txt
+++ b/CesiumUtility/CMakeLists.txt
@@ -50,7 +50,7 @@ target_link_libraries_system(
 target_link_libraries(CesiumUtility
     PUBLIC
         GSL
-	phmap
+        phmap
 )
 
 install(TARGETS CesiumUtility

--- a/CesiumUtility/CMakeLists.txt
+++ b/CesiumUtility/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries_system(
 target_link_libraries(CesiumUtility
     PUBLIC
         GSL
+	phmap
 )
 
 install(TARGETS CesiumUtility

--- a/CesiumUtility/include/CesiumUtility/ExtensibleObject.h
+++ b/CesiumUtility/include/CesiumUtility/ExtensibleObject.h
@@ -3,8 +3,9 @@
 #include "JsonValue.h"
 #include "Library.h"
 
+#include <parallel_hashmap/phmap.h>
+
 #include <any>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -84,7 +85,7 @@ struct CESIUMUTILITY_API ExtensibleObject {
    * type. Use {@link getGenericExtension} to get unknown extensions as a
    * generic {@link CesiumUtility::JsonValue}.
    */
-  std::unordered_map<std::string, std::any> extensions;
+  phmap::flat_hash_map<std::string, std::any> extensions;
 
   /**
    * @brief Application-specific data.

--- a/CesiumUtility/include/CesiumUtility/ExtensibleObject.h
+++ b/CesiumUtility/include/CesiumUtility/ExtensibleObject.h
@@ -6,8 +6,6 @@
 #include <parallel_hashmap/phmap.h>
 #if __GNUC__
 #include <experimental/any>
-
-#include <utility>
 #else
 #include <any>
 #endif
@@ -82,7 +80,7 @@ struct CESIUMUTILITY_API ExtensibleObject {
   template <typename T> T& addExtension() {
 #if __GNUC__
     std::experimental::any& extension =
-        extensions.try_emplace(T::ExtensionName, std::experimental::any())
+        extensions.try_emplace(T::ExtensionName, std::experimental::any(T()))
             .first->second;
     return std::experimental::any_cast<T&>(extension);
 #else

--- a/CesiumUtility/include/CesiumUtility/ExtensibleObject.h
+++ b/CesiumUtility/include/CesiumUtility/ExtensibleObject.h
@@ -4,7 +4,7 @@
 #include "Library.h"
 
 #include <parallel_hashmap/phmap.h>
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
 #include <experimental/any>
 #else
 #include <any>
@@ -40,7 +40,7 @@ struct CESIUMUTILITY_API ExtensibleObject {
     if (it == this->extensions.end()) {
       return nullptr;
     }
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
     return std::experimental::any_cast<T>(&it->second);
 #else
     return std::any_cast<T>(&it->second);
@@ -78,7 +78,7 @@ struct CESIUMUTILITY_API ExtensibleObject {
    * @return The added extension.
    */
   template <typename T> T& addExtension() {
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
     std::experimental::any& extension =
         extensions.try_emplace(T::ExtensionName, std::experimental::any(T()))
             .first->second;
@@ -98,7 +98,7 @@ struct CESIUMUTILITY_API ExtensibleObject {
    * type. Use {@link getGenericExtension} to get unknown extensions as a
    * generic {@link CesiumUtility::JsonValue}.
    */
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
   phmap::flat_hash_map<std::string, std::experimental::any> extensions;
 #else
   phmap::flat_hash_map<std::string, std::any> extensions;

--- a/CesiumUtility/include/CesiumUtility/ExtensibleObject.h
+++ b/CesiumUtility/include/CesiumUtility/ExtensibleObject.h
@@ -4,7 +4,7 @@
 #include "Library.h"
 
 #include <parallel_hashmap/phmap.h>
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #include <experimental/any>
 #else
 #include <any>
@@ -40,7 +40,7 @@ struct CESIUMUTILITY_API ExtensibleObject {
     if (it == this->extensions.end()) {
       return nullptr;
     }
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
     return std::experimental::any_cast<T>(&it->second);
 #else
     return std::any_cast<T>(&it->second);
@@ -78,7 +78,7 @@ struct CESIUMUTILITY_API ExtensibleObject {
    * @return The added extension.
    */
   template <typename T> T& addExtension() {
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
     std::experimental::any& extension =
         extensions.try_emplace(T::ExtensionName, std::experimental::any(T()))
             .first->second;
@@ -98,7 +98,7 @@ struct CESIUMUTILITY_API ExtensibleObject {
    * type. Use {@link getGenericExtension} to get unknown extensions as a
    * generic {@link CesiumUtility::JsonValue}.
    */
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
   phmap::flat_hash_map<std::string, std::experimental::any> extensions;
 #else
   phmap::flat_hash_map<std::string, std::any> extensions;

--- a/CesiumUtility/include/CesiumUtility/JsonValue.h
+++ b/CesiumUtility/include/CesiumUtility/JsonValue.h
@@ -3,6 +3,7 @@
 #include "Library.h"
 
 #include <gsl/narrow>
+#include <parallel_hashmap/phmap.h>
 
 #include <cmath>
 #include <cstdint>
@@ -69,7 +70,7 @@ public:
   /**
    * @brief The type to represent an `Object` JSON value.
    */
-  using Object = std::map<std::string, JsonValue>;
+  using Object = phmap::flat_hash_map<std::string, JsonValue>;
 
   /**
    * @brief The type to represent an `Array` JSON value.
@@ -168,12 +169,13 @@ public:
   /**
    * @brief Creates an `Object` JSON value with the given properties.
    */
-  JsonValue(const std::map<std::string, JsonValue>& v) : value(v) {}
+  JsonValue(const phmap::flat_hash_map<std::string, JsonValue>& v) : value(v) {}
 
   /**
    * @brief Creates an `Object` JSON value with the given properties.
    */
-  JsonValue(std::map<std::string, JsonValue>&& v) : value(std::move(v)) {}
+  JsonValue(phmap::flat_hash_map<std::string, JsonValue>&& v)
+      : value(std::move(v)) {}
 
   /**
    * @brief Creates an `Array` JSON value with the given elements.
@@ -194,8 +196,8 @@ public:
   /**
    * @brief Creates an JSON value from the given initializer list.
    */
-  JsonValue(std::initializer_list<std::pair<const std::string, JsonValue>> v)
-      : value(std::map<std::string, JsonValue>(v)) {}
+  // JsonValue(std::initializer_list<std::pair<const std::string, JsonValue>> v)
+  //    : value(phmap::flat_hash_map<std::string, JsonValue>(v)) {}
 
   [[nodiscard]] const JsonValue*
   getValuePtrForKey(const std::string& key) const;

--- a/CesiumUtility/src/ExtensibleObject.cpp
+++ b/CesiumUtility/src/ExtensibleObject.cpp
@@ -14,7 +14,11 @@ const JsonValue* ExtensibleObject::getGenericExtension(
     return nullptr;
   }
 
+#if __GNUC__
+  const JsonValue* pValue = std::experimental::any_cast<JsonValue>(&it->second);
+#else
   const JsonValue* pValue = std::any_cast<JsonValue>(&it->second);
+#endif
   return pValue;
 }
 } // namespace CesiumUtility

--- a/CesiumUtility/src/ExtensibleObject.cpp
+++ b/CesiumUtility/src/ExtensibleObject.cpp
@@ -14,7 +14,7 @@ const JsonValue* ExtensibleObject::getGenericExtension(
     return nullptr;
   }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ <= 10 && !defined(__clang__)
   const JsonValue* pValue = std::experimental::any_cast<JsonValue>(&it->second);
 #else
   const JsonValue* pValue = std::any_cast<JsonValue>(&it->second);

--- a/CesiumUtility/src/ExtensibleObject.cpp
+++ b/CesiumUtility/src/ExtensibleObject.cpp
@@ -14,7 +14,7 @@ const JsonValue* ExtensibleObject::getGenericExtension(
     return nullptr;
   }
 
-#if __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
   const JsonValue* pValue = std::experimental::any_cast<JsonValue>(&it->second);
 #else
   const JsonValue* pValue = std::any_cast<JsonValue>(&it->second);

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -15,6 +15,10 @@ endif()
 
 add_subdirectory(KTX-Software)
 
+option(PHMAP_BUILD_TESTS "" off)
+option(PHMAP_BUILD_EXAMPLES "" off)
+add_subdirectory(parallel-hashmap)
+
 option(URIPARSER_BUILD_TESTS "" off)
 option(URIPARSER_BUILD_DOCS "" off)
 option(URIPARSER_ENABLE_INSTALL "" on)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,210 @@
 {
   "name": "cesium-native",
-  "version": "0.17.0",
-  "lockfileVersion": 1,
+  "version": "0.18.1",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "cesium-native",
+      "version": "0.18.1",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "clang-format": "^1.5.0"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+      "dev": true
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/clang-format": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.8.0.tgz",
+      "integrity": "sha512-pK8gzfu55/lHzIpQ1givIbWfn3eXnU7SfxqIwVgnn5jEM6j4ZJYjpFqFs4iSBPNedzRMmfjYjuQhu657WAXHXw==",
+      "dev": true,
+      "dependencies": {
+        "async": "^3.2.3",
+        "glob": "^7.0.0",
+        "resolve": "^1.1.6"
+      },
+      "bin": {
+        "check-clang-format": "bin/check-clang-format.js",
+        "clang-format": "index.js",
+        "git-clang-format": "bin/git-clang-format"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-core-module": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    }
+  },
   "dependencies": {
     "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
       "dev": true
     },
     "balanced-match": {
@@ -27,12 +224,12 @@
       }
     },
     "clang-format": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.6.0.tgz",
-      "integrity": "sha512-W3/L7fWkA8DoLkz9UGjrRnNi+J5a5TuS2HDLqk6WsicpOzb66MBu4eY/EcXhicHriVnAXWQVyk5/VeHWY6w4ow==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.8.0.tgz",
+      "integrity": "sha512-pK8gzfu55/lHzIpQ1givIbWfn3eXnU7SfxqIwVgnn5jEM6j4ZJYjpFqFs4iSBPNedzRMmfjYjuQhu657WAXHXw==",
       "dev": true,
       "requires": {
-        "async": "^1.5.2",
+        "async": "^3.2.3",
         "glob": "^7.0.0",
         "resolve": "^1.1.6"
       }
@@ -40,13 +237,13 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "function-bind": {
@@ -56,15 +253,15 @@
       "dev": true
     },
     "glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -81,7 +278,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -95,18 +292,18 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -115,7 +312,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -124,7 +321,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "path-parse": {
@@ -134,12 +331,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -153,7 +350,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     }
   }

--- a/tools/generate-classes/generate.js
+++ b/tools/generate-classes/generate.js
@@ -281,6 +281,16 @@ function generate(options, schema, writers) {
         }
 
         ${thisConfig.extensionName ? `
+	#if __GNUC__
+        void ${name}JsonHandler::reset(CesiumJsonReader::IJsonHandler* pParentHandler, CesiumUtility::ExtensibleObject& o, const std::string_view& extensionName) {
+          std::experimental::any& value =
+              o.extensions.emplace(extensionName, ${namespace}::${name}())
+                  .first->second;
+          this->reset(
+              pParentHandler,
+              &std::experimental::any_cast<${namespace}::${name}&>(value));
+        }
+	#else
         void ${name}JsonHandler::reset(CesiumJsonReader::IJsonHandler* pParentHandler, CesiumUtility::ExtensibleObject& o, const std::string_view& extensionName) {
           std::any& value =
               o.extensions.emplace(extensionName, ${namespace}::${name}())
@@ -288,7 +298,8 @@ function generate(options, schema, writers) {
           this->reset(
               pParentHandler,
               &std::any_cast<${namespace}::${name}&>(value));
-        }
+	}
+	#endif
         ` : ""}
 
         CesiumJsonReader::IJsonHandler* ${name}JsonHandler::readObjectKey${name}(const std::string& objectType, const std::string_view& str, ${namespace}::${name}& o) {

--- a/tools/generate-classes/generate.js
+++ b/tools/generate-classes/generate.js
@@ -493,7 +493,7 @@ function formatWriterPropertyImpl(property) {
   const isId = property.requiredId !== undefined;
   const isRequiredEnum = property.requiredEnum === true;
   const isVector = type.startsWith("std::vector");
-  const isMap = type.startsWith("std::unordered_map");
+  const isMap = type.startsWith("phmap::flat_hash_map");
   const isOptional = type.startsWith("std::optional");
 
   // Somewhat opinionated but it's helpful to see byteOffset: 0 in accessors and bufferViews

--- a/tools/generate-classes/generateCombinedWriter.js
+++ b/tools/generate-classes/generateCombinedWriter.js
@@ -138,7 +138,7 @@ function generateCombinedWriter(options) {
 
         template <typename T>
         [[maybe_unused]] void writeJson(
-            const std::unordered_map<std::string, T>& obj,
+            const phmap::flat_hash_map<std::string, T>& obj,
             CesiumJsonWriter::JsonWriter& jsonWriter,
             const CesiumJsonWriter::ExtensionWriterContext& context) {
           jsonWriter.StartObject();

--- a/tools/generate-classes/resolveProperty.js
+++ b/tools/generate-classes/resolveProperty.js
@@ -383,10 +383,10 @@ function resolveDictionary(
   return {
     ...propertyDefaults(propertyName, cppSafeName, propertyDetails),
     name: propertyName,
-    headers: ["<unordered_map>", ...additional.headers],
+    headers: ["<parallel_hashmap/phmap.h>", ...additional.headers],
     schemas: additional.schemas,
     localTypes: additional.localTypes,
-    type: `std::unordered_map<std::string, ${additional.type}>`,
+    type: `phmap::flat_hash_map<std::string, ${additional.type}>`,
     readerHeaders: [
       `<CesiumJsonReader/DictionaryJsonHandler.h>`,
       ...additional.readerHeaders,


### PR DESCRIPTION
Trying to fix #375.

Conclusion: Testing with upsampleGltfForRasterOverlays, there is an improvement (like 10%). In upsampling OSM buildings, when the file sizes can get up to 3 megabytes, the discrepancy is higher, maybe around 25% faster.

However, in this test,

```TEST_CASE("Add gigantic buffer") {
  Model model;

  long long total_count = 0;

  const int size = 10000000;

  std::vector<std::byte> bigVector;

  for (int i = 0; i < size; i++) {
    bigVector.push_back(std::byte(23));
  }

  auto start = high_resolution_clock::now();
  for (int i = 0; i < 1000; i++) {
    // create buffer
    model.buffers.emplace_back();
    Buffer& buffer = model.buffers.back();
    buffer.cesium.data.resize(size);
    std::memcpy(buffer.cesium.data.data(), bigVector.data(), bigVector.size());
  }
  auto stop = high_resolution_clock::now();

  auto duration = duration_cast<microseconds>(stop - start);
  total_count += duration.count();

  std::cout << "duration: " << total_count << std::endl;


}
```

the phmap is over 10x faster, 2,712,062 microseconds vs 32,561,647 microseconds