### PR TITLE
Add up axis to TileLoadResult

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetContentLoader.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetContentLoader.h
@@ -136,6 +136,11 @@ struct CESIUM3DTILESSELECTION_API TileLoadResult {
   TileContentKind contentKind;
 
   /**
+   * @brief The up axis of glTF content.
+   */
+  CesiumGeometry::Axis glTFUpAxis;
+
+  /**
    * @brief A tile can potentially store a more fit bounding volume along with
    * its content. If this field is set, the tile's bounding volume will be
    * updated after the loading is finished.
@@ -174,6 +179,22 @@ struct CESIUM3DTILESSELECTION_API TileLoadResult {
    * applied to a tile when the loading is finished
    */
   TileLoadResultState state;
+
+  /**
+   * @brief Create a result with Failed state
+   *
+   * @param pCompletedRequest The failed request
+   */
+  static TileLoadResult createFailedResult(
+      std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest);
+
+  /**
+   * @brief Create a result with RetryLater state
+   *
+   * @param pCompletedRequest The failed request
+   */
+  static TileLoadResult createRetryLaterResult(
+      std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest);
 };
 
 /**
@@ -233,8 +254,5 @@ public:
    * @return The {@link TileChildrenResult} that stores the tile's children
    */
   virtual TileChildrenResult createTileChildren(const Tile& tile) = 0;
