### PR TITLE
Make `IPrepareRendererResources::prepareInLoadThread` asynchronous, return a Future

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -56,3 +56,6 @@
 [submodule "extern/libmorton"]
 	path = extern/libmorton
 	url = https://github.com/Forceflow/libmorton.git
+[submodule "extern/expected-lite"]
+	path = extern/expected-lite
+	url = https://github.com/martinmoene/expected-lite.git

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - `TileRenderContent::lodTransitionPercentage` now always goes from 0.0 --> 1.0 regardless of if the tile is fading in or out.
 - Added a new parameter, `rendererOptions`, to `IPrepareRendererResources::prepareInLoadThread`.
+- `IPrepareRendererResources::prepareInLoadThread` now takes a `TileLoadResult` and returns a `Future<TileLoadResultAndRenderResources>`, allowing it to work asynchronously rather than just blocking a worker thread until it is finished.
 
 ##### Additions :tada:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - On `IPrepareRendererResources`, the `image` parameter passed to `prepareRasterInLoadThread` and the `rasterTile` parameter passed to `prepareRasterInMainThread` are no longer const. These methods are now allowed to modify the parameters during load.
 - `IPrepareRendererResources::prepareInLoadThread` now takes a `TileLoadResult` and returns a `Future<TileLoadResultAndRenderResources>`, allowing it to work asynchronously rather than just blocking a worker thread until it is finished.
+- `RasterOverlay::createTileProvider` now takes the owner pointer as an `IntrusivePointer` instead of a raw pointer, and returns a future that resolves to a `RasterOverlay::CreateTileProviderResult`.
 
 ##### Additions :tada:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,3 +199,6 @@ install(TARGETS webpdecoder)
 install(DIRECTORY ${CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR}/rapidjson TYPE INCLUDE)
 
 install(TARGETS s2geometry)
+
+install(TARGETS expected-lite)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/extern/expected-lite/include/nonstd TYPE INCLUDE)

--- a/Cesium3DTilesSelection/CMakeLists.txt
+++ b/Cesium3DTilesSelection/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries(Cesium3DTilesSelection
         tinyxml2
         uriparser
         libmorton
+        expected-lite
 )
 
 install(TARGETS Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/BingMapsRasterOverlay.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/BingMapsRasterOverlay.h
@@ -113,8 +113,7 @@ public:
       const RasterOverlayOptions& overlayOptions = {});
   virtual ~BingMapsRasterOverlay() override;
 
-  virtual CesiumAsync::Future<
-      CesiumUtility::IntrusivePointer<RasterOverlayTileProvider>>
+  virtual CesiumAsync::Future<CreateTileProviderResult>
   createTileProvider(
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
@@ -122,7 +121,8 @@ public:
       const std::shared_ptr<IPrepareRendererResources>&
           pPrepareRendererResources,
       const std::shared_ptr<spdlog::logger>& pLogger,
-      const RasterOverlay* pOwner) const override;
+      CesiumUtility::IntrusivePointer<const RasterOverlay> pOwner)
+      const override;
 
 private:
   static const std::string BING_LOGO_HTML;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/BingMapsRasterOverlay.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/BingMapsRasterOverlay.h
@@ -113,8 +113,7 @@ public:
       const RasterOverlayOptions& overlayOptions = {});
   virtual ~BingMapsRasterOverlay() override;
 
