### PR TITLE
Flip the range for fade-out

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+### v0.20.0 - 2022-10-01
+
+##### Breaking Changes :mega:
+- `TileRenderContent::lodTransitionPercentage` now always goes from 0.0 --> 1.0 regardless of if the tile is fading in or out.
+
 ### v0.19.0 - 2022-09-01
 
 ##### Breaking Changes :mega:

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
@@ -163,7 +163,7 @@ public:
   void setRenderResources(void* pRenderResources) noexcept;
 
   /**
-   * @brief Get the fade percentage that this tile should be rendered with.
+   * @brief Get the fade percentage that this tile during an LOD transition.
    *
    * This will be used when {@link TilesetOptions::enableLodTransitionPeriod}
    * is true. Tile fades can be used to make LOD transitions appear less abrupt
@@ -175,8 +175,8 @@ public:
   float getLodTransitionFadePercentage() const noexcept;
 
   /**
-   * @brief Set the fade percentage that this tile should be rendered with. Not
-   * to be used by clients.
+   * @brief Set the fade percentage of this tile during an LOD transition with. 
+   * Not to be used by clients.
    *
    * @param percentage The new fade percentage.
    */

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
@@ -175,7 +175,7 @@ public:
   float getLodTransitionFadePercentage() const noexcept;
 
   /**
-   * @brief Set the fade percentage of this tile during an LOD transition with. 
+   * @brief Set the fade percentage of this tile during an LOD transition with.
    * Not to be used by clients.
    *
    * @param percentage The new fade percentage.

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -165,8 +165,9 @@ void Tileset::_updateLodTransitions(
     float deltaTime,
     ViewUpdateResult& result) const noexcept {
   if (_options.enableLodTransitionPeriod) {
-    // We fade the old tile from 1.0 --> 0.0 while the new tile fades from
-    // 0.0 --> 1.0.
+    // We always fade tiles from 0.0 --> 1.0. Whether the tile is fading in or
+    // out is determined by whether the tile is in the tilesToRenderThisFrame
+    // or tilesFadingOut list.
     float deltaTransitionPercentage =
         deltaTime / this->_options.lodTransitionLength;
 
@@ -197,7 +198,7 @@ void Tileset::_updateLodTransitions(
       float currentPercentage =
           pRenderContent->getLodTransitionFadePercentage();
       if (currentPercentage >= 1.0f) {
-        // Remove this tile from the fading out list if it is already at 0%.
+        // Remove this tile from the fading out list if it is already done.
         // The client will already have had a chance to stop rendering the tile
         // last frame.
         pRenderContent->setLodTransitionFadePercentage(0.0f);

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -1400,11 +1400,9 @@ void Tileset::_unloadCachedTiles() noexcept {
       break;
     }
 
-    // Still fading out, can't unload this tile.
-    const TileRenderContent* pRenderContent =
-        pTile->getContent().getRenderContent();
-    if (_options.enableLodTransitionPeriod && pRenderContent &&
-        pRenderContent->getLodTransitionFadePercentage() < 1.0f) {
+    // Don't unload this tile if it is still fading out.
+    if (_updateResult.tilesFadingOut.find(pTile) !=
+        _updateResult.tilesFadingOut.end()) {
       pTile = this->_loadedTiles.next(*pTile);
       continue;
     }


### PR DESCRIPTION
Previously, fading in tiles went from 0.0 --> 1.0 and fading out tiles went from 1.0 --> 0.0. When these values are used to threshold a dither texture in a renderer, this small discrepancy might cause floating point disagreement between fading in tiles and fading out tiles. So instead, we now want fading in and fading out tiles to have the exact same dither threshold (fade percentage) and simply invert the resulting sample if it is fading out. Since the dither texture is sampled in screen-space, this allows the fading out tiles and fading in tiles to blend together perfectly without appearing transparent.

@kring came up with the idea and it works quite nicely! 