### PR TITLE
Include string header for string enums.

### DIFF
--- a/Cesium3DTiles/generated/include/Cesium3DTiles/ImplicitTiling.h
+++ b/Cesium3DTiles/generated/include/Cesium3DTiles/ImplicitTiling.h
@@ -8,6 +8,7 @@
 #include <CesiumUtility/ExtensibleObject.h>
 
 #include <cstdint>
+#include <string>
 
 namespace Cesium3DTiles {
 /**

--- a/Cesium3DTiles/generated/include/Cesium3DTiles/PropertyTableProperty.h
+++ b/Cesium3DTiles/generated/include/Cesium3DTiles/PropertyTableProperty.h
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <string>
 
 namespace Cesium3DTiles {
 /**

--- a/Cesium3DTiles/generated/include/Cesium3DTiles/Tile.h
+++ b/Cesium3DTiles/generated/include/Cesium3DTiles/Tile.h
@@ -11,6 +11,7 @@
 #include <CesiumUtility/ExtensibleObject.h>
 
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace Cesium3DTiles {

--- a/CesiumGltf/generated/include/CesiumGltf/AccessorSpec.h
+++ b/CesiumGltf/generated/include/CesiumGltf/AccessorSpec.h
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace CesiumGltf {

--- a/CesiumGltf/generated/include/CesiumGltf/AnimationChannelTarget.h
+++ b/CesiumGltf/generated/include/CesiumGltf/AnimationChannelTarget.h
@@ -7,6 +7,7 @@
 #include <CesiumUtility/ExtensibleObject.h>
 
 #include <cstdint>
+#include <string>
 
 namespace CesiumGltf {
 /**

--- a/CesiumGltf/generated/include/CesiumGltf/AnimationSampler.h
+++ b/CesiumGltf/generated/include/CesiumGltf/AnimationSampler.h
@@ -7,6 +7,7 @@
 #include <CesiumUtility/ExtensibleObject.h>
 
 #include <cstdint>
+#include <string>
 
 namespace CesiumGltf {
 /**

--- a/CesiumGltf/generated/include/CesiumGltf/Camera.h
+++ b/CesiumGltf/generated/include/CesiumGltf/Camera.h
@@ -8,6 +8,7 @@
 #include "CesiumGltf/NamedObject.h"
 
 #include <optional>
+#include <string>
 
 namespace CesiumGltf {
 /**

--- a/CesiumGltf/generated/include/CesiumGltf/ExtensionBufferViewExtMeshoptCompression.h
+++ b/CesiumGltf/generated/include/CesiumGltf/ExtensionBufferViewExtMeshoptCompression.h
@@ -7,6 +7,7 @@
 #include <CesiumUtility/ExtensibleObject.h>
 
 #include <cstdint>
+#include <string>
 
 namespace CesiumGltf {
 /**

--- a/CesiumGltf/generated/include/CesiumGltf/ExtensionExtStructuralMetadataPropertyTableProperty.h
+++ b/CesiumGltf/generated/include/CesiumGltf/ExtensionExtStructuralMetadataPropertyTableProperty.h
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <string>
 
 namespace CesiumGltf {
 /**

--- a/CesiumGltf/generated/include/CesiumGltf/FeatureTableProperty.h
+++ b/CesiumGltf/generated/include/CesiumGltf/FeatureTableProperty.h
@@ -7,6 +7,7 @@
 #include <CesiumUtility/ExtensibleObject.h>
 
 #include <cstdint>
+#include <string>
 
 namespace CesiumGltf {
 /**

--- a/CesiumGltf/generated/include/CesiumGltf/Material.h
+++ b/CesiumGltf/generated/include/CesiumGltf/Material.h
@@ -10,6 +10,7 @@
 #include "CesiumGltf/TextureInfo.h"
 
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace CesiumGltf {

--- a/tools/generate-classes/resolveProperty.js
+++ b/tools/generate-classes/resolveProperty.js
@@ -553,6 +553,10 @@ function resolveEnum(
     requiredEnum: isRequired,
   };
 
+  if (enumType === "string") {
+    result.headers.push("<string>");
+  }
+
   if (readerTypes.length > 0) {
     result.readerType = `${enumName}JsonHandler`;
   } else if (enumType === "integer") {


### PR DESCRIPTION
The generated glTF and 3D Tiles classes would previously use `std::string` for enums without first adding `#include <string>`. So this would fail to compile if someone else hadn't coincidentally included the string header prior.