### PR TITLE
Update to new mesh_features extension

### DIFF
--- a/CesiumGltf/include/CesiumGltf/MetadataPropertyTableView.h
+++ b/CesiumGltf/include/CesiumGltf/MetadataPropertyTableView.h
@@ -1,0 +1,542 @@
+#pragma once
+
+#include "CesiumGltf/ExtensionModelExtFeatureMetadata.h"
+#include "CesiumGltf/ExtensionModelExtStructuralMetadata.h"
+#include "CesiumGltf/MetadataPropertyView.h"
+#include "CesiumGltf/Model.h"
+#include "CesiumGltf/PropertyType.h"
+
+#include <glm/common.hpp>
+
+#include <optional>
+
+namespace CesiumGltf {
+/**
+ * @brief Utility to retrieve the data of FeatureTable
+ *
+ * This should be used to get {@link MetadataPropertyView} of a property since
+ * it will validate the EXT_Feature_Metadata format to make sure {@link MetadataPropertyView}
+ * not access out of bound
+ */
+class MetadataPropertyTableView {
+public:
+  /**
+   * @brief Create an instance of MetadataFeatureTableView
+   * @param model The Gltf Model that stores featureTable data
+   * @param propertyTable The FeatureTable that will be used to retrieve the
+   * data from
+   */
+  MetadataPropertyTableView(
+      const Model* pModel,
+      const ExtensionExtStructuralMetadataPropertyTable* pFeatureTable);
+
+  /**
+   * @brief Find the {@link ClassProperty} which stores the type information of a property based on the property name
+   * @param propertyName The name of the property to retrieve type info
+   * @return ClassProperty of a property. Return nullptr if no property is found
+   */
+  const ExtensionExtStructuralMetadataClassProperty*
+  getClassProperty(const std::string& propertyName) const;
+
+  /**
+   * @brief Get MetadataPropertyView to view the data of a property stored in
+   * the FeatureTable.
+   *
+   * This method will validate the EXT_Feature_Metadata format to ensure
+   * MetadataPropertyView retrieve the correct data. T must be uin8_t, int8_t,
+   * uint16_t, int16_t, uint32_t, int32_t, uint64_t, int64_t, float, double,
+   * bool, std::string_view, and MetadataArrayView<T> with T must be one of the
+   * types mentioned above
+   *
+   * @param propertyName The name of the property to retrieve data from
+   * @return ClassProperty of a property. Return nullptr if no property is found
+   */
+  template <typename T>
+  MetadataPropertyView<T>
+  getPropertyView(const std::string& propertyName) const {
+    if (_pFeatureTable->count < 0) {
+      return createInvalidPropertyView<T>(
+          MetadataPropertyViewStatus::InvalidPropertyNotExist);
+    }
+
+    const ClassProperty* pClassProperty = getClassProperty(propertyName);
+    if (!pClassProperty) {
+      return createInvalidPropertyView<T>(
+          MetadataPropertyViewStatus::InvalidPropertyNotExist);
+    }
+
+    return getPropertyViewImpl<T>(propertyName, *pClassProperty);
+  }
+
+  /**
+   * @brief Get MetadataPropertyView through a callback that accepts property
+   * name and std::optional<MetadataPropertyView<T>> to view the data of a
+   * property stored in the FeatureTable.
+   *
+   * This method will validate the EXT_Feature_Metadata format to ensure
+   * MetadataPropertyView retrieve the correct data. T must be uin8_t, int8_t,
+   * uint16_t, int16_t, uint32_t, int32_t, uint64_t, int64_t, float, double,
+   * bool, std::string_view, and MetadataArrayView<T> with T must be one of the
+   * types mentioned above. If the property is invalid, std::nullopt will be
+   * passed to the callback. Otherwise, a valid property view will be passed to
+   * the callback
+   *
+   * @param propertyName The name of the property to retrieve data from
+   * @tparam callback A callback function that accepts property name and
+   * std::optional<MetadataPropertyView<T>>
+   */
+  template <typename Callback>
+  void
+  getPropertyView(const std::string& propertyName, Callback&& callback) const {
+    const ExtensionExtStructuralMetadataClassProperty* pClassProperty =
+        getClassProperty(propertyName);
+    if (!pClassProperty) {
+      return;
+    }
+
+    PropertyType type = convertStringToPropertyType(pClassProperty->type);
+    PropertyType componentType = PropertyType::None;
+    if (pClassProperty->componentType.has_value()) {
+      componentType =
+          convertStringToPropertyType(pClassProperty->componentType.value());
+    }
+
+    if (type != PropertyType::Array) {
+      getScalarPropertyViewImpl(
+          propertyName,
+          *pClassProperty,
+          type,
+          std::forward<Callback>(callback));
+    } else {
+      getArrayPropertyViewImpl(
+          propertyName,
+          *pClassProperty,
+          componentType,
+          std::forward<Callback>(callback));
+    }
+  }
+
+  /**
+   * @brief Get MetadataPropertyView for each property in the FeatureTable
+   * through a callback that accepts property name and
+   * std::optional<MetadataPropertyView<T>> to view the data stored in the
+   * FeatureTableProperty.
+   *
+   * This method will validate the EXT_Feature_Metadata format to ensure
+   * MetadataPropertyView retrieve the correct data. T must be uin8_t, int8_t,
+   * uint16_t, int16_t, uint32_t, int32_t, uint64_t, int64_t, float, double,
+   * bool, std::string_view, and MetadataArrayView<T> with T must be one of the
+   * types mentioned above. If the property is invalid, std::nullopt will be
+   * passed to the callback. Otherwise, a valid property view will be passed to
+   * the callback
+   *
+   * @param propertyName The name of the property to retrieve data from
+   * @tparam callback A callback function that accepts property name and
+   * std::optional<MetadataPropertyView<T>>
+   */
+  template <typename Callback> void forEachProperty(Callback&& callback) const {
+    for (const auto& property : this->_pClass->properties) {
+      getPropertyView(property.first, std::forward<Callback>(callback));
+    }
+  }
+
+private:
+  template <typename Callback>
+  void getArrayPropertyViewImpl(
+      const std::string& propertyName,
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      PropertyType type,
+      Callback&& callback) const {
+    switch (type) {
+    case PropertyType::Int8:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<int8_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Uint8:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<uint8_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Int16:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<int16_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Uint16:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<uint16_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Int32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<int32_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Uint32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<uint32_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Int64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<int64_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Uint64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<uint64_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Float32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<float>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Float64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<double>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Boolean:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<bool>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::String:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<std::string_view>>(
+              propertyName,
+              classProperty));
+      break;
+    default:
+      break;
+    }
+  }
+
+  template <typename Callback>
+  void getScalarPropertyViewImpl(
+      const std::string& propertyName,
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      PropertyType type,
+      Callback&& callback) const {
+    switch (type) {
+    case PropertyType::Int8:
+      callback(
+          propertyName,
+          getPropertyViewImpl<int8_t>(propertyName, classProperty));
+      break;
+    case PropertyType::Uint8:
+      callback(
+          propertyName,
+          getPropertyViewImpl<uint8_t>(propertyName, classProperty));
+      break;
+    case PropertyType::Int16:
+      callback(
+          propertyName,
+          getPropertyViewImpl<int16_t>(propertyName, classProperty));
+      break;
+    case PropertyType::Uint16:
+      callback(
+          propertyName,
+          getPropertyViewImpl<uint16_t>(propertyName, classProperty));
+      break;
+    case PropertyType::Int32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<int32_t>(propertyName, classProperty));
+      break;
+    case PropertyType::Uint32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<uint32_t>(propertyName, classProperty));
+      break;
+    case PropertyType::Int64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<int64_t>(propertyName, classProperty));
+      break;
+    case PropertyType::Uint64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<uint64_t>(propertyName, classProperty));
+      break;
+    case PropertyType::Float32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<float>(propertyName, classProperty));
+      break;
+    case PropertyType::Float64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<double>(propertyName, classProperty));
+      break;
+    case PropertyType::Boolean:
+      callback(
+          propertyName,
+          getPropertyViewImpl<bool>(propertyName, classProperty));
+      break;
+    case PropertyType::String:
+      callback(
+          propertyName,
+          getPropertyViewImpl<std::string_view>(propertyName, classProperty));
+      break;
+    default:
+      break;
+    }
+  }
+
+  template <typename T>
+  MetadataPropertyView<T> getPropertyViewImpl(
+      const std::string& propertyName,
+      const ExtensionExtStructuralMetadataClassProperty& classProperty) const {
+    auto featureTablePropertyIter =
+        _pFeatureTable->properties.find(propertyName);
+    if (featureTablePropertyIter == _pFeatureTable->properties.end()) {
+      return createInvalidPropertyView<T>(
+          MetadataPropertyViewStatus::InvalidPropertyNotExist);
+    }
+
+    const ExtensionExtStructuralMetadataPropertyTableProperty&
+        featureTableProperty = featureTablePropertyIter->second;
+
+    if constexpr (IsMetadataNumeric<T>::value || IsMetadataBoolean<T>::value) {
+      return getPrimitivePropertyValues<T>(classProperty, featureTableProperty);
+    }
+
+    if constexpr (IsMetadataString<T>::value) {
+      return getStringPropertyValues(classProperty, featureTableProperty);
+    }
+
+    if constexpr (
+        IsMetadataNumericArray<T>::value || IsMetadataBooleanArray<T>::value) {
+      return getPrimitiveArrayPropertyValues<
+          typename MetadataArrayType<T>::type>(
+          classProperty,
+          featureTableProperty);
+    }
+
+    if constexpr (IsMetadataStringArray<T>::value) {
+      return getStringArrayPropertyValues(classProperty, featureTableProperty);
+    }
+  }
+
+  template <typename T>
+  MetadataPropertyView<T> getPrimitivePropertyValues(
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      const ExtensionExtStructuralMetadataPropertyTableProperty&
+          featureTableProperty) const {
+    const PropertyType type = convertStringToPropertyType(classProperty.type);
+    if (TypeToPropertyType<T>::value != type) {
+      return createInvalidPropertyView<T>(
+          MetadataPropertyViewStatus::InvalidTypeMismatch);
+    }
+
+    gsl::span<const std::byte> valueBuffer;
+    const auto status = getBufferSafe(featureTableProperty.values, valueBuffer);
+    if (status != MetadataPropertyViewStatus::Valid) {
+      return createInvalidPropertyView<T>(status);
+    }
+
+    if (valueBuffer.size() % sizeof(T) != 0) {
+      return createInvalidPropertyView<T>(
+          MetadataPropertyViewStatus::
+              InvalidBufferViewSizeNotDivisibleByTypeSize);
+    }
+
+    size_t maxRequiredBytes = 0;
+    if (IsMetadataBoolean<T>::value) {
+      maxRequiredBytes = static_cast<size_t>(
+          glm::ceil(static_cast<double>(_pFeatureTable->count) / 8.0));
+    } else {
+      maxRequiredBytes = _pFeatureTable->count * sizeof(T);
+    }
+
+    if (valueBuffer.size() < maxRequiredBytes) {
+      return createInvalidPropertyView<T>(
+          MetadataPropertyViewStatus::InvalidBufferViewSizeNotFitInstanceCount);
+    }
+
+    return MetadataPropertyView<T>(
+        MetadataPropertyViewStatus::Valid,
+        valueBuffer,
+        gsl::span<const std::byte>(),
+        gsl::span<const std::byte>(),
+        PropertyType::None,
+        0,
+        _pFeatureTable->count,
+        classProperty.normalized);
+  }
+
+  MetadataPropertyView<std::string_view> getStringPropertyValues(
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      const ExtensionExtStructuralMetadataPropertyTableProperty&
+          featureTableProperty) const;
+
+  template <typename T>
+  MetadataPropertyView<MetadataArrayView<T>> getPrimitiveArrayPropertyValues(
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      const ExtensionExtStructuralMetadataPropertyTableProperty&
+          featureTableProperty) const {
+    if (classProperty.type != ClassProperty::Type::ARRAY) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(
+          MetadataPropertyViewStatus::InvalidTypeMismatch);
+    }
+
+    if (!classProperty.componentType.has_value()) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(
+          MetadataPropertyViewStatus::InvalidTypeMismatch);
+    }
+
+    const PropertyType componentType =
+        convertStringToPropertyType(classProperty.componentType.value());
+    if (TypeToPropertyType<T>::value != componentType) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(
+          MetadataPropertyViewStatus::InvalidTypeMismatch);
+    }
+
+    gsl::span<const std::byte> valueBuffer;
+    auto status = getBufferSafe(featureTableProperty.values, valueBuffer);
+    if (status != MetadataPropertyViewStatus::Valid) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(status);
+    }
+
+    if (valueBuffer.size() % sizeof(T) != 0) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(
+          MetadataPropertyViewStatus::
+              InvalidBufferViewSizeNotDivisibleByTypeSize);
+    }
+
+    const int64_t componentCount = classProperty.count.value_or(0);
+    if (componentCount > 0 && featureTableProperty.arrayOffsets >= 0) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(
+          MetadataPropertyViewStatus::
+              InvalidArrayComponentCountAndOffsetBufferCoexist);
+    }
+
+    if (componentCount <= 0 && featureTableProperty.arrayOffsets < 0) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(
+          MetadataPropertyViewStatus::
+              InvalidArrayComponentCountOrOffsetBufferNotExist);
+    }
+
+    // fixed array
+    if (componentCount > 0) {
+      size_t maxRequiredBytes = 0;
+      if constexpr (IsMetadataBoolean<T>::value) {
+        maxRequiredBytes = static_cast<size_t>(glm::ceil(
+            static_cast<double>(_pFeatureTable->count * componentCount) / 8.0));
+      } else {
+        maxRequiredBytes = static_cast<size_t>(
+            _pFeatureTable->count * componentCount * sizeof(T));
+      }
+
+      if (valueBuffer.size() < maxRequiredBytes) {
+        return createInvalidPropertyView<MetadataArrayView<T>>(
+            MetadataPropertyViewStatus::
+                InvalidBufferViewSizeNotFitInstanceCount);
+      }
+
+      return MetadataPropertyView<MetadataArrayView<T>>(
+          MetadataPropertyViewStatus::Valid,
+          valueBuffer,
+          gsl::span<const std::byte>(),
+          gsl::span<const std::byte>(),
+          PropertyType::None,
+          static_cast<size_t>(componentCount),
+          static_cast<size_t>(_pFeatureTable->count),
+          classProperty.normalized);
+    }
+
+    // dynamic array
+    const PropertyType offsetType =
+        convertOffsetStringToPropertyType(featureTableProperty.arrayOffsetType);
+    if (offsetType == PropertyType::None) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(
+          MetadataPropertyViewStatus::InvalidOffsetType);
+    }
+
+    constexpr bool checkBitsSize = IsMetadataBoolean<T>::value;
+    gsl::span<const std::byte> offsetBuffer;
+    status = getOffsetBufferSafe(
+        featureTableProperty.arrayOffsets,
+        offsetType,
+        valueBuffer.size(),
+        static_cast<size_t>(_pFeatureTable->count),
+        checkBitsSize,
+        offsetBuffer);
+    if (status != MetadataPropertyViewStatus::Valid) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(status);
+    }
+
+    return MetadataPropertyView<MetadataArrayView<T>>(
+        MetadataPropertyViewStatus::Valid,
+        valueBuffer,
+        offsetBuffer,
+        gsl::span<const std::byte>(),
+        offsetType,
+        0,
+        static_cast<size_t>(_pFeatureTable->count),
+        classProperty.normalized);
+  }
+
+  MetadataPropertyView<MetadataArrayView<std::string_view>>
+  getStringArrayPropertyValues(
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      const ExtensionExtStructuralMetadataPropertyTableProperty&
+          featureTableProperty) const;
+
+  MetadataPropertyViewStatus getBufferSafe(
+      int32_t bufferViewIdx,
+      gsl::span<const std::byte>& buffer) const noexcept;
+
+  MetadataPropertyViewStatus getOffsetBufferSafe(
+      int32_t bufferViewIdx,
+      PropertyType offsetType,
+      size_t valueBufferSize,
+      size_t instanceCount,
+      bool checkBitsSize,
+      gsl::span<const std::byte>& offsetBuffer) const noexcept;
+
+  template <typename T>
+  static MetadataPropertyView<T>
+  createInvalidPropertyView(MetadataPropertyViewStatus invalidStatus) noexcept {
+    return MetadataPropertyView<T>(
+        invalidStatus,
+        gsl::span<const std::byte>(),
+        gsl::span<const std::byte>(),
+        gsl::span<const std::byte>(),
+        PropertyType::None,
+        0,
+        0,
+        false);
+  }
+
+  const Model* _pModel;
+  const ExtensionExtStructuralMetadataPropertyTable* _pFeatureTable;
+  const ExtensionExtStructuralMetadataClass* _pClass;
+};
+} // namespace CesiumGltf

