### PR TITLE
Create placeholder tile properly when rectangle is unknown.

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterMappedTo3DTile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterMappedTo3DTile.h
@@ -200,7 +200,10 @@ public:
    *
    * @param maximumScreenSpaceError The maximum screen space error that is used
    * for the current tile
-   * @param tileProvider The overlay tile provider to map to the tile.
+   * @param tileProvider The overlay tile provider to map to the tile. This may
+   * be a placeholder if the tile provider is not yet ready.
+   * @param placeholder The placeholder tile provider for this overlay. This is
+   * always a placeholder, even if the tile provider is already ready.
    * @param tile The tile to which to map the overlay.
    * @param missingProjections The list of projections for which there are not
    * yet any texture coordiantes. On return, the given overlay's Projection may
@@ -214,6 +217,7 @@ public:
   static RasterMappedTo3DTile* mapOverlayToTile(
       double maximumScreenSpaceError,
       RasterOverlayTileProvider& tileProvider,
+      RasterOverlayTileProvider& placeholder,
       Tile& tile,
       std::vector<CesiumGeospatial::Projection>& missingProjections);
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayCollection.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayCollection.h
@@ -102,7 +102,15 @@ public:
   getTileProviders() const;
 
   /**
-   * @brief Finds the tile provider for a given provider.
+   * @brief Gets the placeholder tile providers in this collection. Each
+   * placeholder tile provider corresponds with the overlay at the same position
+   * in the collection returned by {@link getOverlays}.
+   */
+  const std::vector<CesiumUtility::IntrusivePointer<RasterOverlayTileProvider>>&
+  getPlaceholderTileProviders() const;
+
+  /**
+   * @brief Finds the tile provider for a given overlay.
    *
    * If the specified raster overlay is not part of this collection, this method
    * will return nullptr.
@@ -122,6 +130,29 @@ public:
    */
   const RasterOverlayTileProvider*
   findTileProviderForOverlay(const RasterOverlay& overlay) const noexcept;
+
+  /**
+   * @brief Finds the placeholder tile provider for a given overlay.
+   *
+   * If the specified raster overlay is not part of this collection, this method
+   * will return nullptr.
+   *
+   * This method will return the placeholder tile provider even if the real one
+   * has been created. This is useful to create placeholder tiles when the
+   * rectangle in the overlay's projection is not yet known.
+   *
+   * @param overlay The overlay for which to obtain the tile provider.
+   * @return The placeholder tile provider, if any, corresponding to the raster
+   * overlay.
+   */
+  RasterOverlayTileProvider*
+  findPlaceholderTileProviderForOverlay(RasterOverlay& overlay) noexcept;
+
+  /**
+   * @copydoc findPlaceholderTileProviderForOverlay
+   */
+  const RasterOverlayTileProvider* findPlaceholderTileProviderForOverlay(
+      const RasterOverlay& overlay) const noexcept;
 
   /**
    * @brief A constant iterator for {@link RasterOverlay} instances.

--- a/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
@@ -210,6 +210,14 @@ RasterOverlayCollection::getTileProviders() const {
   return this->_pOverlays->tileProviders;
 }
 
+const std::vector<CesiumUtility::IntrusivePointer<RasterOverlayTileProvider>>&
+RasterOverlayCollection::getPlaceholderTileProviders() const {
+  if (!this->_pOverlays)
+    return emptyTileProviders;
+
+  return this->_pOverlays->placeholders;
+}
+
 RasterOverlayTileProvider* RasterOverlayCollection::findTileProviderForOverlay(
     RasterOverlay& overlay) noexcept {
   // Call the const version
@@ -232,6 +240,35 @@ RasterOverlayCollection::findTileProviderForOverlay(
   for (size_t i = 0; i < overlays.size() && i < tileProviders.size(); ++i) {
     if (overlays[i].get() == &overlay)
       return tileProviders[i].get();
+  }
+
+  return nullptr;
+}
+
+RasterOverlayTileProvider*
+RasterOverlayCollection::findPlaceholderTileProviderForOverlay(
+    RasterOverlay& overlay) noexcept {
+  // Call the const version
+  const RasterOverlayTileProvider* pResult =
+      this->findPlaceholderTileProviderForOverlay(
+          const_cast<const RasterOverlay&>(overlay));
+  return const_cast<RasterOverlayTileProvider*>(pResult);
+}
+
+const RasterOverlayTileProvider*
+RasterOverlayCollection::findPlaceholderTileProviderForOverlay(
+    const RasterOverlay& overlay) const noexcept {
+  if (!this->_pOverlays)
+    return nullptr;
+
+  const auto& overlays = this->_pOverlays->overlays;
+  const auto& placeholders = this->_pOverlays->placeholders;
+
+  assert(overlays.size() == placeholders.size());
+
+  for (size_t i = 0; i < overlays.size() && i < placeholders.size(); ++i) {
+    if (overlays[i].get() == &overlay)
+      return placeholders[i].get();
   }
 
   return nullptr;


### PR DESCRIPTION
This fixes a bug, probably introduced in #554, that made it impossible to add raster overlays to some tilesets, such as Melbourne Photogrammetry.

When a tile turns out to not have the projection necessary for a particular raster overlay, we have no way to determine the tile's rectangle for overlay mapping purposes. So we attach a placeholder raster overlay tile to it and then kick the tile back to the unloaded state to start over. Except we weren't creating the placeholder tile properly, and instead ended up creating a RasterMappedTo3DTile that had both its loading and ready tiles null. So it would get stuck there not ready forever.

This PR fixes the problem by creating the placeholder tile correctly, which requires access to the placeholder tile provider. I also considered making a regular tile provider able to provide placeholder tiles, but this seemed slightly more elegant.