### PR TITLE
Use `EXT_mesh_features` to indicate batch IDs

### DIFF
--- a/Cesium3DTilesSelection/src/B3dmToGltfConverter.cpp
+++ b/Cesium3DTilesSelection/src/B3dmToGltfConverter.cpp
@@ -1,6 +1,6 @@
 #include "B3dmToGltfConverter.h"
 
-#include "BatchTableToGltfFeatureMetadata.h"
+#include "BatchTableToGltfStructuralMetadata.h"
 #include "BinaryToGltfConverter.h"
 
 #include <CesiumGltf/ExtensionCesiumRTC.h>
@@ -220,7 +220,7 @@ void convertB3dmMetadataToGltfFeatureMetadata(
       }
 
       // upgrade batch table to glTF feature metadata and append the result
-      result.errors.merge(BatchTableToGltfFeatureMetadata::convertFromB3dm(
+      result.errors.merge(BatchTableToGltfStructuralMetadata::convertFromB3dm(
           featureTableJson,
           batchTableJson,
           batchTableBinaryData,

--- a/Cesium3DTilesSelection/src/BatchTableToGltfStructuralMetadata.cpp
+++ b/Cesium3DTilesSelection/src/BatchTableToGltfStructuralMetadata.cpp
@@ -1,10 +1,9 @@
-#include "BatchTableToGltfFeatureMetadata.h"
+#include "BatchTableToGltfStructuralMetadata.h"
 
 #include "BatchTableHierarchyPropertyValues.h"
 #include "Cesium3DTilesSelection/spdlog-cesium.h"
 
 #include <CesiumGltf/ExtensionExtMeshFeatures.h>
-#include <CesiumGltf/ExtensionMeshPrimitiveExtFeatureMetadata.h>
 #include <CesiumGltf/ExtensionModelExtFeatureMetadata.h>
 #include <CesiumGltf/Model.h>
 #include <CesiumGltf/PropertyType.h>
@@ -1383,7 +1382,7 @@ void updateExtensionWithBatchTableHierarchy(
   }
 }
 
-void convertBatchTableToGltfFeatureMetadataExtension(
+void convertBatchTableToGltfStructuralMetadataExtension(
     const rapidjson::Document& batchTableJson,
     const gsl::span<const std::byte>& batchTableBinaryData,
     CesiumGltf::Model& gltf,
@@ -1486,7 +1485,7 @@ void convertBatchTableToGltfFeatureMetadataExtension(
 
 } // namespace
 
-ErrorList BatchTableToGltfFeatureMetadata::convertFromB3dm(
+ErrorList BatchTableToGltfStructuralMetadata::convertFromB3dm(
     const rapidjson::Document& featureTableJson,
     const rapidjson::Document& batchTableJson,
     const gsl::span<const std::byte>& batchTableBinaryData,
@@ -1515,7 +1514,7 @@ ErrorList BatchTableToGltfFeatureMetadata::convertFromB3dm(
 
   const int64_t batchLength = batchLengthIt->value.GetInt64();
 
-  convertBatchTableToGltfFeatureMetadataExtension(
+  convertBatchTableToGltfStructuralMetadataExtension(
       batchTableJson,
       batchTableBinaryData,
       gltf,
@@ -1546,6 +1545,7 @@ ErrorList BatchTableToGltfFeatureMetadata::convertFromB3dm(
       // subtitute the batch table length.
       featureID.featureCount = batchLength;
       featureID.attribute = 0;
+      featureID.label = "_FEATURE_ID_0";
       featureID.propertyTable = 0;
     }
   }
@@ -1553,7 +1553,7 @@ ErrorList BatchTableToGltfFeatureMetadata::convertFromB3dm(
   return result;
 }
 
-ErrorList BatchTableToGltfFeatureMetadata::convertFromPnts(
+ErrorList BatchTableToGltfStructuralMetadata::convertFromPnts(
     const rapidjson::Document& featureTableJson,
     const rapidjson::Document& batchTableJson,
     const gsl::span<const std::byte>& batchTableBinaryData,
@@ -1597,7 +1597,7 @@ ErrorList BatchTableToGltfFeatureMetadata::convertFromPnts(
     featureCount = pointsLengthIt->value.GetInt64();
   }
 
-  convertBatchTableToGltfFeatureMetadataExtension(
+  convertBatchTableToGltfStructuralMetadataExtension(
       batchTableJson,
       batchTableBinaryData,
       gltf,
@@ -1626,6 +1626,7 @@ ErrorList BatchTableToGltfFeatureMetadata::convertFromPnts(
     primitive.attributes["_FEATURE_ID_0"] = primitiveBatchIdIt->second;
     primitive.attributes.erase("_BATCHID");
     featureID.attribute = 0;
+    featureID.label = "_FEATURE_ID_0";
   }
 
   return result;

--- a/Cesium3DTilesSelection/src/BatchTableToGltfStructuralMetadata.h
+++ b/Cesium3DTilesSelection/src/BatchTableToGltfStructuralMetadata.h
@@ -9,7 +9,7 @@
 #include <cstddef>
 
 namespace Cesium3DTilesSelection {
-struct BatchTableToGltfFeatureMetadata {
+struct BatchTableToGltfStructuralMetadata {
   static ErrorList convertFromB3dm(
       const rapidjson::Document& featureTableJson,
       const rapidjson::Document& batchTableJson,

--- a/Cesium3DTilesSelection/src/PntsToGltfConverter.cpp
+++ b/Cesium3DTilesSelection/src/PntsToGltfConverter.cpp
@@ -1,6 +1,6 @@
 #include "PntsToGltfConverter.h"
 
-#include "BatchTableToGltfFeatureMetadata.h"
+#include "BatchTableToGltfStructuralMetadata.h"
 
 #include <CesiumGeometry/Transforms.h>
 #include <CesiumGltf/ExtensionCesiumRTC.h>
@@ -701,7 +701,7 @@ void parseDracoExtensionFromBatchTableJson(
     const std::string name = dracoPropertyIt->name.GetString();
 
     // If there are issues with the extension, skip parsing metadata altogether.
-    // Otherwise, BatchTableToGltfFeatureMetadata will still try to parse the
+    // Otherwise, BatchTableToGltfStructuralMetadata will still try to parse the
     // invalid Draco-compressed properties.
     auto batchTablePropertyIt = batchTableJson.FindMember(name.c_str());
     if (batchTablePropertyIt == batchTableJson.MemberEnd() ||
@@ -723,7 +723,7 @@ void parseDracoExtensionFromBatchTableJson(
     }
 
     // If the batch table binary property is invalid, it will also be ignored by
-    // BatchTableToGltfFeatureMetadata, so it's fine to continue parsing the
+    // BatchTableToGltfStructuralMetadata, so it's fine to continue parsing the
     // other properties.
     const rapidjson::Value& batchTableProperty = batchTablePropertyIt->value;
     auto byteOffsetIt = batchTableProperty.FindMember("byteOffset");
@@ -1464,7 +1464,7 @@ void addBatchIdsToGltf(PntsContent& parsedContent, CesiumGltf::Model& gltf) {
         Accessor::Type::SCALAR);
 
     MeshPrimitive& primitive = gltf.meshes[0].primitives[0];
-    // This will be renamed by BatchTableToGltfFeatureMetadata.
+    // This will be renamed by BatchTableToGltfStructuralMetadata.
     primitive.attributes.emplace("_BATCHID", accessorId);
   }
 }
@@ -1610,7 +1610,7 @@ void convertPntsContentToGltf(
           gsl::span<const std::byte>(parsedContent.dracoBatchTableBinary);
     }
 
-    result.errors.merge(BatchTableToGltfFeatureMetadata::convertFromPnts(
+    result.errors.merge(BatchTableToGltfStructuralMetadata::convertFromPnts(
         featureTableJson,
         batchTableJson,
         batchTableBinaryData,

--- a/Cesium3DTilesSelection/test/TestPntsToGltfConverter.cpp
+++ b/Cesium3DTilesSelection/test/TestPntsToGltfConverter.cpp
@@ -1096,7 +1096,7 @@ TEST_CASE("Converts batched point cloud with Draco compression to glTF") {
   MeshPrimitive& primitive = mesh.primitives[0];
   CHECK(primitive.mode == MeshPrimitive::Mode::POINTS);
 
- auto primitiveExtension = primitive.getExtension<ExtensionExtMeshFeatures>();
+  auto primitiveExtension = primitive.getExtension<ExtensionExtMeshFeatures>();
   REQUIRE(primitiveExtension);
   REQUIRE(primitiveExtension->featureIds.size() == 1);
   ExtensionExtMeshFeaturesFeatureId& featureId =

--- a/Cesium3DTilesSelection/test/TestPntsToGltfConverter.cpp
+++ b/Cesium3DTilesSelection/test/TestPntsToGltfConverter.cpp
@@ -3,8 +3,8 @@
 #include <CesiumAsync/AsyncSystem.h>
 #include <CesiumAsync/HttpHeaders.h>
 #include <CesiumGltf/ExtensionCesiumRTC.h>
+#include <CesiumGltf/ExtensionExtMeshFeatures.h>
 #include <CesiumGltf/ExtensionKhrMaterialsUnlit.h>
-#include <CesiumGltf/ExtensionMeshPrimitiveExtFeatureMetadata.h>
 #include <CesiumGltf/ExtensionModelExtFeatureMetadata.h>
 #include <CesiumUtility/Math.h>
 
@@ -675,13 +675,13 @@ TEST_CASE(
   MeshPrimitive& primitive = mesh.primitives[0];
   CHECK(primitive.mode == MeshPrimitive::Mode::POINTS);
 
-  auto primitiveExtension =
-      primitive.getExtension<ExtensionMeshPrimitiveExtFeatureMetadata>();
+  auto primitiveExtension = primitive.getExtension<ExtensionExtMeshFeatures>();
   REQUIRE(primitiveExtension);
-  REQUIRE(primitiveExtension->featureIdAttributes.size() == 1);
-  FeatureIDAttribute& attribute = primitiveExtension->featureIdAttributes[0];
-  CHECK(attribute.featureTable == "default");
-  CHECK(attribute.featureIds.attribute == "_FEATURE_ID_0");
+  REQUIRE(primitiveExtension->featureIds.size() == 1);
+  ExtensionExtMeshFeaturesFeatureId& featureId =
+      primitiveExtension->featureIds[0];
+  CHECK(featureId.featureCount == 8);
+  CHECK(featureId.attribute == 0);
 
   CHECK(gltf.materials.size() == 1);
 
@@ -754,16 +754,14 @@ TEST_CASE("Converts point cloud with per-point properties to glTF with "
   MeshPrimitive& primitive = mesh.primitives[0];
   CHECK(primitive.mode == MeshPrimitive::Mode::POINTS);
 
-  auto primitiveExtension =
-      primitive.getExtension<ExtensionMeshPrimitiveExtFeatureMetadata>();
+  auto primitiveExtension = primitive.getExtension<ExtensionExtMeshFeatures>();
   REQUIRE(primitiveExtension);
-  REQUIRE(primitiveExtension->featureIdAttributes.size() == 1);
-  FeatureIDAttribute& attribute = primitiveExtension->featureIdAttributes[0];
-  CHECK(attribute.featureTable == "default");
+  REQUIRE(primitiveExtension->featureIds.size() == 1);
+  ExtensionExtMeshFeaturesFeatureId& featureId =
+      primitiveExtension->featureIds[0];
   // Check for implicit feature IDs
-  CHECK(!attribute.featureIds.attribute);
-  CHECK(attribute.featureIds.constant == 0);
-  CHECK(attribute.featureIds.divisor == 1);
+  CHECK(featureId.featureCount == pointsLength);
+  CHECK(!featureId.attribute);
 
   CHECK(gltf.materials.size() == 1);
 
@@ -815,16 +813,14 @@ TEST_CASE("Converts point cloud with Draco compression to glTF") {
   MeshPrimitive& primitive = mesh.primitives[0];
   CHECK(primitive.mode == MeshPrimitive::Mode::POINTS);
 
-  auto primitiveExtension =
-      primitive.getExtension<ExtensionMeshPrimitiveExtFeatureMetadata>();
+  auto primitiveExtension = primitive.getExtension<ExtensionExtMeshFeatures>();
   REQUIRE(primitiveExtension);
-  REQUIRE(primitiveExtension->featureIdAttributes.size() == 1);
-  FeatureIDAttribute& attribute = primitiveExtension->featureIdAttributes[0];
-  CHECK(attribute.featureTable == "default");
+  REQUIRE(primitiveExtension->featureIds.size() == 1);
+  ExtensionExtMeshFeaturesFeatureId& featureId =
+      primitiveExtension->featureIds[0];
   // Check for implicit feature IDs
-  CHECK(!attribute.featureIds.attribute);
-  CHECK(attribute.featureIds.constant == 0);
-  CHECK(attribute.featureIds.divisor == 1);
+  CHECK(featureId.featureCount == pointsLength);
+  CHECK(!featureId.attribute);
 
   REQUIRE(gltf.materials.size() == 1);
   Material& material = gltf.materials[0];
@@ -961,16 +957,14 @@ TEST_CASE("Converts point cloud with partial Draco compression to glTF") {
   MeshPrimitive& primitive = mesh.primitives[0];
   CHECK(primitive.mode == MeshPrimitive::Mode::POINTS);
 
-  auto primitiveExtension =
-      primitive.getExtension<ExtensionMeshPrimitiveExtFeatureMetadata>();
+  auto primitiveExtension = primitive.getExtension<ExtensionExtMeshFeatures>();
   REQUIRE(primitiveExtension);
-  REQUIRE(primitiveExtension->featureIdAttributes.size() == 1);
-  FeatureIDAttribute& attribute = primitiveExtension->featureIdAttributes[0];
-  CHECK(attribute.featureTable == "default");
+  REQUIRE(primitiveExtension->featureIds.size() == 1);
+  ExtensionExtMeshFeaturesFeatureId& featureId =
+      primitiveExtension->featureIds[0];
   // Check for implicit feature IDs
-  CHECK(!attribute.featureIds.attribute);
-  CHECK(attribute.featureIds.constant == 0);
-  CHECK(attribute.featureIds.divisor == 1);
+  CHECK(featureId.featureCount == pointsLength);
+  CHECK(!featureId.attribute);
 
   REQUIRE(gltf.materials.size() == 1);
   Material& material = gltf.materials[0];
@@ -1102,13 +1096,13 @@ TEST_CASE("Converts batched point cloud with Draco compression to glTF") {
   MeshPrimitive& primitive = mesh.primitives[0];
   CHECK(primitive.mode == MeshPrimitive::Mode::POINTS);
 
-  auto primitiveExtension =
-      primitive.getExtension<ExtensionMeshPrimitiveExtFeatureMetadata>();
+ auto primitiveExtension = primitive.getExtension<ExtensionExtMeshFeatures>();
   REQUIRE(primitiveExtension);
-  REQUIRE(primitiveExtension->featureIdAttributes.size() == 1);
-  FeatureIDAttribute& attribute = primitiveExtension->featureIdAttributes[0];
-  CHECK(attribute.featureTable == "default");
-  CHECK(attribute.featureIds.attribute == "_FEATURE_ID_0");
+  REQUIRE(primitiveExtension->featureIds.size() == 1);
+  ExtensionExtMeshFeaturesFeatureId& featureId =
+      primitiveExtension->featureIds[0];
+  CHECK(featureId.featureCount == 8);
+  CHECK(featureId.attribute == 0);
 
   CHECK(gltf.materials.size() == 1);
 

--- a/Cesium3DTilesSelection/test/TestUpgradeBatchTableToExtFeatureMetadata.cpp
+++ b/Cesium3DTilesSelection/test/TestUpgradeBatchTableToExtFeatureMetadata.cpp
@@ -3,7 +3,7 @@
 
 #include <CesiumAsync/AsyncSystem.h>
 #include <CesiumAsync/HttpHeaders.h>
-#include <CesiumGltf/ExtensionMeshPrimitiveExtFeatureMetadata.h>
+#include <CesiumGltf/ExtensionExtMeshFeatures.h>
 #include <CesiumGltf/ExtensionModelExtFeatureMetadata.h>
 #include <CesiumGltf/MetadataFeatureTableView.h>
 #include <CesiumGltf/MetadataPropertyView.h>
@@ -360,15 +360,15 @@ TEST_CASE("Converts JSON B3DM batch table to EXT_feature_metadata") {
           primitive.attributes.find("_FEATURE_ID_1") ==
           primitive.attributes.end());
 
-      ExtensionMeshPrimitiveExtFeatureMetadata* pPrimitiveExtension =
-          primitive.getExtension<ExtensionMeshPrimitiveExtFeatureMetadata>();
+      ExtensionExtMeshFeatures* pPrimitiveExtension =
+          primitive.getExtension<ExtensionExtMeshFeatures>();
       REQUIRE(pPrimitiveExtension);
-      REQUIRE(pPrimitiveExtension->featureIdAttributes.size() == 1);
-
-      FeatureIDAttribute& attribute =
-          pPrimitiveExtension->featureIdAttributes[0];
-      CHECK(attribute.featureIds.attribute == "_FEATURE_ID_0");
-      CHECK(attribute.featureTable == "default");
+      REQUIRE(pPrimitiveExtension->featureIds.size() == 1);
+      ExtensionExtMeshFeaturesFeatureId& featureId =
+          pPrimitiveExtension->featureIds[0];
+      CHECK(featureId.featureCount == 10);
+      CHECK(featureId.attribute == 0);
+      CHECK(featureId.propertyTable == 0);
     }
   }
 
@@ -677,14 +677,15 @@ TEST_CASE("Converts batched PNTS batch table to EXT_feature_metadata") {
   CHECK(
       primitive.attributes.find("_FEATURE_ID_0") != primitive.attributes.end());
 
-  ExtensionMeshPrimitiveExtFeatureMetadata* pPrimitiveExtension =
-      primitive.getExtension<ExtensionMeshPrimitiveExtFeatureMetadata>();
+  ExtensionExtMeshFeatures* pPrimitiveExtension =
+      primitive.getExtension<ExtensionExtMeshFeatures>();
   REQUIRE(pPrimitiveExtension);
-  REQUIRE(pPrimitiveExtension->featureIdAttributes.size() == 1);
-
-  FeatureIDAttribute& attribute = pPrimitiveExtension->featureIdAttributes[0];
-  CHECK(attribute.featureTable == "default");
-  CHECK(attribute.featureIds.attribute == "_FEATURE_ID_0");
+  REQUIRE(pPrimitiveExtension->featureIds.size() == 1);
+  ExtensionExtMeshFeaturesFeatureId& featureId =
+      pPrimitiveExtension->featureIds[0];
+  CHECK(featureId.featureCount ==8);
+  CHECK(featureId.attribute == 0);
+  CHECK(featureId.propertyTable == 0);
 
   // Check metadata values
   {
@@ -824,17 +825,15 @@ TEST_CASE("Converts per-point PNTS batch table to EXT_feature_metadata") {
   CHECK(
       primitive.attributes.find("_FEATURE_ID_0") == primitive.attributes.end());
 
-  ExtensionMeshPrimitiveExtFeatureMetadata* pPrimitiveExtension =
-      primitive.getExtension<ExtensionMeshPrimitiveExtFeatureMetadata>();
+  ExtensionExtMeshFeatures* pPrimitiveExtension =
+      primitive.getExtension<ExtensionExtMeshFeatures>();
   REQUIRE(pPrimitiveExtension);
-  REQUIRE(pPrimitiveExtension->featureIdAttributes.size() == 1);
-
-  FeatureIDAttribute& attribute = pPrimitiveExtension->featureIdAttributes[0];
-  CHECK(attribute.featureTable == "default");
-  // Check for implicit feature IDs
-  CHECK(!attribute.featureIds.attribute);
-  CHECK(attribute.featureIds.constant == 0);
-  CHECK(attribute.featureIds.divisor == 1);
+  REQUIRE(pPrimitiveExtension->featureIds.size() == 1);
+  ExtensionExtMeshFeaturesFeatureId& featureId =
+      pPrimitiveExtension->featureIds[0];
+  CHECK(featureId.featureCount == 8);
+  CHECK(!featureId.attribute);
+  CHECK(featureId.propertyTable == 0);
 
   // Check metadata values
   {
@@ -974,17 +973,16 @@ TEST_CASE("Converts Draco per-point PNTS batch table to "
   CHECK(
       primitive.attributes.find("_FEATURE_ID_0") == primitive.attributes.end());
 
-  ExtensionMeshPrimitiveExtFeatureMetadata* pPrimitiveExtension =
-      primitive.getExtension<ExtensionMeshPrimitiveExtFeatureMetadata>();
-  REQUIRE(pPrimitiveExtension);
-  REQUIRE(pPrimitiveExtension->featureIdAttributes.size() == 1);
 
-  FeatureIDAttribute& attribute = pPrimitiveExtension->featureIdAttributes[0];
-  CHECK(attribute.featureTable == "default");
-  // Check for implicit feature IDs
-  CHECK(!attribute.featureIds.attribute);
-  CHECK(attribute.featureIds.constant == 0);
-  CHECK(attribute.featureIds.divisor == 1);
+      ExtensionExtMeshFeatures* pPrimitiveExtension =
+      primitive.getExtension<ExtensionExtMeshFeatures>();
+  REQUIRE(pPrimitiveExtension);
+  REQUIRE(pPrimitiveExtension->featureIds.size() == 1);
+  ExtensionExtMeshFeaturesFeatureId& featureId =
+      pPrimitiveExtension->featureIds[0];
+  CHECK(featureId.featureCount == 8);
+  CHECK(!featureId.attribute);
+  CHECK(featureId.propertyTable == 0);
 
   // Check metadata values
   {
@@ -1248,7 +1246,7 @@ TEST_CASE("Upgrade fixed json number array") {
       {1244, 12200000, 1222, 544662},
       {123, 10, 122, 334},
       {13, 45, 122, 94},
-      {11, 22, 3, 4294967295}};
+      {11, 22, 3, (uint32_t)4294967295}};
     // clang-format on
 
     std::string expectedComponentType = "UINT32";
@@ -1408,7 +1406,7 @@ TEST_CASE("Upgrade dynamic json number array") {
       {1244, 12200000, 1222, 544662},
       {123, 10},
       {13, 45, 122, 94, 333, 212, 534, 1122},
-      {11, 22, 3, 4294967295}};
+      {11, 22, 3, (uint32_t)4294967295}};
     // clang-format on
 
     std::string expectedComponentType = "UINT32";

--- a/Cesium3DTilesSelection/test/TestUpgradeBatchTableToExtFeatureMetadata.cpp
+++ b/Cesium3DTilesSelection/test/TestUpgradeBatchTableToExtFeatureMetadata.cpp
@@ -1,4 +1,4 @@
-#include "BatchTableToGltfFeatureMetadata.h"
+#include "BatchTableToGltfStructuralMetadata.h"
 #include "ConvertTileToGltf.h"
 
 #include <CesiumAsync/AsyncSystem.h>
@@ -136,7 +136,7 @@ static void createTestForScalarJson(
       scalarProperty,
       batchTableJson.GetAllocator());
 
-  auto errors = BatchTableToGltfFeatureMetadata::convertFromB3dm(
+  auto errors = BatchTableToGltfStructuralMetadata::convertFromB3dm(
       featureTableJson,
       batchTableJson,
       gsl::span<const std::byte>(),
@@ -212,7 +212,7 @@ static void createTestForArrayJson(
       fixedArrayProperties,
       batchTableJson.GetAllocator());
 
-  auto errors = BatchTableToGltfFeatureMetadata::convertFromB3dm(
+  auto errors = BatchTableToGltfStructuralMetadata::convertFromB3dm(
       featureTableJson,
       batchTableJson,
       gsl::span<const std::byte>(),
@@ -683,7 +683,7 @@ TEST_CASE("Converts batched PNTS batch table to EXT_feature_metadata") {
   REQUIRE(pPrimitiveExtension->featureIds.size() == 1);
   ExtensionExtMeshFeaturesFeatureId& featureId =
       pPrimitiveExtension->featureIds[0];
-  CHECK(featureId.featureCount ==8);
+  CHECK(featureId.featureCount == 8);
   CHECK(featureId.attribute == 0);
   CHECK(featureId.propertyTable == 0);
 
@@ -973,8 +973,7 @@ TEST_CASE("Converts Draco per-point PNTS batch table to "
   CHECK(
       primitive.attributes.find("_FEATURE_ID_0") == primitive.attributes.end());
 
-
-      ExtensionExtMeshFeatures* pPrimitiveExtension =
+  ExtensionExtMeshFeatures* pPrimitiveExtension =
       primitive.getExtension<ExtensionExtMeshFeatures>();
   REQUIRE(pPrimitiveExtension);
   REQUIRE(pPrimitiveExtension->featureIds.size() == 1);
@@ -1133,7 +1132,7 @@ TEST_CASE("Upgrade bool json to boolean binary") {
       boolProperties,
       batchTableJson.GetAllocator());
 
-  auto errors = BatchTableToGltfFeatureMetadata::convertFromB3dm(
+  auto errors = BatchTableToGltfStructuralMetadata::convertFromB3dm(
       featureTableJson,
       batchTableJson,
       gsl::span<const std::byte>(),
@@ -1675,7 +1674,7 @@ TEST_CASE("Converts Feature Classes 3DTILES_batch_table_hierarchy example to "
   rapidjson::Document batchTableParsed;
   batchTableParsed.Parse(batchTableJson.data(), batchTableJson.size());
 
-  auto errors = BatchTableToGltfFeatureMetadata::convertFromB3dm(
+  auto errors = BatchTableToGltfStructuralMetadata::convertFromB3dm(
       featureTableParsed,
       batchTableParsed,
       gsl::span<const std::byte>(),
@@ -1805,7 +1804,7 @@ TEST_CASE("Converts Feature Hierarchy 3DTILES_batch_table_hierarchy example to "
   rapidjson::Document batchTableParsed;
   batchTableParsed.Parse(batchTableJson.data(), batchTableJson.size());
 
-  BatchTableToGltfFeatureMetadata::convertFromB3dm(
+  BatchTableToGltfStructuralMetadata::convertFromB3dm(
       featureTableParsed,
       batchTableParsed,
       gsl::span<const std::byte>(),
@@ -1999,7 +1998,7 @@ TEST_CASE(
   auto pLog = std::make_shared<spdlog::sinks::ringbuffer_sink_mt>(3);
   spdlog::default_logger()->sinks().emplace_back(pLog);
 
-  BatchTableToGltfFeatureMetadata::convertFromB3dm(
+  BatchTableToGltfStructuralMetadata::convertFromB3dm(
       featureTableParsed,
       batchTableParsed,
       gsl::span<const std::byte>(),
@@ -2091,7 +2090,7 @@ TEST_CASE(
   auto pLog = std::make_shared<spdlog::sinks::ringbuffer_sink_mt>(3);
   spdlog::default_logger()->sinks().emplace_back(pLog);
 
-  auto errors = BatchTableToGltfFeatureMetadata::convertFromB3dm(
+  auto errors = BatchTableToGltfStructuralMetadata::convertFromB3dm(
       featureTableParsed,
       batchTableParsed,
       gsl::span<const std::byte>(),


### PR DESCRIPTION
I'm going to use `upgrade-feature-metadata` as a staging branch for the metadata extension changes, since it's going to involve a larger overhaul and I want to make changes as incrementally as possible.

In this PR, batch IDs are stored `EXT_mesh_features` instead of an `EXT_feature_metadata` extension on the mesh primitive. This change only affects `b3dm` / `pnts`; a separate class should be written to convert `EXT_feature_metadata` to `EXT_mesh_features` for glTFs.

I also prematurely renamed the file before deciding to split up PRs. In this PR it doesn't handle `EXT_structural_metadata` yet.