### PR TITLE
Use snprintf instead of sprintf.

### DIFF
--- a/Cesium3DTilesSelection/src/WebMapServiceRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/WebMapServiceRasterOverlay.cpp
@@ -219,8 +219,9 @@ static bool validateCapabilities(
       const int numLayers = static_cast<int>(configLayers.size());
       if (numLayers > layerLimit) {
         char buffer[512];
-        std::sprintf(
+        std::snprintf(
             buffer,
+            512,
             "the number of configured layers (%d) exceeds WMS LayerLimit %d",
             numLayers,
             layerLimit);


### PR DESCRIPTION
It's safer and Xcode 14 reports a warning on use of sprintf which turns into an error, breaking the build.