### PR TITLE
Update raster tile right after content has glTF render resources

### DIFF
--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -904,16 +904,12 @@ void TilesetContentManager::loadTileContent(
 void TilesetContentManager::updateTileContent(
     Tile& tile,
     const TilesetOptions& tilesetOptions) {
-  TileLoadState state = tile.getState();
-  switch (state) {
-  case TileLoadState::ContentLoaded:
+  if (tile.getState() == TileLoadState::ContentLoaded) {
     updateContentLoadedState(tile, tilesetOptions);
-    break;
-  case TileLoadState::Done:
+  }
+
+  if (tile.getState() == TileLoadState::Done) {
     updateDoneState(tile, tilesetOptions);
-    break;
-  default:
-    break;
   }
 
   if (tile.shouldContentContinueUpdating()) {


### PR DESCRIPTION
Fixes #555 

The reason is the tile is transitioned to a new state after per frame instead of transitioning to Done within a single frame. So the glTF render resources maybe created when transitioning fron ContentLoaded -> Done, but the raster overlay hasn't attached to it yet before the tile is rendered