### PR TITLE
Fix gcc-11 build

### DIFF
--- a/Cesium3DTilesSelection/src/B3dmToGltfConverter.cpp
+++ b/Cesium3DTilesSelection/src/B3dmToGltfConverter.cpp
@@ -235,7 +235,7 @@ GltfConverterResult B3dmToGltfConverter::convert(
     const CesiumGltfReader::GltfReaderOptions& options) {
   GltfConverterResult result;
   B3dmHeader header;
-  uint32_t headerLength;
+  uint32_t headerLength = 0;
   parseB3dmHeader(b3dmBinary, header, headerLength, result);
   if (result.errors) {
     return result;


### PR DESCRIPTION
Maybe there's different approach? Initializing `headerLength` shouldn't be necessary in this case but it keeps gcc quiet.

```
cmake -B build -S . -D CMAKE_CXX_COMPILER=g++-11 -D CMAKE_C_COMPILER=gcc-11 && cmake --build build --parallel 8

/home/slilley/Code/cesium-native/Cesium3DTilesSelection/src/B3dmToGltfConverter.cpp: In static member function ‘static Cesium3DTilesSelection::GltfConverterResult Cesium3DTilesSelection::B3dmToGltfConverter::convert(const gsl::span<const std::byte>&, const CesiumGltfReader::GltfReaderOptions&)’:
/home/slilley/Code/cesium-native/Cesium3DTilesSelection/src/B3dmToGltfConverter.cpp:249:43: error: ‘headerLength’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  249 |   convertB3dmMetadataToGltfFeatureMetadata(
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  250 |       b3dmBinary,
      |       ~~~~~~~~~~~                          
  251 |       header,
      |       ~~~~~~~                              
  252 |       headerLength,
      |       ~~~~~~~~~~~~~                        
  253 |       result);
      |       ~~~~~~~                              
cc1plus: all warnings being treated as errors
gmake[2]: *** [Cesium3DTilesSelection/CMakeFiles/Cesium3DTilesSelection.dir/build.make:76: Cesium3DTilesSelection/CMakeFiles/Cesium3DTilesSelection.dir/src/B3dmToGltfConverter.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
gmake[1]: *** [CMakeFiles/Makefile2:3504: Cesium3DTilesSelection/CMakeFiles/Cesium3DTilesSelection.dir/all] Error 2
gmake: *** [Makefile:166: all] Error 2
```