### PR TITLE
Support layer.json when passing url

### DIFF
--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
@@ -571,9 +571,9 @@ Cesium3DTilesSelection::LayerJsonTerrainLoader::createLoader(
     const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
     const TilesetContentOptions& contentOptions,
     const std::string& layerJsonUrl,
-    const rapidjson::Document& layerJson,
     const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders,
-    bool showCreditsOnScreen) {
+    bool showCreditsOnScreen,
+    const rapidjson::Document& layerJson) {
   return loadLayerJson(
              asyncSystem,
              pAssetAccessor,

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
@@ -567,15 +567,16 @@ LayerJsonTerrainLoader::createLoader(
 
 CesiumAsync::Future<TilesetContentLoaderResult<LayerJsonTerrainLoader>>
 Cesium3DTilesSelection::LayerJsonTerrainLoader::createLoader(
-    const TilesetExternals& externals,
+    const CesiumAsync::AsyncSystem& asyncSystem,
+    const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
     const TilesetContentOptions& contentOptions,
     const std::string& layerJsonUrl,
     const rapidjson::Document& layerJson,
     const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders,
     bool showCreditsOnScreen) {
   return loadLayerJson(
-             externals.asyncSystem,
-             externals.pAssetAccessor,
+             asyncSystem,
+             pAssetAccessor,
              layerJsonUrl,
              requestHeaders,
              layerJson,

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
@@ -39,7 +39,8 @@ public:
 
   static CesiumAsync::Future<TilesetContentLoaderResult<LayerJsonTerrainLoader>>
   createLoader(
-      const TilesetExternals& externals,
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const TilesetContentOptions& contentOptions,
       const std::string& layerJsonUrl,
       const rapidjson::Document& layerJson,

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
@@ -11,6 +11,8 @@
 #include <CesiumGeometry/QuadtreeTilingScheme.h>
 #include <CesiumGeospatial/Projection.h>
 
+#include <rapidjson/fwd.h>
+
 #include <memory>
 #include <optional>
 #include <string>
@@ -32,6 +34,15 @@ public:
       const TilesetExternals& externals,
       const TilesetContentOptions& contentOptions,
       const std::string& layerJsonUrl,
+      const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders,
+      bool showCreditsOnScreen);
+
+  static CesiumAsync::Future<TilesetContentLoaderResult<LayerJsonTerrainLoader>>
+  createLoader(
+      const TilesetExternals& externals,
+      const TilesetContentOptions& contentOptions,
+      const std::string& layerJsonUrl,
+      const rapidjson::Document& layerJson,
       const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders,
       bool showCreditsOnScreen);
 

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
@@ -43,9 +43,9 @@ public:
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const TilesetContentOptions& contentOptions,
       const std::string& layerJsonUrl,
-      const rapidjson::Document& layerJson,
       const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders,
-      bool showCreditsOnScreen);
+      bool showCreditsOnScreen,
+      const rapidjson::Document& layerJson);
 
   struct Layer {
     Layer(

--- a/Cesium3DTilesSelection/src/TilesetContentLoaderResult.h
+++ b/Cesium3DTilesSelection/src/TilesetContentLoaderResult.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <vector>
+#include <type_traits>
 
 namespace Cesium3DTilesSelection {
 struct LoaderCreditResult {
@@ -16,6 +17,66 @@ struct LoaderCreditResult {
 };
 
 template <class TilesetContentLoaderType> struct TilesetContentLoaderResult {
+  TilesetContentLoaderResult() = default;
+
+  TilesetContentLoaderResult(
+      std::unique_ptr<TilesetContentLoaderType>&& pLoader_,
+      std::unique_ptr<Tile>&& pRootTile_,
+      std::vector<LoaderCreditResult>&& credits_,
+      std::vector<CesiumAsync::IAssetAccessor::THeader>&& requestHeaders_,
+      ErrorList&& errors_)
+      : pLoader{std::move(pLoader_)},
+        pRootTile{std::move(pRootTile_)},
+        credits{std::move(credits_)},
+        requestHeaders{std::move(requestHeaders_)},
+        errors{std::move(errors_)} {}
+
+  TilesetContentLoaderResult(const TilesetContentLoaderResult&) = delete;
+
+  TilesetContentLoaderResult(TilesetContentLoaderResult&&) noexcept = default;
+
+  TilesetContentLoaderResult&
+  operator=(const TilesetContentLoaderResult&) = delete;
+
+  TilesetContentLoaderResult&
+  operator=(TilesetContentLoaderResult&&) noexcept = default;
+
+  template <
+      class OtherLoaderType,
+      typename Enable_Type = std::enable_if_t<
+          !std::is_same_v<OtherLoaderType, TilesetContentLoaderResult> &&
+              std::is_convertible_v<
+                  std::unique_ptr<OtherLoaderType>,
+                  std::unique_ptr<TilesetContentLoaderType>>,
+          int>>
+  TilesetContentLoaderResult(
+      TilesetContentLoaderResult<OtherLoaderType>&& rhs) noexcept
+      : pLoader{std::move(rhs.pLoader)},
+        pRootTile{std::move(rhs.pRootTile)},
+        credits{std::move(rhs.credits)},
+        requestHeaders{std::move(rhs.requestHeaders)},
+        errors{std::move(rhs.errors)} {}
+
+  template <
+      class OtherLoaderType,
+      typename Enable_Type = std::enable_if_t<
+          !std::is_same_v<OtherLoaderType, TilesetContentLoaderResult> &&
+              std::is_convertible_v<
+                  std::unique_ptr<OtherLoaderType>,
+                  std::unique_ptr<TilesetContentLoaderType>>,
+          int>>
+  TilesetContentLoaderResult&
+  operator=(TilesetContentLoaderResult<OtherLoaderType>&& rhs) noexcept {
+    using std::swap;
+    swap(this->pLoader, rhs.pLoader);
+    swap(this->pRootTile, rhs.pRootTile);
+    swap(this->credits, rhs.credits);
+    swap(this->requestHeaders, rhs.requestHeaders);
+    swap(this->errors, rhs.errors);
+
+    return *this;
+  }
+
   std::unique_ptr<TilesetContentLoaderType> pLoader;
 
   std::unique_ptr<Tile> pRootTile;

--- a/Cesium3DTilesSelection/src/TilesetContentLoaderResult.h
+++ b/Cesium3DTilesSelection/src/TilesetContentLoaderResult.h
@@ -6,8 +6,8 @@
 #include <CesiumGeometry/Axis.h>
 
 #include <memory>
-#include <vector>
 #include <type_traits>
+#include <vector>
 
 namespace Cesium3DTilesSelection {
 struct LoaderCreditResult {

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -601,7 +601,10 @@ TilesetContentManager::TilesetContentManager(
   if (!url.empty()) {
     this->notifyTileStartLoading(nullptr);
 
-    TilesetJsonLoader::createLoader(externals, url, {})
+    TilesetJsonLoader::createLoader(
+        externals,
+        url,
+        std::vector<CesiumAsync::IAssetAccessor::THeader>{})
         .thenInMainThread(
             [this, errorCallback = tilesetOptions.loadErrorCallback](
                 TilesetContentLoaderResult<TilesetJsonLoader>&& result) {

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -367,12 +367,6 @@ void calcRasterOverlayDetailsInWorkerThread(
       pRegion ? std::make_optional(pRegion->getRectangle()) : std::nullopt,
       std::move(projections));
 
-  if (result.rasterOverlayDetails && overlayDetails) {
-    result.rasterOverlayDetails->merge(*overlayDetails);
-  } else if (overlayDetails) {
-    result.rasterOverlayDetails = std::move(*overlayDetails);
-  }
-
   if (pRegion && overlayDetails) {
     // If the original bounding region was wrong, report it.
     const CesiumGeospatial::GlobeRectangle& original = pRegion->getRectangle();
@@ -409,6 +403,12 @@ void calcRasterOverlayDetailsInWorkerThread(
           "content, so culling and raster overlays may be incorrect: {}",
           url);
     }
+  }
+
+  if (result.rasterOverlayDetails && overlayDetails) {
+    result.rasterOverlayDetails->merge(*overlayDetails);
+  } else if (overlayDetails) {
+    result.rasterOverlayDetails = std::move(*overlayDetails);
   }
 }
 

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -615,6 +615,7 @@ TilesetContentManager::TilesetContentManager(
              showCreditsOnScreen = tilesetOptions.showCreditsOnScreen](
                 const std::shared_ptr<CesiumAsync::IAssetRequest>&
                     pCompletedRequest) {
+              // Check if request is successful
               const CesiumAsync::IAssetResponse* pResponse =
                   pCompletedRequest->response();
               const std::string& url = pCompletedRequest->url();
@@ -636,6 +637,7 @@ TilesetContentManager::TilesetContentManager(
                 return asyncSystem.createResolvedFuture(std::move(result));
               }
 
+              // Parse Json response
               gsl::span<const std::byte> tilesetJsonBinary = pResponse->data();
               rapidjson::Document tilesetJson;
               tilesetJson.Parse(
@@ -651,6 +653,8 @@ TilesetContentManager::TilesetContentManager(
                 return asyncSystem.createResolvedFuture(std::move(result));
               }
 
+              // Check if the json is a tileset.json format or layer.json format
+              // and create corresponding loader
               const auto rootIt = tilesetJson.FindMember("root");
               if (rootIt != tilesetJson.MemberEnd()) {
                 TilesetContentLoaderResult<TilesetContentLoader> result =
@@ -674,9 +678,9 @@ TilesetContentManager::TilesetContentManager(
                              pAssetAccessor,
                              contentOptions,
                              url,
-                             tilesetJson,
                              flatHeaders,
-                             showCreditsOnScreen)
+                             showCreditsOnScreen,
+                             tilesetJson)
                       .thenImmediately(
                           [](TilesetContentLoaderResult<TilesetContentLoader>&&
                                  result) { return std::move(result); });

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -734,11 +734,11 @@ TilesetJsonLoader::createLoader(
 }
 
 TilesetContentLoaderResult<TilesetJsonLoader> TilesetJsonLoader::createLoader(
-    const TilesetExternals& externals,
+    const std::shared_ptr<spdlog::logger>& pLogger,
     const std::string& tilesetJsonUrl,
     const rapidjson::Document& tilesetJson) {
   return parseTilesetJson(
-      externals.pLogger,
+      pLogger,
       tilesetJsonUrl,
       tilesetJson,
       glm::dmat4(1.0),

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.h
@@ -7,6 +7,8 @@
 #include <CesiumAsync/Future.h>
 #include <CesiumAsync/IAssetAccessor.h>
 
+#include <rapidjson/fwd.h>
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -32,6 +34,11 @@ public:
       const TilesetExternals& externals,
       const std::string& tilesetJsonUrl,
       const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders);
+
+  static TilesetContentLoaderResult<TilesetJsonLoader> createLoader(
+      const TilesetExternals& externals,
+      const std::string& tilesetJsonUrl,
+      const rapidjson::Document& tilesetJson);
 
 private:
   std::string _baseUrl;

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.h
@@ -36,7 +36,7 @@ public:
       const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders);
 
   static TilesetContentLoaderResult<TilesetJsonLoader> createLoader(
-      const TilesetExternals& externals,
+      const std::shared_ptr<spdlog::logger>& pLogger,
       const std::string& tilesetJsonUrl,
       const rapidjson::Document& tilesetJson);
 


### PR DESCRIPTION
Previously when a url is passed to tileset, it will be able to load the layer.json format as well. This PR adds that support for the refactor