### PR TITLE
Add LocalHorizontalCoordinateSystem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 ##### Additions :tada:
 
 - Added a `rendererOptions` property to `TilesetOptions` to pass arbitrary data to `prepareInLoadThread`.
+- Added `LocalHorizontalCoordinateSystem`, which is used to create convenient right- or left-handeded coordinate systems with an origin at a point on the globe.
 
 ##### Fixes :wrench:
 

--- a/CesiumGeospatial/include/CesiumGeospatial/LocalHorizontalCoordinateSystem.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/LocalHorizontalCoordinateSystem.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include "Ellipsoid.h"
+#include "Library.h"
+
+#include <glm/mat4x4.hpp>
+#include <glm/vec3.hpp>
+
+namespace CesiumGeospatial {
+class Cartographic;
+}
+
+namespace CesiumGeospatial {
+
+enum class LocalDirection { East, North, West, South, Up, Down };
+
+/**
+ * @brief A coordinate system created from a local horizontal plane at a
+ * particular origin point on the globe.
+ *
+ * Each principal axis in the new coordinate system can be specified to point in
+ * a particular compass direction, or it can point up or down. In this way, a
+ * right-handed or left-handed coordinate system can be created.
+ */
+class CESIUMGEOSPATIAL_API LocalHorizontalCoordinateSystem {
+public:
+  /**
+   * @brief Create a new coordinate system centered at a given longitude,
+   * latitude, and ellipsoidal height.
+   *
+   * @param origin The origin of the coordinate system.
+   * @param xAxisDirection The local direction in which the X axis points at the
+   * origin.
+   * @param yAxisDirection The local direction in which the Y axis points at the
+   * origin.
+   * @param zAxisDirection The local direction in which the Z axis points at the
+   * origin.
+   * @param scaleToMeters A scaling factor of local units to meters.
+   * @param ellipsoid The ellipsoid on which the coordinate system is based.
+   */
+  LocalHorizontalCoordinateSystem(
+      const Cartographic& origin,
+      LocalDirection xAxisDirection = LocalDirection::East,
+      LocalDirection yAxisDirection = LocalDirection::North,
+      LocalDirection zAxisDirection = LocalDirection::Up,
+      double scaleToMeters = 1.0,
+      const Ellipsoid& ellipsoid = Ellipsoid::WGS84);
+
+  /**
+   * @brief Create a new coordinate system centered at a Earth-Centered,
+   * Earth-Fixed position.
+   *
+   * @param origin The origin of the coordinate system.
+   * @param xAxisDirection The local direction in which the X axis points at the
+   * origin.
+   * @param yAxisDirection The local direction in which the Y axis points at the
+   * origin.
+   * @param zAxisDirection The local direction in which the Z axis points at the
+   * origin.
+   * @param scaleToMeters A scaling factor of local units to meters.
+   * @param ellipsoid The ellipsoid on which the coordinate system is based.
+   */
+  LocalHorizontalCoordinateSystem(
+      const glm::dvec3& originEcef,
+      LocalDirection xAxisDirection = LocalDirection::East,
+      LocalDirection yAxisDirection = LocalDirection::North,
+      LocalDirection zAxisDirection = LocalDirection::Up,
+      double scaleToMeters = 1.0,
+      const Ellipsoid& ellipsoid = Ellipsoid::WGS84);
+
+  /**
+   * @brief Gets the transformation matrix from the local horizontal coordinate
+   * system managed by this instance to the Earth-Centered, Earth-fixed
+   * coordinate system.
+   *
+   * @return The transformation.
+   */
+  const glm::dmat4& getLocalToEcefTransformation() const noexcept {
+    return this->_localToEcef;
+  }
+
+  /**
+   * @brief Gets the transformation matrix from the Earth-Centered, Earth-Fixed
+   * (ECEF) coordinate system to the local horizontal coordinate system managed
+   * by this instance.
+   *
+   * @return The transformation.
+   */
+  const glm::dmat4& getEcefToLocalTransformation() const noexcept {
+    return this->_ecefToLocal;
+  };
+
+  /**
+   * @brief Converts a position in the local horizontal coordinate system
+   * managed by this instance to Earth-Centered, Earth-Fixed (ECEF).
+   *
+   * @param localPosition The position in the local coordinate system.
+   * @return The equivalent position in the ECEF coordinate system.
+   */
+  glm::dvec3 localPositionToEcef(const glm::dvec3& localPosition) const;
+
+  /**
+   * @brief Converts a position in the Earth-Centered, Earth-Fixed (ECEF)
+   * coordinate system to the local horizontal coordinate system managed by this
+   * instance.
+   *
+   * @param ecefPosition The position in the ECEF coordinate system.
+   * @return The equivalent position in the local coordinate system.
+   */
+  glm::dvec3 ecefPositionToLocal(const glm::dvec3& ecefPosition) const;
+
+  /**
+   * @brief Converts a direction in the local horizontal coordinate system
+   * managed by this instance to Earth-Centered, Earth-Fixed (ECEF).
+   *
+   * Because the vector is treated as a direction only, the translation portion
+   * of the transformation is ignored.
+   *
+   * @param localPosition The direction in the local coordinate system.
+   * @return The equivalent direction in the ECEF coordinate system.
+   */
+  glm::dvec3 localDirectionToEcef(const glm::dvec3& localDirection) const;
+
+  /**
+   * @brief Converts a direction in the Earth-Centered, Earth-Fixed (ECEF)
+   * coordinate system to the local horizontal coordinate system managed by this
+   * instance.
+   *
+   * Because the vector is treated as a direction only, the translation portion
+   * of the transformation is ignored.
+   *
+   * @param ecefPosition The direction in the ECEF coordinate system.
+   * @return The equivalent direction in the local coordinate system.
+   */
+  glm::dvec3 ecefDirectionToLocal(const glm::dvec3& ecefDirection) const;
+
+private:
+  glm::dmat4 _ecefToLocal;
+  glm::dmat4 _localToEcef;
+};
+
+} // namespace CesiumGeospatial

