### PR TITLE
Add ITileExcluder::startNewFrame

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - Changed how `TilesetOptions::forbidHoles` works so that it loads much more quickly, while still guaranteeing there are no holes in the tileset.
 - Added `frameNumber` property to `ViewUpdateResult`.
 - Added getters for the `stride` and `data` fields of `AccessorView`.
+- Added `startNewFrame` method to `ITileExcluder`.
 
 ##### Fixes :wrench:
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ITileExcluder.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ITileExcluder.h
@@ -22,7 +22,7 @@ public:
    *
    * @param tile The tile to test
    * @return true if this tile and all of its descendants in the bounding volume
-   * hiearchy should be excluded from loading and rendering.
+   * hierarchy should be excluded from loading and rendering.
    * @return false if this tile should be included.
    */
   virtual bool shouldExclude(const Tile& tile) const noexcept = 0;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ITileExcluder.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ITileExcluder.h
@@ -11,6 +11,7 @@ class Tile;
 class ITileExcluder {
 public:
   virtual ~ITileExcluder() = default;
+  virtual void startNewFrame() noexcept {}
   virtual bool shouldExclude(const Tile& tile) const noexcept = 0;
 };
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ITileExcluder.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ITileExcluder.h
@@ -11,7 +11,20 @@ class Tile;
 class ITileExcluder {
 public:
   virtual ~ITileExcluder() = default;
+
+  /**
+   * @brief Indicates the start of a new frame, initiated with a call to {@link Tileset::updateView}.
+   */
   virtual void startNewFrame() noexcept {}
+
+  /**
+   * @brief Determines whether a given tile should be excluded.
+   *
+   * @param tile The tile to test
+   * @return true if this tile and all of its descendants in the bounding volume
+   * hiearchy should be excluded from loading and rendering.
+   * @return false if this tile should be included.
+   */
   virtual bool shouldExclude(const Tile& tile) const noexcept = 0;
 };
 

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -307,6 +307,11 @@ Tileset::updateView(const std::vector<ViewState>& frustums, float deltaTime) {
     return result;
   }
 
+  for (const std::shared_ptr<ITileExcluder>& pExcluder :
+       this->_options.excluders) {
+    pExcluder->startNewFrame();
+  }
+
   this->_workerThreadLoadQueue.clear();
   this->_mainThreadLoadQueue.clear();
 


### PR DESCRIPTION
This gives a tile excluder an opportunity to do once-per-frame updates, such as computing a new transformation if a tileset moved.