### PR TITLE
Add `rendererOptions` to `TilesetOptions`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Change Log
 
+### ? - ?
+
+##### Breaking Changes :mega:
+
+- Added a new parameter, `rendererOptions`, to `IPrepareRendererResources::prepareInLoadThread`.
+
+##### Additions :tada:
+
+- Added a `rendererOptions` property to `TilesetOptions` to pass arbitrary data to `prepareInLoadThread`.
+
 ### v0.19.0 - 2022-09-01
 
 ##### Breaking Changes :mega:

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/IPrepareRendererResources.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/IPrepareRendererResources.h
@@ -45,13 +45,16 @@ public:
    *
    * @param model The glTF model to prepare.
    * @param transform The tile's transformation.
+   * @param rendererOptions Renderer options associated with the tile from
+   * {@link TilesetOptions::rendererOptions}.
    * @returns Arbitrary data representing the result of the load process. This
    * data is passed to {@link prepareInMainThread} as the `pLoadThreadResult`
    * parameter.
    */
   virtual void* prepareInLoadThread(
       const CesiumGltf::Model& model,
-      const glm::dmat4& transform) = 0;
+      const glm::dmat4& transform,
+      const std::any& rendererOptions) = 0;
 
   /**
    * @brief Further prepares renderer resources.

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetOptions.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetOptions.h
@@ -284,6 +284,14 @@ struct CESIUM3DTILESSELECTION_API TilesetOptions {
    * and construction of Gltf models.
    */
   TilesetContentOptions contentOptions;
+
+  /**
+   * @brief Arbitrary data that will be passed to {@link prepareInLoadThread}.
+   *
+   * This object is copied and given to tile preparation threads,
+   * so it must be inexpensive to copy.
+   */
+  std::any rendererOptions;
 };
 
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -859,8 +859,7 @@ void TilesetContentManager::loadTileContent(
       this->_externals.asyncSystem,
       this->_externals.pAssetAccessor,
       this->_externals.pLogger,
-      this->_requestHeaders,
-  };
+      this->_requestHeaders};
 
   pLoader->loadTileContent(loadInput)
       .thenImmediately([tileLoadInfo = std::move(tileLoadInfo),

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -515,7 +515,7 @@ postProcessContentInWorkerThread(
           [result = std::move(result),
            projections = std::move(projections),
            tileLoadInfo = std::move(tileLoadInfo),
-           rendererOptions = rendererOptions](
+           rendererOptions](
               CesiumGltfReader::GltfReaderResult&& gltfResult) mutable {
             if (!gltfResult.errors.empty()) {
               if (result.pCompletedRequest) {
@@ -880,7 +880,7 @@ void TilesetContentManager::loadTileContent(
                 [result = std::move(result),
                  projections = std::move(projections),
                  tileLoadInfo = std::move(tileLoadInfo),
-                 rendererOptions = rendererOptions]() mutable {
+                 rendererOptions]() mutable {
                   return postProcessContentInWorkerThread(
                       std::move(result),
                       std::move(projections),

--- a/Cesium3DTilesSelection/test/SimplePrepareRendererResource.h
+++ b/Cesium3DTilesSelection/test/SimplePrepareRendererResource.h
@@ -27,7 +27,8 @@ public:
 
   virtual void* prepareInLoadThread(
       const CesiumGltf::Model& /*model*/,
-      const glm::dmat4& /*transform*/) override {
+      const glm::dmat4& /*transform*/,
+      const std::any& /*rendererOptions*/) override {
     return new AllocationResult{totalAllocation};
   }
 


### PR DESCRIPTION
Closes #480. This PR adds a `rendererOptions` field to `TilesetOptions`, which gets passed to `IPrepareRendererResources::prepareInLoadThread` similar to how `RasterOverlayOptions` has its `rendererOptions` passed to `IPrepareRendererResources::prepareRasterInLoadThread`.

I couldn't find an equivalent unit test for `RasterOverlayOptions / RasteryOverlayTileProvider` -- would it be good to write one for this PR?