### PR TITLE
Don't try to upsample tiles with no geometry.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
 - Added the `getImage` method to `RasterOverlayTile`.
 - Added `LocalHorizontalCoordinateSystem`, which is used to create convenient right- or left-handeded coordinate systems with an origin at a point on the globe.
 
+##### Fixes :wrench:
+
+- Fixed a bug that could cause a crash when adding raster overlays to sparse tilesets and zooming close enough to cause them to be upsampled.
+
 ### v0.20.0 - 2022-10-03
 
 ##### Breaking Changes :mega:

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/GltfUtilities.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/GltfUtilities.h
@@ -110,6 +110,11 @@ struct CESIUM3DTILESSELECTION_API GltfUtilities {
    * values will be in the usual -PI to PI range, but east will have a smaller
    * value than west.
    *
+   * If the glTF contains no geometry, the returned region's rectangle
+   * will be {@link GlobeRectangle::EMPTY}, its minimum height will be 1.0, and
+   * its maximum height will be -1.0 (the minimum will be greater than the
+   * maximum).
+   *
    * @param gltf The model.
    * @param transform The transform from model coordinates to ECEF coordinates.
    * @return The computed bounding region.

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -129,6 +129,12 @@ void createQuadtreeSubdividedChildren(
     return;
   }
 
+  // Don't try to upsample a parent tile without geometry.
+  if (maybeRegionAndCenter->region.getMaximumHeight() <
+      maybeRegionAndCenter->region.getMinimumHeight()) {
+    return;
+  }
+
   // The quadtree tile ID doesn't actually matter, because we're not going to
   // use the standard tile bounds for the ID. But having a tile ID that reflects
   // the level and _approximate_ location is helpful for debugging.

--- a/CesiumGeospatial/include/CesiumGeospatial/BoundingRegionBuilder.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/BoundingRegionBuilder.h
@@ -14,6 +14,11 @@ public:
 
   /**
    * @brief Gets the final region from this builder.
+   *
+   * If no positions are added to this builder, the returned region's rectangle
+   * will be {@link GlobeRectangle::EMPTY}, its minimum height will be 1.0, and
+   * its maximum height will be -1.0 (the minimum will be greater than the
+   * maximum).
    */
   BoundingRegion toRegion() const;
 

--- a/CesiumGeospatial/src/BoundingRegionBuilder.cpp
+++ b/CesiumGeospatial/src/BoundingRegionBuilder.cpp
@@ -26,10 +26,7 @@ BoundingRegionBuilder::BoundingRegionBuilder() noexcept
 
 BoundingRegion BoundingRegionBuilder::toRegion() const {
   if (this->_longitudeRangeIsEmpty) {
-    return BoundingRegion(
-        GlobeRectangle::EMPTY,
-        this->_minimumHeight,
-        this->_maximumHeight);
+    return BoundingRegion(GlobeRectangle::EMPTY, 1.0, -1.0);
   } else {
     return BoundingRegion(
         this->_rectangle,


### PR DESCRIPTION
This fixes a problem reported on the community forum:
https://community.cesium.com/t/unreal-crash-when-i-add-a-cesiumtmsrasteroverlay-to-a-cesium3dtileset/20996

The tileset from the forum consisted of buildings, and was (as is typical of buildings) relatively sparse. Some areas had buildings, some areas had holes where there were no buildings. So if we zoomed in close, we might need to upsample for the raster overlays, and some of the upsampled children might not contain any geometry at all. The computed bounding volume for such a tile would by empty: west would be greater than east, south greater than north, and minimum height greater than maximum. However, the min/max heights would be roughly +/- 1e308. When we later tried to create a BoundingRegion like this, we'd end up with an invalid Plane, and throw an exception.

The two solutions implemented here are to use more "sane" heights to indicate an empty region, and to avoid trying to upsample empty tiles.