-  virtual CesiumAsync::Future<CreateTileProviderResult>
-  createTileProvider(
+  virtual CesiumAsync::Future<CreateTileProviderResult> createTileProvider(
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const std::shared_ptr<CreditSystem>& pCreditSystem,

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/DebugColorizeTilesRasterOverlay.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/DebugColorizeTilesRasterOverlay.h
@@ -22,16 +22,15 @@ public:
   /**
    * @copydoc RasterOverlay::createTileProvider
    */
-  virtual CesiumAsync::Future<
-      CesiumUtility::IntrusivePointer<RasterOverlayTileProvider>>
-  createTileProvider(
+  virtual CesiumAsync::Future<CreateTileProviderResult> createTileProvider(
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const std::shared_ptr<CreditSystem>& pCreditSystem,
       const std::shared_ptr<IPrepareRendererResources>&
           pPrepareRendererResources,
       const std::shared_ptr<spdlog::logger>& pLogger,
-      const RasterOverlay* pOwner) const override;
+      CesiumUtility::IntrusivePointer<const RasterOverlay> pOwner)
+      const override;
 };
 
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/IPrepareRendererResources.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/IPrepareRendererResources.h
@@ -1,12 +1,19 @@
 #pragma once
 
 #include "Library.h"
+#include "TileLoadResult.h"
+
+#include <CesiumAsync/Future.h>
 
 #include <glm/mat4x4.hpp>
 #include <glm/vec2.hpp>
 #include <gsl/span>
 
 #include <any>
+
+namespace CesiumAsync {
+class AsyncSystem;
+}
 
 namespace CesiumGeometry {
 struct Rectangle;
@@ -21,6 +28,11 @@ namespace Cesium3DTilesSelection {
 
 class Tile;
 class RasterOverlayTile;
+
+struct TileLoadResultAndRenderResources {
+  TileLoadResult result;
+  void* pRenderResources{nullptr};
+};
 
 /**
  * @brief When implemented for a rendering engine, allows renderer resources to
@@ -39,20 +51,24 @@ public:
   virtual ~IPrepareRendererResources() = default;
 
   /**
-   * @brief Prepares renderer resources for the given tile.
+   * @brief Prepares renderer resources for the given tile. This method is
+   * invoked in the load thread.
    *
-   * This method is invoked in the load thread, and it may not modify the tile.
-   *
-   * @param model The glTF model to prepare.
+   * @param asyncSystem The AsyncSystem used to do work in threads.
+   * @param tileLoadResult The tile data loaded so far.
    * @param transform The tile's transformation.
    * @param rendererOptions Renderer options associated with the tile from
    * {@link TilesetOptions::rendererOptions}.
-   * @returns Arbitrary data representing the result of the load process. This
-   * data is passed to {@link prepareInMainThread} as the `pLoadThreadResult`
-   * parameter.
+   * @returns A future that resolves to the loaded tile data along with
+   * arbitrary "render resources" data representing the result of the load
+   * process. The loaded data may be the same as was originally given to this
+   * method, or it may be modified. The render resources are passed to
+   * {@link prepareInMainThread} as the `pLoadThreadResult` parameter.
    */
-  virtual void* prepareInLoadThread(
-      const CesiumGltf::Model& model,
+  virtual CesiumAsync::Future<TileLoadResultAndRenderResources>
+  prepareInLoadThread(
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      TileLoadResult&& tileLoadResult,
       const glm::dmat4& transform,
       const std::any& rendererOptions) = 0;
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/IonRasterOverlay.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/IonRasterOverlay.h
@@ -37,16 +37,15 @@ public:
       const RasterOverlayOptions& overlayOptions = {});
   virtual ~IonRasterOverlay() override;
 
-  virtual CesiumAsync::Future<
-      CesiumUtility::IntrusivePointer<RasterOverlayTileProvider>>
-  createTileProvider(
+  virtual CesiumAsync::Future<CreateTileProviderResult> createTileProvider(
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const std::shared_ptr<CreditSystem>& pCreditSystem,
       const std::shared_ptr<IPrepareRendererResources>&
           pPrepareRendererResources,
       const std::shared_ptr<spdlog::logger>& pLogger,
-      const RasterOverlay* pOwner) const override;
+      CesiumUtility::IntrusivePointer<const RasterOverlay> pOwner)
+      const override;
 
 private:
   int64_t _ionAssetID;
@@ -69,9 +68,7 @@ private:
 
   static std::unordered_map<std::string, ExternalAssetEndpoint> endpointCache;
 
-  CesiumAsync::Future<
-      CesiumUtility::IntrusivePointer<RasterOverlayTileProvider>>
-  createTileProvider(
+  CesiumAsync::Future<CreateTileProviderResult> createTileProvider(
       const ExternalAssetEndpoint& endpoint,
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
@@ -79,7 +76,7 @@ private:
       const std::shared_ptr<IPrepareRendererResources>&
           pPrepareRendererResources,
       const std::shared_ptr<spdlog::logger>& pLogger,
-      const RasterOverlay* pOwner) const;
+      CesiumUtility::IntrusivePointer<const RasterOverlay> pOwner) const;
 };
 
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayLoadFailureDetails.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayLoadFailureDetails.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <CesiumUtility/IntrusivePointer.h>
+
 #include <memory>
 #include <string>
 
@@ -33,11 +35,6 @@ enum class RasterOverlayLoadType {
 
 class RasterOverlayLoadFailureDetails {
 public:
-  /**
-   * @brief The raster overlay that encountered the load failure.
-   */
-  const RasterOverlay* pOverlay = nullptr;
-
   /**
    * @brief The type of request that failed to load.
    */

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsOverlay.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsOverlay.h
@@ -30,16 +30,15 @@ public:
       const RasterOverlayOptions& overlayOptions = {});
   virtual ~RasterizedPolygonsOverlay() override;
 
-  virtual CesiumAsync::Future<
-      CesiumUtility::IntrusivePointer<RasterOverlayTileProvider>>
-  createTileProvider(
+  virtual CesiumAsync::Future<CreateTileProviderResult> createTileProvider(
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const std::shared_ptr<CreditSystem>& pCreditSystem,
       const std::shared_ptr<IPrepareRendererResources>&
           pPrepareRendererResources,
       const std::shared_ptr<spdlog::logger>& pLogger,
-      const RasterOverlay* pOwner) const override;
+      CesiumUtility::IntrusivePointer<const RasterOverlay> pOwner)
+      const override;
 
   const std::vector<CesiumGeospatial::CartographicPolygon>&
   getPolygons() const noexcept {

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileLoadResult.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileLoadResult.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include "BoundingVolume.h"
+#include "RasterOverlayDetails.h"
+#include "TileContent.h"
+
+#include <CesiumAsync/IAssetRequest.h>
+#include <CesiumGeometry/Axis.h>
+#include <CesiumGltf/Model.h>
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <variant>
+
+namespace Cesium3DTilesSelection {
+
+class Tile;
+
+/**
+ * @brief Store the content of the tile after finishing
+ * loading tile using {@link TilesetContentLoader::loadTileContent}:
+ *
+ * 1. Returning {@link TileUnknownContent} means that the loader doesn't know
+ * the content of the tile. This content type is useful when loader fails to
+ * load the tile content; or a background task is running to determine the tile
+ * content and the loader wants the client to retry later at some point in the
+ * future
+ *
+ * 2. Returning {@link TileEmptyContent} means that this tile has no content and mostly used
+ * for efficient culling during the traversal process
+ *
+ * 3. Returning {@link TileExternalContent} means that this tile points to an external tileset
+ *
+ * 4. Returning {@link CesiumGltf::Model} means that this tile has glTF model
+ */
+using TileContentKind = std::variant<
+    TileUnknownContent,
+    TileEmptyContent,
+    TileExternalContent,
+    CesiumGltf::Model>;
+
+/**
+ * @brief Indicate the status of {@link TilesetContentLoader::loadTileContent} and
+ * {@link TilesetContentLoader::createTileChildren} operations
+ */
+enum class TileLoadResultState {
+  /**
+   * @brief The operation is successful and all the fields in {@link TileLoadResult}
+   * or {@link TileChildrenResult} are applied to the tile
+   */
+  Success,
+
+  /**
+   * @brief The operation is failed and __none__ of the fields in {@link TileLoadResult}
+   * or {@link TileChildrenResult} are applied to the tile
+   */
+  Failed,
+
+  /**
+   * @brief The operation requires the client to retry later due to some
+   * background work happenning and
+   * __none__ of the fields in {@link TileLoadResult} or {@link TileChildrenResult} are applied to the tile
+   */
+  RetryLater
+};
+
+/**
+ * @brief Store the result of loading a tile content after
+ * invoking {@link TilesetContentLoader::loadTileContent}
+ */
+struct CESIUM3DTILESSELECTION_API TileLoadResult {
+  /**
+   * @brief The content type of the tile.
+   */
+  TileContentKind contentKind;
+
+  /**
+   * @brief The up axis of glTF content.
+   */
+  CesiumGeometry::Axis glTFUpAxis;
+
+  /**
+   * @brief A tile can potentially store a more fit bounding volume along with
+   * its content. If this field is set, the tile's bounding volume will be
+   * updated after the loading is finished.
+   */
+  std::optional<BoundingVolume> updatedBoundingVolume;
+
+  /**
+   * @brief A tile can potentially store a more fit content bounding volume
+   * along with its content. If this field is set, the tile's content bounding
+   * volume will be updated after the loading is finished.
+   */
+  std::optional<BoundingVolume> updatedContentBoundingVolume;
+
+  /**
+   * @brief Holds details of the {@link TileRenderContent} that are useful
+   * for raster overlays.
+   */
+  std::optional<RasterOverlayDetails> rasterOverlayDetails;
+
+  /**
+   * @brief The request that is created to download the tile content.
+   */
+  std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest;
+
+  /**
+   * @brief A callback that is invoked in the main thread immediately when the
+   * loading is finished. This callback is useful when the content request has
+   * other fields like geometric error,
+   * children (in the case of {@link TileExternalContent}), etc, to override the existing fields.
+   */
+  std::function<void(Tile&)> tileInitializer;
+
+  /**
+   * @brief The result of loading a tile. Note that if the state is Failed or
+   * RetryLater, __none__ of the fields above (including {@link TileLoadResult::tileInitializer}) will be
+   * applied to a tile when the loading is finished
+   */
+  TileLoadResultState state;
+
+  /**
+   * @brief Create a result with Failed state
+   *
+   * @param pCompletedRequest The failed request
+   */
+  static TileLoadResult createFailedResult(
+      std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest);
+
+  /**
+   * @brief Create a result with RetryLater state
+   *
+   * @param pCompletedRequest The failed request
+   */
+  static TileLoadResult createRetryLaterResult(
+      std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest);
+};
+
+} // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileMapServiceRasterOverlay.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileMapServiceRasterOverlay.h
@@ -117,16 +117,15 @@ public:
       const RasterOverlayOptions& overlayOptions = {});
   virtual ~TileMapServiceRasterOverlay() override;
 
-  virtual CesiumAsync::Future<
-      CesiumUtility::IntrusivePointer<RasterOverlayTileProvider>>
-  createTileProvider(
+  virtual CesiumAsync::Future<CreateTileProviderResult> createTileProvider(
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const std::shared_ptr<CreditSystem>& pCreditSystem,
       const std::shared_ptr<IPrepareRendererResources>&
           pPrepareRendererResources,
       const std::shared_ptr<spdlog::logger>& pLogger,
-      const RasterOverlay* pOwner) const override;
+      CesiumUtility::IntrusivePointer<const RasterOverlay> pOwner)
+      const override;
 
 private:
   std::string _url;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -75,6 +75,13 @@ public:
       const std::string& ionAssetEndpointUrl = "https://api.cesium.com/");
 
   /**
+   * @brief A future that resolves when this Tileset has been destroyed (i.e.
+   * its destructor has been called) and all async operations that it was
+   * executing have completed.
+   */
+  CesiumAsync::SharedFuture<void> GetAsyncDestructionCompleteEvent();
+
+  /**
    * @brief Destroys this tileset.
    *
    * This may block the calling thread while waiting for pending asynchronous

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -79,7 +79,7 @@ public:
    * its destructor has been called) and all async operations that it was
    * executing have completed.
    */
-  CesiumAsync::SharedFuture<void> GetAsyncDestructionCompleteEvent();
+  CesiumAsync::SharedFuture<void>& getAsyncDestructionCompleteEvent();
 
   /**
    * @brief Destroys this tileset.

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetContentLoader.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetContentLoader.h
@@ -4,6 +4,7 @@
 #include "Library.h"
 #include "RasterOverlayDetails.h"
 #include "TileContent.h"
+#include "TileLoadResult.h"
 #include "TilesetOptions.h"
 
 #include <CesiumAsync/AsyncSystem.h>
@@ -21,54 +22,6 @@
 
 namespace Cesium3DTilesSelection {
 class Tile;
-
-/**
- * @brief Indicate the status of {@link TilesetContentLoader::loadTileContent} and
- * {@link TilesetContentLoader::createTileChildren} operations
- */
-enum class TileLoadResultState {
-  /**
-   * @brief The operation is successful and all the fields in {@link TileLoadResult}
-   * or {@link TileChildrenResult} are applied to the tile
-   */
-  Success,
-
-  /**
-   * @brief The operation is failed and __none__ of the fields in {@link TileLoadResult}
-   * or {@link TileChildrenResult} are applied to the tile
-   */
-  Failed,
-
-  /**
-   * @brief The operation requires the client to retry later due to some
-   * background work happenning and
-   * __none__ of the fields in {@link TileLoadResult} or {@link TileChildrenResult} are applied to the tile
-   */
-  RetryLater
-};
-
-/**
- * @brief Store the content of the tile after finishing
- * loading tile using {@link TilesetContentLoader::loadTileContent}:
- *
- * 1. Returning {@link TileUnknownContent} means that the loader doesn't know
- * the content of the tile. This content type is useful when loader fails to
- * load the tile content; or a background task is running to determine the tile
- * content and the loader wants the client to retry later at some point in the
- * future
- *
- * 2. Returning {@link TileEmptyContent} means that this tile has no content and mostly used
- * for efficient culling during the traversal process
- *
- * 3. Returning {@link TileExternalContent} means that this tile points to an external tileset
- *
- * 4. Returning {@link CesiumGltf::Model} means that this tile has glTF model
- */
-using TileContentKind = std::variant<
-    TileUnknownContent,
-    TileEmptyContent,
-    TileExternalContent,
-    CesiumGltf::Model>;
 
 /**
  * @brief Store the parameters that are needed to load a tile
@@ -123,78 +76,6 @@ struct CESIUM3DTILESSELECTION_API TileLoadInput {
    * @brief The request headers that will be attached to the request.
    */
   const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders;
-};
-
-/**
- * @brief Store the result of loading a tile content after
- * invoking {@link TilesetContentLoader::loadTileContent}
- */
-struct CESIUM3DTILESSELECTION_API TileLoadResult {
-  /**
-   * @brief The content type of the tile.
-   */
-  TileContentKind contentKind;
-
-  /**
-   * @brief The up axis of glTF content.
-   */
-  CesiumGeometry::Axis glTFUpAxis;
-
-  /**
-   * @brief A tile can potentially store a more fit bounding volume along with
-   * its content. If this field is set, the tile's bounding volume will be
-   * updated after the loading is finished.
-   */
-  std::optional<BoundingVolume> updatedBoundingVolume;
-
-  /**
-   * @brief A tile can potentially store a more fit content bounding volume
-   * along with its content. If this field is set, the tile's content bounding
-   * volume will be updated after the loading is finished.
-   */
-  std::optional<BoundingVolume> updatedContentBoundingVolume;
-
-  /**
-   * @brief Holds details of the {@link TileRenderContent} that are useful
-   * for raster overlays.
-   */
-  std::optional<RasterOverlayDetails> rasterOverlayDetails;
-
-  /**
-   * @brief The request that is created to download the tile content.
-   */
-  std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest;
-
-  /**
-   * @brief A callback that is invoked in the main thread immediately when the
-   * loading is finished. This callback is useful when the content request has
-   * other fields like geometric error,
-   * children (in the case of {@link TileExternalContent}), etc, to override the existing fields.
-   */
-  std::function<void(Tile&)> tileInitializer;
-
-  /**
-   * @brief The result of loading a tile. Note that if the state is Failed or
-   * RetryLater, __none__ of the fields above (including {@link TileLoadResult::tileInitializer}) will be
-   * applied to a tile when the loading is finished
-   */
-  TileLoadResultState state;
-
-  /**
-   * @brief Create a result with Failed state
-   *
-   * @param pCompletedRequest The failed request
-   */
-  static TileLoadResult createFailedResult(
-      std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest);
-
-  /**
-   * @brief Create a result with RetryLater state
-   *
-   * @param pCompletedRequest The failed request
-   */
-  static TileLoadResult createRetryLaterResult(
-      std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest);
 };
 
 /**

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ViewUpdateResult.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ViewUpdateResult.h
@@ -2,6 +2,7 @@
 
 #include "Library.h"
 
+#include <cstdint>
 #include <unordered_set>
 #include <vector>
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/WebMapServiceRasterOverlay.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/WebMapServiceRasterOverlay.h
@@ -91,16 +91,15 @@ public:
       const RasterOverlayOptions& overlayOptions = {});
   virtual ~WebMapServiceRasterOverlay() override;
 
-  virtual CesiumAsync::Future<
-      CesiumUtility::IntrusivePointer<RasterOverlayTileProvider>>
-  createTileProvider(
+  virtual CesiumAsync::Future<CreateTileProviderResult> createTileProvider(
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const std::shared_ptr<CreditSystem>& pCreditSystem,
       const std::shared_ptr<IPrepareRendererResources>&
           pPrepareRendererResources,
       const std::shared_ptr<spdlog::logger>& pLogger,
-      const RasterOverlay* pOwner) const override;
+      CesiumUtility::IntrusivePointer<const RasterOverlay> pOwner)
+      const override;
 
 private:
   std::string _baseUrl;

--- a/Cesium3DTilesSelection/src/DebugColorizeTilesRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/DebugColorizeTilesRasterOverlay.cpp
@@ -69,19 +69,19 @@ DebugColorizeTilesRasterOverlay::DebugColorizeTilesRasterOverlay(
     const RasterOverlayOptions& overlayOptions)
     : RasterOverlay(name, overlayOptions) {}
 
-CesiumAsync::Future<IntrusivePointer<RasterOverlayTileProvider>>
+CesiumAsync::Future<RasterOverlay::CreateTileProviderResult>
 DebugColorizeTilesRasterOverlay::createTileProvider(
     const CesiumAsync::AsyncSystem& asyncSystem,
     const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
     const std::shared_ptr<CreditSystem>& /* pCreditSystem */,
     const std::shared_ptr<IPrepareRendererResources>& pPrepareRendererResources,
     const std::shared_ptr<spdlog::logger>& pLogger,
-    const RasterOverlay* pOwner) const {
+    CesiumUtility::IntrusivePointer<const RasterOverlay> pOwner) const {
   pOwner = pOwner ? pOwner : this;
 
-  return asyncSystem.createResolvedFuture(
+  return asyncSystem.createResolvedFuture<CreateTileProviderResult>(
       IntrusivePointer<RasterOverlayTileProvider>(new DebugTileProvider(
-          this,
+          pOwner,
           asyncSystem,
           pAssetAccessor,
           pPrepareRendererResources,

--- a/Cesium3DTilesSelection/src/RasterizedPolygonsOverlay.cpp
+++ b/Cesium3DTilesSelection/src/RasterizedPolygonsOverlay.cpp
@@ -241,21 +241,21 @@ RasterizedPolygonsOverlay::RasterizedPolygonsOverlay(
 
 RasterizedPolygonsOverlay::~RasterizedPolygonsOverlay() {}
 
-CesiumAsync::Future<IntrusivePointer<RasterOverlayTileProvider>>
+CesiumAsync::Future<RasterOverlay::CreateTileProviderResult>
 RasterizedPolygonsOverlay::createTileProvider(
     const CesiumAsync::AsyncSystem& asyncSystem,
     const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
     const std::shared_ptr<CreditSystem>& /*pCreditSystem*/,
     const std::shared_ptr<IPrepareRendererResources>& pPrepareRendererResources,
     const std::shared_ptr<spdlog::logger>& pLogger,
-    const RasterOverlay* pOwner) const {
+    CesiumUtility::IntrusivePointer<const RasterOverlay> pOwner) const {
 
   pOwner = pOwner ? pOwner : this;
 
-  return asyncSystem.createResolvedFuture(
+  return asyncSystem.createResolvedFuture<CreateTileProviderResult>(
       IntrusivePointer<RasterOverlayTileProvider>(
           new RasterizedPolygonsTileProvider(
-              this,
+              pOwner,
               asyncSystem,
               pAssetAccessor,
               pPrepareRendererResources,

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -85,8 +85,8 @@ Tileset::Tileset(
           ionAccessToken,
           ionAssetEndpointUrl)} {}
 
-CesiumAsync::SharedFuture<void> Tileset::GetAsyncDestructionCompleteEvent() {
-  return this->_pTilesetContentManager->GetAsyncDestructionCompleteEvent();
+CesiumAsync::SharedFuture<void>& Tileset::getAsyncDestructionCompleteEvent() {
+  return this->_pTilesetContentManager->getAsyncDestructionCompleteEvent();
 }
 
 Tileset::~Tileset() noexcept {

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -85,6 +85,10 @@ Tileset::Tileset(
           ionAccessToken,
           ionAssetEndpointUrl)} {}
 
+CesiumAsync::SharedFuture<void> Tileset::GetAsyncDestructionCompleteEvent() {
+  return this->_pTilesetContentManager->GetAsyncDestructionCompleteEvent();
+}
+
 Tileset::~Tileset() noexcept {
   this->_pTilesetContentManager->unloadAll();
   if (this->_externals.pTileOcclusionProxyPool) {

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -789,8 +789,8 @@ TilesetContentManager::TilesetContentManager(
   }
 }
 
-CesiumAsync::SharedFuture<void>
-TilesetContentManager::GetAsyncDestructionCompleteEvent() {
+CesiumAsync::SharedFuture<void>&
+TilesetContentManager::getAsyncDestructionCompleteEvent() {
   return this->_destructionCompleteFuture;
 }
 

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -581,7 +581,8 @@ TilesetContentManager::TilesetContentManager(
       _loadedTilesCount{0},
       _tilesDataUsed{0},
       _destructionCompletePromise{externals.asyncSystem.createPromise<void>()},
-      _destructionCompleteFuture{this->_destructionCompletePromise.getFuture().share()} {}
+      _destructionCompleteFuture{
+          this->_destructionCompletePromise.getFuture().share()} {}
 
 TilesetContentManager::TilesetContentManager(
     const TilesetExternals& externals,
@@ -604,7 +605,8 @@ TilesetContentManager::TilesetContentManager(
       _loadedTilesCount{0},
       _tilesDataUsed{0},
       _destructionCompletePromise{externals.asyncSystem.createPromise<void>()},
-      _destructionCompleteFuture{this->_destructionCompletePromise.getFuture().share()} {
+      _destructionCompleteFuture{
+          this->_destructionCompletePromise.getFuture().share()} {
   if (!url.empty()) {
     this->notifyTileStartLoading(nullptr);
 
@@ -738,7 +740,8 @@ TilesetContentManager::TilesetContentManager(
       _loadedTilesCount{0},
       _tilesDataUsed{0},
       _destructionCompletePromise{externals.asyncSystem.createPromise<void>()},
-      _destructionCompleteFuture{this->_destructionCompletePromise.getFuture().share()} {
+      _destructionCompleteFuture{
+          this->_destructionCompletePromise.getFuture().share()} {
   if (ionAssetID > 0) {
     auto authorizationChangeListener = [this](
                                            const std::string& header,
@@ -786,7 +789,8 @@ TilesetContentManager::TilesetContentManager(
   }
 }
 
-CesiumAsync::SharedFuture<void> TilesetContentManager::GetAsyncDestructionCompleteEvent() {
+CesiumAsync::SharedFuture<void>
+TilesetContentManager::GetAsyncDestructionCompleteEvent() {
   return this->_destructionCompleteFuture;
 }
 

--- a/Cesium3DTilesSelection/src/TilesetContentManager.h
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.h
@@ -48,7 +48,7 @@ public:
    * content manager have completed and all tiles are unloaded, but before the
    * content manager itself is destroyed.
    */
-  CesiumAsync::SharedFuture<void> GetAsyncDestructionCompleteEvent();
+  CesiumAsync::SharedFuture<void>& getAsyncDestructionCompleteEvent();
 
   ~TilesetContentManager() noexcept;
 

--- a/Cesium3DTilesSelection/src/TilesetContentManager.h
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.h
@@ -43,6 +43,13 @@ public:
       const std::string& ionAccessToken,
       const std::string& ionAssetEndpointUrl = "https://api.cesium.com/");
 
+  /**
+   * @brief A future that resolves after all async operations initiated by this
+   * content manager have completed and all tiles are unloaded, but before the
+   * content manager itself is destroyed.
+   */
+  CesiumAsync::SharedFuture<void> GetAsyncDestructionCompleteEvent();
+
   ~TilesetContentManager() noexcept;
 
   void loadTileContent(Tile& tile, const TilesetOptions& tilesetOptions);
@@ -154,5 +161,8 @@ private:
   };
 
   std::vector<MainThreadLoadTask> _finishLoadingQueue;
+
+  CesiumAsync::Promise<void> _destructionCompletePromise;
+  CesiumAsync::SharedFuture<void> _destructionCompleteFuture;
 };
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/test/SimplePrepareRendererResource.h
+++ b/Cesium3DTilesSelection/test/SimplePrepareRendererResource.h
@@ -25,11 +25,15 @@ public:
 
   ~SimplePrepareRendererResource() noexcept { CHECK(totalAllocation == 0); }
 
-  virtual void* prepareInLoadThread(
-      const CesiumGltf::Model& /*model*/,
+  virtual CesiumAsync::Future<TileLoadResultAndRenderResources>
+  prepareInLoadThread(
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      TileLoadResult&& tileLoadResult,
       const glm::dmat4& /*transform*/,
       const std::any& /*rendererOptions*/) override {
-    return new AllocationResult{totalAllocation};
+    return asyncSystem.createResolvedFuture(TileLoadResultAndRenderResources{
+        std::move(tileLoadResult),
+        new AllocationResult{totalAllocation}});
   }
 
   virtual void* prepareInMainThread(

--- a/Cesium3DTilesSelection/test/TestQuadtreeRasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/test/TestQuadtreeRasterOverlayTileProvider.cpp
@@ -82,7 +82,7 @@ public:
       const RasterOverlayOptions& options = RasterOverlayOptions())
       : RasterOverlay(name, options) {}
 
-  virtual CesiumAsync::Future<IntrusivePointer<RasterOverlayTileProvider>>
+  virtual CesiumAsync::Future<CreateTileProviderResult>
   createTileProvider(
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
@@ -90,13 +90,14 @@ public:
       const std::shared_ptr<IPrepareRendererResources>&
           pPrepareRendererResources,
       const std::shared_ptr<spdlog::logger>& pLogger,
-      const RasterOverlay* pOwner) const override {
+      CesiumUtility::IntrusivePointer<const RasterOverlay> pOwner)
+      const override {
     if (!pOwner) {
       pOwner = this;
     }
 
     return asyncSystem
-        .createResolvedFuture<IntrusivePointer<RasterOverlayTileProvider>>(
+        .createResolvedFuture<CreateTileProviderResult>(
             new TestTileProvider(
                 pOwner,
                 asyncSystem,
@@ -143,8 +144,9 @@ TEST_CASE("QuadtreeRasterOverlayTileProvider getTile") {
           spdlog::default_logger(),
           nullptr)
       .thenInMainThread(
-          [&pProvider](IntrusivePointer<RasterOverlayTileProvider>&& pCreated) {
-            pProvider = pCreated;
+          [&pProvider](RasterOverlay::CreateTileProviderResult&& created) {
+            CHECK(created);
+            pProvider = *created;
           });
 
   asyncSystem.dispatchMainThreadTasks();

--- a/Cesium3DTilesSelection/test/TestQuadtreeRasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/test/TestQuadtreeRasterOverlayTileProvider.cpp
@@ -82,8 +82,7 @@ public:
       const RasterOverlayOptions& options = RasterOverlayOptions())
       : RasterOverlay(name, options) {}
 
-  virtual CesiumAsync::Future<CreateTileProviderResult>
-  createTileProvider(
+  virtual CesiumAsync::Future<CreateTileProviderResult> createTileProvider(
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const std::shared_ptr<CreditSystem>& /* pCreditSystem */,
@@ -96,25 +95,24 @@ public:
       pOwner = this;
     }
 
-    return asyncSystem
-        .createResolvedFuture<CreateTileProviderResult>(
-            new TestTileProvider(
-                pOwner,
-                asyncSystem,
-                pAssetAccessor,
-                std::nullopt,
-                pPrepareRendererResources,
-                pLogger,
-                WebMercatorProjection(),
-                QuadtreeTilingScheme(
-                    WebMercatorProjection::computeMaximumProjectedRectangle(),
-                    1,
-                    1),
+    return asyncSystem.createResolvedFuture<CreateTileProviderResult>(
+        new TestTileProvider(
+            pOwner,
+            asyncSystem,
+            pAssetAccessor,
+            std::nullopt,
+            pPrepareRendererResources,
+            pLogger,
+            WebMercatorProjection(),
+            QuadtreeTilingScheme(
                 WebMercatorProjection::computeMaximumProjectedRectangle(),
-                0,
-                10,
-                256,
-                256));
+                1,
+                1),
+            WebMercatorProjection::computeMaximumProjectedRectangle(),
+            0,
+            10,
+            256,
+            256));
   }
 };
 

--- a/CesiumAsync/include/CesiumAsync/AsyncSystem.h
+++ b/CesiumAsync/include/CesiumAsync/AsyncSystem.h
@@ -276,6 +276,20 @@ public:
    */
   ThreadPool createThreadPool(int32_t numberOfThreads) const;
 
+  /**
+   * Returns true if this instance and the right-hand side can be used
+   * interchangeably because they schedule continuations identically. Otherwise,
+   * returns false.
+   */
+  bool operator==(const AsyncSystem& rhs) const noexcept;
+
+  /**
+   * Returns true if this instance and the right-hand side can _not_ be used
+   * interchangeably because they schedule continuations differently. Otherwise,
+   * returns false.
+   */
+  bool operator!=(const AsyncSystem& rhs) const noexcept;
+
 private:
   // Common implementation of 'all' for both Future and SharedFuture.
   template <typename T, typename TFutureType>

--- a/CesiumAsync/include/CesiumAsync/SharedFuture.h
+++ b/CesiumAsync/include/CesiumAsync/SharedFuture.h
@@ -199,10 +199,19 @@ public:
    * @throws An exception if the future rejected.
    */
   template <
-      typename TReturn =
-          std::conditional_t<std::is_same_v<T, void>, T, const T&>>
-  TReturn wait() const {
+      typename U = T,
+      std::enable_if_t<std::is_same_v<U, T>, int> = 0,
+      std::enable_if_t<!std::is_same_v<U, void>, int> = 0>
+  const U& wait() const {
     return this->_task.get();
+  }
+
+  template <
+      typename U = T,
+      std::enable_if_t<std::is_same_v<U, T>, int> = 0,
+      std::enable_if_t<std::is_same_v<U, void>, int> = 0>
+  void wait() const {
+    this->_task.get();
   }
 
   /**

--- a/CesiumAsync/include/CesiumAsync/SharedFuture.h
+++ b/CesiumAsync/include/CesiumAsync/SharedFuture.h
@@ -8,6 +8,7 @@
 
 #include <CesiumUtility/Tracing.h>
 
+#include <type_traits>
 #include <variant>
 
 namespace CesiumAsync {
@@ -197,7 +198,10 @@ public:
    * @return The value if the future resolves successfully.
    * @throws An exception if the future rejected.
    */
-  const T& wait() const { return this->_task.get(); }
+  template <typename TReturn = std::conditional_t<std::is_same_v<T, void>, T, const T&>>
+  TReturn wait() const {
+    return this->_task.get();
+  }
 
   /**
    * @brief Determines if this future is already resolved or rejected.

--- a/CesiumAsync/include/CesiumAsync/SharedFuture.h
+++ b/CesiumAsync/include/CesiumAsync/SharedFuture.h
@@ -198,7 +198,9 @@ public:
    * @return The value if the future resolves successfully.
    * @throws An exception if the future rejected.
    */
-  template <typename TReturn = std::conditional_t<std::is_same_v<T, void>, T, const T&>>
+  template <
+      typename TReturn =
+          std::conditional_t<std::is_same_v<T, void>, T, const T&>>
   TReturn wait() const {
     return this->_task.get();
   }

--- a/CesiumAsync/src/AsyncSystem.cpp
+++ b/CesiumAsync/src/AsyncSystem.cpp
@@ -23,4 +23,12 @@ ThreadPool AsyncSystem::createThreadPool(int32_t numberOfThreads) const {
   return ThreadPool(numberOfThreads);
 }
 
+bool AsyncSystem::operator==(const AsyncSystem& rhs) const noexcept {
+  return this->_pSchedulers == rhs._pSchedulers;
+}
+
+bool AsyncSystem::operator!=(const AsyncSystem& rhs) const noexcept {
+  return this->_pSchedulers != rhs._pSchedulers;
+}
+
 } // namespace CesiumAsync

--- a/CesiumAsync/test/TestAsyncSystem.cpp
+++ b/CesiumAsync/test/TestAsyncSystem.cpp
@@ -529,4 +529,14 @@ TEST_CASE("AsyncSystem") {
     promise.resolve(4);
     CHECK(future.isReady());
   }
+
+  SECTION("SharedFuture may resolve to void") {
+    auto promise = asyncSystem.createPromise<void>();
+    auto future = promise.getFuture().share();
+
+    CHECK(!future.isReady());
+    promise.resolve();
+    CHECK(future.isReady());
+    future.wait();
+  }
 }

--- a/CesiumUtility/include/CesiumUtility/IntrusivePointer.h
+++ b/CesiumUtility/include/CesiumUtility/IntrusivePointer.h
@@ -85,9 +85,7 @@ public:
 
     return *this;
   }
-  template <
-      class U,
-      typename std::enable_if_t<std::is_convertible<U, T>::value>* = nullptr>
+  template <class U>
   IntrusivePointer& operator=(const IntrusivePointer<U>& rhs) noexcept {
     if (this->_p != rhs._p) {
       // addReference the new pointer before releaseReference'ing the old.
@@ -159,9 +157,7 @@ public:
   bool operator==(const IntrusivePointer<T>& rhs) const noexcept {
     return this->_p == rhs._p;
   }
-  template <
-      class U,
-      typename std::enable_if_t<std::is_convertible<U, T>::value>* = nullptr>
+  template <class U>
   bool operator==(const IntrusivePointer<U>& rhs) const noexcept {
     return this->_p == rhs._p;
   }

--- a/ThirdParty.json
+++ b/ThirdParty.json
@@ -30,6 +30,12 @@
     "license": ["ISC License"]
   },
   {
+    "name": "expected-lite",
+    "url": "https://github.com/martinmoene/expected-lite",
+    "version": "0.6.2",
+    "license": ["Boost Software License 1.0"]
+  },
+  {
     "name": "GLM",
     "url": "https://github.com/g-truc/glm",
     "version": "0.9.9.8",

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -64,6 +64,8 @@ endif()
 
 add_subdirectory(modp_b64)
 
+add_subdirectory(expected-lite)
+
 # s2geometry's CMake requires OpenSSL, even though it's not needed for any of
 # the functionality we actually use. So a simple library with enough functionality
 # for our needs is defined here.


### PR DESCRIPTION
This is a PR into  #554.

Previously, `prepareInLoadThread` was invoked in the load thread (as is hopefully obvious from the name), but it had no option to do any truly asynchronous work. Once the function returned, the load-thread part of the process was considered complete.

This PR changes the paradigm so that `prepareInLoadThread` now returns a Future, and the load-thread part of the process isn't complete until the Future resolves. This allows additional network requests, work in other threads, etc. without requiring the load thread to block while those other operations are in progress. For example, it could be used to dispatch part of the work to a render thread, thread pool, or game thread.