### PR TITLE
Add optional field for custom ion endpoint in IonRasterOverlay

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/IonRasterOverlay.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/IonRasterOverlay.h
@@ -34,7 +34,8 @@ public:
       const std::string& name,
       int64_t ionAssetID,
       const std::string& ionAccessToken,
-      const RasterOverlayOptions& overlayOptions = {});
+      const RasterOverlayOptions& overlayOptions = {},
+      const std::string& ionAssetEndpointUrl = "https://api.cesium.com/");
   virtual ~IonRasterOverlay() override;
 
   virtual CesiumAsync::Future<CreateTileProviderResult> createTileProvider(
@@ -50,6 +51,7 @@ public:
 private:
   int64_t _ionAssetID;
   std::string _ionAccessToken;
+  std::string _ionAssetEndpointUrl;
 
   struct AssetEndpointAttribution {
     std::string html;

--- a/Cesium3DTilesSelection/src/IonRasterOverlay.cpp
+++ b/Cesium3DTilesSelection/src/IonRasterOverlay.cpp
@@ -24,10 +24,12 @@ IonRasterOverlay::IonRasterOverlay(
     const std::string& name,
     int64_t ionAssetID,
     const std::string& ionAccessToken,
-    const RasterOverlayOptions& overlayOptions)
+    const RasterOverlayOptions& overlayOptions,
+    const std::string& ionAssetEndpointUrl)
     : RasterOverlay(name, overlayOptions),
       _ionAssetID(ionAssetID),
-      _ionAccessToken(ionAccessToken) {}
+      _ionAccessToken(ionAccessToken),
+      _ionAssetEndpointUrl(ionAssetEndpointUrl) {}
 
 IonRasterOverlay::~IonRasterOverlay() {}
 
@@ -85,7 +87,7 @@ IonRasterOverlay::createTileProvider(
     const std::shared_ptr<IPrepareRendererResources>& pPrepareRendererResources,
     const std::shared_ptr<spdlog::logger>& pLogger,
     CesiumUtility::IntrusivePointer<const RasterOverlay> pOwner) const {
-  std::string ionUrl = "https://api.cesium.com/v1/assets/" +
+  std::string ionUrl = this->_ionAssetEndpointUrl + "v1/assets/" +
                        std::to_string(this->_ionAssetID) + "/endpoint";
   ionUrl = CesiumUtility::Uri::addQuery(
       ionUrl,


### PR DESCRIPTION
For an internal application, we need to be able to set a custom ion endpoint to retrieve imagery with an access token. This PR sets an optional field to do so, with the default being cesium ion, similar to how it's done in [Tileset.cpp](https://github.com/CesiumGS/cesium-native/blob/main/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h#L75)