### PR TITLE
Fix a bug causing holes in some tilesets, like San Francisco.

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -442,7 +442,7 @@ private:
       TileLoadPriorityGroup priorityGroup,
       double priority);
 
-  TraversalDetails createTraversalDetailsForSingleTile(
+  static TraversalDetails createTraversalDetailsForSingleTile(
       const FrameState& frameState,
       const Tile& tile,
       const TileSelectionState& lastFrameSelectionState);

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -442,6 +442,11 @@ private:
       TileLoadPriorityGroup priorityGroup,
       double priority);
 
+  TraversalDetails createTraversalDetailsForSingleTile(
+      const FrameState& frameState,
+      const Tile& tile,
+      const TileSelectionState& lastFrameSelectionState);
+
   Tileset(const Tileset& rhs) = delete;
   Tileset& operator=(const Tileset& rhs) = delete;
 };

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -272,11 +272,6 @@ private:
       const FrameState& frameState,
       Tile& tile,
       ViewUpdateResult& result);
-  TraversalDetails _refineToNothing(
-      const FrameState& frameState,
-      Tile& tile,
-      ViewUpdateResult& result,
-      bool areChildrenRenderable);
   bool _kickDescendantsAndRenderTile(
       const FrameState& frameState,
       Tile& tile,

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -790,7 +790,7 @@ Tileset::TraversalDetails Tileset::_visitTileIfNeeded(
       // render it, though.
       addTileToLoadQueue(tile, TileLoadPriorityGroup::Normal, tilePriority);
 
-      traversalDetails = this->createTraversalDetailsForSingleTile(
+      traversalDetails = Tileset::createTraversalDetailsForSingleTile(
           frameState,
           tile,
           lastFrameSelectionState);
@@ -839,7 +839,7 @@ Tileset::TraversalDetails Tileset::_renderLeaf(
 
   addTileToLoadQueue(tile, TileLoadPriorityGroup::Normal, tilePriority);
 
-  return this->createTraversalDetailsForSingleTile(
+  return Tileset::createTraversalDetailsForSingleTile(
       frameState,
       tile,
       lastFrameSelectionState);
@@ -890,7 +890,7 @@ Tileset::TraversalDetails Tileset::_renderInnerTile(
       TileSelectionState::Result::Rendered));
   result.tilesToRenderThisFrame.push_back(&tile);
 
-  return this->createTraversalDetailsForSingleTile(
+  return Tileset::createTraversalDetailsForSingleTile(
       frameState,
       tile,
       lastFrameSelectionState);


### PR DESCRIPTION
This fixes a bug that causes holes to sometimes appear when flying around the San Francisco tileset, even with "Forbid Holes" enabled.

Unfortunately, I don't know exactly why it happens. The immediate cause is that the selection algorithm is choosing to "render" an external tileset Tile, which is not actually renderable because it has no content. It does this because it can't render the tileset's children, because they're not loaded yet. This situation is supposed to be prevented by the "Forbid Holes" mode's requirement that all sibling tiles - even culled ones - be loaded before any of them can be rendered. This should be further enforced by the "kick" mechanism, which should "un-select" a subtree that doesn't meet this requirement. But in this case, the kicking doesn't (and can't) happen because some of the tiles in the subtree were already rendered in the last frame. This is the part that has me stumped - I haven't been able to figure out why it happens! I don't know how an external tileset Tile would ever get marked rendered in the first place.

But what I do know is that these tiles that were "rendered" in the last frame weren't actually renderable yet, and therefore they weren't "really" rendered after all. So this PR essentially says "yeah, previously-rendered tiles need to block kicking (otherwise, detail would disappear from one frame to the next), but that's actually true only for tiles that _actually_ rendered something." So when traversing, we now only set the `anyWereRenderedLastFrame` flag when the tile was marked as rendered last frame, _and_ it actually had something to render.

In short, this feels like a bit of a band-aid over another problem, but it's not an unreasonable change, and it shouldn't have any downsides.