### PR TITLE
Clean up mapped raster tiles when a geometry tile is failed to load

### DIFF
--- a/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
@@ -48,7 +48,13 @@ void RasterOverlayCollection::add(std::unique_ptr<RasterOverlay>&& pOverlay) {
   // Add this overlay to existing geometry tiles.
   forEachTile(*this->_pLoadedTiles, [pOverlayRaw](Tile& tile) {
     // The tile rectangle and geometric error don't matter for a placeholder.
-    if (tile.getState() != TileLoadState::Unloaded) {
+    // - When a tile is transitioned from Unloaded to Loading, raster overlay tiles will
+    // be mapped to the tile automatically by TilesetContentManager, so we don't need to
+    // map the raster tiles to this unloaded tile now.
+    // - When a tile is already failed to load, there is no need to map the raster tiles to the
+    // tile as it is not rendered any way 
+    TileLoadState tileState = tile.getState(); 
+    if (tileState != TileLoadState::Unloaded && tileState != TileLoadState::Failed) {
       tile.getMappedRasterTiles().push_back(RasterMappedTo3DTile(
           pOverlayRaw->getPlaceholder()->getTile(Rectangle(), glm::dvec2(0.0)),
           -1));

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -1077,37 +1077,35 @@ void TilesetContentManager::setTileContent(
     TileLoadResult&& result,
     void* pWorkerRenderResources) {
   if (result.state == TileLoadResultState::Failed) {
+    tile.getMappedRasterTiles().clear();
     tile.setState(TileLoadState::Failed);
-    return;
-  }
-
-  if (result.state == TileLoadResultState::RetryLater) {
+  } else if (result.state == TileLoadResultState::RetryLater) {
+    tile.getMappedRasterTiles().clear();
     tile.setState(TileLoadState::FailedTemporarily);
-    return;
+  } else {
+    // update tile if the result state is success
+    if (result.updatedBoundingVolume) {
+      tile.setBoundingVolume(*result.updatedBoundingVolume);
+    }
+
+    if (result.updatedContentBoundingVolume) {
+      tile.setContentBoundingVolume(*result.updatedContentBoundingVolume);
+    }
+
+    auto& content = tile.getContent();
+    std::visit(
+        ContentKindSetter{
+            content,
+            std::move(result.rasterOverlayDetails),
+            pWorkerRenderResources},
+        std::move(result.contentKind));
+
+    if (result.tileInitializer) {
+      result.tileInitializer(tile);
+    }
+
+    tile.setState(TileLoadState::ContentLoaded);
   }
-
-  // update tile if the result state is success
-  if (result.updatedBoundingVolume) {
-    tile.setBoundingVolume(*result.updatedBoundingVolume);
-  }
-
-  if (result.updatedContentBoundingVolume) {
-    tile.setContentBoundingVolume(*result.updatedContentBoundingVolume);
-  }
-
-  auto& content = tile.getContent();
-  std::visit(
-      ContentKindSetter{
-          content,
-          std::move(result.rasterOverlayDetails),
-          pWorkerRenderResources},
-      std::move(result.contentKind));
-
-  if (result.tileInitializer) {
-    result.tileInitializer(tile);
-  }
-
-  tile.setState(TileLoadState::ContentLoaded);
 }
 
 void TilesetContentManager::updateContentLoadedState(


### PR DESCRIPTION
When a tile is failed to load, it will be treated and rendered as an empty tile by the traversal system. But when there are raster tiles mapped to the failed tiles, it cannot be rendered at all because `Tile::isRenderable()` will see that none of the raster tiles are renderable. So for those failed tiles, we need to clean up the mapped raster tiles or don't map any raster tiles to those tiles from the beginning

