### PR TITLE
Fix compile error when tracing is enabled, disable trace tracks for raster overlays

### DIFF
--- a/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
@@ -47,7 +47,7 @@ RasterOverlayCollection::~RasterOverlayCollection() noexcept {
 
 void RasterOverlayCollection::add(
     const CesiumUtility::IntrusivePointer<RasterOverlay>& pOverlay) {
-  CESIUM_TRACE_USE_TRACK_SET(this->_loadingSlots);
+  //CESIUM_TRACE_USE_TRACK_SET(this->_loadingSlots);
 
   if (!this->_pOverlays)
     this->_pOverlays = new OverlayList();
@@ -64,7 +64,7 @@ void RasterOverlayCollection::add(
   pList->tileProviders.emplace_back(pPlaceholder);
   pList->placeholders.emplace_back(pPlaceholder);
 
-  CESIUM_TRACE_BEGIN_IN_TRACK("createTileProvider");
+  //CESIUM_TRACE_BEGIN_IN_TRACK("createTileProvider");
 
   CesiumAsync::Future<RasterOverlay::CreateTileProviderResult> future =
       pOverlay->createTileProvider(
@@ -131,7 +131,7 @@ void RasterOverlayCollection::add(
           }
         }
 
-        CESIUM_TRACE_END_IN_TRACK("createTileProvider");
+        //CESIUM_TRACE_END_IN_TRACK("createTileProvider");
       });
 }
 

--- a/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
@@ -47,7 +47,7 @@ RasterOverlayCollection::~RasterOverlayCollection() noexcept {
 
 void RasterOverlayCollection::add(
     const CesiumUtility::IntrusivePointer<RasterOverlay>& pOverlay) {
-  //CESIUM_TRACE_USE_TRACK_SET(this->_loadingSlots);
+  // CESIUM_TRACE_USE_TRACK_SET(this->_loadingSlots);
 
   if (!this->_pOverlays)
     this->_pOverlays = new OverlayList();
@@ -64,7 +64,7 @@ void RasterOverlayCollection::add(
   pList->tileProviders.emplace_back(pPlaceholder);
   pList->placeholders.emplace_back(pPlaceholder);
 
-  //CESIUM_TRACE_BEGIN_IN_TRACK("createTileProvider");
+  // CESIUM_TRACE_BEGIN_IN_TRACK("createTileProvider");
 
   CesiumAsync::Future<RasterOverlay::CreateTileProviderResult> future =
       pOverlay->createTileProvider(
@@ -131,7 +131,7 @@ void RasterOverlayCollection::add(
           }
         }
 
-        //CESIUM_TRACE_END_IN_TRACK("createTileProvider");
+        // CESIUM_TRACE_END_IN_TRACK("createTileProvider");
       });
 }
 

--- a/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
@@ -305,7 +305,7 @@ void RasterOverlayTileProvider::doLoad(
     return;
   }
 
-  CESIUM_TRACE_USE_TRACK_SET(this->_loadingSlots);
+  //CESIUM_TRACE_USE_TRACK_SET(this->_loadingSlots);
 
   // Don't let this tile be destroyed while it's loading.
   tile.setState(RasterOverlayTile::LoadState::Loading);

--- a/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayTileProvider.cpp
@@ -305,7 +305,7 @@ void RasterOverlayTileProvider::doLoad(
     return;
   }
 
-  //CESIUM_TRACE_USE_TRACK_SET(this->_loadingSlots);
+  // CESIUM_TRACE_USE_TRACK_SET(this->_loadingSlots);
 
   // Don't let this tile be destroyed while it's loading.
   tile.setState(RasterOverlayTile::LoadState::Loading);

--- a/CesiumUtility/include/CesiumUtility/Tracing.h
+++ b/CesiumUtility/include/CesiumUtility/Tracing.h
@@ -276,6 +276,9 @@ public:
 
   int64_t getTracingID(size_t trackIndex) noexcept;
 
+  TrackSet(TrackSet&& rhs) noexcept;
+  TrackSet& operator=(TrackSet&& rhs) noexcept;
+
 private:
   struct Track {
     Track(int64_t id_, bool inUse_)

--- a/CesiumUtility/src/Tracing.cpp
+++ b/CesiumUtility/src/Tracing.cpp
@@ -212,6 +212,20 @@ int64_t TrackSet::getTracingID(size_t trackIndex) noexcept {
   return this->tracks[trackIndex].id;
 }
 
+TrackSet::TrackSet(TrackSet&& rhs) noexcept : name(), tracks(), mutex() {
+  std::scoped_lock lock(rhs.mutex);
+  name = rhs.name;
+  tracks = rhs.tracks;
+}
+
+TrackSet& TrackSet::operator=(TrackSet&& rhs) noexcept {
+  std::scoped_lock lock(rhs.mutex);
+  std::scoped_lock lock2(this->mutex);
+  name = std::move(rhs.name);
+  tracks = std::move(rhs.tracks);
+  return *this;
+}
+
 LambdaCaptureTrack::LambdaCaptureTrack() : pSet(nullptr), index(0) {
   const TrackReference* pTrack = TrackReference::current();
   if (pTrack) {


### PR DESCRIPTION
cesium-native didn't compile with tracing enabled (see #267 for details of how to set that up), so this PR fixes that.

It also disables the use of tracks for raster overlay loading. The idea behind a "track" is to visualize each of our loading slots as a virtual thread, so we can see the breakdown of the entire loading process even as it progresses across multiple threads. But we lost the ability to do this for tileset content loading in #548. And for raster overlays, we still had it in theory, but it didn't work right after #325 because multiple overlay tiles could end up loaded in parallel in a single track when multiple tiles from the raster overlay service overlapped a single terrain/geometry tile.

Rather than fixing all that, this PR just removes the use of tracks entirely. So at least we can see what work the threads are doing and how long it takes, which is still very useful.