### PR TITLE
Let content manager owns root tile and raster overlay collection

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayCollection.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayCollection.h
@@ -39,6 +39,36 @@ public:
       Tile::LoadedLinkedList& loadedTiles,
       const TilesetExternals& externals) noexcept;
 
+  /**
+   * @brief Deleted Copy constructor.
+   *
+   * @param rhs The other instance.
+   */
+  RasterOverlayCollection(const RasterOverlayCollection& rhs) = delete;
+
+  /**
+   * @brief Move constructor.
+   *
+   * @param rhs The other instance.
+   */
+  RasterOverlayCollection(RasterOverlayCollection&& rhs) noexcept = default;
+
+  /**
+   * @brief Deleted copy assignment.
+   *
+   * @param rhs The other instance.
+   */
+  RasterOverlayCollection&
+  operator=(const RasterOverlayCollection& rhs) = delete;
+
+  /**
+   * @brief Move assignment.
+   *
+   * @param rhs The other instance.
+   */
+  RasterOverlayCollection&
+  operator=(RasterOverlayCollection&& rhs) noexcept = default;
+
   ~RasterOverlayCollection() noexcept;
 
   /**

--- a/Cesium3DTilesSelection/src/TilesetContentManager.h
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.h
@@ -91,11 +91,11 @@ private:
 
   void unloadDoneState(Tile& tile);
 
-  void notifyTileStartLoading(Tile& tile) noexcept;
+  void notifyTileStartLoading(const Tile* pTile) noexcept;
 
-  void notifyTileDoneLoading(Tile& tile) noexcept;
+  void notifyTileDoneLoading(const Tile* pTile) noexcept;
 
-  void notifyTileUnloading(Tile& tile) noexcept;
+  void notifyTileUnloading(const Tile* pTile) noexcept;
 
   template <class TilesetContentLoaderType>
   void propagateTilesetContentLoaderResult(


### PR DESCRIPTION
This PR is part of the refactor series #481. In the current refactor-branch, the content manager doesn't own the root tile and the raster overlay collection. The tileset itself owns those fields. However, it is quite awkward to manage the lifetime of those components:
- Because the manager only captures the pointer of `RasterOverlayCollection`, client of the manager (in this case, it's the `Tileset`) has to make sure the collection doesn't die; otherwise, we have a dangling pointer. But the `Tileset` itself doesn't use the collection in its implementation, so it doesn't make sense to let the tileset own it. Instead, the manager should own this collection, since it is the main client of the collection.
- The reason for moving the root tile to the manager is that the manager will create render resources for tile, and those resources are raw pointer, so [it requires client to explicitly unload the tile when not used](https://github.com/CesiumGS/cesium-native/blob/ef87387b6d85ddb57e737ddcfac230db2a71c1c7/Cesium3DTilesSelection/src/Tileset.cpp#L162). In addition, when loading a tile, the manager needs that tile to be alive at least when the loading returns to the main thread. So it probably makes sense to let the manager manages the lifetime of the tile as well, instead of letting client of the manager do it