### PR TITLE
CesiumGltfWriter - remove special case for `byteOffset`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug where the Raster Overlay passed to the `loadErrorCallback` would not be the one that the user created, but instead an aggregated overlay that was created internally.
+- In `CesiumGltfWriter`, `accessor.byteOffset` and `bufferView.byteOffset` are no longer written if the value is 0. This fixes validation errors for accessors that don't have buffer views, e.g. attributes that are Draco compressed.
 
 ### v0.18.1 - 2022-08-04
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- In `CesiumGltfWriter`, `accessor.byteOffset` and `bufferView.byteOffset` are no longer written if the value is 0. This fixes validation errors for accessors that don't have buffer views, e.g. attributes that are Draco compressed.
+
 ### v0.19.0 - 2022-09-01
 
 ##### Breaking Changes :mega:
@@ -25,7 +31,6 @@
 ##### Fixes :wrench:
 
 - Fixed a bug where the Raster Overlay passed to the `loadErrorCallback` would not be the one that the user created, but instead an aggregated overlay that was created internally.
-- In `CesiumGltfWriter`, `accessor.byteOffset` and `bufferView.byteOffset` are no longer written if the value is 0. This fixes validation errors for accessors that don't have buffer views, e.g. attributes that are Draco compressed.
 
 ### v0.18.1 - 2022-08-04
 

--- a/CesiumGltfWriter/generated/src/ModelJsonWriter.cpp
+++ b/CesiumGltfWriter/generated/src/ModelJsonWriter.cpp
@@ -810,8 +810,10 @@ void writeJson(
     writeJson(obj.buffer, jsonWriter, context);
   }
 
-  jsonWriter.Key("byteOffset");
-  writeJson(obj.byteOffset, jsonWriter, context);
+  if (obj.byteOffset != 0) {
+    jsonWriter.Key("byteOffset");
+    writeJson(obj.byteOffset, jsonWriter, context);
+  }
 
   jsonWriter.Key("byteLength");
   writeJson(obj.byteLength, jsonWriter, context);
@@ -2545,8 +2547,10 @@ void writeJson(
     writeJson(obj.buffer, jsonWriter, context);
   }
 
-  jsonWriter.Key("byteOffset");
-  writeJson(obj.byteOffset, jsonWriter, context);
+  if (obj.byteOffset != 0) {
+    jsonWriter.Key("byteOffset");
+    writeJson(obj.byteOffset, jsonWriter, context);
+  }
 
   jsonWriter.Key("byteLength");
   writeJson(obj.byteLength, jsonWriter, context);
@@ -2711,8 +2715,10 @@ void writeJson(
     writeJson(obj.bufferView, jsonWriter, context);
   }
 
-  jsonWriter.Key("byteOffset");
-  writeJson(obj.byteOffset, jsonWriter, context);
+  if (obj.byteOffset != 0) {
+    jsonWriter.Key("byteOffset");
+    writeJson(obj.byteOffset, jsonWriter, context);
+  }
 
   jsonWriter.Key("componentType");
   writeJson(obj.componentType, jsonWriter, context);
@@ -2779,8 +2785,10 @@ void writeJson(
     writeJson(obj.bufferView, jsonWriter, context);
   }
 
-  jsonWriter.Key("byteOffset");
-  writeJson(obj.byteOffset, jsonWriter, context);
+  if (obj.byteOffset != 0) {
+    jsonWriter.Key("byteOffset");
+    writeJson(obj.byteOffset, jsonWriter, context);
+  }
 
   writeExtensibleObject(obj, jsonWriter, context);
 
@@ -2798,8 +2806,10 @@ void writeJson(
     writeJson(obj.bufferView, jsonWriter, context);
   }
 
-  jsonWriter.Key("byteOffset");
-  writeJson(obj.byteOffset, jsonWriter, context);
+  if (obj.byteOffset != 0) {
+    jsonWriter.Key("byteOffset");
+    writeJson(obj.byteOffset, jsonWriter, context);
+  }
 
   jsonWriter.Key("componentType");
   writeJson(obj.componentType, jsonWriter, context);

--- a/CesiumGltfWriter/test/TestGltfWriter.cpp
+++ b/CesiumGltfWriter/test/TestGltfWriter.cpp
@@ -89,14 +89,12 @@ TEST_CASE("Writes glTF") {
       "accessors": [
         {
           "bufferView": 0,
-          "byteOffset": 0,
           "componentType": 5123,
           "count": 36,
           "type": "SCALAR"
         },
         {
           "bufferView": 1,
-          "byteOffset": 0,
           "componentType": 5126,
           "count": 24,
           "type": "VEC3"
@@ -120,7 +118,6 @@ TEST_CASE("Writes glTF") {
         },
         {
           "bufferView": 2,
-          "byteOffset": 0,
           "componentType": 5126,
           "count": 24,
           "type": "VEC2"
@@ -169,7 +166,6 @@ TEST_CASE("Writes glTF") {
         },
         {
           "buffer": 0,
-          "byteOffset": 0,
           "byteLength": 576,
           "byteStride": 12,
           "target": 34962
@@ -295,7 +291,6 @@ TEST_CASE("Writes glTF with default values removed") {
       "accessors": [
         {
           "bufferView": 0,
-          "byteOffset": 0,
           "componentType": 5123,
           "count": 36,
           "type": "SCALAR"
@@ -359,7 +354,6 @@ TEST_CASE("Writes glTF with default values removed") {
         },
         {
           "buffer": 0,
-          "byteOffset": 0,
           "byteLength": 576,
           "byteStride": 12,
           "target": 34962
@@ -408,7 +402,6 @@ TEST_CASE("Writes glTF with default values removed") {
       "accessors": [
         {
           "bufferView": 0,
-          "byteOffset": 0,
           "componentType": 5123,
           "count": 36,
           "type": "SCALAR"
@@ -467,7 +460,6 @@ TEST_CASE("Writes glTF with default values removed") {
         },
         {
           "buffer": 0,
-          "byteOffset": 0,
           "byteLength": 576,
           "byteStride": 12,
           "target": 34962

--- a/tools/generate-classes/generate.js
+++ b/tools/generate-classes/generate.js
@@ -496,14 +496,8 @@ function formatWriterPropertyImpl(property) {
   const isMap = type.startsWith("std::unordered_map");
   const isOptional = type.startsWith("std::optional");
 
-  // Somewhat opinionated but it's helpful to see byteOffset: 0 in accessors and bufferViews
-  const requiredPropertyOverride = ["byteOffset"];
-
   const hasDefaultValueGuard =
-    !isId &&
-    !isRequiredEnum &&
-    !requiredPropertyOverride.includes(property.cppSafeName) &&
-    defaultValue !== undefined;
+    !isId && !isRequiredEnum && defaultValue !== undefined;
   const hasDefaultVectorGuard = hasDefaultValueGuard && isVector;
   const hasEmptyGuard = isVector || isMap;
   const hasOptionalGuard = isOptional;


### PR DESCRIPTION
In CesiumGltfWriter we had a special case where `byteOffset` would always get written out even if the value was 0. This causes problems when you have accessors that don't point to buffer views since it's invalid to have `byteOffset: 0` if no `bufferView` is defined. I noticed this when writing out glTFs with `KHR_draco_mesh_compression`.