### PR TITLE
Add ability to override `showOnScreen` in credit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Added `frameNumber` property to `ViewUpdateResult`.
 - Added getters for the `stride` and `data` fields of `AccessorView`.
 - Added `startNewFrame` method to `ITileExcluder`.
+- Added `CreditSystem.setShowOnScreen` and `Tileset.setShowCreditsOnScreen`, which allow on-screen credit rendering to be toggled at runtime. 
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@
 - Added `frameNumber` property to `ViewUpdateResult`.
 - Added getters for the `stride` and `data` fields of `AccessorView`.
 - Added `startNewFrame` method to `ITileExcluder`.
-- Added `CreditSystem.setShowOnScreen` and `Tileset.setShowCreditsOnScreen`, which allow on-screen credit rendering to be toggled at runtime. 
+- Added `CreditSystem.setShowOnScreen` and `Tileset.setShowCreditsOnScreen` to allow on-screen credit rendering to be toggled at runtime. 
 
 ##### Fixes :wrench:
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/CreditSystem.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/CreditSystem.h
@@ -52,6 +52,11 @@ public:
   bool shouldBeShownOnScreen(Credit credit) const noexcept;
 
   /**
+   * @brief Sets whether or not the credit should be shown on screen.
+   */
+  void setShowOnScreen(Credit credit, bool showOnScreen) noexcept;
+
+  /**
    * @brief Get the HTML string for this credit
    */
   const std::string& getHtml(Credit credit) const noexcept;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -96,7 +96,8 @@ public:
   const std::vector<Credit>& getTilesetCredits() const noexcept;
 
   /**
-   * @brief Sets whether the tileset's credits should be shown on screen.
+   * @brief Sets whether or not the tileset's credits should be shown on screen.
+   * @param showCreditsOnScreen Whether the credits should be shown on screen.
    */
   void setShowCreditsOnScreen(bool showCreditsOnScreen) noexcept;
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -96,6 +96,11 @@ public:
   const std::vector<Credit>& getTilesetCredits() const noexcept;
 
   /**
+   * @brief Sets whether the tileset's credits should be shown on screen.
+   */
+  void setShowCreditsOnScreen(bool showCreditsOnScreen) noexcept;
+
+  /**
    * @brief Gets the {@link TilesetExternals} that summarize the external
    * interfaces used by this tileset.
    */

--- a/Cesium3DTilesSelection/src/CreditSystem.cpp
+++ b/Cesium3DTilesSelection/src/CreditSystem.cpp
@@ -8,14 +8,14 @@ Credit CreditSystem::createCredit(const std::string& html, bool showOnScreen) {
   // if this credit already exists, return a Credit handle to it
   for (size_t id = 0; id < _credits.size(); ++id) {
     if (_credits[id].html == html) {
+      // Override the existing credit's showOnScreen value.
+      _credits[id].showOnScreen = showOnScreen;
       return Credit(id);
     }
   }
 
-  // this is a new credit so add it to _credits
   _credits.push_back({html, showOnScreen, -1, 0});
 
-  // return a Credit handle to the newly created entry
   return Credit(_credits.size() - 1);
 }
 

--- a/Cesium3DTilesSelection/src/CreditSystem.cpp
+++ b/Cesium3DTilesSelection/src/CreditSystem.cpp
@@ -26,6 +26,12 @@ bool CreditSystem::shouldBeShownOnScreen(Credit credit) const noexcept {
   return false;
 }
 
+void CreditSystem::setShowOnScreen(Credit credit, bool showOnScreen) noexcept {
+  if (credit.id < _credits.size()) {
+    _credits[credit.id].showOnScreen = showOnScreen;
+  }
+}
+
 const std::string& CreditSystem::getHtml(Credit credit) const noexcept {
   if (credit.id < _credits.size()) {
     return _credits[credit.id].html;

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -100,6 +100,16 @@ const std::vector<Credit>& Tileset::getTilesetCredits() const noexcept {
   return this->_pTilesetContentManager->getTilesetCredits();
 }
 
+void Tileset::setShowCreditsOnScreen(bool showCreditsOnScreen) noexcept {
+  this->_options.showCreditsOnScreen = showCreditsOnScreen;
+
+  const std::vector<Credit>& credits = this->getTilesetCredits();
+  auto creditSystem = this->_externals.pCreditSystem;
+  for (size_t i = 0, size = credits.size(); i < size; i++) {
+    creditSystem->setShowOnScreen(credits[i], showCreditsOnScreen);
+  }
+}
+
 Tile* Tileset::getRootTile() noexcept {
   return this->_pTilesetContentManager->getRootTile();
 }

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -104,9 +104,9 @@ void Tileset::setShowCreditsOnScreen(bool showCreditsOnScreen) noexcept {
   this->_options.showCreditsOnScreen = showCreditsOnScreen;
 
   const std::vector<Credit>& credits = this->getTilesetCredits();
-  auto creditSystem = this->_externals.pCreditSystem;
+  auto pCreditSystem = this->_externals.pCreditSystem;
   for (size_t i = 0, size = credits.size(); i < size; i++) {
-    creditSystem->setShowOnScreen(credits[i], showCreditsOnScreen);
+    pCreditSystem->setShowOnScreen(credits[i], showCreditsOnScreen);
   }
 }
 

--- a/Cesium3DTilesSelection/test/TestCreditSystem.cpp
+++ b/Cesium3DTilesSelection/test/TestCreditSystem.cpp
@@ -74,7 +74,7 @@ TEST_CASE("Test wrong credit handling") {
 
   // NOTE: This is using a Credit from a different credit
   // system, which coincidentally has a valid ID here.
-  // This is  not (and can hardly be) checked right now,
+  // This is not (and can hardly be) checked right now,
   // so this returns a valid HTML string:
   REQUIRE(creditSystemB.getHtml(creditA0) == html0);
 
@@ -118,4 +118,31 @@ TEST_CASE("Test sorting credits by frequency") {
 
   std::vector<Credit> expectedShow1{credit2, credit1, credit0};
   REQUIRE(creditSystem.getCreditsToShowThisFrame() == expectedShow1);
+}
+
+TEST_CASE("Test setting showOnScreen on credits") {
+
+  CreditSystem creditSystem;
+
+  std::string html0 = "<html>Credit0</html>";
+  std::string html1 = "<html>Credit1</html>";
+  std::string html2 = "<html>Credit2</html>";
+
+  Credit credit0 = creditSystem.createCredit(html0, true);
+  Credit credit1 = creditSystem.createCredit(html1, false);
+  Credit credit2 = creditSystem.createCredit(html2, true);
+
+  REQUIRE(creditSystem.getHtml(credit1) == html1);
+
+  CHECK(creditSystem.shouldBeShownOnScreen(credit0) == true);
+  CHECK(creditSystem.shouldBeShownOnScreen(credit1) == false);
+  CHECK(creditSystem.shouldBeShownOnScreen(credit2) == true);
+
+  creditSystem.setShowOnScreen(credit0, false);
+  creditSystem.setShowOnScreen(credit1, true);
+  creditSystem.setShowOnScreen(credit2, true);
+
+  CHECK(creditSystem.shouldBeShownOnScreen(credit0) == false);
+  CHECK(creditSystem.shouldBeShownOnScreen(credit1) == true);
+  CHECK(creditSystem.shouldBeShownOnScreen(credit2) == true);
 }


### PR DESCRIPTION
This is a small change that allows a credit's `showOnScreen` value to be overridden whenever it is retrieved. This allows a tileset's `showCreditsOnScreen` option to immediately take place.