### PR TITLE
Don't cull with children bounds for additive-refined tilesets.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug that could cause parent tiles to be incorrectly culled in tilesets with additive ("ADD") refinement. This could cause geometry to disappear when moving in closer, or fail to appear at all.
+
 ### v0.21.2 - 2022-12-09
 
 ##### Additions :tada:

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -738,7 +738,10 @@ Tileset::TraversalDetails Tileset::_visitTileIfNeeded(
 
   CullResult cullResult{};
 
-  bool cullWithChildrenBounds = !tile.getChildren().empty();
+  // Culling with children bounds will give us incorrect results with Add
+  // refinement, but is a useful optimization for Replace refinement.
+  bool cullWithChildrenBounds =
+      tile.getRefine() == TileRefine::Replace && !tile.getChildren().empty();
   for (Tile& child : tile.getChildren()) {
     if (child.getUnconditionallyRefine()) {
       cullWithChildrenBounds = false;


### PR DESCRIPTION
Fixes #585 

Before:
![image](https://user-images.githubusercontent.com/924374/211950739-537ddbc5-2cfc-4429-a5c8-de57e7c8e23a.png)

After:
![image](https://user-images.githubusercontent.com/924374/211950931-7b630c88-4cc9-4624-82c2-3be64666f1ba.png)

I saw some more obvious examples yesterday, but can't find them now. In some cases the bug might prevent buildings from showing up at all, no matter how much you zoom in, which makes it harder to spot that you've been impacted by the bug.