--- a/CesiumGeospatial/include/CesiumGeospatial/LocalHorizontalCoordinateSystem.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/LocalHorizontalCoordinateSystem.h
@@ -35,7 +35,9 @@ public:
    * origin.
    * @param zAxisDirection The local direction in which the Z axis points at the
    * origin.
-   * @param scaleToMeters A scaling factor of local units to meters.
+   * @param scaleToMeters Local units are converted to meters by multiplying
+   * them by this factor. For example, if the local units are centimeters, this
+   * parameter should be 1.0 / 100.0.
    * @param ellipsoid The ellipsoid on which the coordinate system is based.
    */
   LocalHorizontalCoordinateSystem(
@@ -57,7 +59,9 @@ public:
    * origin.
    * @param zAxisDirection The local direction in which the Z axis points at the
    * origin.
-   * @param scaleToMeters A scaling factor of local units to meters.
+   * @param scaleToMeters Local units are converted to meters by multiplying
+   * them by this factor. For example, if the local units are centimeters, this
+   * parameter should be 1.0 / 100.0.
    * @param ellipsoid The ellipsoid on which the coordinate system is based.
    */
   LocalHorizontalCoordinateSystem(

--- a/CesiumGeospatial/src/LocalHorizontalCoordinateSystem.cpp
+++ b/CesiumGeospatial/src/LocalHorizontalCoordinateSystem.cpp
@@ -1,0 +1,109 @@
+#include <CesiumGeospatial/Cartographic.h>
+#include <CesiumGeospatial/LocalHorizontalCoordinateSystem.h>
+#include <CesiumGeospatial/Transforms.h>
+
+#include <glm/gtc/matrix_inverse.hpp>
+
+using namespace CesiumGeospatial;
+
+namespace {
+
+enum class DirectionAxis { WestEast, SouthNorth, DownUp };
+
+[[maybe_unused]] DirectionAxis directionToAxis(LocalDirection direction) {
+  switch (direction) {
+  case LocalDirection::West:
+  case LocalDirection::East:
+    return DirectionAxis::WestEast;
+  case LocalDirection::South:
+  case LocalDirection::North:
+    return DirectionAxis::SouthNorth;
+  case LocalDirection::Down:
+  case LocalDirection::Up:
+  default:
+    return DirectionAxis::DownUp;
+  }
+}
+
+glm::dvec3 directionToEnuVector(LocalDirection direction) {
+  switch (direction) {
+  case LocalDirection::West:
+    return glm::dvec3(-1.0, 0.0, 0.0);
+  case LocalDirection::East:
+    return glm::dvec3(1.0, 0.0, 0.0);
+  case LocalDirection::South:
+    return glm::dvec3(0.0, -1.0, 0.0);
+  case LocalDirection::North:
+    return glm::dvec3(0.0, 1.0, 0.0);
+  case LocalDirection::Down:
+    return glm::dvec3(0.0, 0.0, -1.0);
+  case LocalDirection::Up:
+  default:
+    return glm::dvec3(0.0, 0.0, 1.0);
+  }
+}
+
+} // namespace
+
+LocalHorizontalCoordinateSystem::LocalHorizontalCoordinateSystem(
+    const Cartographic& origin,
+    LocalDirection xAxisDirection,
+    LocalDirection yAxisDirection,
+    LocalDirection zAxisDirection,
+    double scaleToMeters,
+    const Ellipsoid& ellipsoid)
+    : LocalHorizontalCoordinateSystem(
+          ellipsoid.cartographicToCartesian(origin),
+          xAxisDirection,
+          yAxisDirection,
+          zAxisDirection,
+          scaleToMeters) {}
+
+LocalHorizontalCoordinateSystem::LocalHorizontalCoordinateSystem(
+    const glm::dvec3& originEcef,
+    LocalDirection xAxisDirection,
+    LocalDirection yAxisDirection,
+    LocalDirection zAxisDirection,
+    double scaleToMeters,
+    const Ellipsoid& ellipsoid) {
+  // The three axes must be orthogonal
+  assert(directionToAxis(xAxisDirection) != directionToAxis(yAxisDirection));
+  assert(directionToAxis(xAxisDirection) != directionToAxis(zAxisDirection));
+  assert(directionToAxis(yAxisDirection) != directionToAxis(zAxisDirection));
+
+  // Construct a local horizontal system with East-North-Up axes (right-handed)
+  glm::dmat4 enuToFixed =
+      Transforms::eastNorthUpToFixedFrame(originEcef, ellipsoid);
+
+  // Construct a matrix to swap and invert axes as necessary
+  glm::dmat4 localToEnu(
+      glm::dvec4(directionToEnuVector(xAxisDirection), 0.0),
+      glm::dvec4(directionToEnuVector(yAxisDirection), 0.0),
+      glm::dvec4(directionToEnuVector(zAxisDirection), 0.0),
+      glm::dvec4(0.0, 0.0, 0.0, 1.0));
+
+  glm::dmat4 scale(scaleToMeters);
+
+  this->_localToEcef = enuToFixed * localToEnu * scale;
+  this->_ecefToLocal = glm::affineInverse(this->_localToEcef);
+}
+
+glm::dvec3 LocalHorizontalCoordinateSystem::localPositionToEcef(
+    const glm::dvec3& localPosition) const {
+  return glm::dvec3(this->_localToEcef * glm::dvec4(localPosition, 1.0));
+}
+
+glm::dvec3 LocalHorizontalCoordinateSystem::ecefPositionToLocal(
+    const glm::dvec3& ecefPosition) const {
+  return glm::dvec3(this->_ecefToLocal * glm::dvec4(ecefPosition, 1.0));
+}
+
+glm::dvec3 LocalHorizontalCoordinateSystem::localDirectionToEcef(
+    const glm::dvec3& localDirection) const {
+  return glm::dvec3(this->_localToEcef * glm::dvec4(localDirection, 0.0));
+}
+
+glm::dvec3 LocalHorizontalCoordinateSystem::ecefDirectionToLocal(
+    const glm::dvec3& ecefDirection) const {
+  return glm::dvec3(this->_ecefToLocal * glm::dvec4(ecefDirection, 0.0));
+}

--- a/CesiumGeospatial/src/LocalHorizontalCoordinateSystem.cpp
+++ b/CesiumGeospatial/src/LocalHorizontalCoordinateSystem.cpp
@@ -3,6 +3,7 @@
 #include <CesiumGeospatial/Transforms.h>
 
 #include <glm/gtc/matrix_inverse.hpp>
+#include <glm/mat3x3.hpp>
 
 using namespace CesiumGeospatial;
 
@@ -82,7 +83,7 @@ LocalHorizontalCoordinateSystem::LocalHorizontalCoordinateSystem(
       glm::dvec4(directionToEnuVector(zAxisDirection), 0.0),
       glm::dvec4(0.0, 0.0, 0.0, 1.0));
 
-  glm::dmat4 scale(scaleToMeters);
+  glm::dmat4 scale{glm::dmat3(scaleToMeters)};
 
   this->_localToEcef = enuToFixed * localToEnu * scale;
   this->_ecefToLocal = glm::affineInverse(this->_localToEcef);

--- a/CesiumGeospatial/test/TestLocalHorizontalCoordinateSystem.cpp
+++ b/CesiumGeospatial/test/TestLocalHorizontalCoordinateSystem.cpp
@@ -1,0 +1,120 @@
+#include <CesiumGeospatial/LocalHorizontalCoordinateSystem.h>
+#include <CesiumUtility/Math.h>
+
+#include <catch2/catch.hpp>
+
+using namespace CesiumGeospatial;
+using namespace CesiumUtility;
+
+TEST_CASE("LocalHorizontalCoordinateSystem") {
+  Cartographic nullIsland = Cartographic(0.0, 0.0, 0.0);
+  glm::dvec3 nullIslandEcef =
+      Ellipsoid::WGS84.cartographicToCartesian(nullIsland);
+  glm::dvec3 oneMeterEastEcef(0.0, 1.0, 0.0);
+  glm::dvec3 oneMeterNorthEcef(0.0, 0.0, 1.0);
+  glm::dvec3 oneMeterUpEcef(1.0, 0.0, 0.0);
+
+  SECTION("East-north-up") {
+    LocalHorizontalCoordinateSystem lh(
+        nullIsland,
+        LocalDirection::East,
+        LocalDirection::North,
+        LocalDirection::Up);
+
+    CHECK(Math::equalsEpsilon(
+        lh.ecefPositionToLocal(nullIslandEcef + oneMeterEastEcef),
+        glm::dvec3(1.0, 0.0, 0.0),
+        0.0,
+        1e-10));
+
+    CHECK(Math::equalsEpsilon(
+        lh.ecefPositionToLocal(nullIslandEcef + oneMeterNorthEcef),
+        glm::dvec3(0.0, 1.0, 0.0),
+        0.0,
+        1e-10));
+
+    CHECK(Math::equalsEpsilon(
+        lh.ecefPositionToLocal(nullIslandEcef + oneMeterUpEcef),
+        glm::dvec3(0.0, 0.0, 1.0),
+        0.0,
+        1e-10));
+  }
+
+  SECTION("North-east-down") {
+    LocalHorizontalCoordinateSystem lh(
+        nullIsland,
+        LocalDirection::North,
+        LocalDirection::East,
+        LocalDirection::Down);
+
+    CHECK(Math::equalsEpsilon(
+        lh.ecefPositionToLocal(nullIslandEcef + oneMeterEastEcef),
+        glm::dvec3(0.0, 1.0, 0.0),
+        0.0,
+        1e-10));
+
+    CHECK(Math::equalsEpsilon(
+        lh.ecefPositionToLocal(nullIslandEcef + oneMeterNorthEcef),
+        glm::dvec3(1.0, 0.0, 0.0),
+        0.0,
+        1e-10));
+
+    CHECK(Math::equalsEpsilon(
+        lh.ecefPositionToLocal(nullIslandEcef + oneMeterUpEcef),
+        glm::dvec3(0.0, 0.0, -1.0),
+        0.0,
+        1e-10));
+  }
+
+  SECTION("Left handed East South Up") {
+    LocalHorizontalCoordinateSystem lh(
+        nullIsland,
+        LocalDirection::East,
+        LocalDirection::South,
+        LocalDirection::Up);
+
+    CHECK(Math::equalsEpsilon(
+        lh.ecefPositionToLocal(nullIslandEcef + oneMeterEastEcef),
+        glm::dvec3(1.0, 0.0, 0.0),
+        0.0,
+        1e-10));
+
+    CHECK(Math::equalsEpsilon(
+        lh.ecefPositionToLocal(nullIslandEcef + oneMeterNorthEcef),
+        glm::dvec3(0.0, -1.0, 0.0),
+        0.0,
+        1e-10));
+
+    CHECK(Math::equalsEpsilon(
+        lh.ecefPositionToLocal(nullIslandEcef + oneMeterUpEcef),
+        glm::dvec3(0.0, 0.0, 1.0),
+        0.0,
+        1e-10));
+  }
+
+  SECTION("Left handed East Up North") {
+    LocalHorizontalCoordinateSystem lh(
+        nullIsland,
+        LocalDirection::East,
+        LocalDirection::Up,
+        LocalDirection::North);
+
+    CHECK(Math::equalsEpsilon(
+        lh.ecefPositionToLocal(nullIslandEcef + oneMeterEastEcef),
+        glm::dvec3(1.0, 0.0, 0.0),
+        0.0,
+        1e-10));
+
+    CHECK(Math::equalsEpsilon(
+        lh.ecefPositionToLocal(nullIslandEcef + oneMeterNorthEcef),
+        glm::dvec3(0.0, 0.0, 1.0),
+        0.0,
+        1e-10));
+
+    CHECK(Math::equalsEpsilon(
+        lh.ecefPositionToLocal(nullIslandEcef + oneMeterUpEcef),
+        glm::dvec3(0.0, 1.0, 0.0),
+        0.0,
+        1e-10));
+  }
+}

--- a/CesiumGeospatial/test/TestLocalHorizontalCoordinateSystem.cpp
+++ b/CesiumGeospatial/test/TestLocalHorizontalCoordinateSystem.cpp
@@ -117,4 +117,31 @@ TEST_CASE("LocalHorizontalCoordinateSystem") {
         0.0,
         1e-10));
   }