-
-  virtual CesiumGeometry::Axis
-  getTileUpAxis(const Tile& tile) const noexcept = 0;
 };
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
@@ -336,23 +336,11 @@ CesiumIonTilesetLoader::CesiumIonTilesetLoader(
 CesiumAsync::Future<TileLoadResult>
 CesiumIonTilesetLoader::loadTileContent(const TileLoadInput& loadInput) {
   if (this->_refreshTokenState == TokenRefreshState::Loading) {
-    return loadInput.asyncSystem.createResolvedFuture(TileLoadResult{
-        TileUnknownContent{},
-        std::nullopt,
-        std::nullopt,
-        std::nullopt,
-        nullptr,
-        {},
-        TileLoadResultState::RetryLater});
+    return loadInput.asyncSystem.createResolvedFuture(
+        TileLoadResult::createRetryLaterResult(nullptr));
   } else if (this->_refreshTokenState == TokenRefreshState::Failed) {
-    return loadInput.asyncSystem.createResolvedFuture(TileLoadResult{
-        TileUnknownContent{},
-        std::nullopt,
-        std::nullopt,
-        std::nullopt,
-        nullptr,
-        {},
-        TileLoadResultState::Failed});
+    return loadInput.asyncSystem.createResolvedFuture(
+        TileLoadResult::createFailedResult(nullptr));
   }
 
   const auto& asyncSystem = loadInput.asyncSystem;
@@ -390,12 +378,6 @@ TileChildrenResult
 CesiumIonTilesetLoader::createTileChildren(const Tile& tile) {
   auto pLoader = tile.getLoader();
   return pLoader->createTileChildren(tile);
-}
-
-CesiumGeometry::Axis
-CesiumIonTilesetLoader::getTileUpAxis(const Tile& tile) const noexcept {
-  const auto pLoader = tile.getLoader();
-  return pLoader->getTileUpAxis(tile);
 }
 
 void CesiumIonTilesetLoader::refreshTokenInMainThread(

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.h
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.h
@@ -28,8 +28,6 @@ public:
 
   TileChildrenResult createTileChildren(const Tile& tile) override;
 
-  CesiumGeometry::Axis getTileUpAxis(const Tile& tile) const noexcept override;
-
   static CesiumAsync::Future<TilesetContentLoaderResult<CesiumIonTilesetLoader>>
   createLoader(
       const TilesetExternals& externals,

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.h
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.h
@@ -43,8 +43,6 @@ public:
 
   TileChildrenResult createTileChildren(const Tile& tile) override;
 
-  CesiumGeometry::Axis getTileUpAxis(const Tile& tile) const noexcept override;
-
   uint32_t getSubtreeLevels() const noexcept;
 
   uint32_t getAvailableLevels() const noexcept;

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.h
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.h
@@ -45,8 +45,6 @@ public:
 
   TileChildrenResult createTileChildren(const Tile& tile) override;
 
-  CesiumGeometry::Axis getTileUpAxis(const Tile& tile) const noexcept override;
-
   uint32_t getSubtreeLevels() const noexcept;
 
   uint32_t getAvailableLevels() const noexcept;

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
@@ -21,18 +21,12 @@ using namespace CesiumUtility;
 namespace {
 TileLoadResult convertToTileLoadResult(QuantizedMeshLoadResult&& loadResult) {
   if (loadResult.errors || !loadResult.model) {
-    return TileLoadResult{
-        TileUnknownContent{},
-        std::nullopt,
-        std::nullopt,
-        std::nullopt,
-        nullptr,
-        {},
-        TileLoadResultState::Failed};
+    return TileLoadResult::createFailedResult(nullptr);
   }
 
   return TileLoadResult{
       std::move(*loadResult.model),
+      CesiumGeometry::Axis::Y,
       loadResult.updatedBoundingVolume,
       std::nullopt,
       std::nullopt,
@@ -692,14 +686,8 @@ LayerJsonTerrainLoader::loadTileContent(const TileLoadInput& loadInput) {
         std::get_if<UpsampledQuadtreeNode>(&tile.getTileID());
     if (!pUpsampleTileID) {
       // This loader only handles QuadtreeTileIDs and UpsampledQuadtreeNode.
-      return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
-          TileUnknownContent{},
-          std::nullopt,
-          std::nullopt,
-          std::nullopt,
-          nullptr,
-          {},
-          TileLoadResultState::Failed});
+      return asyncSystem.createResolvedFuture(
+          TileLoadResult::createFailedResult(nullptr));
     }
 
     // now do upsampling
@@ -717,15 +705,8 @@ LayerJsonTerrainLoader::loadTileContent(const TileLoadInput& loadInput) {
 
   if (firstAvailableIt == this->_layers.end()) {
     // No layer has this tile available.
-    return asyncSystem.createResolvedFuture<TileLoadResult>(TileLoadResult{
-        TileUnknownContent{},
-        std::nullopt,
-        std::nullopt,
-        std::nullopt,
-        nullptr,
-        {},
-        TileLoadResultState::Failed,
-    });
+    return asyncSystem.createResolvedFuture(
+        TileLoadResult::createFailedResult(nullptr));
   }
 
   // Also load the same tile in any underlying layers for which this tile
@@ -885,11 +866,6 @@ LayerJsonTerrainLoader::createTileChildren(const Tile& tile) {
   }
 
   return {{}, TileLoadResultState::Failed};
-}
-
-CesiumGeometry::Axis
-LayerJsonTerrainLoader::getTileUpAxis(const Tile&) const noexcept {
-  return CesiumGeometry::Axis::Y;
 }
 
 const CesiumGeometry::QuadtreeTilingScheme&
@@ -1072,14 +1048,8 @@ CesiumAsync::Future<TileLoadResult> LayerJsonTerrainLoader::upsampleParentTile(
   const TileRenderContent* pParentRenderContent =
       parentContent.getRenderContent();
   if (!pParentRenderContent) {
-    return asyncSystem.createResolvedFuture(TileLoadResult{
-        TileUnknownContent{},
-        std::nullopt,
-        std::nullopt,
-        std::nullopt,
-        nullptr,
-        {},
-        TileLoadResultState::Failed});
+    return asyncSystem.createResolvedFuture(
+        TileLoadResult::createFailedResult(nullptr));
   }
 
   const UpsampledQuadtreeNode* pUpsampledTileID =
@@ -1116,18 +1086,12 @@ CesiumAsync::Future<TileLoadResult> LayerJsonTerrainLoader::upsampleParentTile(
             tileID,
             textureCoordinateIndex);
         if (!model) {
-          return TileLoadResult{
-              TileUnknownContent{},
-              std::nullopt,
-              std::nullopt,
-              std::nullopt,
-              nullptr,
-              {},
-              TileLoadResultState::Failed};
+          return TileLoadResult::createFailedResult(nullptr);
         }
 
         return TileLoadResult{
             std::move(*model),
+            CesiumGeometry::Axis::Y,
             std::nullopt,
             std::nullopt,
             std::nullopt,

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
@@ -62,8 +62,6 @@ public:
 
   TileChildrenResult createTileChildren(const Tile& tile) override;
 
-  CesiumGeometry::Axis getTileUpAxis(const Tile& tile) const noexcept override;
-
   const CesiumGeometry::QuadtreeTilingScheme& getTilingScheme() const noexcept;
 
   const CesiumGeospatial::Projection& getProjection() const noexcept;

--- a/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
@@ -17,14 +17,8 @@ CesiumAsync::Future<TileLoadResult>
 RasterOverlayUpsampler::loadTileContent(const TileLoadInput& loadInput) {
   const Tile* pParent = loadInput.tile.getParent();
   if (pParent == nullptr) {
-    return loadInput.asyncSystem.createResolvedFuture(TileLoadResult{
-        TileUnknownContent{},
-        std::nullopt,
-        std::nullopt,
-        std::nullopt,
-        nullptr,
-        {},
-        TileLoadResultState::Failed});
+    return loadInput.asyncSystem.createResolvedFuture(
+        TileLoadResult::createFailedResult(nullptr));
   }
 
   const CesiumGeometry::UpsampledQuadtreeNode* pTileID =
@@ -32,14 +26,8 @@ RasterOverlayUpsampler::loadTileContent(const TileLoadInput& loadInput) {
           &loadInput.tile.getTileID());
   if (pTileID == nullptr) {
     // this tile is not marked to be upsampled, so just fail it
-    return loadInput.asyncSystem.createResolvedFuture(TileLoadResult{
-        TileUnknownContent{},
-        std::nullopt,
-        std::nullopt,
-        std::nullopt,
-        nullptr,
-        {},
-        TileLoadResultState::Failed});
+    return loadInput.asyncSystem.createResolvedFuture(
+        TileLoadResult::createFailedResult(nullptr));
   }
 
   // The tile content manager guarantees that the parent tile is already loaded
@@ -53,14 +41,8 @@ RasterOverlayUpsampler::loadTileContent(const TileLoadInput& loadInput) {
       parentContent.getRenderContent();
   if (!pParentRenderContent) {
     // parent doesn't have mesh, so it's not possible to upsample
-    return loadInput.asyncSystem.createResolvedFuture(TileLoadResult{
-        TileUnknownContent{},
-        std::nullopt,
-        std::nullopt,
-        std::nullopt,
-        nullptr,
-        {},
-        TileLoadResultState::Failed});
+    return loadInput.asyncSystem.createResolvedFuture(
+        TileLoadResult::createFailedResult(nullptr));
   }
 
   int32_t index = 0;
@@ -92,18 +74,12 @@ RasterOverlayUpsampler::loadTileContent(const TileLoadInput& loadInput) {
             TileID,
             textureCoordinateIndex);
         if (!model) {
-          return TileLoadResult{
-              TileUnknownContent{},
-              std::nullopt,
-              std::nullopt,
-              std::nullopt,
-              nullptr,
-              {},
-              TileLoadResultState::Failed};
+          return TileLoadResult::createFailedResult(nullptr);
         }
 
         return TileLoadResult{
             std::move(*model),
+            CesiumGeometry::Axis::Y,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -116,10 +92,5 @@ RasterOverlayUpsampler::loadTileContent(const TileLoadInput& loadInput) {
 TileChildrenResult
 RasterOverlayUpsampler::createTileChildren([[maybe_unused]] const Tile& tile) {
   return {{}, TileLoadResultState::Failed};
-}
-
-CesiumGeometry::Axis
-RasterOverlayUpsampler::getTileUpAxis(const Tile&) const noexcept {
-  return CesiumGeometry::Axis::Y;
 }
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/RasterOverlayUpsampler.h
+++ b/Cesium3DTilesSelection/src/RasterOverlayUpsampler.h
@@ -9,7 +9,5 @@ public:
   loadTileContent(const TileLoadInput& loadInput) override;
 
   TileChildrenResult createTileChildren(const Tile& tile) override;
-
-  CesiumGeometry::Axis getTileUpAxis(const Tile& tile) const noexcept override;
 };
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/TileContentLoadInfo.cpp
+++ b/Cesium3DTilesSelection/src/TileContentLoadInfo.cpp
@@ -21,6 +21,5 @@ TileContentLoadInfo::TileContentLoadInfo(
       tileRefine(tile.getRefine()),
       tileGeometricError(tile.getGeometricError()),
       tileTransform(tile.getTransform()),
-      upAxis(tile.getLoader()->getTileUpAxis(tile)),
       contentOptions(contentOptions_) {}
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/TileContentLoadInfo.h
+++ b/Cesium3DTilesSelection/src/TileContentLoadInfo.h
@@ -47,8 +47,6 @@ struct TileContentLoadInfo {
 
   glm::dmat4 tileTransform;
 
-  CesiumGeometry::Axis upAxis;
-
   TilesetContentOptions contentOptions;
 };
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/TilesetContentLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentLoader.cpp
@@ -14,4 +14,30 @@ TileLoadInput::TileLoadInput(
       pAssetAccessor{pAssetAccessor_},
       pLogger{pLogger_},
       requestHeaders{requestHeaders_} {}
+
+TileLoadResult TileLoadResult::createFailedResult(
+    std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest) {
+  return TileLoadResult{
+      TileUnknownContent{},
+      CesiumGeometry::Axis::Y,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      std::move(pCompletedRequest),
+      {},
+      TileLoadResultState::Failed};
+}
+
+TileLoadResult TileLoadResult::createRetryLaterResult(
+    std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest) {
+  return TileLoadResult{
+      TileUnknownContent{},
+      CesiumGeometry::Axis::Y,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      std::move(pCompletedRequest),
+      {},
+      TileLoadResultState::RetryLater};
+}
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -445,7 +445,7 @@ TileLoadResultAndRenderResources postProcessGltfInWorkerThread(
   // have to pass the up axis to extra for backward compatibility
   model.extras["gltfUpAxis"] =
       static_cast<std::underlying_type_t<CesiumGeometry::Axis>>(
-          tileLoadInfo.upAxis);
+          result.glTFUpAxis);
 
   // calculate raster overlay details
   calcRasterOverlayDetailsInWorkerThread(
@@ -542,14 +542,7 @@ postProcessContentInWorkerThread(
 
             if (!gltfResult.model) {
               return TileLoadResultAndRenderResources{
-                  TileLoadResult{
-                      TileUnknownContent{},
-                      std::nullopt,
-                      std::nullopt,
-                      std::nullopt,
-                      nullptr,
-                      {},
-                      TileLoadResultState::Failed},
+                  TileLoadResult::createFailedResult(nullptr),
                   nullptr};
             }
 

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.h
@@ -21,9 +21,9 @@ public:
 
   TileChildrenResult createTileChildren(const Tile& tile) override;
 
-  CesiumGeometry::Axis getTileUpAxis(const Tile& tile) const noexcept override;
-
   const std::string& getBaseUrl() const noexcept;
+
+  CesiumGeometry::Axis getUpAxis() const noexcept;
 
   void addChildLoader(std::unique_ptr<TilesetContentLoader> pLoader);
 

--- a/Cesium3DTilesSelection/test/TestTilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/test/TestTilesetContentManager.cpp
@@ -43,13 +43,8 @@ public:
     return std::move(mockCreateTileChildren);
   }
 
-  CesiumGeometry::Axis getTileUpAxis(const Tile&) const noexcept override {
-    return upAxis;
-  }
-
   TileLoadResult mockLoadTileContent;
   TileChildrenResult mockCreateTileChildren;
-  CesiumGeometry::Axis upAxis{CesiumGeometry::Axis::Y};
 };
 
 std::shared_ptr<SimpleAssetRequest>
@@ -206,6 +201,7 @@ TEST_CASE("Test tile state machine") {
     auto pMockedLoader = std::make_unique<SimpleTilesetContentLoader>();
     pMockedLoader->mockLoadTileContent = {
         CesiumGltf::Model(),
+        CesiumGeometry::Axis::Y,
         std::nullopt,
         std::nullopt,
         std::nullopt,
@@ -308,6 +304,7 @@ TEST_CASE("Test tile state machine") {
     auto pMockedLoader = std::make_unique<SimpleTilesetContentLoader>();
     pMockedLoader->mockLoadTileContent = {
         CesiumGltf::Model(),
+        CesiumGeometry::Axis::Y,
         std::nullopt,
         std::nullopt,
         std::nullopt,
@@ -381,6 +378,7 @@ TEST_CASE("Test tile state machine") {
     auto pMockedLoader = std::make_unique<SimpleTilesetContentLoader>();
     pMockedLoader->mockLoadTileContent = {
         CesiumGltf::Model(),
+        CesiumGeometry::Axis::Y,
         std::nullopt,
         std::nullopt,
         std::nullopt,
@@ -471,6 +469,7 @@ TEST_CASE("Test tile state machine") {
 
     pMockedLoader->mockLoadTileContent = {
         CesiumGltf::Model(),
+        CesiumGeometry::Axis::Y,
         std::nullopt,
         std::nullopt,
         std::nullopt,
@@ -541,6 +540,7 @@ TEST_CASE("Test tile state machine") {
     initializerCall = false;
     pMockedLoaderRaw->mockLoadTileContent = {
         CesiumGltf::Model(),
+        CesiumGeometry::Axis::Y,
         std::nullopt,
         std::nullopt,
         std::nullopt,
@@ -619,6 +619,7 @@ TEST_CASE("Test the tileset content manager's post processing for gltf") {
     auto pMockedLoader = std::make_unique<SimpleTilesetContentLoader>();
     pMockedLoader->mockLoadTileContent = {
         std::move(*modelReadResult.model),
+        CesiumGeometry::Axis::Y,
         std::nullopt,
         std::nullopt,
         std::nullopt,
@@ -687,6 +688,7 @@ TEST_CASE("Test the tileset content manager's post processing for gltf") {
     auto pMockedLoader = std::make_unique<SimpleTilesetContentLoader>();
     pMockedLoader->mockLoadTileContent = {
         std::move(*modelReadResult.model),
+        CesiumGeometry::Axis::Y,
         std::nullopt,
         std::nullopt,
         std::nullopt,
@@ -750,9 +752,9 @@ TEST_CASE("Test the tileset content manager's post processing for gltf") {
   SECTION("Embed gltf up axis to extra") {
     // create mock loader
     auto pMockedLoader = std::make_unique<SimpleTilesetContentLoader>();
-    pMockedLoader->upAxis = CesiumGeometry::Axis::Z;
     pMockedLoader->mockLoadTileContent = {
         CesiumGltf::Model{},
+        CesiumGeometry::Axis::Z,
         std::nullopt,
         std::nullopt,
         std::nullopt,
@@ -798,10 +800,10 @@ TEST_CASE("Test the tileset content manager's post processing for gltf") {
 
     // create mock loader
     auto pMockedLoader = std::make_unique<SimpleTilesetContentLoader>();
-    pMockedLoader->upAxis = CesiumGeometry::Axis::Z;
     Cartographic beginCarto{glm::radians(32.0), glm::radians(48.0), 100.0};
     pMockedLoader->mockLoadTileContent = {
         createGlobeGrid(beginCarto, 10, 10, 0.01),
+        CesiumGeometry::Axis::Z,
         std::nullopt,
         std::nullopt,
         std::nullopt,
@@ -1032,9 +1034,9 @@ TEST_CASE("Test the tileset content manager's post processing for gltf") {
 
     // create mock loader
     auto pMockedLoader = std::make_unique<SimpleTilesetContentLoader>();
-    pMockedLoader->upAxis = CesiumGeometry::Axis::Z;
     pMockedLoader->mockLoadTileContent = {
         std::move(model),
+        CesiumGeometry::Axis::Z,
         std::nullopt,
         std::nullopt,
         std::move(rasterOverlayDetails),

--- a/Cesium3DTilesSelection/test/TestTilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/test/TestTilesetJsonLoader.cpp
@@ -171,9 +171,7 @@ TEST_CASE("Test creating tileset json loader") {
         children[3].getBoundingVolume()));
 
     // check loader up axis
-    CHECK(
-        loaderResult.pLoader->getTileUpAxis(*pRootTile) ==
-        CesiumGeometry::Axis::Y);
+    CHECK(loaderResult.pLoader->getUpAxis() == CesiumGeometry::Axis::Y);
   }
 
   SECTION("Create valid tileset json with ADD refinement") {
@@ -218,9 +216,7 @@ TEST_CASE("Test creating tileset json loader") {
     }
 
     // check loader up axis
-    CHECK(
-        loaderResult.pLoader->getTileUpAxis(*pRootTile) ==
-        CesiumGeometry::Axis::Y);
+    CHECK(loaderResult.pLoader->getUpAxis() == CesiumGeometry::Axis::Y);
   }
 
   SECTION("Tileset has tile with sphere bounding volume") {
@@ -237,9 +233,7 @@ TEST_CASE("Test creating tileset json loader") {
     CHECK(sphere.getRadius() == 141.4214);
 
     // check loader up axis
-    CHECK(
-        loaderResult.pLoader->getTileUpAxis(rootTile) ==
-        CesiumGeometry::Axis::Y);
+    CHECK(loaderResult.pLoader->getUpAxis() == CesiumGeometry::Axis::Y);
   }
 
   SECTION("Tileset has tile with box bounding volume") {
@@ -270,9 +264,7 @@ TEST_CASE("Test creating tileset json loader") {
     CHECK(loaderResult.pRootTile->getChildren().empty());
 
     // check loader up axis
-    CHECK(
-        loaderResult.pLoader->getTileUpAxis(*loaderResult.pRootTile) ==
-        CesiumGeometry::Axis::Y);
+    CHECK(loaderResult.pLoader->getUpAxis() == CesiumGeometry::Axis::Y);
   }
 
   SECTION("Tileset has tile with no geometric error field") {
@@ -289,9 +281,7 @@ TEST_CASE("Test creating tileset json loader") {
     }
 
     // check loader up axis
-    CHECK(
-        loaderResult.pLoader->getTileUpAxis(*loaderResult.pRootTile) ==
-        CesiumGeometry::Axis::Y);
+    CHECK(loaderResult.pLoader->getUpAxis() == CesiumGeometry::Axis::Y);
   }
 
   SECTION("Tileset has tile with no capitalized Refinement field") {
@@ -310,9 +300,7 @@ TEST_CASE("Test creating tileset json loader") {
     }
 
     // check loader up axis
-    CHECK(
-        loaderResult.pLoader->getTileUpAxis(*loaderResult.pRootTile) ==
-        CesiumGeometry::Axis::Y);
+    CHECK(loaderResult.pLoader->getUpAxis() == CesiumGeometry::Axis::Y);
   }
 
   SECTION("Scale geometric error along with tile transform") {
@@ -329,9 +317,7 @@ TEST_CASE("Test creating tileset json loader") {
     }
 
     // check loader up axis
-    CHECK(
-        loaderResult.pLoader->getTileUpAxis(*loaderResult.pRootTile) ==
-        CesiumGeometry::Axis::Y);
+    CHECK(loaderResult.pLoader->getUpAxis() == CesiumGeometry::Axis::Y);
   }
 
   SECTION("Tileset with empty tile") {
@@ -346,9 +332,7 @@ TEST_CASE("Test creating tileset json loader") {
     CHECK(child.isEmptyContent());
 
     // check loader up axis
-    CHECK(
-        loaderResult.pLoader->getTileUpAxis(*loaderResult.pRootTile) ==
-        CesiumGeometry::Axis::Y);
+    CHECK(loaderResult.pLoader->getUpAxis() == CesiumGeometry::Axis::Y);
   }
 
   SECTION("Tileset with quadtree implicit tile") {


### PR DESCRIPTION
This is part of the refactor series #481. This addresses the PR comment https://github.com/CesiumGS/cesium-native/pull/508#discussion_r947569181 by adding up axis to TileLoadResult structure.

This also creates helper methods `TileLoadResult::createFailedResult()` and `TileLoadResult::createRetryLaterResult()` to create results with Failed and RetryLater states