### PR TITLE
Disable gltf-up-axis warning

### DIFF
--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -79,11 +79,11 @@ CesiumGeometry::Axis obtainGltfUpAxis(
     return CesiumGeometry::Axis::Y;
   }
 
-  SPDLOG_LOGGER_WARN(
-      pLogger,
-      "The tileset contains a gltfUpAxis property. "
-      "This property is not part of the specification. "
-      "All glTF content should use the Y-axis as the up-axis.");
+  // SPDLOG_LOGGER_WARN(
+  //     pLogger,
+  //     "The tileset contains a gltfUpAxis property. "
+  //     "This property is not part of the specification. "
+  //     "All glTF content should use the Y-axis as the up-axis.");
 
   const rapidjson::Value& gltfUpAxisJson = gltfUpAxisIt->value;
   auto gltfUpAxisString = std::string(gltfUpAxisJson.GetString());


### PR DESCRIPTION
This warning was added a couple months back and I think it ends up being mostly spam to end users. We have no plans to remove support for the gltf-up-axis property anyways so it's probably not too useful either. Even worse, this error floods the console when the Aerometrex Denver tileset is open - Denver is a tileset that is in our samples and we showcase it often.

If we would prefer to just lower the verbosity of it, that's fine too - but I thought it was best to just remove it (plus I didn't know how to lower the verbosity :) ).