--- a/CesiumGltf/src/MetadataPropertyTableView.cpp
+++ b/CesiumGltf/src/MetadataPropertyTableView.cpp
@@ -1,0 +1,386 @@
+#include "CesiumGltf/MetadataPropertyTableView.h"
+
+namespace CesiumGltf {
+template <typename T>
+static MetadataPropertyViewStatus checkOffsetBuffer(
+    const gsl::span<const std::byte>& offsetBuffer,
+    size_t valueBufferSize,
+    size_t instanceCount,
+    bool checkBitSize) noexcept {
+  if (offsetBuffer.size() % sizeof(T) != 0) {
+    return MetadataPropertyViewStatus::
+        InvalidBufferViewSizeNotDivisibleByTypeSize;
+  }
+
+  const size_t size = offsetBuffer.size() / sizeof(T);
+  if (size != instanceCount + 1) {
+    return MetadataPropertyViewStatus::InvalidBufferViewSizeNotFitInstanceCount;
+  }
+
+  const gsl::span<const T> offsetValues(
+      reinterpret_cast<const T*>(offsetBuffer.data()),
+      size);
+
+  for (size_t i = 1; i < offsetValues.size(); ++i) {
+    if (offsetValues[i] < offsetValues[i - 1]) {
+      return MetadataPropertyViewStatus::InvalidOffsetValuesNotSortedAscending;
+    }
+  }
+
+  if (!checkBitSize) {
+    if (offsetValues.back() <= valueBufferSize) {
+      return MetadataPropertyViewStatus::Valid;
+    } else {
+      return MetadataPropertyViewStatus::
+          InvalidOffsetValuePointsToOutOfBoundBuffer;
+    }
+  }
+
+  if (offsetValues.back() / 8 <= valueBufferSize) {
+    return MetadataPropertyViewStatus::Valid;
+  } else {
+    return MetadataPropertyViewStatus::
+        InvalidOffsetValuePointsToOutOfBoundBuffer;
+  }
+}
+
+template <typename T>
+static MetadataPropertyViewStatus checkStringArrayOffsetBuffer(
+    const gsl::span<const std::byte>& arrayOffsetBuffer,
+    const gsl::span<const std::byte>& stringOffsetBuffer,
+    size_t valueBufferSize,
+    size_t instanceCount) noexcept {
+  const auto status = checkOffsetBuffer<T>(
+      arrayOffsetBuffer,
+      stringOffsetBuffer.size(),
+      instanceCount,
+      false);
+  if (status != MetadataPropertyViewStatus::Valid) {
+    return status;
+  }
+
+  const T* pValue = reinterpret_cast<const T*>(arrayOffsetBuffer.data());
+  return checkOffsetBuffer<T>(
+      stringOffsetBuffer,
+      valueBufferSize,
+      pValue[instanceCount] / sizeof(T),
+      false);
+}
+
+MetadataPropertyTableView::MetadataPropertyTableView(
+    const Model* pModel,
+    const ExtensionExtStructuralMetadataPropertyTable* pFeatureTable)
+    : _pModel{pModel}, _pFeatureTable{pFeatureTable}, _pClass{nullptr} {
+  assert(pModel != nullptr && "model must not be nullptr");
+  assert(pFeatureTable != nullptr && "featureTable must not be nullptr");
+
+  const ExtensionModelExtStructuralMetadata* pMetadata =
+      pModel->getExtension<ExtensionModelExtStructuralMetadata>();
+  assert(
+      pMetadata != nullptr &&
+      "Model must contain ExtensionModelExtFeatureMetadata to use "
+      "PropertyTableView");
+
+  const std::optional<ExtensionExtStructuralMetadataSchema>& schema =
+      pMetadata->schema;
+  assert(
+      schema != std::nullopt && "ExtensionModelExtFeatureMetadata must contain "
+                                "Schema to use PropertyTableView");
+
+  auto classIter = schema->classes.find(_pFeatureTable->classProperty);
+  if (classIter != schema->classes.end()) {
+    _pClass = &classIter->second;
+  }
+}
+
+const ExtensionExtStructuralMetadataClassProperty*
+MetadataPropertyTableView::getClassProperty(
+    const std::string& propertyName) const {
+  if (_pClass == nullptr) {
+    return nullptr;
+  }
+
+  auto propertyIter = _pClass->properties.find(propertyName);
+  if (propertyIter == _pClass->properties.end()) {
+    return nullptr;
+  }
+
+  return &propertyIter->second;
+}
+
+MetadataPropertyViewStatus MetadataPropertyTableView::getBufferSafe(
+    int32_t bufferViewIdx,
+    gsl::span<const std::byte>& buffer) const noexcept {
+  buffer = {};
+
+  const BufferView* pBufferView =
+      _pModel->getSafe(&_pModel->bufferViews, bufferViewIdx);
+  if (!pBufferView) {
+    return MetadataPropertyViewStatus::InvalidValueBufferViewIndex;
+  }
+
+  const Buffer* pBuffer =
+      _pModel->getSafe(&_pModel->buffers, pBufferView->buffer);
+  if (!pBuffer) {
+    return MetadataPropertyViewStatus::InvalidValueBufferIndex;
+  }
+
+  // This is technically required for the EXT_feature_metadata spec, but not
+  // necessarily required for EXT_mesh_features. Due to the discrepancy between
+  // the two specs, a lot of EXT_feature_metadata glTFs fail to be 8-byte
+  // aligned. To be forgiving and more compatible, we do not enforce this.
+  /*
+  if (pBufferView->byteOffset % 8 != 0) {
+    return MetadataPropertyViewStatus::InvalidBufferViewNotAligned8Bytes;
+  }
+  */
+
+  if (pBufferView->byteOffset + pBufferView->byteLength >
+      static_cast<int64_t>(pBuffer->cesium.data.size())) {
+    return MetadataPropertyViewStatus::InvalidBufferViewOutOfBound;
+  }
+
+  buffer = gsl::span<const std::byte>(
+      pBuffer->cesium.data.data() + pBufferView->byteOffset,
+      static_cast<size_t>(pBufferView->byteLength));
+  return MetadataPropertyViewStatus::Valid;
+}
+
+MetadataPropertyViewStatus MetadataPropertyTableView::getOffsetBufferSafe(
+    int32_t bufferViewIdx,
+    PropertyType offsetType,
+    size_t valueBufferSize,
+    size_t instanceCount,
+    bool checkBitsSize,
+    gsl::span<const std::byte>& offsetBuffer) const noexcept {
+  auto status = getBufferSafe(bufferViewIdx, offsetBuffer);
+  if (status != MetadataPropertyViewStatus::Valid) {
+    return status;
+  }
+
+  switch (offsetType) {
+  case PropertyType::Uint8:
+    status = checkOffsetBuffer<uint8_t>(
+        offsetBuffer,
+        valueBufferSize,
+        instanceCount,
+        checkBitsSize);
+    break;
+  case PropertyType::Uint16:
+    status = checkOffsetBuffer<uint16_t>(
+        offsetBuffer,
+        valueBufferSize,
+        instanceCount,
+        checkBitsSize);
+    break;
+  case PropertyType::Uint32:
+    status = checkOffsetBuffer<uint32_t>(
+        offsetBuffer,
+        valueBufferSize,
+        instanceCount,
+        checkBitsSize);
+    break;
+  case PropertyType::Uint64:
+    status = checkOffsetBuffer<uint64_t>(
+        offsetBuffer,
+        valueBufferSize,
+        instanceCount,
+        checkBitsSize);
+    break;
+  default:
+    status = MetadataPropertyViewStatus::InvalidOffsetType;
+    break;
+  }
+
+  return status;
+}
+
+MetadataPropertyView<std::string_view>
+MetadataPropertyTableView::getStringPropertyValues(
+    const ExtensionExtStructuralMetadataClassProperty& classProperty,
+    const ExtensionExtStructuralMetadataPropertyTableProperty&
+        featureTableProperty) const {
+  if (classProperty.type != ClassProperty::Type::STRING) {
+    return createInvalidPropertyView<std::string_view>(
+        MetadataPropertyViewStatus::InvalidTypeMismatch);
+  }
+
+  gsl::span<const std::byte> valueBuffer;
+  auto status = getBufferSafe(featureTableProperty.values, valueBuffer);
+  if (status != MetadataPropertyViewStatus::Valid) {
+    return createInvalidPropertyView<std::string_view>(status);
+  }
+
+  const PropertyType offsetType =
+      convertOffsetStringToPropertyType(featureTableProperty.arrayOffsetType);
+  if (offsetType == PropertyType::None) {
+    return createInvalidPropertyView<std::string_view>(
+        MetadataPropertyViewStatus::InvalidOffsetType);
+  }
+
+  gsl::span<const std::byte> offsetBuffer;
+  status = getOffsetBufferSafe(
+      featureTableProperty.stringOffsets,
+      offsetType,
+      valueBuffer.size(),
+      static_cast<size_t>(_pFeatureTable->count),
+      false,
+      offsetBuffer);
+  if (status != MetadataPropertyViewStatus::Valid) {
+    return createInvalidPropertyView<std::string_view>(status);
+  }
+
+  return MetadataPropertyView<std::string_view>(
+      MetadataPropertyViewStatus::Valid,
+      valueBuffer,
+      gsl::span<const std::byte>(),
+      offsetBuffer,
+      offsetType,
+      0,
+      _pFeatureTable->count,
+      classProperty.normalized);
+}
+
+MetadataPropertyView<MetadataArrayView<std::string_view>>
+MetadataPropertyTableView::getStringArrayPropertyValues(
+    const ExtensionExtStructuralMetadataClassProperty& classProperty,
+    const ExtensionExtStructuralMetadataPropertyTableProperty&
+        featureTableProperty) const {
+  if (classProperty.type != ClassProperty::Type::ARRAY) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::InvalidTypeMismatch);
+  }
+
+  if (classProperty.componentType != ClassProperty::ComponentType::STRING) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::InvalidTypeMismatch);
+  }
+
+  // get value buffer
+  gsl::span<const std::byte> valueBuffer;
+  auto status = getBufferSafe(featureTableProperty.values, valueBuffer);
+  if (status != MetadataPropertyViewStatus::Valid) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        status);
+  }
+
+  // check fixed or dynamic array
+  const int64_t componentCount = classProperty.count.value_or(0);
+  if (componentCount > 0 && featureTableProperty.arrayOffsets >= 0) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::
+            InvalidArrayComponentCountAndOffsetBufferCoexist);
+  }
+
+  if (componentCount <= 0 && featureTableProperty.arrayOffsets < 0) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::
+            InvalidArrayComponentCountOrOffsetBufferNotExist);
+  }
+
+  // get offset type
+  const PropertyType offsetType =
+      convertOffsetStringToPropertyType(featureTableProperty.arrayOffsetType);
+  if (offsetType == PropertyType::None) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::InvalidOffsetType);
+  }
+
+  // get string offset buffer
+  if (featureTableProperty.stringOffsets < 0) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::InvalidStringOffsetBufferViewIndex);
+  }
+
+  // fixed array
+  if (componentCount > 0) {
+    gsl::span<const std::byte> stringOffsetBuffer;
+    status = getOffsetBufferSafe(
+        featureTableProperty.stringOffsets,
+        offsetType,
+        valueBuffer.size(),
+        static_cast<size_t>(_pFeatureTable->count * componentCount),
+        false,
+        stringOffsetBuffer);
+    if (status != MetadataPropertyViewStatus::Valid) {
+      return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+          status);
+    }
+
+    return MetadataPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::Valid,
+        valueBuffer,
+        gsl::span<const std::byte>(),
+        stringOffsetBuffer,
+        offsetType,
+        componentCount,
+        _pFeatureTable->count,
+        classProperty.normalized);
+  }
+
+  // dynamic array
+  gsl::span<const std::byte> stringOffsetBuffer;
+  status =
+      getBufferSafe(featureTableProperty.stringOffsets, stringOffsetBuffer);
+  if (status != MetadataPropertyViewStatus::Valid) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        status);
+  }
+
+  gsl::span<const std::byte> arrayOffsetBuffer;
+  status = getBufferSafe(featureTableProperty.arrayOffsets, arrayOffsetBuffer);
+  if (status != MetadataPropertyViewStatus::Valid) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        status);
+  }
+
+  switch (offsetType) {
+  case PropertyType::Uint8:
+    status = checkStringArrayOffsetBuffer<uint8_t>(
+        arrayOffsetBuffer,
+        stringOffsetBuffer,
+        valueBuffer.size(),
+        static_cast<size_t>(_pFeatureTable->count));
+    break;
+  case PropertyType::Uint16:
+    status = checkStringArrayOffsetBuffer<uint16_t>(
+        arrayOffsetBuffer,
+        stringOffsetBuffer,
+        valueBuffer.size(),
+        static_cast<size_t>(_pFeatureTable->count));
+    break;
+  case PropertyType::Uint32:
+    status = checkStringArrayOffsetBuffer<uint32_t>(
+        arrayOffsetBuffer,
+        stringOffsetBuffer,
+        valueBuffer.size(),
+        static_cast<size_t>(_pFeatureTable->count));
+    break;
+  case PropertyType::Uint64:
+    status = checkStringArrayOffsetBuffer<uint64_t>(
+        arrayOffsetBuffer,
+        stringOffsetBuffer,
+        valueBuffer.size(),
+        static_cast<size_t>(_pFeatureTable->count));
+    break;
+  default:
+    status = MetadataPropertyViewStatus::InvalidOffsetType;
+    break;
+  }
+
+  if (status != MetadataPropertyViewStatus::Valid) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        status);
+  }
+
+  return MetadataPropertyView<MetadataArrayView<std::string_view>>(
+      MetadataPropertyViewStatus::Valid,
+      valueBuffer,
+      arrayOffsetBuffer,
+      stringOffsetBuffer,
+      offsetType,
+      0,
+      _pFeatureTable->count,
+      classProperty.normalized);
+}
+} // namespace CesiumGltf


