### PR TITLE
Upgrade tinyxml2

### DIFF
--- a/CesiumAsync/test/TestInternalTimegm.cpp
+++ b/CesiumAsync/test/TestInternalTimegm.cpp
@@ -1,3 +1,4 @@
+#define _CRT_SECURE_NO_WARNINGS
 #include "InternalTimegm.h"
 
 #include <catch2/catch.hpp>

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -50,8 +50,14 @@ if (NOT TARGET glm)
     add_subdirectory(glm GLM)
 endif()
 
-set(BUILD_TESTS OFF CACHE BOOL "Build tinyxml2 tests" FORCE)
-add_subdirectory(tinyxml2)
+# tinyxml2's CMake build tries to generate a pkg-config file in a way that's incompatible with multi-config generators
+# (e.g., Visual Studio). And anyway it's trivial to build manually, so we do that here.
+add_library(tinyxml2 tinyxml2/tinyxml2.cpp)
+target_include_directories(
+    tinyxml2
+    PUBLIC
+        tinyxml2
+)
 
 add_subdirectory(asyncplusplus)
 


### PR DESCRIPTION
The version we were previously using (untagged, roughly v8.0.0) cannot be build for x86_64 Android (Magic Leap 2). This PR upgrades to the current head of the master branch, because no tagged version supports this architecture yet.

But the CMake scripts at the head commit (and also the last tagged release, v9.0.0) don't work with multi-config generators (Visual Studio). tinyxml2 is one .cpp file and one .h, so I just added a two line manual build for it instead.