### PR TITLE
Create TMS and WMS tile providers in the main thread.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug that could cause an assertion failure - and on rare occasions a more serious problem - when creating a tile provider for a `TileMapServiceRasterOverlay` or a `WebMapServiceRasterOverlay`.
+
 ### v0.21.0 - 2022-11-01
 
 ##### Breaking Changes :mega:

--- a/Cesium3DTilesSelection/src/TileMapServiceRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/TileMapServiceRasterOverlay.cpp
@@ -277,7 +277,7 @@ TileMapServiceRasterOverlay::createTileProvider(
                             : std::nullopt;
 
   return getXmlDocument(asyncSystem, pAssetAccessor, xmlUrl, this->_headers)
-      .thenInWorkerThread(
+      .thenInMainThread(
           [pOwner,
            asyncSystem,
            pAssetAccessor,

--- a/Cesium3DTilesSelection/src/WebMapServiceRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/WebMapServiceRasterOverlay.cpp
@@ -266,7 +266,7 @@ WebMapServiceRasterOverlay::createTileProvider(
                             : std::nullopt;
 
   return pAssetAccessor->get(asyncSystem, xmlUrlGetcapabilities, this->_headers)
-      .thenInWorkerThread(
+      .thenInMainThread(
           [pOwner,
            asyncSystem,
            pAssetAccessor,


### PR DESCRIPTION
`TileMapServiceRasterOverlay` and `WebMapServiceRasterOverlay` (unlike all the other raster overlay types) were both creating their tile provider in a `thenInWorkerThread` continuation, capturing an intrusive pointer to the `RasterOverlay` in order to do this. This can trigger an assertion failure in `ReferenceCountedNonThreadSafe` when it detects an attempt to decrement the reference count from the wrong thread, and could also (rarely) cause the reference count itself to get corrupted.

The fix in this PR is to do this small amount of work in the main thread instead. If response parsing for these raster overlay types ever turns out to be a main thread bottleneck, we can refactor it into a `thenInWorkerThread` continuation that does the parsing followed by a `thenInMainThread` that creates the tile provider. But I didn't bother doing that in this PR because it's unlikely to ever be a concern.