+
+  SECTION("Scale") {
+    LocalHorizontalCoordinateSystem lh(
+        nullIsland,
+        LocalDirection::East,
+        LocalDirection::South,
+        LocalDirection::Up,
+        1.0 / 100.0);
+
+    CHECK(Math::equalsEpsilon(
+        lh.ecefPositionToLocal(nullIslandEcef + oneMeterEastEcef),
+        glm::dvec3(100.0, 0.0, 0.0),
+        0.0,
+        1e-10));
+
+    CHECK(Math::equalsEpsilon(
+        lh.ecefPositionToLocal(nullIslandEcef + oneMeterNorthEcef),
+        glm::dvec3(0.0, -100.0, 0.0),
+        0.0,
+        1e-10));
+
+    CHECK(Math::equalsEpsilon(
+        lh.ecefPositionToLocal(nullIslandEcef + oneMeterUpEcef),
+        glm::dvec3(0.0, 0.0, 100.0),
+        0.0,
+        1e-10));
+  }
 }


### PR DESCRIPTION
This is kind of like the cesium-native side of cesium-unreal's CesiumGeoreference.

You give it a point on the globe and tell it which direction (west, south, east, north, up, down) each coordinate axis points, and it creates a coordinate system centered on the point and with the axes you specified. Depending on the directions you choose for the axes, the coordinate system may be right- or left-handed. You can also specify a `scale` parameter if the coordinate system is not in meters.

For example, it's easy to construct a left-handed, East-South-Up coordinate system in centimeters, like the one we use in Unreal Engine:

```
LocalHorizontalCoordinateSystem coordinateSystem(
    Cartographic::fromDegrees(-105.25737, 39.736401, 2250.0),
    LocalDirection::East,
    LocalDirection::South,
    LocalDirection::Up,
    1.0 / 100.0);
```

It then provides methods for transforming between the constructed coordinate system and ECEF.

The three axes directions must be orthogonal, i.e., it makes no sense for X to point West and Y to point East. This is only enforced with assertions, as it's almost certainly a developer error.