### PR DESCRIPTION
In the old version there were two extensions: Model Feature Metadata, and Mesh Primitive Feature Metadata.

The Model metadata was an extension on the Model and Mesh Primitive metadata was a extension on the primitive.

In the new version, there are two extensions, Mesh Features and Structural Metadata.

The Structural Metadata extension is similar to the Model Feature Metadata. 

The similarities are:

Both contain a schema which defines classes. Both contain feature tables containing metadata values.

One difference is that the Feature Table has been renamed to Property Table. 

The Class is the same in that it contains a set of properties. However, the number of types the property can take has expanded. The Class properties can now be of type Vec2, Vec3, Vec4, Mat3, and Mat4.

Also, Array is no longer a type. Instead it is a boolean property and the number of elements in the array is in the property "count", which used to be "componentCount."

The Mesh Features extension takes the place of the Mesh Primitive extension with some changes.

In the old extension, the primitive had an array of Feature ID attributes. Each Feature ID attribute contains the Feature Table name to use. It also contained the attribute name with the pattern "_FEATURE_ID_X".

Similarly, the Mesh Features extension has a link to the property table. It also contains the name of the attribute to use. One difference is that it only gives the number, X, which is used to build the string "_FEATURE_ID_X."

It also includes two new features, nullfeatureid, which is the number used to indicate that a Feature does not exist, and "count" which is the number of non-null features.

The changes to the code would consist of:

Making a Property Table View, similar to the Feature Table View.

Updating the Property View to include the new types, for Vec3 Vec4, etc.

In Unity, possibly utilizing the Mathematics package, which can map to all the types necessary.