### PR TITLE
Add `MetadataPropertyTableView`

### DIFF
--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataArrayView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataArrayView.h
@@ -15,7 +15,7 @@ namespace StructuralMetadata {
 
 /**
  * @brief A view on an array element of a
- * ExtensionExtStructuralMetadataPropertyTableProperty.
+ * {@link ExtensionExtStructuralMetadataPropertyTableProperty}.
  *
  * Provides utility to retrieve the data stored in the array of
  * elements via the array index operator.

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
@@ -16,36 +16,38 @@ namespace StructuralMetadata {
  * @brief Utility to retrieve the data of
  * ExtensionExtStructuralMetadataPropertyTable.
  *
- * This should be used to get a {@link MetadataPropertyView} of a property.
+ * This should be used to get a {@link MetadataPropertyView} of a property in the property table.
  * It will validate the EXT_structural_metadata format and ensure {@link MetadataPropertyView}
- *  does not access out of bounds.
+ * does not access out of bounds.
  */
 
 class MetadataPropertyTableView {
 public:
   /**
-   * @brief Create an instance of MetadataPropertyTableView.
-   * @param pModel The Gltf Model that stores property table data
-   * @param pPropertyTable The ExtensionExtStructuralMetadataPropertyTable from
-   * which the view will retrieve data.
+   * @brief Creates an instance of MetadataPropertyTableView.
+   * @param pModel A pointer to the Gltf Model that contains property table
+   * data.
+   * @param pPropertyTable A pointer to the
+   * ExtensionExtStructuralMetadataPropertyTable from which the view will
+   * retrieve data.
    */
   MetadataPropertyTableView(
       const Model* pModel,
       const ExtensionExtStructuralMetadataPropertyTable* pPropertyTable);
 
   /**
-   * @brief Find the {@link ExtensionExtStructuralMetadataClassProperty} which
-   * stores the type information of a property based on the property's name.
-   * @param propertyName The name of the property to retrieve type info
-   * @return Pointer to the ExtensionExtStructuralMetadataClassProperty. Return
-   * nullptr if no property was found.
+   * @brief Finds the {@link ExtensionExtStructuralMetadataClassProperty} that
+   * describes the type information of the property with the specified name.
+   * @param propertyName The name of the property to retrieve the class for.
+   * @return A pointer to the ExtensionExtStructuralMetadataClassProperty.
+   * Return nullptr if no property was found.
    */
   const ExtensionExtStructuralMetadataClassProperty*
   getClassProperty(const std::string& propertyName) const;
 
   /**
-   * @brief Gets a MetadataPropertyView to view the data of a property stored in
-   * the ExtensionExtStructuralMetadataPropertyTable.
+   * @brief Gets a MetadataPropertyView that views the data of a property stored
+   * in the ExtensionExtStructuralMetadataPropertyTable.
    *
    * This method will validate the EXT_structural_metadata format to ensure
    * MetadataPropertyView retrieves the correct data. T must be one of the
@@ -56,8 +58,8 @@ public:
    * aforementioned types.
    *
    * @param propertyName The name of the property to retrieve data from
-   * @return MetadataPropertyView of a property. The property view will be
-   * invalid if no property is found.
+   * @return A MetadataPropertyView of the property. If no valid property is
+   * found, the property view will be invalid.
    */
   template <typename T>
   MetadataPropertyView<T>
@@ -81,8 +83,8 @@ public:
 
   /**
    * @brief Gets a MetadataPropertyView through a callback that accepts a
-   * property name and a MetadataPropertyView<T> to view the data
-   * of a property stored in the ExtensionExtStructuralMetadataPropertyTable.
+   * property name and a MetadataPropertyView<T> that views the data
+   * of the property with the specified name.
    *
    * This method will validate the EXT_structural_metadata format to ensure
    * MetadataPropertyView retrieves the correct data. T must be one of the
@@ -91,11 +93,11 @@ public:
    * types, a glm matN composed of one of the scalar types, bool,
    * std::string_view, or MetadataArrayView<T> with T as one of the
    * aforementioned types. If the property is invalid, an empty
-   * MetadataPropertyView with an error status code will be passed to the
+   * MetadataPropertyView with an error status will be passed to the
    * callback. Otherwise, a valid property view will be passed to the callback.
    *
    * @param propertyName The name of the property to retrieve data from
-   * @tparam callback A callback function that accepts property name and
+   * @tparam callback A callback function that accepts a property name and a
    * MetadataPropertyView<T>
    */
   template <typename Callback>
@@ -564,7 +566,6 @@ private:
           type,
           componentType,
           std::forward<Callback>(callback));
-
     } else if (type == PropertyType::Boolean) {
       callback(
           propertyName,
@@ -990,11 +991,6 @@ private:
     return MetadataPropertyView<T>(
         MetadataPropertyViewStatus::Valid,
         values,
-        gsl::span<const std::byte>(),
-        gsl::span<const std::byte>(),
-        PropertyComponentType::None,
-        PropertyComponentType::None,
-        0,
         _pPropertyTable->count,
         classProperty.normalized);
   }
@@ -1147,11 +1143,6 @@ private:
     return MetadataPropertyView<T>(
         invalidStatus,
         gsl::span<const std::byte>(),
-        gsl::span<const std::byte>(),
-        gsl::span<const std::byte>(),
-        PropertyComponentType::None,
-        PropertyComponentType::None,
-        0,
         0,
         false);
   }

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
@@ -1,0 +1,793 @@
+#pragma once
+
+#include "CesiumGltf/ExtensionModelExtStructuralMetadata.h"
+#include "CesiumGltf/Model.h"
+#include "CesiumGltf/StructuralMetadataPropertyType.h"
+#include "CesiumGltf/StructuralMetadataPropertyView.h"
+
+#include <glm/common.hpp>
+
+#include <optional>
+
+namespace CesiumGltf {
+namespace StructuralMetadata {
+
+/**
+ * @brief Utility to retrieve the data of
+ * ExtensionExtStructuralMetadataPropertyTable.
+ *
+ * This should be used to get a {@link MetadataPropertyView} of a property.
+ * It will validate the EXT_structural_metadata format and ensure {@link MetadataPropertyView}
+ *  does not access out of bounds.
+ */
+
+class MetadataPropertyTableView {
+public:
+  /**
+   * @brief Create an instance of MetadataPropertyTableView.
+   * @param pModel The Gltf Model that stores property table data
+   * @param pPropertyTable The ExtensionExtStructuralMetadataPropertyTable from
+   * which the view will retrieve data.
+   */
+  MetadataPropertyTableView(
+      const Model* pModel,
+      const ExtensionExtStructuralMetadataPropertyTable* pPropertyTable);
+
+  /**
+   * @brief Find the {@link ExtensionExtStructuralMetadataClassProperty} which
+   * stores the type information of a property based on the property's name.
+   * @param propertyName The name of the property to retrieve type info
+   * @return Pointer to the ExtensionExtStructuralMetadataClassProperty. Return
+   * nullptr if no property was found.
+   */
+  const ExtensionExtStructuralMetadataClassProperty*
+  getClassProperty(const std::string& propertyName) const;
+
+  /**
+   * @brief Gets a MetadataPropertyView to view the data of a property stored in
+   * the ExtensionExtStructuralMetadataPropertyTable.
+   *
+   * This method will validate the EXT_structural_metadata format to ensure
+   * MetadataPropertyView retrieves the correct data. T must be one of the
+   * following: a scalar (uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t,
+   * uint64_t, int64_t, float, double), a glm vecN composed of one of the scalar
+   * types, a glm matN composed of one of the scalar types, bool,
+   * std::string_view, or MetadataArrayView<T> with T as one of the
+   * aforementioned types.
+   *
+   * @param propertyName The name of the property to retrieve data from
+   * @return MetadataPropertyView of a property. The property view will be
+   * invalid if no property is found.
+   */
+  template <typename T>
+  MetadataPropertyView<T>
+  getPropertyView(const std::string& propertyName) const {
+    if (_pPropertyTable->count <= 0) {
+      return createInvalidPropertyView<T>(
+          StructuralMetadata::MetadataPropertyViewStatus::
+              ErrorPropertyDoesNotExist);
+    }
+
+    const ExtensionExtStructuralMetadataClassProperty* pClassProperty =
+        getClassProperty(propertyName);
+    if (!pClassProperty) {
+      return createInvalidPropertyView<T>(
+          StructuralMetadata::MetadataPropertyViewStatus::
+              ErrorPropertyDoesNotExist);
+    }
+
+    return getPropertyViewImpl<T>(propertyName, *pClassProperty);
+  }
+
+  /**
+   * @brief Gets a MetadataPropertyView through a callback that accepts a
+   * property name and a std::optional<MetadataPropertyView<T>> to view the data
+   * of a property stored in the ExtensionExtStructuralMetadataPropertyTable.
+   *
+   * This method will validate the EXT_structural_metadata format to ensure
+   * MetadataPropertyView retrieves the correct data. T must be one of the
+   * following: a scalar (uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t,
+   * uint64_t, int64_t, float, double), a glm vecN composed of one of the scalar
+   * types, a glm matN composed of one of the scalar types, bool,
+   * std::string_view, or MetadataArrayView<T> with T as one of the
+   * aforementioned types. If the property is invalid, std::nullopt will be
+   * passed to the callback. Otherwise, a valid property view will be passed to
+   * the callback.
+   *
+   * @param propertyName The name of the property to retrieve data from
+   * @tparam callback A callback function that accepts property name and
+   * std::optional<MetadataPropertyView<T>>
+   */
+  template <typename Callback>
+  void
+  getPropertyView(const std::string& propertyName, Callback&& callback) const {
+    const ExtensionExtStructuralMetadataClassProperty* pClassProperty =
+        getClassProperty(propertyName);
+    if (!pClassProperty) {
+      return;
+    }
+
+    PropertyType type = convertStringToPropertyType(pClassProperty->type);
+    PropertyComponentType componentType =
+        convertStringToPropertyType(pClassProperty->componentType);
+
+    if (pClassProperty->array) {
+      getArrayPropertyViewImpl(
+          propertyName,
+          *pClassProperty,
+          componentType,
+          std::forward<Callback>(callback));
+    } else if (isPropertyTypeVecN(type)) {
+      getVecNPropertyViewImpl(
+          propertyName,
+          *pClassProperty,
+          componentType,
+          std::forward<Callback>(callback));
+    } else if (isPropertyTypeMatN(type)) {
+      getMatNPropertyViewImpl(
+          propertyName,
+          *pClassProperty,
+          componentType,
+          std::forward<Callback>(callback));
+    } else {
+      getPrimitivePropertyViewImpl(
+          propertyName,
+          *pClassProperty,
+          type,
+          std::forward<Callback>(callback));
+    }
+  }
+
+  /**
+   * @brief Iterates over each property in the
+   * ExtensionExtStructuralMetadataPropertyTable with a callback that accepts a
+   * property name and a std::optional<MetadataPropertyView<T>> to view the data
+   * stored in the ExtensionExtStructuralMetadataPropertyTableProperty.
+   *
+   * This method will validate the EXT_structural_metadata format to ensure
+   * MetadataPropertyView retrieves the correct data. T must be one of the
+   * following: a scalar (uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t,
+   * uint64_t, int64_t, float, double), a glm vecN composed of one of the scalar
+   * types, a glm matN composed of one of the scalar types, bool,
+   * std::string_view, or MetadataArrayView<T> with T as one of the
+   * aforementioned types. If the property is invalid, std::nullopt will be
+   * passed to the callback. Otherwise, a valid property view will be passed to
+   * the callback.
+   *
+   * @param propertyName The name of the property to retrieve data from
+   * @tparam callback A callback function that accepts property name and
+   * std::optional<MetadataPropertyView<T>>
+   */
+  template <typename Callback> void forEachProperty(Callback&& callback) const {
+    for (const auto& property : this->_pClass->properties) {
+      getPropertyView(property.first, std::forward<Callback>(callback));
+    }
+  }
+
+private:
+  template <typename Callback>
+  void getArrayPropertyViewImpl(
+      const std::string& propertyName,
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      StructuralMetadata::PropertyType type,
+      Callback&& callback) const {
+    switch (type) {
+    case PropertyType::Int8:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<int8_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Uint8:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<uint8_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Int16:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<int16_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Uint16:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<uint16_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Int32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<int32_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Uint32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<uint32_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Int64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<int64_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Uint64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<uint64_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Float32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<float>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Float64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<double>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::Boolean:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<bool>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyType::String:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<std::string_view>>(
+              propertyName,
+              classProperty));
+      break;
+    default:
+      break;
+    }
+  }
+
+  template <typename Callback>
+  void getVecNPropertyViewImpl(
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      const ExtensionExtStructuralMetadataPropertyTableProperty&
+          propertyTableProperty,
+      PropertyType type,
+      PropertyComponentType componentType,
+      Callback&& callback) {
+    glm::length_t N;
+    switch (type) {
+    case PropertyType::Vec2:
+      N = 2;
+      break;
+    case PropertyType::Vec3:
+      N = 3;
+      break;
+    case PropertyType::Vec4:
+      N = 4;
+      break;
+    default:
+      return;
+    }
+
+    switch (componentType) {
+    case PropertyComponentType::Int8:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::vec<N, int8_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Uint8:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::vec<N, uint8_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Int16:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::vec<N, int16_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Uint16:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::vec<N, uint16_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Int32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::vec<N, int32_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Uint32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::vec<N, uint32_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Int64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::vec<N, int64_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Uint64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::vec<N, uint64_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Float32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::vec<N, float>>(propertyName, classProperty));
+      break;
+    case PropertyComponentType::Float64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::vec<N, double>>(
+              propertyName,
+              classProperty));
+      break;
+    default:
+      break;
+    }
+  }
+
+  template <typename Callback>
+  void getMatNPropertyViewImpl(
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      const ExtensionExtStructuralMetadataPropertyTableProperty&
+          propertyTableProperty,
+      PropertyType type,
+      PropertyComponentType componentType,
+      Callback&& callback) {
+    glm::length_t N;
+    switch (type) {
+    case PropertyType::Mat2:
+      N = 2;
+      break;
+    case PropertyType::Mat3:
+      N = 3;
+      break;
+    case PropertyType::Mat4:
+      N = 4;
+      break;
+    default:
+      return;
+    }
+
+    switch (componentType) {
+    case PropertyComponentType::Int8:
+      callback(
+          propertyName,
+          getPropertyViewImpl <
+              glm::mat<N, N, int8_t>(propertyName, classProperty));
+      break;
+    case PropertyComponentType::Uint8:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::mat<N, N, uint8_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Int16:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::mat<N, N, int16_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Uint16:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::mat<N, N, uint16_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Int32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::mat<N, N, int32_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Uint32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::mat<N, N, uint32_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Int64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::mat<N, N, int64_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Uint64:
+      callback(
+          propertyName,
+          getPropertyViewImp<glm::mat<N, N, uint64_t>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Float32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::mat<N, N, float>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Float64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<glm::mat<N, N, double>>(
+              propertyName,
+              classProperty));
+      break;
+    default:
+      break;
+    }
+  }
+
+  template <typename Callback>
+  void getPrimitivePropertyViewImpl(
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      const ExtensionExtStructuralMetadataPropertyTableProperty&
+          propertyTableProperty,
+      PropertyComponentType type,
+      Callback&& callback) const {
+    switch (type) {
+    case PropertyType::Int8:
+      callback(
+          propertyName,
+          getPropertyViewImpl<int8_t>(propertyName, classProperty));
+      break;
+    case PropertyType::Uint8:
+      callback(
+          propertyName,
+          getPropertyViewImpl<uint8_t>(propertyName, classProperty));
+      break;
+    case PropertyType::Int16:
+      callback(
+          propertyName,
+          getPropertyViewImpl<int16_t>(propertyName, classProperty));
+      break;
+    case PropertyType::Uint16:
+      callback(
+          propertyName,
+          getPropertyViewImpl<uint16_t>(propertyName, classProperty));
+      break;
+    case PropertyType::Int32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<int32_t>(propertyName, classProperty));
+      break;
+    case PropertyType::Uint32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<uint32_t>(propertyName, classProperty));
+      break;
+    case PropertyType::Int64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<int64_t>(propertyName, classProperty));
+      break;
+    case PropertyType::Uint64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<uint64_t>(propertyName, classProperty));
+      break;
+    case PropertyType::Float32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<float>(propertyName, classProperty));
+      break;
+    case PropertyType::Float64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<double>(propertyName, classProperty));
+      break;
+    case PropertyType::Boolean:
+      callback(
+          propertyName,
+          getPropertyViewImpl<bool>(propertyName, classProperty));
+      break;
+    case PropertyType::String:
+      callback(
+          propertyName,
+          getPropertyViewImpl<std::string_view>(propertyName, classProperty));
+      break;
+    default:
+      break;
+    }
+  }
+
+  template <typename T>
+  MetadataPropertyView<T> getPropertyViewImpl(
+      const std::string& propertyName,
+      const ExtensionExtStructuralMetadataClassProperty& classProperty) const {
+    auto propertyTablePropertyIter =
+        _pPropertyTable->properties.find(propertyName);
+    if (propertyTablePropertyIter == _pPropertyTable->properties.end()) {
+      return createInvalidPropertyView<T>(
+          MetadataPropertyViewStatus::ErrorPropertyDoesNotExist);
+    }
+
+    const ExtensionExtStructuralMetadataPropertyTableProperty&
+        propertyTableProperty = propertyTablePropertyIter->second;
+
+    if constexpr (IsMetadataNumeric<T>::value || IsMetadataBoolean<T>::value) {
+      return getNumericOrBooleanPropertyValues<T>(
+          classProperty,
+          propertyTableProperty);
+    }
+
+    if constexpr (IsMetadataString<T>::value) {
+      return getStringPropertyValues(classProperty, propertyTableProperty);
+    }
+
+    if constexpr (
+        IsMetadataNumericArray<T>::value || IsMetadataBooleanArray<T>::value) {
+      return getPrimitiveArrayPropertyValues<
+          typename MetadataArrayType<T>::type>(
+          classProperty,
+          propertyTableProperty);
+    }
+
+    if constexpr (IsMetadataStringArray<T>::value) {
+      return getStringArrayPropertyValues(classProperty, propertyTableProperty);
+    }
+  }
+
+  template <typename T>
+  StructuralMetadata::MetadataPropertyView<T> getNumericOrBooleanPropertyValues(
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      const ExtensionExtStructuralMetadataPropertyTableProperty&
+          propertyTableProperty) const {
+    if (classProperty.array) {
+      return createInvalidPropertyView<T>(
+          MetadataPropertyViewStatus::ErrorArrayTypeMismatch);
+    }
+
+    const PropertyType type = convertStringToPropertyType(classProperty.type);
+    if (TypeToPropertyType<T>::value != type) {
+      return createInvalidPropertyView<T>(
+          MetadataPropertyViewStatus::ErrorTypeMismatch);
+    }
+    const PropertyComponentType componentType =
+        convertStringToPropertyComponentType(
+            classProperty.componentType.value_or(""));
+    if (TypeToPropertyType<T>::component != componentType) {
+      return createInvalidPropertyView<T>(
+          MetadataPropertyViewStatus::ErrorComponentTypeMismatch);
+    }
+
+    gsl::span<const std::byte> values;
+    const auto status = getBufferSafe(propertyTableProperty.values, values);
+    if (status != MetadataPropertyViewStatus::Valid) {
+      return createInvalidPropertyView<T>(status);
+    }
+
+    if (values.size() % sizeof(T) != 0) {
+      return createInvalidPropertyView<T>(
+          StructuralMetadata::MetadataPropertyViewStatus::
+              ErrorBufferViewSizeNotDivisibleByTypeSize);
+    }
+
+    size_t maxRequiredBytes = 0;
+    if (IsMetadataBoolean<T>::value) {
+      maxRequiredBytes = static_cast<size_t>(
+          glm::ceil(static_cast<double>(_pPropertyTable->count) / 8.0));
+    } else {
+      maxRequiredBytes = _pPropertyTable->count * sizeof(T);
+    }
+
+    if (values.size() < maxRequiredBytes) {
+      return createInvalidPropertyView<T>(
+          MetadataPropertyViewStatus::
+              ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+    }
+
+    return MetadataPropertyView<T>(
+        MetadataPropertyViewStatus::Valid,
+        values,
+        gsl::span<const std::byte>(),
+        gsl::span<const std::byte>(),
+        PropertyComponentType::None,
+        PropertyComponentType::None,
+        0,
+        _pPropertyTable->count,
+        classProperty.normalized);
+  }
+
+  MetadataPropertyView<std::string_view> getStringPropertyValues(
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      const ExtensionExtStructuralMetadataPropertyTableProperty&
+          propertyTableProperty) const;
+
+  template <typename T>
+  MetadataPropertyView<MetadataArrayView<T>> getPrimitiveArrayPropertyValues(
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      const ExtensionExtStructuralMetadataPropertyTableProperty&
+          propertyTableProperty) const {
+    if (!classProperty.array) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(
+          MetadataPropertyViewStatus::ErrorArrayTypeMismatch);
+    }
+
+    const PropertyType type = convertStringToPropertyType(classProperty.type);
+    if (TypeToPropertyType<T>::value != type) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(
+          MetadataPropertyViewStatus::ErrorTypeMismatch);
+    }
+
+    const PropertyComponentType componentType =
+        convertStringToPropertyComponentType(
+            classProperty.componentType.value_or(""));
+    if (TypeToPropertyType<T>::component != componentType) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(
+          MetadataPropertyViewStatus::ErrorComponentTypeMismatch);
+    }
+
+    gsl::span<const std::byte> values;
+    auto status = getBufferSafe(propertyTableProperty.values, values);
+    if (status != MetadataPropertyViewStatus::Valid) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(status);
+    }
+
+    if (values.size() % sizeof(T) != 0) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(
+          MetadataPropertyViewStatus::
+              ErrorBufferViewSizeNotDivisibleByTypeSize);
+    }
+
+    const int64_t fixedLengthArrayCount = classProperty.count.value_or(0);
+    if (fixedLengthArrayCount > 0 && propertyTableProperty.arrayOffsets >= 0) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(
+          MetadataPropertyViewStatus::ErrorArrayCountAndOffsetBufferCoexist);
+    }
+
+    if (fixedLengthArrayCount <= 0 && propertyTableProperty.arrayOffsets < 0) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(
+          MetadataPropertyViewStatus::ErrorArrayCountAndOffsetBufferDontExist);
+    }
+
+    // Handle fixed-length arrays
+    if (fixedLengthArrayCount > 0) {
+      size_t maxRequiredBytes = 0;
+      if constexpr (IsMetadataBoolean<T>::value) {
+        maxRequiredBytes = static_cast<size_t>(glm::ceil(
+            static_cast<double>(
+                _pPropertyTable->count * fixedLengthArrayCount) /
+            8.0));
+      } else {
+        maxRequiredBytes = static_cast<size_t>(
+            _pPropertyTable->count * fixedLengthArrayCount * sizeof(T));
+      }
+
+      if (values.size() < maxRequiredBytes) {
+        return createInvalidPropertyView<MetadataArrayView<T>>(
+            MetadataPropertyViewStatus::
+                ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+      }
+
+      return MetadataPropertyView<MetadataArrayView<T>>(
+          MetadataPropertyViewStatus::Valid,
+          values,
+          gsl::span<const std::byte>(),
+          gsl::span<const std::byte>(),
+          PropertyComponentType::None,
+          PropertyComponentType::None,
+          static_cast<size_t>(fixedLengthArrayCount),
+          static_cast<size_t>(_pPropertyTable->count),
+          classProperty.normalized);
+    }
+
+    // Handle variable-length arrays
+    const PropertyComponentType arrayOffsetType =
+        convertArrayOffsetTypeStringToPropertyComponentType(
+            propertyTableProperty.arrayOffsetType);
+    if (arrayOffsetType == PropertyComponentType::None) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(
+          MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType);
+    }
+
+    constexpr bool checkBitsSize = IsMetadataBoolean<T>::value;
+    gsl::span<const std::byte> arrayOffsets;
+    status = getArrayOffsetsBufferSafe(
+        propertyTableProperty.arrayOffsets,
+        arrayOffsetType,
+        values.size(),
+        static_cast<size_t>(_pPropertyTable->count),
+        checkBitsSize,
+        arrayOffsets);
+    if (status != MetadataPropertyViewStatus::Valid) {
+      return createInvalidPropertyView<MetadataArrayView<T>>(status);
+    }
+
+    return MetadataPropertyView<MetadataArrayView<T>>(
+        MetadataPropertyViewStatus::Valid,
+        values,
+        arrayOffsets,
+        gsl::span<const std::byte>(),
+        arrayOffsetType,
+        PropertyComponentType::None,
+        0,
+        static_cast<size_t>(_pPropertyTable->count),
+        classProperty.normalized);
+  }
+
+  MetadataPropertyView<MetadataArrayView<std::string_view>>
+  getStringArrayPropertyValues(
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      const ExtensionExtStructuralMetadataPropertyTableProperty&
+          propertyTableProperty) const;
+
+  MetadataPropertyViewStatus getBufferSafe(
+      int32_t bufferView,
+      gsl::span<const std::byte>& buffer) const noexcept;
+
+  MetadataPropertyViewStatus getArrayOffsetsBufferSafe(
+      int32_t arrayOffsetsBufferView,
+      PropertyComponentType arrayOffsetType,
+      size_t valuesBufferSize,
+      size_t propertyTableCount,
+      bool checkBitsSize,
+      gsl::span<const std::byte>& arrayOffsetsBuffer) const noexcept;
+
+  MetadataPropertyViewStatus getStringOffsetsBufferSafe(
+      int32_t stringOffsetsBufferView,
+      PropertyComponentType stringOffsetType,
+      size_t valuesBufferSize,
+      size_t propertyTableCount,
+      gsl::span<const std::byte>& stringOffsetsBuffer) const noexcept;
+
+  template <typename T>
+  static MetadataPropertyView<T>
+  createInvalidPropertyView(MetadataPropertyViewStatus invalidStatus) noexcept {
+    return MetadataPropertyView<T>(
+        invalidStatus,
+        gsl::span<const std::byte>(),
+        gsl::span<const std::byte>(),
+        gsl::span<const std::byte>(),
+        PropertyComponentType::None,
+        PropertyComponentType::None,
+        0,
+        0,
+        false);
+  }
+
+  const Model* _pModel;
+  const ExtensionExtStructuralMetadataPropertyTable* _pPropertyTable;
+  const ExtensionExtStructuralMetadataClass* _pClass;
+};
+
+} // namespace StructuralMetadata
+} // namespace CesiumGltf

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
@@ -115,6 +115,7 @@ public:
       getArrayPropertyViewImpl(
           propertyName,
           *pClassProperty,
+          type,
           componentType,
           std::forward<Callback>(callback));
     } else if (isPropertyTypeVecN(type)) {
@@ -134,6 +135,7 @@ public:
           propertyName,
           *pClassProperty,
           type,
+          componentType,
           std::forward<Callback>(callback));
     }
   }
@@ -165,99 +167,321 @@ public:
   }
 
 private:
+  glm::length_t getDimensionsFromType(PropertyType type) {
+    switch (type) {
+    case PropertyType::Vec2:
+    case PropertyType::Mat2:
+      return 2;
+    case PropertyType::Vec3:
+    case PropertyType::Mat3:
+      return 3;
+    case PropertyType::Vec4:
+    case PropertyType::Mat4:
+      return 4;
+    default:
+      return 0;
+    }
+  }
+
   template <typename Callback>
-  void getArrayPropertyViewImpl(
+  void getScalarArrayPropertyViewImpl(
       const std::string& propertyName,
       const ExtensionExtStructuralMetadataClassProperty& classProperty,
-      StructuralMetadata::PropertyType type,
+      PropertyComponentType componentType,
       Callback&& callback) const {
-    switch (type) {
-    case PropertyType::Int8:
+    switch (componentType) {
+    case PropertyComponentType::Int8:
       callback(
           propertyName,
           getPropertyViewImpl<MetadataArrayView<int8_t>>(
               propertyName,
               classProperty));
       break;
-    case PropertyType::Uint8:
+    case PropertyComponentType::Uint8:
       callback(
           propertyName,
           getPropertyViewImpl<MetadataArrayView<uint8_t>>(
               propertyName,
               classProperty));
       break;
-    case PropertyType::Int16:
+    case PropertyComponentType::Int16:
       callback(
           propertyName,
           getPropertyViewImpl<MetadataArrayView<int16_t>>(
               propertyName,
               classProperty));
       break;
-    case PropertyType::Uint16:
+    case PropertyComponentType::Uint16:
       callback(
           propertyName,
           getPropertyViewImpl<MetadataArrayView<uint16_t>>(
               propertyName,
               classProperty));
       break;
-    case PropertyType::Int32:
+    case PropertyComponentType::Int32:
       callback(
           propertyName,
           getPropertyViewImpl<MetadataArrayView<int32_t>>(
               propertyName,
               classProperty));
       break;
-    case PropertyType::Uint32:
+    case PropertyComponentType::Uint32:
       callback(
           propertyName,
           getPropertyViewImpl<MetadataArrayView<uint32_t>>(
               propertyName,
               classProperty));
       break;
-    case PropertyType::Int64:
+    case PropertyComponentType::Int64:
       callback(
           propertyName,
           getPropertyViewImpl<MetadataArrayView<int64_t>>(
               propertyName,
               classProperty));
       break;
-    case PropertyType::Uint64:
+    case PropertyComponentType::Uint64:
       callback(
           propertyName,
           getPropertyViewImpl<MetadataArrayView<uint64_t>>(
               propertyName,
               classProperty));
       break;
-    case PropertyType::Float32:
+    case PropertyComponentType::Float32:
       callback(
           propertyName,
           getPropertyViewImpl<MetadataArrayView<float>>(
               propertyName,
               classProperty));
       break;
-    case PropertyType::Float64:
+    case PropertyComponentType::Float64:
       callback(
           propertyName,
           getPropertyViewImpl<MetadataArrayView<double>>(
               propertyName,
               classProperty));
       break;
-    case PropertyType::Boolean:
+    default:
+      break;
+    }
+  }
+
+  template <typename Callback>
+  void getVecNArrayPropertyViewImpl(
+      const std::string& propertyName,
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      PropertyType type,
+      PropertyComponentType componentType,
+      Callback&& callback) const {
+    glm::length_t N = getDimensionsFromType(type);
+    if (N <= 1) {
+      return;
+    }
+
+    switch (componentType) {
+    case PropertyComponentType::Int8:
       callback(
           propertyName,
-          getPropertyViewImpl<MetadataArrayView<bool>>(
+          getPropertyViewImpl<MetadataArrayView<glm::vec<N, int8_t>>>(
               propertyName,
               classProperty));
       break;
-    case PropertyType::String:
+    case PropertyComponentType::Uint8:
       callback(
           propertyName,
-          getPropertyViewImpl<MetadataArrayView<std::string_view>>(
+          getPropertyViewImpl<MetadataArrayView<glm::vec<N, uint8_t>>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Int16:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::vec<N, int16_t>>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Uint16:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::vec<N, uint16_t>>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Int32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::vec<N, int32_t>>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Uint32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::vec<N, uint32_t>>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Int64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::vec<N, int64_t>>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Uint64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::vec<N, uint64_t>>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Float32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::vec<N, float>>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Float64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::vec<N, double>>>(
               propertyName,
               classProperty));
       break;
     default:
       break;
+    }
+  }
+
+  template <typename Callback>
+  void getMatNArrayPropertyViewImpl(
+      const std::string& propertyName,
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      PropertyType type,
+      PropertyComponentType componentType,
+      Callback&& callback) const {
+    glm::length_t N = getDimensionsFromType(type);
+    if (N <= 1) {
+      return;
+    }
+
+    switch (componentType) {
+    case PropertyComponentType::Int8:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::mat<N, N, int8_t>>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Uint8:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::mat<N, N, uint8_t>>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Int16:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::mat<N, N, int16_t>>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Uint16:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::mat<N, N, uint16_t>>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Int32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::mat<N, N, int32_t>>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Uint32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::mat<N, N, uint32_t>>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Int64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::mat<N, N, int64_t>>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Uint64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::mat<N, N, uint64_t>>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Float32:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::mat<N, N, float>>>(
+              propertyName,
+              classProperty));
+      break;
+    case PropertyComponentType::Float64:
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<glm::mat<N, N, double>>>(
+              propertyName,
+              classProperty));
+      break;
+    default:
+      break;
+    }
+  }
+
+  template <typename Callback>
+  void getArrayPropertyViewImpl(
+      const std::string& propertyName,
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      PropertyType type,
+      PropertyComponentType componentType,
+      Callback&& callback) const {
+    if (type == PropertyType::Scalar) {
+      getScalarArrayPropertyViewImpl(
+          propertyName,
+          classProperty,
+          componentType,
+          std::forward<Callback>(callback))
+    } else if (isPropertyTypeVecN(type)) {
+      getVecNArrayPropertyViewImpl(
+          propertyName,
+          classProperty,
+          type,
+          componentType,
+          std::forward<Callback>(callback));
+    } else if (isPropertyTypeMatN(type)) {
+      getMatNArrayPropertyViewImpl(
+          propertyName,
+          classProperty,
+          type,
+          componentType,
+          std::forward<Callback>(callback));
+
+    } else if (type == PropertyType::Boolean) {
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<bool>>(
+              propertyName,
+              classProperty));
+
+    } else if (type == PropertyType::String) {
+      callback(
+          propertyName,
+          getPropertyViewImpl<MetadataArrayView<std::string_view>>(
+              propertyName,
+              classProperty));
     }
   }
 
@@ -269,18 +493,8 @@ private:
       PropertyType type,
       PropertyComponentType componentType,
       Callback&& callback) {
-    glm::length_t N;
-    switch (type) {
-    case PropertyType::Vec2:
-      N = 2;
-      break;
-    case PropertyType::Vec3:
-      N = 3;
-      break;
-    case PropertyType::Vec4:
-      N = 4;
-      break;
-    default:
+    glm::length_t N = getDimensionsFromType(type);
+    if (N <= 1) {
       return;
     }
 
@@ -366,18 +580,8 @@ private:
       PropertyType type,
       PropertyComponentType componentType,
       Callback&& callback) {
-    glm::length_t N;
-    switch (type) {
-    case PropertyType::Mat2:
-      N = 2;
-      break;
-    case PropertyType::Mat3:
-      N = 3;
-      break;
-    case PropertyType::Mat4:
-      N = 4;
-      break;
-    default:
+    glm::length_t N = getDimensionsFromType(type);
+    if (N <= 1) {
       return;
     }
 
@@ -461,71 +665,72 @@ private:
       const ExtensionExtStructuralMetadataClassProperty& classProperty,
       const ExtensionExtStructuralMetadataPropertyTableProperty&
           propertyTableProperty,
-      PropertyComponentType type,
+      PropertyType type,
+      PropertyComponentType componentType,
       Callback&& callback) const {
-    switch (type) {
-    case PropertyType::Int8:
-      callback(
-          propertyName,
-          getPropertyViewImpl<int8_t>(propertyName, classProperty));
-      break;
-    case PropertyType::Uint8:
-      callback(
-          propertyName,
-          getPropertyViewImpl<uint8_t>(propertyName, classProperty));
-      break;
-    case PropertyType::Int16:
-      callback(
-          propertyName,
-          getPropertyViewImpl<int16_t>(propertyName, classProperty));
-      break;
-    case PropertyType::Uint16:
-      callback(
-          propertyName,
-          getPropertyViewImpl<uint16_t>(propertyName, classProperty));
-      break;
-    case PropertyType::Int32:
-      callback(
-          propertyName,
-          getPropertyViewImpl<int32_t>(propertyName, classProperty));
-      break;
-    case PropertyType::Uint32:
-      callback(
-          propertyName,
-          getPropertyViewImpl<uint32_t>(propertyName, classProperty));
-      break;
-    case PropertyType::Int64:
-      callback(
-          propertyName,
-          getPropertyViewImpl<int64_t>(propertyName, classProperty));
-      break;
-    case PropertyType::Uint64:
-      callback(
-          propertyName,
-          getPropertyViewImpl<uint64_t>(propertyName, classProperty));
-      break;
-    case PropertyType::Float32:
-      callback(
-          propertyName,
-          getPropertyViewImpl<float>(propertyName, classProperty));
-      break;
-    case PropertyType::Float64:
-      callback(
-          propertyName,
-          getPropertyViewImpl<double>(propertyName, classProperty));
-      break;
-    case PropertyType::Boolean:
-      callback(
-          propertyName,
-          getPropertyViewImpl<bool>(propertyName, classProperty));
-      break;
-    case PropertyType::String:
+    if (type == PropertyType::Scalar) {
+      switch (componentType) {
+      case PropertyComponentType::Int8:
+        callback(
+            propertyName,
+            getPropertyViewImpl<int8_t>(propertyName, classProperty));
+        break;
+      case PropertyComponentType::Uint8:
+        callback(
+            propertyName,
+            getPropertyViewImpl<uint8_t>(propertyName, classProperty));
+        break;
+      case PropertyComponentType::Int16:
+        callback(
+            propertyName,
+            getPropertyViewImpl<int16_t>(propertyName, classProperty));
+        break;
+      case PropertyComponentType::Uint16:
+        callback(
+            propertyName,
+            getPropertyViewImpl<uint16_t>(propertyName, classProperty));
+        break;
+      case PropertyComponentType::Int32:
+        callback(
+            propertyName,
+            getPropertyViewImpl<int32_t>(propertyName, classProperty));
+        break;
+      case PropertyComponentType::Uint32:
+        callback(
+            propertyName,
+            getPropertyViewImpl<uint32_t>(propertyName, classProperty));
+        break;
+      case PropertyComponentType::Int64:
+        callback(
+            propertyName,
+            getPropertyViewImpl<int64_t>(propertyName, classProperty));
+        break;
+      case PropertyComponentType::Uint64:
+        callback(
+            propertyName,
+            getPropertyViewImpl<uint64_t>(propertyName, classProperty));
+        break;
+      case PropertyComponentType::Float32:
+        callback(
+            propertyName,
+            getPropertyViewImpl<float>(propertyName, classProperty));
+        break;
+      case PropertyComponentType::Float64:
+        callback(
+            propertyName,
+            getPropertyViewImpl<double>(propertyName, classProperty));
+        break;
+      default:
+        break;
+      }
+    } else if (type == PropertyType::String) {
       callback(
           propertyName,
           getPropertyViewImpl<std::string_view>(propertyName, classProperty));
-      break;
-    default:
-      break;
+    } else if (type == PropertyType::Boolean) {
+      callback(
+          propertyName,
+          getPropertyViewImpl<bool>(propertyName, classProperty));
     }
   }
 
@@ -567,7 +772,7 @@ private:
   }
 
   template <typename T>
-  StructuralMetadata::MetadataPropertyView<T> getNumericOrBooleanPropertyValues(
+  MetadataPropertyView<T> getNumericOrBooleanPropertyValues(
       const ExtensionExtStructuralMetadataClassProperty& classProperty,
       const ExtensionExtStructuralMetadataPropertyTableProperty&
           propertyTableProperty) const {

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
@@ -366,21 +366,21 @@ private:
           propertyName,
           classProperty,
           componentType,
-          callback);
+          std::forward<Callback>(callback));
       break;
     case 3:
       getVecNArrayPropertyViewImpl<Callback, 3>(
           propertyName,
           classProperty,
           componentType,
-          callback);
+          std::forward<Callback>(callback));
       break;
     case 4:
       getVecNArrayPropertyViewImpl<Callback, 4>(
           propertyName,
           classProperty,
           componentType,
-          callback);
+          std::forward<Callback>(callback));
       break;
     default:
       break;
@@ -483,21 +483,21 @@ private:
           propertyName,
           classProperty,
           componentType,
-          callback);
+          std::forward<Callback>(callback));
       break;
     case 3:
       getMatNArrayPropertyViewImpl<Callback, 3>(
           propertyName,
           classProperty,
           componentType,
-          callback);
+          std::forward<Callback>(callback));
       break;
     case 4:
       getMatNArrayPropertyViewImpl<Callback, 4>(
           propertyName,
           classProperty,
           componentType,
-          callback);
+          std::forward<Callback>(callback));
       break;
     default:
       break;
@@ -643,21 +643,21 @@ private:
           propertyName,
           classProperty,
           componentType,
-          callback);
+          std::forward<Callback>(callback));
       break;
     case 3:
       getVecNPropertyViewImpl<Callback, 3>(
           propertyName,
           classProperty,
           componentType,
-          callback);
+          std::forward<Callback>(callback));
       break;
     case 4:
       getVecNPropertyViewImpl<Callback, 4>(
           propertyName,
           classProperty,
           componentType,
-          callback);
+          std::forward<Callback>(callback));
       break;
     default:
       break;
@@ -723,7 +723,7 @@ private:
     case PropertyComponentType::Uint64:
       callback(
           propertyName,
-          getPropertyViewImp<glm::mat<N, N, uint64_t>>(
+          getPropertyViewImpl<glm::mat<N, N, uint64_t>>(
               propertyName,
               classProperty));
       break;
@@ -760,21 +760,21 @@ private:
           propertyName,
           classProperty,
           componentType,
-          callback);
+          std::forward<Callback>(callback));
       break;
     case 3:
       getMatNPropertyViewImpl<Callback, 3>(
           propertyName,
           classProperty,
           componentType,
-          callback);
+          std::forward<Callback>(callback));
       break;
     case 4:
       getMatNPropertyViewImpl<Callback, 4>(
           propertyName,
           classProperty,
           componentType,
-          callback);
+          std::forward<Callback>(callback));
       break;
     default:
       break;

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
@@ -156,6 +156,15 @@ public:
   template <typename Callback>
   void
   getPropertyView(const std::string& propertyName, Callback&& callback) const {
+    if (this->size() <= 0) {
+      callback(
+          propertyName,
+          createInvalidPropertyView<uint8_t>(
+              StructuralMetadata::MetadataPropertyViewStatus::
+                  ErrorInvalidPropertyTable));
+      return;
+    }
+
     const ExtensionExtStructuralMetadataClassProperty* pClassProperty =
         getClassProperty(propertyName);
     if (!pClassProperty) {

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
@@ -14,32 +14,29 @@ namespace StructuralMetadata {
 
 /**
  * @brief Utility to retrieve the data of
- * ExtensionExtStructuralMetadataPropertyTable.
+ * {@link ExtensionExtStructuralMetadataPropertyTable}.
  *
  * This should be used to get a {@link MetadataPropertyView} of a property in the property table.
  * It will validate the EXT_structural_metadata format and ensure {@link MetadataPropertyView}
  * does not access out of bounds.
  */
-
 class MetadataPropertyTableView {
 public:
   /**
    * @brief Creates an instance of MetadataPropertyTableView.
-   * @param pModel A pointer to the Gltf Model that contains property table
-   * data.
-   * @param pPropertyTable A pointer to the
-   * ExtensionExtStructuralMetadataPropertyTable from which the view will
-   * retrieve data.
+   * @param model The Gltf Model that contains property table data.
+   * @param propertyTable The {@link ExtensionExtStructuralMetadataPropertyTable}
+   * from which the view will retrieve data.
    */
   MetadataPropertyTableView(
-      const Model* pModel,
-      const ExtensionExtStructuralMetadataPropertyTable* pPropertyTable);
+      const Model& model,
+      const ExtensionExtStructuralMetadataPropertyTable& propertyTable);
 
   /**
    * @brief Finds the {@link ExtensionExtStructuralMetadataClassProperty} that
    * describes the type information of the property with the specified name.
    * @param propertyName The name of the property to retrieve the class for.
-   * @return A pointer to the ExtensionExtStructuralMetadataClassProperty.
+   * @return A pointer to the {@link ExtensionExtStructuralMetadataClassProperty}.
    * Return nullptr if no property was found.
    */
   const ExtensionExtStructuralMetadataClassProperty*
@@ -64,7 +61,7 @@ public:
   template <typename T>
   MetadataPropertyView<T>
   getPropertyView(const std::string& propertyName) const {
-    if (_pPropertyTable->count <= 0) {
+    if (_propertyTable.count <= 0) {
       return createInvalidPropertyView<T>(
           StructuralMetadata::MetadataPropertyViewStatus::
               ErrorPropertyDoesNotExist);
@@ -82,23 +79,23 @@ public:
   }
 
   /**
-   * @brief Gets a MetadataPropertyView through a callback that accepts a
-   * property name and a MetadataPropertyView<T> that views the data
+   * @brief Gets a {@link MetadataPropertyView} through a callback that accepts a
+   * property name and a {@link MetadataPropertyView<T>} that views the data
    * of the property with the specified name.
    *
    * This method will validate the EXT_structural_metadata format to ensure
-   * MetadataPropertyView retrieves the correct data. T must be one of the
+   * {@link MetadataPropertyView} retrieves the correct data. T must be one of the
    * following: a scalar (uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t,
    * uint64_t, int64_t, float, double), a glm vecN composed of one of the scalar
    * types, a glm matN composed of one of the scalar types, bool,
-   * std::string_view, or MetadataArrayView<T> with T as one of the
+   * std::string_view, or {@link MetadataArrayView<T>} with T as one of the
    * aforementioned types. If the property is invalid, an empty
-   * MetadataPropertyView with an error status will be passed to the
+   * {@link MetadataPropertyView} with an error status will be passed to the
    * callback. Otherwise, a valid property view will be passed to the callback.
    *
    * @param propertyName The name of the property to retrieve data from
    * @tparam callback A callback function that accepts a property name and a
-   * MetadataPropertyView<T>
+   * {@link MetadataPropertyView<T>}
    */
   template <typename Callback>
   void
@@ -161,24 +158,24 @@ public:
 
   /**
    * @brief Iterates over each property in the
-   * ExtensionExtStructuralMetadataPropertyTable with a callback that accepts a
-   * property name and a MetadataPropertyView<T> to view the data
-   * stored in the ExtensionExtStructuralMetadataPropertyTableProperty.
+   * {@link ExtensionExtStructuralMetadataPropertyTable} with a callback that accepts a
+   * property name and a {@link MetadataPropertyView<T>} to view the data
+   * stored in the {@link ExtensionExtStructuralMetadataPropertyTableProperty}.
    *
    * This method will validate the EXT_structural_metadata format to ensure
-   * MetadataPropertyView retrieves the correct data. T must be one of the
+   * {@link MetadataPropertyView} retrieves the correct data. T must be one of the
    * following: a scalar (uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t,
    * uint64_t, int64_t, float, double), a glm vecN composed of one of the scalar
    * types, a glm matN composed of one of the scalar types, bool,
-   * std::string_view, or MetadataArrayView<T> with T as one of the
+   * std::string_view, or {@link MetadataArrayView<T>} with T as one of the
    * aforementioned types. If the property is invalid, an empty
-   * MetadataPropertyView with an error status code will be passed to the
+   * {@link MetadataPropertyView} with an error status code will be passed to the
    * callback. Otherwise, a valid property view will be passed to
    * the callback.
    *
    * @param propertyName The name of the property to retrieve data from
    * @tparam callback A callback function that accepts property name and
-   * MetadataPropertyView<T>
+   * {@link MetadataPropertyView<T>}
    */
   template <typename Callback> void forEachProperty(Callback&& callback) const {
     for (const auto& property : this->_pClass->properties) {
@@ -907,8 +904,8 @@ private:
       const std::string& propertyName,
       const ExtensionExtStructuralMetadataClassProperty& classProperty) const {
     auto propertyTablePropertyIter =
-        _pPropertyTable->properties.find(propertyName);
-    if (propertyTablePropertyIter == _pPropertyTable->properties.end()) {
+        _propertyTable.properties.find(propertyName);
+    if (propertyTablePropertyIter == _propertyTable.properties.end()) {
       return createInvalidPropertyView<T>(
           MetadataPropertyViewStatus::ErrorPropertyDoesNotExist);
     }
@@ -977,9 +974,9 @@ private:
     size_t maxRequiredBytes = 0;
     if (IsMetadataBoolean<T>::value) {
       maxRequiredBytes = static_cast<size_t>(
-          glm::ceil(static_cast<double>(_pPropertyTable->count) / 8.0));
+          glm::ceil(static_cast<double>(_propertyTable.count) / 8.0));
     } else {
-      maxRequiredBytes = _pPropertyTable->count * sizeof(T);
+      maxRequiredBytes = _propertyTable.count * sizeof(T);
     }
 
     if (values.size() < maxRequiredBytes) {
@@ -991,7 +988,7 @@ private:
     return MetadataPropertyView<T>(
         MetadataPropertyViewStatus::Valid,
         values,
-        _pPropertyTable->count,
+        _propertyTable.count,
         classProperty.normalized);
   }
 
@@ -1052,12 +1049,11 @@ private:
       size_t maxRequiredBytes = 0;
       if constexpr (IsMetadataBoolean<T>::value) {
         maxRequiredBytes = static_cast<size_t>(glm::ceil(
-            static_cast<double>(
-                _pPropertyTable->count * fixedLengthArrayCount) /
+            static_cast<double>(_propertyTable.count * fixedLengthArrayCount) /
             8.0));
       } else {
         maxRequiredBytes = static_cast<size_t>(
-            _pPropertyTable->count * fixedLengthArrayCount * sizeof(T));
+            _propertyTable.count * fixedLengthArrayCount * sizeof(T));
       }
 
       if (values.size() < maxRequiredBytes) {
@@ -1074,7 +1070,7 @@ private:
           PropertyComponentType::None,
           PropertyComponentType::None,
           static_cast<size_t>(fixedLengthArrayCount),
-          static_cast<size_t>(_pPropertyTable->count),
+          static_cast<size_t>(_propertyTable.count),
           classProperty.normalized);
     }
 
@@ -1093,7 +1089,7 @@ private:
         propertyTableProperty.arrayOffsets,
         arrayOffsetType,
         values.size(),
-        static_cast<size_t>(_pPropertyTable->count),
+        static_cast<size_t>(_propertyTable.count),
         checkBitsSize,
         arrayOffsets);
     if (status != MetadataPropertyViewStatus::Valid) {
@@ -1108,7 +1104,7 @@ private:
         arrayOffsetType,
         PropertyComponentType::None,
         0,
-        static_cast<size_t>(_pPropertyTable->count),
+        static_cast<size_t>(_propertyTable.count),
         classProperty.normalized);
   }
 
@@ -1147,8 +1143,8 @@ private:
         false);
   }
 
-  const Model* _pModel;
-  const ExtensionExtStructuralMetadataPropertyTable* _pPropertyTable;
+  const Model& _model;
+  const ExtensionExtStructuralMetadataPropertyTable& _propertyTable;
   const ExtensionExtStructuralMetadataClass* _pClass;
 };
 

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
@@ -125,12 +125,14 @@ public:
       getVecNPropertyViewImpl(
           propertyName,
           *pClassProperty,
+          type,
           componentType,
           std::forward<Callback>(callback));
     } else if (isPropertyTypeMatN(type)) {
       getMatNPropertyViewImpl(
           propertyName,
           *pClassProperty,
+          type,
           componentType,
           std::forward<Callback>(callback));
     } else {
@@ -268,18 +270,12 @@ private:
     }
   }
 
-  template <typename Callback>
+  template <typename Callback, glm::length_t N>
   void getVecNArrayPropertyViewImpl(
       const std::string& propertyName,
       const ExtensionExtStructuralMetadataClassProperty& classProperty,
-      PropertyType type,
       PropertyComponentType componentType,
       Callback&& callback) const {
-    glm::length_t N = getDimensionsFromType(type);
-    if (N <= 1) {
-      return;
-    }
-
     switch (componentType) {
     case PropertyComponentType::Int8:
       callback(
@@ -357,17 +353,46 @@ private:
   }
 
   template <typename Callback>
-  void getMatNArrayPropertyViewImpl(
+  void getVecNArrayPropertyViewImpl(
       const std::string& propertyName,
       const ExtensionExtStructuralMetadataClassProperty& classProperty,
       PropertyType type,
       PropertyComponentType componentType,
       Callback&& callback) const {
-    const glm::length_t N = getDimensionsFromType(type);
-    if (N <= 1) {
-      return;
+    glm::length_t N = getDimensionsFromType(type);
+    switch (N) {
+    case 2:
+      getVecNArrayPropertyViewImpl<Callback, 2>(
+          propertyName,
+          classProperty,
+          componentType,
+          callback);
+      break;
+    case 3:
+      getVecNArrayPropertyViewImpl<Callback, 3>(
+          propertyName,
+          classProperty,
+          componentType,
+          callback);
+      break;
+    case 4:
+      getVecNArrayPropertyViewImpl<Callback, 4>(
+          propertyName,
+          classProperty,
+          componentType,
+          callback);
+      break;
+    default:
+      break;
     }
+  }
 
+  template <typename Callback, glm::length_t N>
+  void getMatNArrayPropertyViewImpl(
+      const std::string& propertyName,
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      PropertyComponentType componentType,
+      Callback&& callback) const {
     switch (componentType) {
     case PropertyComponentType::Int8:
       callback(
@@ -445,6 +470,41 @@ private:
   }
 
   template <typename Callback>
+  void getMatNArrayPropertyViewImpl(
+      const std::string& propertyName,
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      PropertyType type,
+      PropertyComponentType componentType,
+      Callback&& callback) const {
+    const glm::length_t N = getDimensionsFromType(type);
+    switch (N) {
+    case 2:
+      getMatNArrayPropertyViewImpl<Callback, 2>(
+          propertyName,
+          classProperty,
+          componentType,
+          callback);
+      break;
+    case 3:
+      getMatNArrayPropertyViewImpl<Callback, 3>(
+          propertyName,
+          classProperty,
+          componentType,
+          callback);
+      break;
+    case 4:
+      getMatNArrayPropertyViewImpl<Callback, 4>(
+          propertyName,
+          classProperty,
+          componentType,
+          callback);
+      break;
+    default:
+      break;
+    }
+  }
+
+  template <typename Callback>
   void getArrayPropertyViewImpl(
       const std::string& propertyName,
       const ExtensionExtStructuralMetadataClassProperty& classProperty,
@@ -488,19 +548,12 @@ private:
     }
   }
 
-  template <typename Callback>
+  template <typename Callback, glm::length_t N>
   void getVecNPropertyViewImpl(
       const std::string& propertyName,
       const ExtensionExtStructuralMetadataClassProperty& classProperty,
-      const ExtensionExtStructuralMetadataPropertyTableProperty&
-          propertyTableProperty,
-      PropertyType type,
       PropertyComponentType componentType,
-      Callback&& callback) {
-    const glm::length_t N = getDimensionsFromType(type);
-    if (N <= 1) {
-      return;
-    }
+      Callback&& callback) const {
 
     switch (componentType) {
     case PropertyComponentType::Int8:
@@ -577,25 +630,53 @@ private:
   }
 
   template <typename Callback>
+  void getVecNPropertyViewImpl(
+      const std::string& propertyName,
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      PropertyType type,
+      PropertyComponentType componentType,
+      Callback&& callback) const {
+    const glm::length_t N = getDimensionsFromType(type);
+    switch (N) {
+    case 2:
+      getVecNPropertyViewImpl<Callback, 2>(
+          propertyName,
+          classProperty,
+          componentType,
+          callback);
+      break;
+    case 3:
+      getVecNPropertyViewImpl<Callback, 3>(
+          propertyName,
+          classProperty,
+          componentType,
+          callback);
+      break;
+    case 4:
+      getVecNPropertyViewImpl<Callback, 4>(
+          propertyName,
+          classProperty,
+          componentType,
+          callback);
+      break;
+    default:
+      break;
+    }
+  }
+
+  template <typename Callback, glm::length_t N>
   void getMatNPropertyViewImpl(
       const std::string& propertyName,
       const ExtensionExtStructuralMetadataClassProperty& classProperty,
-      const ExtensionExtStructuralMetadataPropertyTableProperty&
-          propertyTableProperty,
-      PropertyType type,
       PropertyComponentType componentType,
-      Callback&& callback) {
-    glm::length_t N = getDimensionsFromType(type);
-    if (N <= 1) {
-      return;
-    }
-
+      Callback&& callback) const {
     switch (componentType) {
     case PropertyComponentType::Int8:
       callback(
           propertyName,
-          getPropertyViewImpl <
-              glm::mat<N, N, int8_t>(propertyName, classProperty));
+          getPropertyViewImpl<glm::mat<N, N, int8_t>>(
+              propertyName,
+              classProperty));
       break;
     case PropertyComponentType::Uint8:
       callback(
@@ -666,10 +747,44 @@ private:
   }
 
   template <typename Callback>
-  void getPrimitivePropertyViewImpl(
+  void getMatNPropertyViewImpl(
+      const std::string& propertyName,
       const ExtensionExtStructuralMetadataClassProperty& classProperty,
-      const ExtensionExtStructuralMetadataPropertyTableProperty&
-          propertyTableProperty,
+      PropertyType type,
+      PropertyComponentType componentType,
+      Callback&& callback) const {
+    glm::length_t N = getDimensionsFromType(type);
+    switch (N) {
+    case 2:
+      getMatNPropertyViewImpl<Callback, 2>(
+          propertyName,
+          classProperty,
+          componentType,
+          callback);
+      break;
+    case 3:
+      getMatNPropertyViewImpl<Callback, 3>(
+          propertyName,
+          classProperty,
+          componentType,
+          callback);
+      break;
+    case 4:
+      getMatNPropertyViewImpl<Callback, 4>(
+          propertyName,
+          classProperty,
+          componentType,
+          callback);
+      break;
+    default:
+      break;
+    }
+  }
+
+  template <typename Callback>
+  void getPrimitivePropertyViewImpl(
+      const std::string& propertyName,
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
       PropertyType type,
       PropertyComponentType componentType,
       Callback&& callback) const {

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
@@ -108,8 +108,11 @@ public:
     }
 
     PropertyType type = convertStringToPropertyType(pClassProperty->type);
-    PropertyComponentType componentType =
-        convertStringToPropertyType(pClassProperty->componentType);
+    PropertyComponentType componentType = PropertyComponentType::None;
+    if (pClassProperty->componentType) {
+      componentType =
+          convertStringToPropertyComponentType(*pClassProperty->componentType);
+    }
 
     if (pClassProperty->array) {
       getArrayPropertyViewImpl(
@@ -167,7 +170,7 @@ public:
   }
 
 private:
-  glm::length_t getDimensionsFromType(PropertyType type) {
+  glm::length_t getDimensionsFromType(PropertyType type) const {
     switch (type) {
     case PropertyType::Vec2:
     case PropertyType::Mat2:
@@ -360,7 +363,7 @@ private:
       PropertyType type,
       PropertyComponentType componentType,
       Callback&& callback) const {
-    glm::length_t N = getDimensionsFromType(type);
+    const glm::length_t N = getDimensionsFromType(type);
     if (N <= 1) {
       return;
     }
@@ -453,7 +456,7 @@ private:
           propertyName,
           classProperty,
           componentType,
-          std::forward<Callback>(callback))
+          std::forward<Callback>(callback));
     } else if (isPropertyTypeVecN(type)) {
       getVecNArrayPropertyViewImpl(
           propertyName,
@@ -487,13 +490,14 @@ private:
 
   template <typename Callback>
   void getVecNPropertyViewImpl(
+      const std::string& propertyName,
       const ExtensionExtStructuralMetadataClassProperty& classProperty,
       const ExtensionExtStructuralMetadataPropertyTableProperty&
           propertyTableProperty,
       PropertyType type,
       PropertyComponentType componentType,
       Callback&& callback) {
-    glm::length_t N = getDimensionsFromType(type);
+    const glm::length_t N = getDimensionsFromType(type);
     if (N <= 1) {
       return;
     }
@@ -574,6 +578,7 @@ private:
 
   template <typename Callback>
   void getMatNPropertyViewImpl(
+      const std::string& propertyName,
       const ExtensionExtStructuralMetadataClassProperty& classProperty,
       const ExtensionExtStructuralMetadataPropertyTableProperty&
           propertyTableProperty,

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyType.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyType.h
@@ -51,5 +51,9 @@ convertArrayOffsetTypeStringToPropertyComponentType(const std::string& str);
 PropertyComponentType
 convertStringOffsetTypeStringToPropertyComponentType(const std::string& str);
 
+bool isPropertyTypeVecN(PropertyType type);
+
+bool isPropertyTypeMatN(PropertyType type);
+
 } // namespace StructuralMetadata
 } // namespace CesiumGltf

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyView.h
@@ -178,6 +178,30 @@ public:
         _normalized{} {}
 
   /**
+   * @brief Construct a new instance pointing to non-array data specified by
+   * ExtensionExtStructuralMetadataPropertyTableProperty.
+   * @param values The raw buffer specified by {@link ExtensionExtStructuralMetadataPropertyTableProperty::values}
+   * @param size The number of elements in the property table specified by {@link ExtensionExtStructuralMetadataPropertyTable::count}
+   * @param normalized Whether this property has a normalized integer type.
+   */
+  MetadataPropertyView(
+      MetadataPropertyViewStatus status,
+      gsl::span<const std::byte> values,
+      int64_t size,
+      bool normalized) noexcept
+      : _status{status},
+        _values{values},
+        _arrayOffsets{},
+        _arrayOffsetType{PropertyComponentType::None},
+        _arrayOffsetTypeSize{0},
+        _stringOffsets{},
+        _stringOffsetType{PropertyComponentType::None},
+        _stringOffsetTypeSize{0},
+        _fixedLengthArrayCount{0},
+        _size{size},
+        _normalized{normalized} {}
+
+  /**
    * @brief Construct a new instance pointing to the data specified by
    * ExtensionExtStructuralMetadataPropertyTableProperty.
    * @param values The raw buffer specified by {@link ExtensionExtStructuralMetadataPropertyTableProperty::values}

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyView.h
@@ -31,7 +31,7 @@ enum class MetadataPropertyViewStatus {
 
   /**
    * @brief This property view does not exist in the
-   * ExtensionExtStructuralMetadataPropertyTable.
+   * {@link ExtensionExtStructuralMetadataPropertyTable}.
    */
   ErrorPropertyDoesNotExist,
 
@@ -153,7 +153,7 @@ enum class MetadataPropertyViewStatus {
 
 /**
  * @brief A view on the data of the
- * ExtensionExtStructuralMetadataPropertyTableProperty
+ * {@link ExtensionExtStructuralMetadataPropertyTableProperty}
  *
  * It provides utility to retrieve the actual data stored in the
  * {@link ExtensionExtStructuralMetadataPropertyTableProperty::values} like an array of elements.
@@ -179,7 +179,7 @@ public:
 
   /**
    * @brief Construct a new instance pointing to non-array data specified by
-   * ExtensionExtStructuralMetadataPropertyTableProperty.
+   * {@link ExtensionExtStructuralMetadataPropertyTableProperty}.
    * @param values The raw buffer specified by {@link ExtensionExtStructuralMetadataPropertyTableProperty::values}
    * @param size The number of elements in the property table specified by {@link ExtensionExtStructuralMetadataPropertyTable::count}
    * @param normalized Whether this property has a normalized integer type.
@@ -203,7 +203,7 @@ public:
 
   /**
    * @brief Construct a new instance pointing to the data specified by
-   * ExtensionExtStructuralMetadataPropertyTableProperty.
+   * {@link ExtensionExtStructuralMetadataPropertyTableProperty}.
    * @param values The raw buffer specified by {@link ExtensionExtStructuralMetadataPropertyTableProperty::values}
    * @param arrayOffsets The raw buffer specified by {@link ExtensionExtStructuralMetadataPropertyTableProperty::arrayOffsets}
    * @param stringOffsets The raw buffer specified by {@link ExtensionExtStructuralMetadataPropertyTableProperty::stringOffsets}
@@ -244,7 +244,7 @@ public:
   MetadataPropertyViewStatus status() const noexcept { return _status; }
 
   /**
-   * @brief Get the value of an element of the FeatureTable.
+   * @brief Get the value of an element of the {@link ExtensionExtStructuralMetadataPropertyTable}.
    * @param index The element index
    * @return The value of the element
    */
@@ -286,10 +286,10 @@ public:
 
   /**
    * @brief Get the number of elements in the
-   * ExtensionExtStructuralMetadataPropertyTable.
+   * {@link ExtensionExtStructuralMetadataPropertyTable}.
    *
    * @return The number of elements in the
-   * ExtensionExtStructuralMetadataPropertyTable.
+   * {@link ExtensionExtStructuralMetadataPropertyTable}.
    */
   int64_t size() const noexcept { return _size; }
 

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyView.h
@@ -231,7 +231,8 @@ public:
     assert(
         size() > 0 &&
         "Check the size() of the view to make sure it's not empty");
-    assert(index >= 0 && "index must be positive");
+    assert(index >= 0 && "index must be non-negative");
+    assert(index < size() && "index must be less than size");
 
     if constexpr (IsMetadataNumeric<ElementType>::value) {
       return getNumericValue(index);

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyView.h
@@ -17,17 +17,23 @@ namespace StructuralMetadata {
 /**
  * @brief Indicates the status of a property view.
  *
- * The {@link MetadataPropertyView} constructor always completes successfully. However,
- * it may not always reflect the actual content of the {@link ExtensionExtStructuralMetadataPropertyTableProperty}, but
- * instead indicate that its {@link MetadataPropertyView::size} is 0. This enumeration
+ * The {@link MetadataPropertyView} constructor always completes successfully.
+ * However, it may not always reflect the actual content of the
+ * {@link ExtensionExtStructuralMetadataPropertyTableProperty}, but instead
+ * indicate that its {@link MetadataPropertyView::size} is 0. This enumeration
  * provides the reason.
  */
-
 enum class MetadataPropertyViewStatus {
   /**
    * @brief This property view is valid and ready to use.
    */
   Valid,
+
+  /**
+   * @brief This property view was attempting to view an invalid
+   * {@link ExtensionExtStructuralMetadataPropertyTable}.
+   */
+  ErrorInvalidPropertyTable,
 
   /**
    * @brief This property view does not exist in the
@@ -153,11 +159,12 @@ enum class MetadataPropertyViewStatus {
 
 /**
  * @brief A view on the data of the
- * {@link ExtensionExtStructuralMetadataPropertyTableProperty}
+ * {@link ExtensionExtStructuralMetadataPropertyTableProperty that is created by
+ * a {@link MetadataPropertyTableView}.
  *
  * It provides utility to retrieve the actual data stored in the
  * {@link ExtensionExtStructuralMetadataPropertyTableProperty::values} like an array of elements.
- * Data of each instance can be accessed through the {@link get(int64_t instance)} method
+ * Data of each instance can be accessed through the {@link get(int64_t instance)} method.
  *
  * @param ElementType must be one of the following: a scalar (uint8_t, int8_t,
  * uint16_t, int16_t, uint32_t, int32_t, uint64_t, int64_t, float, double), a
@@ -240,6 +247,8 @@ public:
    *
    * Indicates whether the view accurately reflects the property's data, or
    * whether an error occurred.
+   *
+   * @return The status of this property view.
    */
   MetadataPropertyViewStatus status() const noexcept { return _status; }
 
@@ -285,13 +294,15 @@ public:
   }
 
   /**
-   * @brief Get the number of elements in the
-   * {@link ExtensionExtStructuralMetadataPropertyTable}.
+   * @brief Get the number of elements in this MetadataPropertyView. If the view
+   * is valid, this returns
+   * {@link ExtensionExtStructuralMetadataPropertyTable::count}. Otherwise, this returns 0.
    *
-   * @return The number of elements in the
-   * {@link ExtensionExtStructuralMetadataPropertyTable}.
+   * @return The number of elements in this MetadataPropertyView.
    */
-  int64_t size() const noexcept { return _size; }
+  int64_t size() const noexcept {
+    return status() == MetadataPropertyViewStatus::Valid ? _size : 0;
+  }
 
   /**
    * @brief Get the element count of the fixed-length arrays in this property.

--- a/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
+++ b/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
@@ -420,7 +420,6 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         MetadataPropertyViewStatus::ErrorInvalidArrayOffsetBufferView);
   }
 
-
   // Handle variable-length arrays
   gsl::span<const std::byte> stringOffsets;
   status = getBufferSafe(propertyTableProperty.stringOffsets, stringOffsets);

--- a/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
+++ b/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
@@ -115,7 +115,6 @@ MetadataPropertyTableView::MetadataPropertyTableView(
       _status() {
   const ExtensionModelExtStructuralMetadata* pMetadata =
       model.getExtension<ExtensionModelExtStructuralMetadata>();
-
   if (!pMetadata) {
     _status =
         MetadataPropertyTableViewStatus::ErrorNoStructuralMetadataExtension;

--- a/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
+++ b/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
@@ -366,15 +366,7 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         MetadataPropertyViewStatus::ErrorArrayCountAndOffsetBufferDontExist);
   }
 
-  // Get offset types
-  const PropertyComponentType arrayOffsetType =
-      convertArrayOffsetTypeStringToPropertyComponentType(
-          propertyTableProperty.arrayOffsetType);
-  if (arrayOffsetType == PropertyComponentType::None) {
-    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
-        MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType);
-  }
-
+  // Get string offset type
   const PropertyComponentType stringOffsetType =
       convertStringOffsetTypeStringToPropertyComponentType(
           propertyTableProperty.stringOffsetType);
@@ -383,14 +375,9 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         MetadataPropertyViewStatus::ErrorInvalidStringOffsetType);
   }
 
-  if (propertyTableProperty.arrayOffsets < 0) {
-    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
-        MetadataPropertyViewStatus::ErrorInvalidArrayOffsetBuffer);
-  }
-
   if (propertyTableProperty.stringOffsets < 0) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
-        MetadataPropertyViewStatus::ErrorInvalidStringOffsetBuffer);
+        MetadataPropertyViewStatus::ErrorInvalidStringOffsetBufferView);
   }
 
   // Handle fixed-length arrays
@@ -418,6 +405,21 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         _pPropertyTable->count,
         classProperty.normalized);
   }
+
+  // Get array offset type
+  const PropertyComponentType arrayOffsetType =
+      convertArrayOffsetTypeStringToPropertyComponentType(
+          propertyTableProperty.arrayOffsetType);
+  if (arrayOffsetType == PropertyComponentType::None) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType);
+  }
+
+  if (propertyTableProperty.arrayOffsets < 0) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::ErrorInvalidArrayOffsetBufferView);
+  }
+
 
   // Handle variable-length arrays
   gsl::span<const std::byte> stringOffsets;

--- a/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
+++ b/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
@@ -1,0 +1,493 @@
+#include "CesiumGltf/StructuralMetadataPropertyTableView.h"
+
+namespace CesiumGltf {
+namespace StructuralMetadata {
+
+template <typename T>
+static MetadataPropertyViewStatus checkOffsetsBuffer(
+    const gsl::span<const std::byte>& offsetBuffer,
+    size_t valueBufferSize,
+    size_t instanceCount,
+    bool checkBitSize,
+    MetadataPropertyViewStatus offsetsNotSortedError,
+    MetadataPropertyViewStatus offsetOutOfBoundsError) noexcept {
+  if (offsetBuffer.size() % sizeof(T) != 0) {
+    return MetadataPropertyViewStatus::
+        ErrorBufferViewSizeNotDivisibleByTypeSize;
+  }
+
+  const size_t size = offsetBuffer.size() / sizeof(T);
+  if (size != instanceCount + 1) {
+    return MetadataPropertyViewStatus::
+        ErrorBufferViewSizeDoesNotMatchPropertyTableCount;
+  }
+
+  const gsl::span<const T> offsetValues(
+      reinterpret_cast<const T*>(offsetBuffer.data()),
+      size);
+
+  for (size_t i = 1; i < offsetValues.size(); ++i) {
+    if (offsetValues[i] < offsetValues[i - 1]) {
+      return offsetsNotSortedError;
+    }
+  }
+
+  if (checkBitSize) {
+    if (offsetValues.back() / 8 <= valueBufferSize) {
+      return MetadataPropertyViewStatus::Valid;
+    }
+
+    return offsetOutOfBoundsError;
+  }
+
+  if (offsetValues.back() <= valueBufferSize) {
+    return MetadataPropertyViewStatus::Valid;
+  }
+
+  return offsetOutOfBoundsError;
+}
+
+template <typename T>
+static MetadataPropertyViewStatus checkStringAndArrayOffsetsBuffers(
+    const gsl::span<const std::byte>& arrayOffsets,
+    const gsl::span<const std::byte>& stringOffsets,
+    size_t valueBufferSize,
+    PropertyComponentType stringOffsetType,
+    size_t propertyTableCount) noexcept {
+  const auto status = checkOffsetsBuffer<T>(
+      arrayOffsets,
+      stringOffsets.size(),
+      propertyTableCount,
+      false,
+      MetadataPropertyViewStatus::ErrorArrayOffsetsNotSorted,
+      MetadataPropertyViewStatus::ErrorArrayOffsetOutOfBounds);
+
+  if (status != MetadataPropertyViewStatus::Valid) {
+    return status;
+  }
+
+  const T* pValue = reinterpret_cast<const T*>(arrayOffsets.data());
+
+  switch (stringOffsetType) {
+  case PropertyComponentType::Uint8:
+    return checkOffsetsBuffer<uint8_t>(
+        stringOffsets,
+        valueBufferSize,
+        pValue[propertyTableCount] / sizeof(T),
+        false,
+        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted,
+        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+  case PropertyComponentType::Uint16:
+    return checkOffsetsBuffer<uint16_t>(
+        stringOffsets,
+        valueBufferSize,
+        pValue[propertyTableCount] / sizeof(T),
+        false,
+        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted,
+        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+  case PropertyComponentType::Uint32:
+    return checkOffsetsBuffer<uint32_t>(
+        stringOffsets,
+        valueBufferSize,
+        pValue[propertyTableCount] / sizeof(T),
+        false,
+        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted,
+        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+  case PropertyComponentType::Uint64:
+    return checkOffsetsBuffer<uint64_t>(
+        stringOffsets,
+        valueBufferSize,
+        pValue[propertyTableCount] / sizeof(T),
+        false,
+        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted,
+        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+  default:
+    return MetadataPropertyViewStatus::ErrorInvalidStringOffsetType;
+  }
+}
+
+MetadataPropertyTableView::MetadataPropertyTableView(
+    const Model* pModel,
+    const ExtensionExtStructuralMetadataPropertyTable* pPropertyTable)
+    : _pModel{pModel}, _pPropertyTable{pPropertyTable}, _pClass{nullptr} {
+  assert(pModel != nullptr && "pModel must not be nullptr");
+  assert(pPropertyTable != nullptr && "pPropertyTable must not be nullptr");
+
+  const ExtensionModelExtStructuralMetadata* pMetadata =
+      pModel->getExtension<ExtensionModelExtStructuralMetadata>();
+  assert(
+      pMetadata != nullptr &&
+      "Model must contain ExtensionModelExtStructuralMetadata to use "
+      "MetadataPropertyTableView");
+
+  const std::optional<ExtensionExtStructuralMetadataSchema>& schema =
+      pMetadata->schema;
+  assert(
+      schema != std::nullopt &&
+      "ExtensionModelExtStructuralMetadata must contain "
+      "Schema to use MetadataPropertyTableView");
+
+  auto classIter = schema->classes.find(_pPropertyTable->classProperty);
+  if (classIter != schema->classes.end()) {
+    _pClass = &classIter->second;
+  }
+}
+
+const ExtensionExtStructuralMetadataClassProperty*
+MetadataPropertyTableView::getClassProperty(
+    const std::string& propertyName) const {
+  if (_pClass == nullptr) {
+    return nullptr;
+  }
+
+  auto propertyIter = _pClass->properties.find(propertyName);
+  if (propertyIter == _pClass->properties.end()) {
+    return nullptr;
+  }
+
+  return &propertyIter->second;
+}
+
+MetadataPropertyViewStatus MetadataPropertyTableView::getBufferSafe(
+    int32_t bufferViewIdx,
+    gsl::span<const std::byte>& buffer) const noexcept {
+  buffer = {};
+
+  const BufferView* pBufferView =
+      _pModel->getSafe(&_pModel->bufferViews, bufferViewIdx);
+  if (!pBufferView) {
+    return MetadataPropertyViewStatus::ErrorInvalidValueBufferView;
+  }
+
+  const Buffer* pBuffer =
+      _pModel->getSafe(&_pModel->buffers, pBufferView->buffer);
+  if (!pBuffer) {
+    return MetadataPropertyViewStatus::ErrorInvalidValueBuffer;
+  }
+
+  if (pBufferView->byteOffset + pBufferView->byteLength >
+      static_cast<int64_t>(pBuffer->cesium.data.size())) {
+    return MetadataPropertyViewStatus::ErrorBufferViewOutOfBounds;
+  }
+
+  buffer = gsl::span<const std::byte>(
+      pBuffer->cesium.data.data() + pBufferView->byteOffset,
+      static_cast<size_t>(pBufferView->byteLength));
+  return MetadataPropertyViewStatus::Valid;
+}
+
+MetadataPropertyViewStatus MetadataPropertyTableView::getArrayOffsetsBufferSafe(
+    int32_t arrayOffsetsBufferView,
+    PropertyComponentType arrayOffsetType,
+    size_t valueBufferSize,
+    size_t propertyTableCount,
+    bool checkBitsSize,
+    gsl::span<const std::byte>& arrayOffsetsBuffer) const noexcept {
+  const MetadataPropertyViewStatus bufferStatus =
+      getBufferSafe(arrayOffsetsBufferView, arrayOffsetsBuffer);
+  if (bufferStatus != MetadataPropertyViewStatus::Valid) {
+    return bufferStatus;
+  }
+
+  switch (arrayOffsetType) {
+  case PropertyComponentType::Uint8:
+    return checkOffsetsBuffer<uint8_t>(
+        arrayOffsetsBuffer,
+        valueBufferSize,
+        propertyTableCount,
+        checkBitsSize,
+        MetadataPropertyViewStatus::ErrorArrayOffsetsNotSorted,
+        MetadataPropertyViewStatus::ErrorArrayOffsetOutOfBounds);
+  case PropertyComponentType::Uint16:
+    return checkOffsetsBuffer<uint16_t>(
+        arrayOffsetsBuffer,
+        valueBufferSize,
+        propertyTableCount,
+        checkBitsSize,
+        MetadataPropertyViewStatus::ErrorArrayOffsetsNotSorted,
+        MetadataPropertyViewStatus::ErrorArrayOffsetOutOfBounds);
+  case PropertyComponentType::Uint32:
+    return checkOffsetsBuffer<uint32_t>(
+        arrayOffsetsBuffer,
+        valueBufferSize,
+        propertyTableCount,
+        checkBitsSize,
+        MetadataPropertyViewStatus::ErrorArrayOffsetsNotSorted,
+        MetadataPropertyViewStatus::ErrorArrayOffsetOutOfBounds);
+  case PropertyComponentType::Uint64:
+    return checkOffsetsBuffer<uint64_t>(
+        arrayOffsetsBuffer,
+        valueBufferSize,
+        propertyTableCount,
+        checkBitsSize,
+        MetadataPropertyViewStatus::ErrorArrayOffsetsNotSorted,
+        MetadataPropertyViewStatus::ErrorArrayOffsetOutOfBounds);
+  default:
+    return MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType;
+  }
+}
+
+MetadataPropertyViewStatus
+MetadataPropertyTableView::getStringOffsetsBufferSafe(
+    int32_t stringOffsetsBufferView,
+    PropertyComponentType stringOffsetType,
+    size_t valueBufferSize,
+    size_t propertyTableCount,
+    gsl::span<const std::byte>& stringOffsetsBuffer) const noexcept {
+  const MetadataPropertyViewStatus bufferStatus =
+      getBufferSafe(stringOffsetsBufferView, stringOffsetsBuffer);
+  if (bufferStatus != MetadataPropertyViewStatus::Valid) {
+    return bufferStatus;
+  }
+
+  switch (stringOffsetType) {
+  case PropertyComponentType::Uint8:
+    return checkOffsetsBuffer<uint8_t>(
+        stringOffsetsBuffer,
+        valueBufferSize,
+        propertyTableCount,
+        false,
+        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted,
+        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+  case PropertyComponentType::Uint16:
+    return checkOffsetsBuffer<uint16_t>(
+        stringOffsetsBuffer,
+        valueBufferSize,
+        propertyTableCount,
+        false,
+        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted,
+        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+  case PropertyComponentType::Uint32:
+    return checkOffsetsBuffer<uint32_t>(
+        stringOffsetsBuffer,
+        valueBufferSize,
+        propertyTableCount,
+        false,
+        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted,
+        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+  case PropertyComponentType::Uint64:
+    return checkOffsetsBuffer<uint64_t>(
+        stringOffsetsBuffer,
+        valueBufferSize,
+        propertyTableCount,
+        false,
+        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted,
+        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+  default:
+    return MetadataPropertyViewStatus::ErrorInvalidStringOffsetType;
+  }
+}
+
+MetadataPropertyView<std::string_view>
+MetadataPropertyTableView::getStringPropertyValues(
+    const ExtensionExtStructuralMetadataClassProperty& classProperty,
+    const ExtensionExtStructuralMetadataPropertyTableProperty&
+        propertyTableProperty) const {
+  if (classProperty.array) {
+    return createInvalidPropertyView<std::string_view>(
+        MetadataPropertyViewStatus::ErrorArrayTypeMismatch);
+  }
+
+  if (classProperty.type !=
+      ExtensionExtStructuralMetadataClassProperty::Type::STRING) {
+    return createInvalidPropertyView<std::string_view>(
+        MetadataPropertyViewStatus::ErrorTypeMismatch);
+  }
+
+  gsl::span<const std::byte> values;
+  auto status = getBufferSafe(propertyTableProperty.values, values);
+  if (status != MetadataPropertyViewStatus::Valid) {
+    return createInvalidPropertyView<std::string_view>(status);
+  }
+
+  const PropertyComponentType offsetType =
+      convertStringOffsetTypeStringToPropertyComponentType(
+          propertyTableProperty.stringOffsetType);
+  if (offsetType == PropertyComponentType::None) {
+    return createInvalidPropertyView<std::string_view>(
+        MetadataPropertyViewStatus::ErrorInvalidStringOffsetType);
+  }
+
+  gsl::span<const std::byte> stringOffsets;
+  status = getStringOffsetsBufferSafe(
+      propertyTableProperty.stringOffsets,
+      offsetType,
+      values.size(),
+      static_cast<size_t>(_pPropertyTable->count),
+      stringOffsets);
+  if (status != MetadataPropertyViewStatus::Valid) {
+    return createInvalidPropertyView<std::string_view>(status);
+  }
+
+  return MetadataPropertyView<std::string_view>(
+      MetadataPropertyViewStatus::Valid,
+      values,
+      gsl::span<const std::byte>(),
+      stringOffsets,
+      PropertyComponentType::None,
+      offsetType,
+      0,
+      _pPropertyTable->count,
+      classProperty.normalized);
+}
+
+MetadataPropertyView<MetadataArrayView<std::string_view>>
+MetadataPropertyTableView::getStringArrayPropertyValues(
+    const ExtensionExtStructuralMetadataClassProperty& classProperty,
+    const ExtensionExtStructuralMetadataPropertyTableProperty&
+        propertyTableProperty) const {
+  if (!classProperty.array) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::ErrorTypeMismatch);
+  }
+
+  if (classProperty.type !=
+      ExtensionExtStructuralMetadataClassProperty::Type::STRING) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::ErrorTypeMismatch);
+  }
+
+  gsl::span<const std::byte> values;
+  auto status = getBufferSafe(propertyTableProperty.values, values);
+  if (status != MetadataPropertyViewStatus::Valid) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        status);
+  }
+
+  // Check if array is fixed or variable length
+  const int64_t fixedLengthArrayCount = classProperty.count.value_or(0);
+  if (fixedLengthArrayCount > 0 && propertyTableProperty.arrayOffsets >= 0) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::ErrorArrayCountAndOffsetBufferCoexist);
+  }
+
+  if (fixedLengthArrayCount <= 0 && propertyTableProperty.arrayOffsets < 0) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::ErrorArrayCountAndOffsetBufferDontExist);
+  }
+
+  // Get offset types
+  const PropertyComponentType arrayOffsetType =
+      convertArrayOffsetTypeStringToPropertyComponentType(
+          propertyTableProperty.arrayOffsetType);
+  if (arrayOffsetType == PropertyComponentType::None) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType);
+  }
+
+  const PropertyComponentType stringOffsetType =
+      convertStringOffsetTypeStringToPropertyComponentType(
+          propertyTableProperty.stringOffsetType);
+  if (stringOffsetType == PropertyComponentType::None) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::ErrorInvalidStringOffsetType);
+  }
+
+  if (propertyTableProperty.arrayOffsets < 0) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::ErrorInvalidArrayOffsetBuffer);
+  }
+
+  if (propertyTableProperty.stringOffsets < 0) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::ErrorInvalidStringOffsetBuffer);
+  }
+
+  // Handle fixed-length arrays
+  if (fixedLengthArrayCount > 0) {
+    gsl::span<const std::byte> stringOffsets;
+    status = getStringOffsetsBufferSafe(
+        propertyTableProperty.stringOffsets,
+        stringOffsetType,
+        values.size(),
+        static_cast<size_t>(_pPropertyTable->count * fixedLengthArrayCount),
+        stringOffsets);
+    if (status != MetadataPropertyViewStatus::Valid) {
+      return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+          status);
+    }
+
+    return MetadataPropertyView<MetadataArrayView<std::string_view>>(
+        MetadataPropertyViewStatus::Valid,
+        values,
+        gsl::span<const std::byte>(),
+        stringOffsets,
+        PropertyComponentType::None,
+        stringOffsetType,
+        fixedLengthArrayCount,
+        _pPropertyTable->count,
+        classProperty.normalized);
+  }
+
+  // Handle variable-length arrays
+  gsl::span<const std::byte> stringOffsets;
+  status = getBufferSafe(propertyTableProperty.stringOffsets, stringOffsets);
+  if (status != MetadataPropertyViewStatus::Valid) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        status);
+  }
+
+  gsl::span<const std::byte> arrayOffsets;
+  status = getBufferSafe(propertyTableProperty.arrayOffsets, arrayOffsets);
+  if (status != MetadataPropertyViewStatus::Valid) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        status);
+  }
+
+  switch (arrayOffsetType) {
+  case PropertyComponentType::Uint8:
+    status = checkStringAndArrayOffsetsBuffers<uint8_t>(
+        arrayOffsets,
+        stringOffsets,
+        values.size(),
+        stringOffsetType,
+        static_cast<size_t>(_pPropertyTable->count));
+    break;
+  case PropertyComponentType::Uint16:
+    status = checkStringAndArrayOffsetsBuffers<uint16_t>(
+        arrayOffsets,
+        stringOffsets,
+        values.size(),
+        stringOffsetType,
+        static_cast<size_t>(_pPropertyTable->count));
+    break;
+  case PropertyComponentType::Uint32:
+    status = checkStringAndArrayOffsetsBuffers<uint32_t>(
+        arrayOffsets,
+        stringOffsets,
+        values.size(),
+        stringOffsetType,
+        static_cast<size_t>(_pPropertyTable->count));
+    break;
+  case PropertyComponentType::Uint64:
+    status = checkStringAndArrayOffsetsBuffers<uint64_t>(
+        arrayOffsets,
+        stringOffsets,
+        values.size(),
+        stringOffsetType,
+        static_cast<size_t>(_pPropertyTable->count));
+    break;
+  default:
+    status = MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType;
+    break;
+  }
+
+  if (status != MetadataPropertyViewStatus::Valid) {
+    return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
+        status);
+  }
+
+  return MetadataPropertyView<MetadataArrayView<std::string_view>>(
+      MetadataPropertyViewStatus::Valid,
+      values,
+      arrayOffsets,
+      stringOffsets,
+      arrayOffsetType,
+      stringOffsetType,
+      0,
+      _pPropertyTable->count,
+      classProperty.normalized);
+}
+
+} // namespace StructuralMetadata
+} // namespace CesiumGltf

--- a/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
+++ b/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
@@ -338,7 +338,7 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         propertyTableProperty) const {
   if (!classProperty.array) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
-        MetadataPropertyViewStatus::ErrorTypeMismatch);
+        MetadataPropertyViewStatus::ErrorArrayTypeMismatch);
   }
 
   if (classProperty.type !=

--- a/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
+++ b/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
@@ -107,14 +107,11 @@ static MetadataPropertyViewStatus checkStringAndArrayOffsetsBuffers(
 }
 
 MetadataPropertyTableView::MetadataPropertyTableView(
-    const Model* pModel,
-    const ExtensionExtStructuralMetadataPropertyTable* pPropertyTable)
-    : _pModel{pModel}, _pPropertyTable{pPropertyTable}, _pClass{nullptr} {
-  assert(pModel != nullptr && "pModel must not be nullptr");
-  assert(pPropertyTable != nullptr && "pPropertyTable must not be nullptr");
-
+    const Model& model,
+    const ExtensionExtStructuralMetadataPropertyTable& propertyTable)
+    : _model{model}, _propertyTable{propertyTable}, _pClass{nullptr} {
   const ExtensionModelExtStructuralMetadata* pMetadata =
-      pModel->getExtension<ExtensionModelExtStructuralMetadata>();
+      model.getExtension<ExtensionModelExtStructuralMetadata>();
   assert(
       pMetadata != nullptr &&
       "Model must contain ExtensionModelExtStructuralMetadata to use "
@@ -127,7 +124,7 @@ MetadataPropertyTableView::MetadataPropertyTableView(
       "ExtensionModelExtStructuralMetadata must contain "
       "Schema to use MetadataPropertyTableView");
 
-  auto classIter = schema->classes.find(_pPropertyTable->classProperty);
+  auto classIter = schema->classes.find(_propertyTable.classProperty);
   if (classIter != schema->classes.end()) {
     _pClass = &classIter->second;
   }
@@ -154,13 +151,12 @@ MetadataPropertyViewStatus MetadataPropertyTableView::getBufferSafe(
   buffer = {};
 
   const BufferView* pBufferView =
-      _pModel->getSafe(&_pModel->bufferViews, bufferViewIdx);
+      _model.getSafe(&_model.bufferViews, bufferViewIdx);
   if (!pBufferView) {
     return MetadataPropertyViewStatus::ErrorInvalidValueBufferView;
   }
 
-  const Buffer* pBuffer =
-      _pModel->getSafe(&_pModel->buffers, pBufferView->buffer);
+  const Buffer* pBuffer = _model.getSafe(&_model.buffers, pBufferView->buffer);
   if (!pBuffer) {
     return MetadataPropertyViewStatus::ErrorInvalidValueBuffer;
   }
@@ -313,7 +309,7 @@ MetadataPropertyTableView::getStringPropertyValues(
       propertyTableProperty.stringOffsets,
       offsetType,
       values.size(),
-      static_cast<size_t>(_pPropertyTable->count),
+      static_cast<size_t>(_propertyTable.count),
       stringOffsets);
   if (status != MetadataPropertyViewStatus::Valid) {
     return createInvalidPropertyView<std::string_view>(status);
@@ -327,7 +323,7 @@ MetadataPropertyTableView::getStringPropertyValues(
       PropertyComponentType::None,
       offsetType,
       0,
-      _pPropertyTable->count,
+      _propertyTable.count,
       classProperty.normalized);
 }
 
@@ -387,7 +383,7 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         propertyTableProperty.stringOffsets,
         stringOffsetType,
         values.size(),
-        static_cast<size_t>(_pPropertyTable->count * fixedLengthArrayCount),
+        static_cast<size_t>(_propertyTable.count * fixedLengthArrayCount),
         stringOffsets);
     if (status != MetadataPropertyViewStatus::Valid) {
       return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
@@ -402,7 +398,7 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         PropertyComponentType::None,
         stringOffsetType,
         fixedLengthArrayCount,
-        _pPropertyTable->count,
+        _propertyTable.count,
         classProperty.normalized);
   }
 
@@ -442,7 +438,7 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         stringOffsets,
         values.size(),
         stringOffsetType,
-        static_cast<size_t>(_pPropertyTable->count));
+        static_cast<size_t>(_propertyTable.count));
     break;
   case PropertyComponentType::Uint16:
     status = checkStringAndArrayOffsetsBuffers<uint16_t>(
@@ -450,7 +446,7 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         stringOffsets,
         values.size(),
         stringOffsetType,
-        static_cast<size_t>(_pPropertyTable->count));
+        static_cast<size_t>(_propertyTable.count));
     break;
   case PropertyComponentType::Uint32:
     status = checkStringAndArrayOffsetsBuffers<uint32_t>(
@@ -458,7 +454,7 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         stringOffsets,
         values.size(),
         stringOffsetType,
-        static_cast<size_t>(_pPropertyTable->count));
+        static_cast<size_t>(_propertyTable.count));
     break;
   case PropertyComponentType::Uint64:
     status = checkStringAndArrayOffsetsBuffers<uint64_t>(
@@ -466,7 +462,7 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         stringOffsets,
         values.size(),
         stringOffsetType,
-        static_cast<size_t>(_pPropertyTable->count));
+        static_cast<size_t>(_propertyTable.count));
     break;
   default:
     status = MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType;
@@ -486,7 +482,7 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
       arrayOffsetType,
       stringOffsetType,
       0,
-      _pPropertyTable->count,
+      _propertyTable.count,
       classProperty.normalized);
 }
 

--- a/CesiumGltf/src/StructuralMetadataPropertyType.cpp
+++ b/CesiumGltf/src/StructuralMetadataPropertyType.cpp
@@ -39,39 +39,39 @@ PropertyType convertStringToPropertyType(const std::string& str) {
   }
 
   if (str == ExtensionExtStructuralMetadataClassProperty::Type::VEC2) {
-    return StructuralMetadata::PropertyType::Vec2;
+    return PropertyType::Vec2;
   }
 
   if (str == ExtensionExtStructuralMetadataClassProperty::Type::VEC3) {
-    return StructuralMetadata::PropertyType::Vec3;
+    return PropertyType::Vec3;
   }
 
   if (str == ExtensionExtStructuralMetadataClassProperty::Type::VEC4) {
-    return StructuralMetadata::PropertyType::Vec4;
+    return PropertyType::Vec4;
   }
 
   if (str == ExtensionExtStructuralMetadataClassProperty::Type::MAT2) {
-    return StructuralMetadata::PropertyType::Mat2;
+    return PropertyType::Mat2;
   }
 
   if (str == ExtensionExtStructuralMetadataClassProperty::Type::MAT3) {
-    return StructuralMetadata::PropertyType::Mat3;
+    return PropertyType::Mat3;
   }
 
   if (str == ExtensionExtStructuralMetadataClassProperty::Type::MAT4) {
-    return StructuralMetadata::PropertyType::Mat4;
+    return PropertyType::Mat4;
   }
 
   if (str == ExtensionExtStructuralMetadataClassProperty::Type::BOOLEAN) {
-    return StructuralMetadata::PropertyType::Boolean;
+    return PropertyType::Boolean;
   }
 
   if (str == ExtensionExtStructuralMetadataClassProperty::Type::STRING) {
-    return StructuralMetadata::PropertyType::String;
+    return PropertyType::String;
   }
 
   if (str == ExtensionExtStructuralMetadataClassProperty::Type::ENUM) {
-    return StructuralMetadata::PropertyType::Enum;
+    return PropertyType::Enum;
   }
 
   return PropertyType::Invalid;
@@ -106,7 +106,7 @@ std::string convertPropertyComponentTypeToString(PropertyComponentType type) {
   }
 }
 
-StructuralMetadata::PropertyComponentType
+PropertyComponentType
 convertStringToPropertyComponentType(const std::string& str) {
   if (str ==
       ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT8) {
@@ -160,7 +160,7 @@ convertStringToPropertyComponentType(const std::string& str) {
   return PropertyComponentType::None;
 }
 
-StructuralMetadata::PropertyComponentType
+PropertyComponentType
 convertArrayOffsetTypeStringToPropertyComponentType(const std::string& str) {
   if (str == ExtensionExtStructuralMetadataPropertyTableProperty::
                  ArrayOffsetType::UINT8) {
@@ -185,7 +185,7 @@ convertArrayOffsetTypeStringToPropertyComponentType(const std::string& str) {
   return PropertyComponentType::None;
 }
 
-StructuralMetadata::PropertyComponentType
+PropertyComponentType
 convertStringOffsetTypeStringToPropertyComponentType(const std::string& str) {
   if (str == ExtensionExtStructuralMetadataPropertyTableProperty::
                  StringOffsetType::UINT8) {
@@ -208,6 +208,16 @@ convertStringOffsetTypeStringToPropertyComponentType(const std::string& str) {
   }
 
   return PropertyComponentType::None;
+}
+
+bool isPropertyTypeVecN(PropertyType type) {
+  return type == PropertyType::Vec2 || type == PropertyType::Vec3 ||
+         type == PropertyType::Vec4;
+}
+
+bool isPropertyTypeMatN(PropertyType type) {
+  return type == PropertyType::Mat2 || type == PropertyType::Mat3 ||
+         type == PropertyType::Mat4;
 }
 
 } // namespace StructuralMetadata

--- a/CesiumGltf/test/TestStructuralMetadataPropertyTableView.cpp
+++ b/CesiumGltf/test/TestStructuralMetadataPropertyTableView.cpp
@@ -554,7 +554,7 @@ TEST_CASE("Test StructuralMetadata matN property") {
   }
 }
 
-TEST_CASE("Test StructuralMetadata boolean properties") {
+TEST_CASE("Test StructuralMetadata boolean property") {
   Model model;
 
   int64_t instanceCount = 21;
@@ -741,6 +741,16 @@ TEST_CASE("Test StructuralMetadata string property") {
     for (size_t i = 0; i < expected.size(); ++i) {
       REQUIRE(stringProperty.get(static_cast<int64_t>(i)) == expected[i]);
     }
+  }
+
+  SECTION("Wrong array type") {
+    MetadataPropertyView<MetadataArrayView<std::string_view>>
+        stringArrayInvalid =
+            view.getPropertyView<MetadataArrayView<std::string_view>>(
+                "TestClassProperty");
+    REQUIRE(
+        stringArrayInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorArrayTypeMismatch);
   }
 
   SECTION("Wrong offset type") {
@@ -3559,7 +3569,7 @@ TEST_CASE("Test StructuralMetadata callback for array of strings") {
 
   view.getPropertyView(
       "TestClassProperty",
-      [&expected](const std::string& /*propertyName*/, auto propertyValue) {
+      [](const std::string& /*propertyName*/, auto propertyValue) {
         REQUIRE(propertyValue.status() == MetadataPropertyViewStatus::Valid);
 
         if constexpr (std::is_same_v<

--- a/CesiumGltf/test/TestStructuralMetadataPropertyTableView.cpp
+++ b/CesiumGltf/test/TestStructuralMetadataPropertyTableView.cpp
@@ -2990,7 +2990,6 @@ TEST_CASE("Test StructuralMetadata callback for vecN property") {
   REQUIRE(!classProperty->array);
 
   uint32_t invokedCallbackCount = 0;
-
   view.getPropertyView(
       "TestClassProperty",
       [&values, &invokedCallbackCount](

--- a/CesiumGltf/test/TestStructuralMetadataPropertyTableView.cpp
+++ b/CesiumGltf/test/TestStructuralMetadataPropertyTableView.cpp
@@ -1,0 +1,2591 @@
+#include "CesiumGltf/StructuralMetadataPropertyTableView.h"
+
+#include <catch2/catch.hpp>
+
+#include <cstring>
+
+using namespace CesiumGltf;
+using namespace CesiumGltf::StructuralMetadata;
+
+TEST_CASE("Test StructuralMetadata scalar property") {
+  Model model;
+
+  std::vector<uint32_t> values = {12, 34, 30, 11, 34, 34, 11, 33, 122, 33};
+
+  size_t valueBufferIndex = 0;
+  size_t valueBufferViewIndex = 0;
+
+  // Buffers are constructed in scope to ensure that the tests don't use their
+  // temporary variables.
+  {
+    Buffer& valueBuffer = model.buffers.emplace_back();
+    valueBuffer.cesium.data.resize(values.size() * sizeof(uint32_t));
+    valueBuffer.byteLength =
+        static_cast<int64_t>(valueBuffer.cesium.data.size());
+    std::memcpy(
+        valueBuffer.cesium.data.data(),
+        values.data(),
+        valueBuffer.cesium.data.size());
+    valueBufferIndex = model.buffers.size() - 1;
+
+    BufferView& valueBufferView = model.bufferViews.emplace_back();
+    valueBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
+    valueBufferView.byteOffset = 0;
+    valueBufferView.byteLength = valueBuffer.byteLength;
+    valueBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::SCALAR;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT32;
+
+  ExtensionExtStructuralMetadataPropertyTable& propertyTable =
+      metadata.propertyTables.emplace_back();
+  propertyTable.classProperty = "TestClass";
+  propertyTable.count = static_cast<int64_t>(values.size());
+
+  ExtensionExtStructuralMetadataPropertyTableProperty& propertyTableProperty =
+      propertyTable.properties["TestClassProperty"];
+  propertyTableProperty.values = static_cast<int32_t>(valueBufferViewIndex);
+
+  MetadataPropertyTableView view(&model, &propertyTable);
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(
+      classProperty->type ==
+      ExtensionExtStructuralMetadataClassProperty::Type::SCALAR);
+  REQUIRE(
+      classProperty->componentType ==
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT32);
+  REQUIRE(classProperty->count == std::nullopt);
+  REQUIRE(!classProperty->array);
+
+  SECTION("Access correct type") {
+    MetadataPropertyView<uint32_t> uint32Property =
+        view.getPropertyView<uint32_t>("TestClassProperty");
+    REQUIRE(uint32Property.status() == MetadataPropertyViewStatus::Valid);
+    REQUIRE(uint32Property.size() > 0);
+
+    for (int64_t i = 0; i < uint32Property.size(); ++i) {
+      REQUIRE(uint32Property.get(i) == values[static_cast<size_t>(i)]);
+    }
+  }
+
+  SECTION("Access wrong type") {
+    MetadataPropertyView<glm::uvec3> uvec3Invalid =
+        view.getPropertyView<glm::uvec3>("TestClassProperty");
+    REQUIRE(
+        uvec3Invalid.status() == MetadataPropertyViewStatus::ErrorTypeMismatch);
+
+    MetadataPropertyView<glm::u32mat3x3> u32mat3x3Invalid =
+        view.getPropertyView<glm::u32mat3x3>("TestClassProperty");
+    REQUIRE(
+        u32mat3x3Invalid.status() ==
+        MetadataPropertyViewStatus::ErrorTypeMismatch);
+
+    MetadataPropertyView<bool> boolInvalid =
+        view.getPropertyView<bool>("TestClassProperty");
+    REQUIRE(
+        boolInvalid.status() == MetadataPropertyViewStatus::ErrorTypeMismatch);
+
+    MetadataPropertyView<std::string_view> stringInvalid =
+        view.getPropertyView<std::string_view>("TestClassProperty");
+    REQUIRE(
+        stringInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorTypeMismatch);
+  }
+
+  SECTION("Access wrong component type") {
+    MetadataPropertyView<uint8_t> uint8Invalid =
+        view.getPropertyView<uint8_t>("TestClassProperty");
+    REQUIRE(
+        uint8Invalid.status() ==
+        MetadataPropertyViewStatus::ErrorComponentTypeMismatch);
+
+    MetadataPropertyView<int32_t> int32Invalid =
+        view.getPropertyView<int32_t>("TestClassProperty");
+    REQUIRE(
+        int32Invalid.status() ==
+        MetadataPropertyViewStatus::ErrorComponentTypeMismatch);
+
+    MetadataPropertyView<uint64_t> uint64Invalid =
+        view.getPropertyView<uint64_t>("TestClassProperty");
+    REQUIRE(
+        uint64Invalid.status() ==
+        MetadataPropertyViewStatus::ErrorComponentTypeMismatch);
+  }
+
+  SECTION("Access incorrectly as array") {
+    MetadataPropertyView<MetadataArrayView<uint32_t>> uint32ArrayInvalid =
+        view.getPropertyView<MetadataArrayView<uint32_t>>("TestClassProperty");
+    REQUIRE(
+        uint32ArrayInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorArrayTypeMismatch);
+  }
+
+  SECTION("Wrong buffer index") {
+    model.bufferViews[valueBufferViewIndex].buffer = 2;
+    MetadataPropertyView<uint32_t> uint32Property =
+        view.getPropertyView<uint32_t>("TestClassProperty");
+    REQUIRE(
+        uint32Property.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidValueBuffer);
+  }
+
+  SECTION("Wrong buffer view index") {
+    propertyTableProperty.values = -1;
+    MetadataPropertyView<uint32_t> uint32Property =
+        view.getPropertyView<uint32_t>("TestClassProperty");
+    REQUIRE(
+        uint32Property.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidValueBufferView);
+  }
+
+  SECTION("Buffer view points outside of the real buffer length") {
+    model.buffers[valueBufferIndex].cesium.data.resize(12);
+    MetadataPropertyView<uint32_t> uint32Property =
+        view.getPropertyView<uint32_t>("TestClassProperty");
+    REQUIRE(
+        uint32Property.status() ==
+        MetadataPropertyViewStatus::ErrorBufferViewOutOfBounds);
+  }
+
+  SECTION("Buffer view length isn't multiple of sizeof(T)") {
+    model.bufferViews[valueBufferViewIndex].byteLength = 13;
+    MetadataPropertyView<uint32_t> uint32Property =
+        view.getPropertyView<uint32_t>("TestClassProperty");
+    REQUIRE(
+        uint32Property.status() ==
+        MetadataPropertyViewStatus::ErrorBufferViewSizeNotDivisibleByTypeSize);
+  }
+
+  SECTION("Buffer view length doesn't match with propertyTableCount") {
+    model.bufferViews[valueBufferViewIndex].byteLength = 12;
+    MetadataPropertyView<uint32_t> uint32Property =
+        view.getPropertyView<uint32_t>("TestClassProperty");
+    REQUIRE(
+        uint32Property.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+  }
+}
+
+TEST_CASE("Test StructuralMetadata vecN property") {
+  Model model;
+
+  std::vector<glm::ivec3> values = {
+      glm::ivec3(-12, 34, 30),
+      glm::ivec3(11, 73, 0),
+      glm::ivec3(-2, 6, 12),
+      glm::ivec3(-4, 8, -13)};
+
+  size_t valueBufferIndex = 0;
+  size_t valueBufferViewIndex = 0;
+
+  // Buffers are constructed in scope to ensure that the tests don't use their
+  // temporary variables.
+  {
+    Buffer& valueBuffer = model.buffers.emplace_back();
+    valueBuffer.cesium.data.resize(values.size() * sizeof(glm::ivec3));
+    valueBuffer.byteLength =
+        static_cast<int64_t>(valueBuffer.cesium.data.size());
+    std::memcpy(
+        valueBuffer.cesium.data.data(),
+        values.data(),
+        valueBuffer.cesium.data.size());
+    valueBufferIndex = model.buffers.size() - 1;
+
+    BufferView& valueBufferView = model.bufferViews.emplace_back();
+    valueBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
+    valueBufferView.byteOffset = 0;
+    valueBufferView.byteLength = valueBuffer.byteLength;
+    valueBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::VEC3;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::INT32;
+
+  ExtensionExtStructuralMetadataPropertyTable& propertyTable =
+      metadata.propertyTables.emplace_back();
+  propertyTable.classProperty = "TestClass";
+  propertyTable.count = static_cast<int64_t>(values.size());
+
+  ExtensionExtStructuralMetadataPropertyTableProperty& propertyTableProperty =
+      propertyTable.properties["TestClassProperty"];
+  propertyTableProperty.values = static_cast<int32_t>(valueBufferViewIndex);
+
+  MetadataPropertyTableView view(&model, &propertyTable);
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(
+      classProperty->type ==
+      ExtensionExtStructuralMetadataClassProperty::Type::VEC3);
+  REQUIRE(
+      classProperty->componentType ==
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::INT32);
+  REQUIRE(classProperty->count == std::nullopt);
+  REQUIRE(!classProperty->array);
+
+  SECTION("Access correct type") {
+    MetadataPropertyView<glm::ivec3> ivec3Property =
+        view.getPropertyView<glm::ivec3>("TestClassProperty");
+    REQUIRE(ivec3Property.status() == MetadataPropertyViewStatus::Valid);
+    REQUIRE(ivec3Property.size() > 0);
+
+    for (int64_t i = 0; i < ivec3Property.size(); ++i) {
+      REQUIRE(ivec3Property.get(i) == values[i]);
+    }
+  }
+
+  SECTION("Access wrong type") {
+    MetadataPropertyView<int32_t> int32Invalid =
+        view.getPropertyView<int32_t>("TestClassProperty");
+    REQUIRE(
+        int32Invalid.status() == MetadataPropertyViewStatus::ErrorTypeMismatch);
+
+    MetadataPropertyView<glm::ivec2> ivec2Invalid =
+        view.getPropertyView<glm::ivec2>("TestClassProperty");
+    REQUIRE(
+        ivec2Invalid.status() == MetadataPropertyViewStatus::ErrorTypeMismatch);
+
+    MetadataPropertyView<glm::i32mat3x3> i32mat3x3Invalid =
+        view.getPropertyView<glm::i32mat3x3>("TestClassProperty");
+    REQUIRE(
+        i32mat3x3Invalid.status() ==
+        MetadataPropertyViewStatus::ErrorTypeMismatch);
+
+    MetadataPropertyView<bool> boolInvalid =
+        view.getPropertyView<bool>("TestClassProperty");
+    REQUIRE(
+        boolInvalid.status() == MetadataPropertyViewStatus::ErrorTypeMismatch);
+
+    MetadataPropertyView<std::string_view> stringInvalid =
+        view.getPropertyView<std::string_view>("TestClassProperty");
+    REQUIRE(
+        stringInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorTypeMismatch);
+  }
+
+  SECTION("Access wrong component type") {
+    MetadataPropertyView<glm::u8vec3> u8vec3Invalid =
+        view.getPropertyView<glm::u8vec3>("TestClassProperty");
+    REQUIRE(
+        u8vec3Invalid.status() ==
+        MetadataPropertyViewStatus::ErrorComponentTypeMismatch);
+
+    MetadataPropertyView<glm::i16vec3> i16vec3Invalid =
+        view.getPropertyView<glm::i16vec3>("TestClassProperty");
+    REQUIRE(
+        i16vec3Invalid.status() ==
+        MetadataPropertyViewStatus::ErrorComponentTypeMismatch);
+
+    MetadataPropertyView<glm::vec3> vec3Invalid =
+        view.getPropertyView<glm::vec3>("TestClassProperty");
+    REQUIRE(
+        vec3Invalid.status() ==
+        MetadataPropertyViewStatus::ErrorComponentTypeMismatch);
+  }
+
+  SECTION("Access incorrectly as array") {
+    MetadataPropertyView<MetadataArrayView<glm::ivec3>> ivec3ArrayInvalid =
+        view.getPropertyView<MetadataArrayView<glm::ivec3>>(
+            "TestClassProperty");
+    REQUIRE(
+        ivec3ArrayInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorArrayTypeMismatch);
+  }
+
+  SECTION("Wrong buffer index") {
+    model.bufferViews[valueBufferViewIndex].buffer = 2;
+    MetadataPropertyView<glm::ivec3> ivec3Property =
+        view.getPropertyView<glm::ivec3>("TestClassProperty");
+    REQUIRE(
+        ivec3Property.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidValueBuffer);
+  }
+
+  SECTION("Wrong buffer view index") {
+    propertyTableProperty.values = -1;
+    MetadataPropertyView<glm::ivec3> ivec3Property =
+        view.getPropertyView<glm::ivec3>("TestClassProperty");
+    REQUIRE(
+        ivec3Property.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidValueBufferView);
+  }
+
+  SECTION("Buffer view points outside of the real buffer length") {
+    model.buffers[valueBufferIndex].cesium.data.resize(12);
+    MetadataPropertyView<glm::ivec3> ivec3Property =
+        view.getPropertyView<glm::ivec3>("TestClassProperty");
+    REQUIRE(
+        ivec3Property.status() ==
+        MetadataPropertyViewStatus::ErrorBufferViewOutOfBounds);
+  }
+
+  SECTION("Buffer view length isn't multiple of sizeof(T)") {
+    model.bufferViews[valueBufferViewIndex].byteLength = 11;
+    MetadataPropertyView<glm::ivec3> ivec3Property =
+        view.getPropertyView<glm::ivec3>("TestClassProperty");
+    REQUIRE(
+        ivec3Property.status() ==
+        MetadataPropertyViewStatus::ErrorBufferViewSizeNotDivisibleByTypeSize);
+  }
+
+  SECTION("Buffer view length doesn't match with propertyTableCount") {
+    model.bufferViews[valueBufferViewIndex].byteLength = 12;
+    MetadataPropertyView<glm::ivec3> ivec3Property =
+        view.getPropertyView<glm::ivec3>("TestClassProperty");
+    REQUIRE(
+        ivec3Property.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+  }
+}
+
+TEST_CASE("Test StructuralMetadata matN property") {
+  Model model;
+
+  // clang-format off
+  std::vector<glm::u32mat2x2> values = {
+      glm::u32mat2x2(
+        12, 34,
+        30, 1),
+      glm::u32mat2x2(
+        11, 8,
+        73, 102),
+      glm::u32mat2x2(
+        1, 0,
+        63, 2),
+      glm::u32mat2x2(
+        4, 8,
+        3, 23)};
+  // clang-format on
+
+  size_t valueBufferIndex = 0;
+  size_t valueBufferViewIndex = 0;
+
+  // Buffers are constructed in scope to ensure that the tests don't use their
+  // temporary variables.
+  {
+    Buffer& valueBuffer = model.buffers.emplace_back();
+    valueBuffer.cesium.data.resize(values.size() * sizeof(glm::u32mat2x2));
+    valueBuffer.byteLength =
+        static_cast<int64_t>(valueBuffer.cesium.data.size());
+    std::memcpy(
+        valueBuffer.cesium.data.data(),
+        values.data(),
+        valueBuffer.cesium.data.size());
+    valueBufferIndex = model.buffers.size() - 1;
+
+    BufferView& valueBufferView = model.bufferViews.emplace_back();
+    valueBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
+    valueBufferView.byteOffset = 0;
+    valueBufferView.byteLength = valueBuffer.byteLength;
+    valueBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::MAT2;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT32;
+
+  ExtensionExtStructuralMetadataPropertyTable& propertyTable =
+      metadata.propertyTables.emplace_back();
+  propertyTable.classProperty = "TestClass";
+  propertyTable.count = static_cast<int64_t>(values.size());
+
+  ExtensionExtStructuralMetadataPropertyTableProperty& propertyTableProperty =
+      propertyTable.properties["TestClassProperty"];
+  propertyTableProperty.values = static_cast<int32_t>(valueBufferViewIndex);
+
+  MetadataPropertyTableView view(&model, &propertyTable);
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(
+      classProperty->type ==
+      ExtensionExtStructuralMetadataClassProperty::Type::MAT2);
+  REQUIRE(
+      classProperty->componentType ==
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT32);
+  REQUIRE(classProperty->count == std::nullopt);
+  REQUIRE(!classProperty->array);
+
+  SECTION("Access correct type") {
+    MetadataPropertyView<glm::u32mat2x2> u32mat2x2Property =
+        view.getPropertyView<glm::u32mat2x2>("TestClassProperty");
+    REQUIRE(u32mat2x2Property.status() == MetadataPropertyViewStatus::Valid);
+    REQUIRE(u32mat2x2Property.size() > 0);
+
+    for (int64_t i = 0; i < u32mat2x2Property.size(); ++i) {
+      REQUIRE(u32mat2x2Property.get(i) == values[i]);
+    }
+  }
+
+  SECTION("Access wrong type") {
+    MetadataPropertyView<uint32_t> uint32Invalid =
+        view.getPropertyView<uint32_t>("TestClassProperty");
+    REQUIRE(
+        uint32Invalid.status() ==
+        MetadataPropertyViewStatus::ErrorTypeMismatch);
+
+    MetadataPropertyView<glm::uvec2> uvec2Invalid =
+        view.getPropertyView<glm::uvec2>("TestClassProperty");
+    REQUIRE(
+        uvec2Invalid.status() == MetadataPropertyViewStatus::ErrorTypeMismatch);
+
+    MetadataPropertyView<glm::u32mat4x4> u32mat4x4Invalid =
+        view.getPropertyView<glm::u32mat4x4>("TestClassProperty");
+    REQUIRE(
+        u32mat4x4Invalid.status() ==
+        MetadataPropertyViewStatus::ErrorTypeMismatch);
+
+    MetadataPropertyView<bool> boolInvalid =
+        view.getPropertyView<bool>("TestClassProperty");
+    REQUIRE(
+        boolInvalid.status() == MetadataPropertyViewStatus::ErrorTypeMismatch);
+
+    MetadataPropertyView<std::string_view> stringInvalid =
+        view.getPropertyView<std::string_view>("TestClassProperty");
+    REQUIRE(
+        stringInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorTypeMismatch);
+  }
+
+  SECTION("Access wrong component type") {
+    MetadataPropertyView<glm::u8mat2x2> u8mat2x2Invalid =
+        view.getPropertyView<glm::u8mat2x2>("TestClassProperty");
+    REQUIRE(
+        u8mat2x2Invalid.status() ==
+        MetadataPropertyViewStatus::ErrorComponentTypeMismatch);
+
+    MetadataPropertyView<glm::i32mat2x2> i32mat2x2Invalid =
+        view.getPropertyView<glm::i32mat2x2>("TestClassProperty");
+    REQUIRE(
+        i32mat2x2Invalid.status() ==
+        MetadataPropertyViewStatus::ErrorComponentTypeMismatch);
+
+    MetadataPropertyView<glm::mat2> mat2Invalid =
+        view.getPropertyView<glm::mat2>("TestClassProperty");
+    REQUIRE(
+        mat2Invalid.status() ==
+        MetadataPropertyViewStatus::ErrorComponentTypeMismatch);
+  }
+
+  SECTION("Access incorrectly as array") {
+    MetadataPropertyView<MetadataArrayView<glm::u32mat2x2>>
+        u32mat2x2ArrayInvalid =
+            view.getPropertyView<MetadataArrayView<glm::u32mat2x2>>(
+                "TestClassProperty");
+    REQUIRE(
+        u32mat2x2ArrayInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorArrayTypeMismatch);
+  }
+
+  SECTION("Wrong buffer index") {
+    model.bufferViews[valueBufferViewIndex].buffer = 2;
+    MetadataPropertyView<glm::u32mat2x2> u32mat2x2Property =
+        view.getPropertyView<glm::u32mat2x2>("TestClassProperty");
+    REQUIRE(
+        u32mat2x2Property.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidValueBuffer);
+  }
+
+  SECTION("Wrong buffer view index") {
+    propertyTableProperty.values = -1;
+    MetadataPropertyView<glm::u32mat2x2> u32mat2x2Property =
+        view.getPropertyView<glm::u32mat2x2>("TestClassProperty");
+    REQUIRE(
+        u32mat2x2Property.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidValueBufferView);
+  }
+
+  SECTION("Buffer view points outside of the real buffer length") {
+    model.buffers[valueBufferIndex].cesium.data.resize(sizeof(glm::u32mat2x2));
+    MetadataPropertyView<glm::u32mat2x2> u32mat2x2Property =
+        view.getPropertyView<glm::u32mat2x2>("TestClassProperty");
+    REQUIRE(
+        u32mat2x2Property.status() ==
+        MetadataPropertyViewStatus::ErrorBufferViewOutOfBounds);
+  }
+
+  SECTION("Buffer view length isn't multiple of sizeof(T)") {
+    model.bufferViews[valueBufferViewIndex].byteLength =
+        sizeof(glm::u32mat2x2) * 4 - 1;
+    MetadataPropertyView<glm::u32mat2x2> u32mat2x2Property =
+        view.getPropertyView<glm::u32mat2x2>("TestClassProperty");
+    REQUIRE(
+        u32mat2x2Property.status() ==
+        MetadataPropertyViewStatus::ErrorBufferViewSizeNotDivisibleByTypeSize);
+  }
+
+  SECTION("Buffer view length doesn't match with propertyTableCount") {
+    model.bufferViews[valueBufferViewIndex].byteLength = sizeof(glm::u32mat2x2);
+
+    MetadataPropertyView<glm::u32mat2x2> u32mat2x2Property =
+        view.getPropertyView<glm::u32mat2x2>("TestClassProperty");
+    REQUIRE(
+        u32mat2x2Property.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+  }
+}
+
+TEST_CASE("Test StructuralMetadata boolean properties") {
+  Model model;
+
+  int64_t instanceCount = 21;
+  std::vector<bool> expected;
+  std::vector<uint8_t> values;
+  values.resize(3);
+  for (int64_t i = 0; i < instanceCount; ++i) {
+    if (i % 2 == 0) {
+      expected.emplace_back(true);
+    } else {
+      expected.emplace_back(false);
+    }
+
+    uint8_t expectedValue = expected.back();
+    int64_t byteIndex = i / 8;
+    int64_t bitIndex = i % 8;
+    values[static_cast<size_t>(byteIndex)] = static_cast<uint8_t>(
+        (expectedValue << bitIndex) | values[static_cast<size_t>(byteIndex)]);
+  }
+
+  // Buffers are constructed in scope to ensure that the tests don't use their
+  // temporary variables.
+  {
+    Buffer& valueBuffer = model.buffers.emplace_back();
+    valueBuffer.cesium.data.resize(values.size());
+    valueBuffer.byteLength =
+        static_cast<int64_t>(valueBuffer.cesium.data.size());
+    std::memcpy(
+        valueBuffer.cesium.data.data(),
+        values.data(),
+        valueBuffer.cesium.data.size());
+
+    BufferView& valueBufferView = model.bufferViews.emplace_back();
+    valueBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
+    valueBufferView.byteOffset = 0;
+    valueBufferView.byteLength = valueBuffer.byteLength;
+  }
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::BOOLEAN;
+
+  ExtensionExtStructuralMetadataPropertyTable& propertyTable =
+      metadata.propertyTables.emplace_back();
+  propertyTable.classProperty = "TestClass";
+  propertyTable.count = static_cast<int64_t>(instanceCount);
+
+  ExtensionExtStructuralMetadataPropertyTableProperty& propertyTableProperty =
+      propertyTable.properties["TestClassProperty"];
+  propertyTableProperty.values =
+      static_cast<int32_t>(model.bufferViews.size() - 1);
+
+  MetadataPropertyTableView view(&model, &propertyTable);
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(
+      classProperty->type ==
+      ExtensionExtStructuralMetadataClassProperty::Type::BOOLEAN);
+  REQUIRE(classProperty->componentType == std::nullopt);
+  REQUIRE(classProperty->count == std::nullopt);
+  REQUIRE(!classProperty->array);
+
+  SECTION("Access correct type") {
+    MetadataPropertyView<bool> boolProperty =
+        view.getPropertyView<bool>("TestClassProperty");
+    REQUIRE(boolProperty.status() == MetadataPropertyViewStatus::Valid);
+    REQUIRE(boolProperty.size() == instanceCount);
+    for (int64_t i = 0; i < boolProperty.size(); ++i) {
+      bool expectedValue = expected[static_cast<size_t>(i)];
+      REQUIRE(boolProperty.get(i) == expectedValue);
+    }
+  }
+
+  SECTION("Buffer size doesn't match with propertyTableCount") {
+    propertyTable.count = 66;
+    MetadataPropertyView<bool> boolProperty =
+        view.getPropertyView<bool>("TestClassProperty");
+    REQUIRE(
+        boolProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+  }
+}
+
+TEST_CASE("Test StructuralMetadata string property") {
+  Model model;
+
+  std::vector<std::string> expected{"What's up", "Test_0", "Test_1", "", "Hi"};
+  size_t totalBytes = 0;
+  for (const std::string& expectedValue : expected) {
+    totalBytes += expectedValue.size();
+  }
+
+  std::vector<std::byte> stringOffsets(
+      (expected.size() + 1) * sizeof(uint32_t));
+  std::vector<std::byte> values(totalBytes);
+  uint32_t* offsetValue = reinterpret_cast<uint32_t*>(stringOffsets.data());
+  for (size_t i = 0; i < expected.size(); ++i) {
+    const std::string& expectedValue = expected[i];
+    std::memcpy(
+        values.data() + offsetValue[i],
+        expectedValue.c_str(),
+        expectedValue.size());
+    offsetValue[i + 1] =
+        offsetValue[i] + static_cast<uint32_t>(expectedValue.size());
+  }
+
+  // Buffers are constructed in scope to ensure that the tests don't use their
+  // temporary variables.
+  size_t valueBufferIndex = 0;
+  size_t valueBufferViewIndex = 0;
+  {
+    Buffer& valueBuffer = model.buffers.emplace_back();
+    valueBuffer.byteLength = static_cast<int64_t>(values.size());
+    valueBuffer.cesium.data = std::move(values);
+    valueBufferIndex = model.buffers.size() - 1;
+
+    BufferView& valueBufferView = model.bufferViews.emplace_back();
+    valueBufferView.buffer = static_cast<int32_t>(valueBufferIndex);
+    valueBufferView.byteOffset = 0;
+    valueBufferView.byteLength = valueBuffer.byteLength;
+    valueBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  size_t offsetBufferIndex = 0;
+  size_t offsetBufferViewIndex = 0;
+  {
+    Buffer& offsetBuffer = model.buffers.emplace_back();
+    offsetBuffer.byteLength = static_cast<int64_t>(stringOffsets.size());
+    offsetBuffer.cesium.data = std::move(stringOffsets);
+    offsetBufferIndex = model.buffers.size() - 1;
+
+    BufferView& offsetBufferView = model.bufferViews.emplace_back();
+    offsetBufferView.buffer = static_cast<int32_t>(offsetBufferIndex);
+    offsetBufferView.byteOffset = 0;
+    offsetBufferView.byteLength = offsetBuffer.byteLength;
+    offsetBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::STRING;
+
+  ExtensionExtStructuralMetadataPropertyTable& propertyTable =
+      metadata.propertyTables.emplace_back();
+  propertyTable.classProperty = "TestClass";
+  propertyTable.count = static_cast<int64_t>(expected.size());
+
+  ExtensionExtStructuralMetadataPropertyTableProperty& propertyTableProperty =
+      propertyTable.properties["TestClassProperty"];
+  propertyTableProperty.stringOffsetType =
+      ExtensionExtStructuralMetadataPropertyTableProperty::StringOffsetType::
+          UINT32;
+  propertyTableProperty.values = static_cast<int32_t>(valueBufferViewIndex);
+  propertyTableProperty.stringOffsets =
+      static_cast<int32_t>(offsetBufferViewIndex);
+
+  MetadataPropertyTableView view(&model, &propertyTable);
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(
+      classProperty->type ==
+      ExtensionExtStructuralMetadataClassProperty::Type::STRING);
+  REQUIRE(classProperty->componentType == std::nullopt);
+  REQUIRE(classProperty->count == std::nullopt);
+  REQUIRE(!classProperty->array);
+
+  SECTION("Access correct type") {
+    MetadataPropertyView<std::string_view> stringProperty =
+        view.getPropertyView<std::string_view>("TestClassProperty");
+    REQUIRE(stringProperty.status() == MetadataPropertyViewStatus::Valid);
+    for (size_t i = 0; i < expected.size(); ++i) {
+      REQUIRE(stringProperty.get(static_cast<int64_t>(i)) == expected[i]);
+    }
+  }
+
+  SECTION("Wrong offset type") {
+    propertyTableProperty.stringOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::StringOffsetType::
+            UINT8;
+    MetadataPropertyView<std::string_view> stringProperty =
+        view.getPropertyView<std::string_view>("TestClassProperty");
+    REQUIRE(
+        stringProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+
+    propertyTableProperty.stringOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::StringOffsetType::
+            UINT64;
+    stringProperty =
+        view.getPropertyView<std::string_view>("TestClassProperty");
+    REQUIRE(
+        stringProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+
+    propertyTableProperty.stringOffsetType = "NONSENSE";
+    stringProperty =
+        view.getPropertyView<std::string_view>("TestClassProperty");
+    REQUIRE(
+        stringProperty.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidStringOffsetType);
+
+    propertyTableProperty.stringOffsetType = "";
+    propertyTableProperty.arrayOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::StringOffsetType::
+            UINT32;
+    stringProperty =
+        view.getPropertyView<std::string_view>("TestClassProperty");
+    REQUIRE(
+        stringProperty.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidStringOffsetType);
+  }
+
+  SECTION("Offset values are not sorted ascending") {
+    uint32_t* offset = reinterpret_cast<uint32_t*>(
+        model.buffers[offsetBufferIndex].cesium.data.data());
+    offset[2] =
+        static_cast<uint32_t>(model.buffers[valueBufferIndex].byteLength + 4);
+    MetadataPropertyView<std::string_view> stringProperty =
+        view.getPropertyView<std::string_view>("TestClassProperty");
+    REQUIRE(
+        stringProperty.status() ==
+        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted);
+  }
+
+  SECTION("Offset value points outside of value buffer") {
+    uint32_t* offset = reinterpret_cast<uint32_t*>(
+        model.buffers[offsetBufferIndex].cesium.data.data());
+    offset[propertyTable.count] =
+        static_cast<uint32_t>(model.buffers[valueBufferIndex].byteLength + 4);
+    MetadataPropertyView<std::string_view> stringProperty =
+        view.getPropertyView<std::string_view>("TestClassProperty");
+    REQUIRE(
+        stringProperty.status() ==
+        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+  }
+}
+
+TEST_CASE("Test StructuralMetadata fixed-length scalar array") {
+  Model model;
+
+  std::vector<uint32_t> values =
+      {12, 34, 30, 11, 34, 34, 11, 33, 122, 33, 223, 11};
+
+  size_t valueBufferViewIndex = 0;
+  {
+    Buffer& valueBuffer = model.buffers.emplace_back();
+    valueBuffer.cesium.data.resize(values.size() * sizeof(uint32_t));
+    valueBuffer.byteLength =
+        static_cast<int64_t>(valueBuffer.cesium.data.size());
+    std::memcpy(
+        valueBuffer.cesium.data.data(),
+        values.data(),
+        valueBuffer.cesium.data.size());
+
+    BufferView& valueBufferView = model.bufferViews.emplace_back();
+    valueBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
+    valueBufferView.byteOffset = 0;
+    valueBufferView.byteLength = valueBuffer.byteLength;
+    valueBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::SCALAR;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT32;
+  testClassProperty.array = true;
+  testClassProperty.count = 3;
+
+  ExtensionExtStructuralMetadataPropertyTable& propertyTable =
+      metadata.propertyTables.emplace_back();
+  propertyTable.classProperty = "TestClass";
+  propertyTable.count = static_cast<int64_t>(
+      values.size() / static_cast<size_t>(testClassProperty.count.value()));
+
+  ExtensionExtStructuralMetadataPropertyTableProperty& propertyTableProperty =
+      propertyTable.properties["TestClassProperty"];
+  propertyTableProperty.values =
+      static_cast<int32_t>(model.bufferViews.size() - 1);
+
+  MetadataPropertyTableView view(&model, &propertyTable);
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(
+      classProperty->type ==
+      ExtensionExtStructuralMetadataClassProperty::Type::SCALAR);
+  REQUIRE(
+      classProperty->componentType ==
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT32);
+  REQUIRE(classProperty->array);
+  REQUIRE(classProperty->count == 3);
+
+  SECTION("Access the right type") {
+    MetadataPropertyView<MetadataArrayView<uint32_t>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<uint32_t>>("TestClassProperty");
+    REQUIRE(arrayProperty.status() == MetadataPropertyViewStatus::Valid);
+
+    for (int64_t i = 0; i < arrayProperty.size(); ++i) {
+      MetadataArrayView<uint32_t> member = arrayProperty.get(i);
+      for (int64_t j = 0; j < member.size(); ++j) {
+        REQUIRE(member[j] == values[static_cast<size_t>(i * 3 + j)]);
+      }
+    }
+  }
+
+  SECTION("Wrong type") {
+    MetadataPropertyView<MetadataArrayView<bool>> boolArrayInvalid =
+        view.getPropertyView<MetadataArrayView<bool>>("TestClassProperty");
+    REQUIRE(
+        boolArrayInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorTypeMismatch);
+
+    MetadataPropertyView<MetadataArrayView<glm::uvec2>> uvec2ArrayInvalid =
+        view.getPropertyView<MetadataArrayView<glm::uvec2>>(
+            "TestClassProperty");
+    REQUIRE(
+        uvec2ArrayInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorTypeMismatch);
+  }
+
+  SECTION("Wrong component type") {
+    MetadataPropertyView<MetadataArrayView<int32_t>> int32ArrayInvalid =
+        view.getPropertyView<MetadataArrayView<int32_t>>("TestClassProperty");
+    REQUIRE(
+        int32ArrayInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorComponentTypeMismatch);
+  }
+
+  SECTION("Not an array type") {
+    MetadataPropertyView<uint32_t> uint32Invalid =
+        view.getPropertyView<uint32_t>("TestClassProperty");
+    REQUIRE(
+        uint32Invalid.status() ==
+        MetadataPropertyViewStatus::ErrorArrayTypeMismatch);
+  }
+
+  SECTION("Buffer size is not a multiple of type size") {
+    model.bufferViews[valueBufferViewIndex].byteLength = 13;
+    MetadataPropertyView<MetadataArrayView<uint32_t>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<uint32_t>>("TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorBufferViewSizeNotDivisibleByTypeSize);
+  }
+
+  SECTION("Negative component count") {
+    testClassProperty.count = -1;
+    MetadataPropertyView<MetadataArrayView<uint32_t>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<uint32_t>>("TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayCountAndOffsetBufferDontExist);
+  }
+
+  SECTION("Value buffer doesn't fit into property table count") {
+    testClassProperty.count = 55;
+    MetadataPropertyView<MetadataArrayView<uint32_t>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<uint32_t>>("TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+  }
+}
+
+TEST_CASE("Test Structural Metadata variable-length scalar array") {
+  Model model;
+
+  std::vector<std::vector<uint16_t>> expected{
+      {12, 33, 11, 344, 112, 444, 1},
+      {},
+      {},
+      {122, 23, 333, 12},
+      {},
+      {333, 311, 22, 34},
+      {},
+      {33, 1888, 233, 33019}};
+  size_t numOfElements = 0;
+  for (const auto& expectedMember : expected) {
+    numOfElements += expectedMember.size();
+  }
+
+  std::vector<std::byte> values(numOfElements * sizeof(uint16_t));
+  std::vector<std::byte> offsets((expected.size() + 1) * sizeof(uint64_t));
+  uint64_t* offsetValue = reinterpret_cast<uint64_t*>(offsets.data());
+  for (size_t i = 0; i < expected.size(); ++i) {
+    std::memcpy(
+        values.data() + offsetValue[i],
+        expected[i].data(),
+        expected[i].size() * sizeof(uint16_t));
+    offsetValue[i + 1] = offsetValue[i] + expected[i].size() * sizeof(uint16_t);
+  }
+
+  size_t valueBufferIndex = 0;
+  size_t valueBufferViewIndex = 0;
+  {
+    Buffer& valueBuffer = model.buffers.emplace_back();
+    valueBuffer.byteLength = static_cast<int64_t>(values.size());
+    valueBuffer.cesium.data = std::move(values);
+    valueBufferIndex = model.buffers.size() - 1;
+
+    BufferView& valueBufferView = model.bufferViews.emplace_back();
+    valueBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
+    valueBufferView.byteOffset = 0;
+    valueBufferView.byteLength = valueBuffer.byteLength;
+    valueBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  size_t offsetBufferIndex = 0;
+  size_t offsetBufferViewIndex = 0;
+  {
+    Buffer& offsetBuffer = model.buffers.emplace_back();
+    offsetBuffer.byteLength = static_cast<int64_t>(offsets.size());
+    offsetBuffer.cesium.data = std::move(offsets);
+    offsetBufferIndex = model.buffers.size() - 1;
+
+    BufferView& offsetBufferView = model.bufferViews.emplace_back();
+    offsetBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
+    offsetBufferView.byteOffset = 0;
+    offsetBufferView.byteLength = offsetBuffer.byteLength;
+    offsetBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::SCALAR;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT16;
+  testClassProperty.array = true;
+
+  ExtensionExtStructuralMetadataPropertyTable& propertyTable =
+      metadata.propertyTables.emplace_back();
+  propertyTable.classProperty = "TestClass";
+  propertyTable.count = static_cast<int64_t>(expected.size());
+
+  ExtensionExtStructuralMetadataPropertyTableProperty& propertyTableProperty =
+      propertyTable.properties["TestClassProperty"];
+  propertyTableProperty.values = static_cast<int32_t>(valueBufferViewIndex);
+  propertyTableProperty.arrayOffsets =
+      static_cast<int32_t>(offsetBufferViewIndex);
+  propertyTableProperty.arrayOffsetType =
+      ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+          UINT64;
+
+  MetadataPropertyTableView view(&model, &propertyTable);
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(
+      classProperty->type ==
+      ExtensionExtStructuralMetadataClassProperty::Type::SCALAR);
+  REQUIRE(
+      classProperty->componentType ==
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT16);
+  REQUIRE(classProperty->array);
+  REQUIRE(!classProperty->count);
+
+  SECTION("Access the correct type") {
+    MetadataPropertyView<MetadataArrayView<uint16_t>> property =
+        view.getPropertyView<MetadataArrayView<uint16_t>>("TestClassProperty");
+    REQUIRE(property.status() == MetadataPropertyViewStatus::Valid);
+    for (size_t i = 0; i < expected.size(); ++i) {
+      MetadataArrayView<uint16_t> valueMember =
+          property.get(static_cast<int64_t>(i));
+      REQUIRE(valueMember.size() == static_cast<int64_t>(expected[i].size()));
+      for (size_t j = 0; j < expected[i].size(); ++j) {
+        REQUIRE(expected[i][j] == valueMember[static_cast<int64_t>(j)]);
+      }
+    }
+  }
+  SECTION("Wrong offset type") {
+    propertyTableProperty.arrayOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+            UINT8;
+    MetadataPropertyView<MetadataArrayView<uint16_t>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<uint16_t>>("TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+
+    propertyTableProperty.arrayOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+            UINT16;
+    arrayProperty =
+        view.getPropertyView<MetadataArrayView<uint16_t>>("TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+
+    propertyTableProperty.arrayOffsetType = "NONSENSE";
+    arrayProperty =
+        view.getPropertyView<MetadataArrayView<uint16_t>>("TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType);
+
+    propertyTableProperty.arrayOffsetType = "";
+    propertyTableProperty.stringOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::StringOffsetType::
+            UINT64;
+    arrayProperty =
+        view.getPropertyView<MetadataArrayView<uint16_t>>("TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType);
+  }
+
+  SECTION("Offset values are not sorted ascending") {
+    propertyTableProperty.arrayOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+            UINT64;
+    uint64_t* offset = reinterpret_cast<uint64_t*>(
+        model.buffers[offsetBufferIndex].cesium.data.data());
+    offset[propertyTable.count] = 0;
+    MetadataPropertyView<MetadataArrayView<uint16_t>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<uint16_t>>("TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayOffsetsNotSorted);
+  }
+
+  SECTION("Offset value points outside of value buffer") {
+    uint64_t* offset = reinterpret_cast<uint64_t*>(
+        model.buffers[offsetBufferIndex].cesium.data.data());
+    offset[propertyTable.count] =
+        static_cast<uint32_t>(model.buffers[valueBufferIndex].byteLength + 4);
+    MetadataPropertyView<MetadataArrayView<uint16_t>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<uint16_t>>("TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayOffsetOutOfBounds);
+  }
+
+  SECTION("Count and offset buffer are both present") {
+    testClassProperty.count = 3;
+    MetadataPropertyView<MetadataArrayView<uint16_t>> property =
+        view.getPropertyView<MetadataArrayView<uint16_t>>("TestClassProperty");
+    REQUIRE(
+        property.status() ==
+        MetadataPropertyViewStatus::ErrorArrayCountAndOffsetBufferCoexist);
+  }
+}
+
+TEST_CASE("Test StructuralMetadata fixed-length vecN array") {
+  Model model;
+
+  std::vector<glm::ivec3> values = {
+      glm::ivec3(12, 34, -30),
+      glm::ivec3(-2, 0, 1),
+      glm::ivec3(1, 2, 8),
+      glm::ivec3(-100, 84, 6),
+      glm::ivec3(2, -2, -2),
+      glm::ivec3(40, 61, 3),
+  };
+
+  size_t valueBufferViewIndex = 0;
+  {
+    Buffer& valueBuffer = model.buffers.emplace_back();
+    valueBuffer.cesium.data.resize(values.size() * sizeof(glm::ivec3));
+    valueBuffer.byteLength =
+        static_cast<int64_t>(valueBuffer.cesium.data.size());
+    std::memcpy(
+        valueBuffer.cesium.data.data(),
+        values.data(),
+        valueBuffer.cesium.data.size());
+
+    BufferView& valueBufferView = model.bufferViews.emplace_back();
+    valueBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
+    valueBufferView.byteOffset = 0;
+    valueBufferView.byteLength = valueBuffer.byteLength;
+    valueBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::VEC3;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::INT32;
+  testClassProperty.array = true;
+  testClassProperty.count = 2;
+
+  ExtensionExtStructuralMetadataPropertyTable& propertyTable =
+      metadata.propertyTables.emplace_back();
+  propertyTable.classProperty = "TestClass";
+  propertyTable.count = static_cast<int64_t>(
+      values.size() / static_cast<size_t>(testClassProperty.count.value()));
+
+  ExtensionExtStructuralMetadataPropertyTableProperty& propertyTableProperty =
+      propertyTable.properties["TestClassProperty"];
+  propertyTableProperty.values =
+      static_cast<int32_t>(model.bufferViews.size() - 1);
+
+  MetadataPropertyTableView view(&model, &propertyTable);
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(
+      classProperty->type ==
+      ExtensionExtStructuralMetadataClassProperty::Type::VEC3);
+  REQUIRE(
+      classProperty->componentType ==
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::INT32);
+  REQUIRE(classProperty->array);
+  REQUIRE(classProperty->count == 2);
+
+  SECTION("Access the right type") {
+    MetadataPropertyView<MetadataArrayView<glm::ivec3>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<glm::ivec3>>(
+            "TestClassProperty");
+    REQUIRE(arrayProperty.status() == MetadataPropertyViewStatus::Valid);
+
+    for (int64_t i = 0; i < arrayProperty.size(); ++i) {
+      MetadataArrayView<glm::ivec3> member = arrayProperty.get(i);
+      for (int64_t j = 0; j < member.size(); ++j) {
+        REQUIRE(member[j] == values[static_cast<size_t>(i * 2 + j)]);
+      }
+    }
+  }
+
+  SECTION("Wrong type") {
+    MetadataPropertyView<MetadataArrayView<int32_t>> int32ArrayInvalid =
+        view.getPropertyView<MetadataArrayView<int32_t>>("TestClassProperty");
+    REQUIRE(
+        int32ArrayInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorTypeMismatch);
+
+    MetadataPropertyView<MetadataArrayView<glm::ivec2>> ivec2ArrayInvalid =
+        view.getPropertyView<MetadataArrayView<glm::ivec2>>(
+            "TestClassProperty");
+    REQUIRE(
+        ivec2ArrayInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorTypeMismatch);
+  }
+
+  SECTION("Wrong component type") {
+    MetadataPropertyView<MetadataArrayView<glm::uvec3>> uvec3ArrayInvalid =
+        view.getPropertyView<MetadataArrayView<glm::uvec3>>(
+            "TestClassProperty");
+    REQUIRE(
+        uvec3ArrayInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorComponentTypeMismatch);
+  }
+
+  SECTION("Not an array type") {
+    MetadataPropertyView<glm::ivec3> ivec3Invalid =
+        view.getPropertyView<glm::ivec3>("TestClassProperty");
+    REQUIRE(
+        ivec3Invalid.status() ==
+        MetadataPropertyViewStatus::ErrorArrayTypeMismatch);
+  }
+
+  SECTION("Buffer size is not a multiple of type size") {
+    model.bufferViews[valueBufferViewIndex].byteLength = 13;
+    MetadataPropertyView<MetadataArrayView<glm::ivec3>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<glm::ivec3>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorBufferViewSizeNotDivisibleByTypeSize);
+  }
+
+  SECTION("Negative component count") {
+    testClassProperty.count = -1;
+    MetadataPropertyView<MetadataArrayView<glm::ivec3>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<glm::ivec3>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayCountAndOffsetBufferDontExist);
+  }
+
+  SECTION("Value buffer doesn't fit into property table count") {
+    testClassProperty.count = 55;
+    MetadataPropertyView<MetadataArrayView<glm::ivec3>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<glm::ivec3>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+  }
+}
+
+TEST_CASE("Test Structural Metadata variable-length vecN array") {
+  Model model;
+
+  // clang-format off
+  std::vector<std::vector<glm::ivec3>> expected{
+      { glm::ivec3(12, 34, -30), glm::ivec3(-2, 0, 1) },
+      { glm::ivec3(1, 2, 8), },
+      {},
+      { glm::ivec3(-100, 84, 6), glm::ivec3(2, -2, -2), glm::ivec3(40, 61, 3) },
+      { glm::ivec3(-1, 4, -7) },
+  };
+  // clang-format on
+
+  size_t numOfElements = 0;
+  for (const auto& expectedMember : expected) {
+    numOfElements += expectedMember.size();
+  }
+
+  std::vector<std::byte> values(numOfElements * sizeof(glm::ivec3));
+  std::vector<std::byte> offsets((expected.size() + 1) * sizeof(uint64_t));
+  uint64_t* offsetValue = reinterpret_cast<uint64_t*>(offsets.data());
+  for (size_t i = 0; i < expected.size(); ++i) {
+    std::memcpy(
+        values.data() + offsetValue[i],
+        expected[i].data(),
+        expected[i].size() * sizeof(glm::ivec3));
+    offsetValue[i + 1] =
+        offsetValue[i] + expected[i].size() * sizeof(glm::ivec3);
+  }
+
+  size_t valueBufferIndex = 0;
+  size_t valueBufferViewIndex = 0;
+  {
+    Buffer& valueBuffer = model.buffers.emplace_back();
+    valueBuffer.byteLength = static_cast<int64_t>(values.size());
+    valueBuffer.cesium.data = std::move(values);
+    valueBufferIndex = model.buffers.size() - 1;
+
+    BufferView& valueBufferView = model.bufferViews.emplace_back();
+    valueBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
+    valueBufferView.byteOffset = 0;
+    valueBufferView.byteLength = valueBuffer.byteLength;
+    valueBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  size_t offsetBufferIndex = 0;
+  size_t offsetBufferViewIndex = 0;
+  {
+    Buffer& offsetBuffer = model.buffers.emplace_back();
+    offsetBuffer.byteLength = static_cast<int64_t>(offsets.size());
+    offsetBuffer.cesium.data = std::move(offsets);
+    offsetBufferIndex = model.buffers.size() - 1;
+
+    BufferView& offsetBufferView = model.bufferViews.emplace_back();
+    offsetBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
+    offsetBufferView.byteOffset = 0;
+    offsetBufferView.byteLength = offsetBuffer.byteLength;
+    offsetBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::VEC3;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::INT32;
+  testClassProperty.array = true;
+
+  ExtensionExtStructuralMetadataPropertyTable& propertyTable =
+      metadata.propertyTables.emplace_back();
+  propertyTable.classProperty = "TestClass";
+  propertyTable.count = static_cast<int64_t>(expected.size());
+
+  ExtensionExtStructuralMetadataPropertyTableProperty& propertyTableProperty =
+      propertyTable.properties["TestClassProperty"];
+  propertyTableProperty.values = static_cast<int32_t>(valueBufferViewIndex);
+  propertyTableProperty.arrayOffsets =
+      static_cast<int32_t>(offsetBufferViewIndex);
+  propertyTableProperty.arrayOffsetType =
+      ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+          UINT64;
+
+  MetadataPropertyTableView view(&model, &propertyTable);
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(
+      classProperty->type ==
+      ExtensionExtStructuralMetadataClassProperty::Type::VEC3);
+  REQUIRE(
+      classProperty->componentType ==
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::INT32);
+  REQUIRE(classProperty->array);
+  REQUIRE(!classProperty->count);
+
+  SECTION("Access the correct type") {
+    MetadataPropertyView<MetadataArrayView<glm::ivec3>> property =
+        view.getPropertyView<MetadataArrayView<glm::ivec3>>(
+            "TestClassProperty");
+    REQUIRE(property.status() == MetadataPropertyViewStatus::Valid);
+    for (size_t i = 0; i < expected.size(); ++i) {
+      MetadataArrayView<glm::ivec3> valueMember =
+          property.get(static_cast<int64_t>(i));
+      REQUIRE(valueMember.size() == static_cast<int64_t>(expected[i].size()));
+      for (size_t j = 0; j < expected[i].size(); ++j) {
+        REQUIRE(expected[i][j] == valueMember[static_cast<int64_t>(j)]);
+      }
+    }
+  }
+
+  SECTION("Wrong offset type") {
+    propertyTableProperty.arrayOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+            UINT8;
+    MetadataPropertyView<MetadataArrayView<glm::ivec3>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<glm::ivec3>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+
+    propertyTableProperty.arrayOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+            UINT16;
+    arrayProperty = view.getPropertyView<MetadataArrayView<glm::ivec3>>(
+        "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+
+    propertyTableProperty.arrayOffsetType = "NONSENSE";
+    arrayProperty = view.getPropertyView<MetadataArrayView<glm::ivec3>>(
+        "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType);
+
+    propertyTableProperty.arrayOffsetType = "";
+    propertyTableProperty.stringOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::StringOffsetType::
+            UINT64;
+    arrayProperty = view.getPropertyView<MetadataArrayView<glm::ivec3>>(
+        "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType);
+  }
+
+  SECTION("Offset values are not sorted ascending") {
+    propertyTableProperty.arrayOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+            UINT64;
+    uint64_t* offset = reinterpret_cast<uint64_t*>(
+        model.buffers[offsetBufferIndex].cesium.data.data());
+    offset[propertyTable.count] = 0;
+    MetadataPropertyView<MetadataArrayView<glm::ivec3>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<glm::ivec3>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayOffsetsNotSorted);
+  }
+
+  SECTION("Offset value points outside of value buffer") {
+    uint64_t* offset = reinterpret_cast<uint64_t*>(
+        model.buffers[offsetBufferIndex].cesium.data.data());
+    offset[propertyTable.count] =
+        static_cast<uint32_t>(model.buffers[valueBufferIndex].byteLength + 4);
+    MetadataPropertyView<MetadataArrayView<glm::ivec3>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<glm::ivec3>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayOffsetOutOfBounds);
+  }
+
+  SECTION("Count and offset buffer are both present") {
+    testClassProperty.count = 3;
+    MetadataPropertyView<MetadataArrayView<glm::ivec3>> property =
+        view.getPropertyView<MetadataArrayView<glm::ivec3>>(
+            "TestClassProperty");
+    REQUIRE(
+        property.status() ==
+        MetadataPropertyViewStatus::ErrorArrayCountAndOffsetBufferCoexist);
+  }
+}
+
+TEST_CASE("Test StructuralMetadata fixed-length matN array") {
+  Model model;
+
+  // clang-format off
+  std::vector<glm::i32mat2x2> values = {
+      glm::i32mat2x2(
+        12, 34,
+        -30, 20),
+      glm::i32mat2x2(
+        -2, -2,
+        0, 1),
+      glm::i32mat2x2(
+        1, 2,
+        8, 5),
+      glm::i32mat2x2(
+        -100, 3,
+        84, 6),
+      glm::i32mat2x2(
+        2, 12,
+        -2, -2),
+      glm::i32mat2x2(
+        40, 61,
+        7, -3),
+  };
+  // clang-format on
+
+  size_t valueBufferViewIndex = 0;
+  {
+    Buffer& valueBuffer = model.buffers.emplace_back();
+    valueBuffer.cesium.data.resize(values.size() * sizeof(glm::i32mat2x2));
+    valueBuffer.byteLength =
+        static_cast<int64_t>(valueBuffer.cesium.data.size());
+    std::memcpy(
+        valueBuffer.cesium.data.data(),
+        values.data(),
+        valueBuffer.cesium.data.size());
+
+    BufferView& valueBufferView = model.bufferViews.emplace_back();
+    valueBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
+    valueBufferView.byteOffset = 0;
+    valueBufferView.byteLength = valueBuffer.byteLength;
+    valueBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::MAT2;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::INT32;
+  testClassProperty.array = true;
+  testClassProperty.count = 2;
+
+  ExtensionExtStructuralMetadataPropertyTable& propertyTable =
+      metadata.propertyTables.emplace_back();
+  propertyTable.classProperty = "TestClass";
+  propertyTable.count = static_cast<int64_t>(
+      values.size() / static_cast<size_t>(testClassProperty.count.value()));
+
+  ExtensionExtStructuralMetadataPropertyTableProperty& propertyTableProperty =
+      propertyTable.properties["TestClassProperty"];
+  propertyTableProperty.values =
+      static_cast<int32_t>(model.bufferViews.size() - 1);
+
+  MetadataPropertyTableView view(&model, &propertyTable);
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(
+      classProperty->type ==
+      ExtensionExtStructuralMetadataClassProperty::Type::MAT2);
+  REQUIRE(
+      classProperty->componentType ==
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::INT32);
+  REQUIRE(classProperty->array);
+  REQUIRE(classProperty->count == 2);
+
+  SECTION("Access the right type") {
+    MetadataPropertyView<MetadataArrayView<glm::i32mat2x2>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<glm::i32mat2x2>>(
+            "TestClassProperty");
+    REQUIRE(arrayProperty.status() == MetadataPropertyViewStatus::Valid);
+
+    for (int64_t i = 0; i < arrayProperty.size(); ++i) {
+      MetadataArrayView<glm::i32mat2x2> member = arrayProperty.get(i);
+      for (int64_t j = 0; j < member.size(); ++j) {
+        REQUIRE(member[j] == values[static_cast<size_t>(i * 2 + j)]);
+      }
+    }
+  }
+
+  SECTION("Wrong type") {
+    MetadataPropertyView<MetadataArrayView<int32_t>> int32ArrayInvalid =
+        view.getPropertyView<MetadataArrayView<int32_t>>("TestClassProperty");
+    REQUIRE(
+        int32ArrayInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorTypeMismatch);
+
+    MetadataPropertyView<MetadataArrayView<glm::ivec2>> ivec2ArrayInvalid =
+        view.getPropertyView<MetadataArrayView<glm::ivec2>>(
+            "TestClassProperty");
+    REQUIRE(
+        ivec2ArrayInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorTypeMismatch);
+  }
+
+  SECTION("Wrong component type") {
+    MetadataPropertyView<MetadataArrayView<glm::u32mat2x2>>
+        u32mat2x2ArrayInvalid =
+            view.getPropertyView<MetadataArrayView<glm::u32mat2x2>>(
+                "TestClassProperty");
+    REQUIRE(
+        u32mat2x2ArrayInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorComponentTypeMismatch);
+  }
+
+  SECTION("Not an array type") {
+    MetadataPropertyView<glm::i32mat2x2> ivec3Invalid =
+        view.getPropertyView<glm::i32mat2x2>("TestClassProperty");
+    REQUIRE(
+        ivec3Invalid.status() ==
+        MetadataPropertyViewStatus::ErrorArrayTypeMismatch);
+  }
+
+  SECTION("Buffer size is not a multiple of type size") {
+    model.bufferViews[valueBufferViewIndex].byteLength = 13;
+    MetadataPropertyView<MetadataArrayView<glm::i32mat2x2>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<glm::i32mat2x2>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorBufferViewSizeNotDivisibleByTypeSize);
+  }
+
+  SECTION("Negative component count") {
+    testClassProperty.count = -1;
+    MetadataPropertyView<MetadataArrayView<glm::i32mat2x2>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<glm::i32mat2x2>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayCountAndOffsetBufferDontExist);
+  }
+
+  SECTION("Value buffer doesn't fit into property table count") {
+    testClassProperty.count = 55;
+    MetadataPropertyView<MetadataArrayView<glm::i32mat2x2>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<glm::i32mat2x2>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+  }
+}
+
+TEST_CASE("Test Structural Metadata variable-length matN array") {
+  Model model;
+
+  // clang-format off
+    std::vector<glm::i32mat2x2> data0{
+        glm::i32mat2x2(
+          3, -2,
+          1, 0),
+        glm::i32mat2x2(
+          40, 3,
+          8, -9)
+    };
+    std::vector<glm::i32mat2x2> data1{
+        glm::i32mat2x2(
+          1, 10,
+          7, 8),
+    };
+    std::vector<glm::i32mat2x2> data2{
+        glm::i32mat2x2(
+          18, 0,
+          1, 17),
+        glm::i32mat2x2(
+          -4, -2,
+          -9, 1),
+        glm::i32mat2x2(
+          1, 8,
+          -99, 3),
+    };
+  // clang-format on
+
+  std::vector<std::vector<glm::i32mat2x2>>
+      expected{data0, {}, data1, data2, {}};
+
+  size_t numOfElements = 0;
+  for (const auto& expectedMember : expected) {
+    numOfElements += expectedMember.size();
+  }
+
+  std::vector<std::byte> values(numOfElements * sizeof(glm::i32mat2x2));
+  std::vector<std::byte> offsets((expected.size() + 1) * sizeof(uint64_t));
+  uint64_t* offsetValue = reinterpret_cast<uint64_t*>(offsets.data());
+  for (size_t i = 0; i < expected.size(); ++i) {
+    std::memcpy(
+        values.data() + offsetValue[i],
+        expected[i].data(),
+        expected[i].size() * sizeof(glm::i32mat2x2));
+    offsetValue[i + 1] =
+        offsetValue[i] + expected[i].size() * sizeof(glm::i32mat2x2);
+  }
+
+  size_t valueBufferIndex = 0;
+  size_t valueBufferViewIndex = 0;
+  {
+    Buffer& valueBuffer = model.buffers.emplace_back();
+    valueBuffer.byteLength = static_cast<int64_t>(values.size());
+    valueBuffer.cesium.data = std::move(values);
+    valueBufferIndex = model.buffers.size() - 1;
+
+    BufferView& valueBufferView = model.bufferViews.emplace_back();
+    valueBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
+    valueBufferView.byteOffset = 0;
+    valueBufferView.byteLength = valueBuffer.byteLength;
+    valueBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  size_t offsetBufferIndex = 0;
+  size_t offsetBufferViewIndex = 0;
+  {
+    Buffer& offsetBuffer = model.buffers.emplace_back();
+    offsetBuffer.byteLength = static_cast<int64_t>(offsets.size());
+    offsetBuffer.cesium.data = std::move(offsets);
+    offsetBufferIndex = model.buffers.size() - 1;
+
+    BufferView& offsetBufferView = model.bufferViews.emplace_back();
+    offsetBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
+    offsetBufferView.byteOffset = 0;
+    offsetBufferView.byteLength = offsetBuffer.byteLength;
+    offsetBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::MAT2;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::INT32;
+  testClassProperty.array = true;
+
+  ExtensionExtStructuralMetadataPropertyTable& propertyTable =
+      metadata.propertyTables.emplace_back();
+  propertyTable.classProperty = "TestClass";
+  propertyTable.count = static_cast<int64_t>(expected.size());
+
+  ExtensionExtStructuralMetadataPropertyTableProperty& propertyTableProperty =
+      propertyTable.properties["TestClassProperty"];
+  propertyTableProperty.values = static_cast<int32_t>(valueBufferViewIndex);
+  propertyTableProperty.arrayOffsets =
+      static_cast<int32_t>(offsetBufferViewIndex);
+  propertyTableProperty.arrayOffsetType =
+      ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+          UINT64;
+
+  MetadataPropertyTableView view(&model, &propertyTable);
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(
+      classProperty->type ==
+      ExtensionExtStructuralMetadataClassProperty::Type::MAT2);
+  REQUIRE(
+      classProperty->componentType ==
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::INT32);
+  REQUIRE(classProperty->array);
+  REQUIRE(!classProperty->count);
+
+  SECTION("Access the correct type") {
+    MetadataPropertyView<MetadataArrayView<glm::i32mat2x2>> property =
+        view.getPropertyView<MetadataArrayView<glm::i32mat2x2>>(
+            "TestClassProperty");
+    REQUIRE(property.status() == MetadataPropertyViewStatus::Valid);
+    for (size_t i = 0; i < expected.size(); ++i) {
+      MetadataArrayView<glm::i32mat2x2> valueMember =
+          property.get(static_cast<int64_t>(i));
+      REQUIRE(valueMember.size() == static_cast<int64_t>(expected[i].size()));
+      for (size_t j = 0; j < expected[i].size(); ++j) {
+        REQUIRE(expected[i][j] == valueMember[static_cast<int64_t>(j)]);
+      }
+    }
+  }
+
+  SECTION("Wrong offset type") {
+    propertyTableProperty.arrayOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+            UINT8;
+    MetadataPropertyView<MetadataArrayView<glm::i32mat2x2>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<glm::i32mat2x2>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+
+    propertyTableProperty.arrayOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+            UINT16;
+    arrayProperty = view.getPropertyView<MetadataArrayView<glm::i32mat2x2>>(
+        "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+
+    propertyTableProperty.arrayOffsetType = "NONSENSE";
+    arrayProperty = view.getPropertyView<MetadataArrayView<glm::i32mat2x2>>(
+        "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType);
+
+    propertyTableProperty.arrayOffsetType = "";
+    propertyTableProperty.stringOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::StringOffsetType::
+            UINT64;
+    arrayProperty = view.getPropertyView<MetadataArrayView<glm::i32mat2x2>>(
+        "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType);
+  }
+
+  SECTION("Offset values are not sorted ascending") {
+    propertyTableProperty.arrayOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+            UINT64;
+    uint64_t* offset = reinterpret_cast<uint64_t*>(
+        model.buffers[offsetBufferIndex].cesium.data.data());
+    offset[propertyTable.count] = 0;
+    MetadataPropertyView<MetadataArrayView<glm::i32mat2x2>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<glm::i32mat2x2>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayOffsetsNotSorted);
+  }
+
+  SECTION("Offset value points outside of value buffer") {
+    uint64_t* offset = reinterpret_cast<uint64_t*>(
+        model.buffers[offsetBufferIndex].cesium.data.data());
+    offset[propertyTable.count] =
+        static_cast<uint32_t>(model.buffers[valueBufferIndex].byteLength + 4);
+    MetadataPropertyView<MetadataArrayView<glm::i32mat2x2>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<glm::i32mat2x2>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayOffsetOutOfBounds);
+  }
+
+  SECTION("Count and offset buffer are both present") {
+    testClassProperty.count = 3;
+    MetadataPropertyView<MetadataArrayView<glm::i32mat2x2>> property =
+        view.getPropertyView<MetadataArrayView<glm::i32mat2x2>>(
+            "TestClassProperty");
+    REQUIRE(
+        property.status() ==
+        MetadataPropertyViewStatus::ErrorArrayCountAndOffsetBufferCoexist);
+  }
+}
+
+TEST_CASE("Test StructuralMetadata fixed-length boolean array") {
+  Model model;
+
+  std::vector<bool> expected = {
+      true,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true};
+  std::vector<uint8_t> values;
+  size_t requiredBytesSize = static_cast<size_t>(
+      glm::ceil(static_cast<double>(expected.size()) / 8.0));
+  values.resize(requiredBytesSize);
+  for (size_t i = 0; i < expected.size(); ++i) {
+    uint8_t expectedValue = expected[i];
+    size_t byteIndex = i / 8;
+    size_t bitIndex = i % 8;
+    values[byteIndex] =
+        static_cast<uint8_t>((expectedValue << bitIndex) | values[byteIndex]);
+  }
+
+  {
+    Buffer& valueBuffer = model.buffers.emplace_back();
+    valueBuffer.cesium.data.resize(values.size());
+    valueBuffer.byteLength =
+        static_cast<int64_t>(valueBuffer.cesium.data.size());
+    std::memcpy(
+        valueBuffer.cesium.data.data(),
+        values.data(),
+        valueBuffer.cesium.data.size());
+
+    BufferView& valueBufferView = model.bufferViews.emplace_back();
+    valueBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
+    valueBufferView.byteOffset = 0;
+    valueBufferView.byteLength = valueBuffer.byteLength;
+  }
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::BOOLEAN;
+  testClassProperty.array = true;
+  testClassProperty.count = 3;
+
+  ExtensionExtStructuralMetadataPropertyTable& propertyTable =
+      metadata.propertyTables.emplace_back();
+  propertyTable.classProperty = "TestClass";
+  propertyTable.count = static_cast<int64_t>(
+      expected.size() / static_cast<size_t>(testClassProperty.count.value()));
+
+  ExtensionExtStructuralMetadataPropertyTableProperty& propertyTableProperty =
+      propertyTable.properties["TestClassProperty"];
+  propertyTableProperty.values =
+      static_cast<int32_t>(model.bufferViews.size() - 1);
+
+  MetadataPropertyTableView view(&model, &propertyTable);
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(
+      classProperty->type ==
+      ExtensionExtStructuralMetadataClassProperty::Type::BOOLEAN);
+  REQUIRE(classProperty->array);
+  REQUIRE(classProperty->count == 3);
+
+  SECTION("Access correct type") {
+    MetadataPropertyView<MetadataArrayView<bool>> boolArrayProperty =
+        view.getPropertyView<MetadataArrayView<bool>>("TestClassProperty");
+    REQUIRE(boolArrayProperty.status() == MetadataPropertyViewStatus::Valid);
+    REQUIRE(boolArrayProperty.size() == propertyTable.count);
+    REQUIRE(boolArrayProperty.size() > 0);
+    for (int64_t i = 0; i < boolArrayProperty.size(); ++i) {
+      MetadataArrayView<bool> valueMember = boolArrayProperty.get(i);
+      for (int64_t j = 0; j < valueMember.size(); ++j) {
+        REQUIRE(valueMember[j] == expected[static_cast<size_t>(i * 3 + j)]);
+      }
+    }
+  }
+
+  SECTION("Wrong type") {
+    MetadataPropertyView<MetadataArrayView<uint8_t>> uint8ArrayInvalid =
+        view.getPropertyView<MetadataArrayView<uint8_t>>("TestClassProperty");
+    REQUIRE(
+        uint8ArrayInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorTypeMismatch);
+  }
+
+  SECTION("View is not array type") {
+    MetadataPropertyView<bool> boolInvalid =
+        view.getPropertyView<bool>("TestClassProperty");
+    REQUIRE(
+        boolInvalid.status() ==
+        MetadataPropertyViewStatus::ErrorArrayTypeMismatch);
+  }
+
+  SECTION("Value buffer doesn't have enough required bytes") {
+    testClassProperty.count = 11;
+    MetadataPropertyView<MetadataArrayView<bool>> boolArrayProperty =
+        view.getPropertyView<MetadataArrayView<bool>>("TestClassProperty");
+    REQUIRE(
+        boolArrayProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+  }
+
+  SECTION("Count is negative") {
+    testClassProperty.count = -1;
+    MetadataPropertyView<MetadataArrayView<bool>> boolArrayProperty =
+        view.getPropertyView<MetadataArrayView<bool>>("TestClassProperty");
+    REQUIRE(
+        boolArrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayCountAndOffsetBufferDontExist);
+  }
+}
+
+TEST_CASE("Test StructuralMetadata variable-length boolean array") {
+  Model model;
+
+  std::vector<std::vector<bool>> expected{
+      {true, false, true, true, false, true, true},
+      {},
+      {},
+      {},
+      {false, false, false, false},
+      {true, false, true},
+      {false},
+      {true, true, true, true, true, false, false}};
+  size_t numOfElements = 0;
+  for (const auto& expectedMember : expected) {
+    numOfElements += expectedMember.size();
+  }
+
+  size_t requiredBytesSize =
+      static_cast<size_t>(glm::ceil(static_cast<double>(numOfElements) / 8.0));
+  std::vector<std::byte> values(requiredBytesSize);
+  std::vector<std::byte> offsets((expected.size() + 1) * sizeof(uint64_t));
+  uint64_t* offsetValue = reinterpret_cast<uint64_t*>(offsets.data());
+  size_t indexSoFar = 0;
+  for (size_t i = 0; i < expected.size(); ++i) {
+    for (size_t j = 0; j < expected[i].size(); ++j) {
+      uint8_t expectedValue = expected[i][j];
+      size_t byteIndex = indexSoFar / 8;
+      size_t bitIndex = indexSoFar % 8;
+      values[byteIndex] = static_cast<std::byte>(
+          (expectedValue << bitIndex) | static_cast<int>(values[byteIndex]));
+      ++indexSoFar;
+    }
+    offsetValue[i + 1] = offsetValue[i] + expected[i].size();
+  }
+
+  size_t valueBufferViewIndex = 0;
+  size_t valueBufferIndex = 0;
+  {
+    Buffer& valueBuffer = model.buffers.emplace_back();
+    valueBuffer.byteLength = static_cast<int64_t>(values.size());
+    valueBuffer.cesium.data = std::move(values);
+    valueBufferIndex = model.buffers.size() - 1;
+
+    BufferView& valueBufferView = model.bufferViews.emplace_back();
+    valueBufferView.buffer = static_cast<int32_t>(valueBufferIndex);
+    valueBufferView.byteOffset = 0;
+    valueBufferView.byteLength = valueBuffer.byteLength;
+    valueBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  size_t offsetBufferIndex = 0;
+  size_t offsetBufferViewIndex = 0;
+  {
+    Buffer& offsetBuffer = model.buffers.emplace_back();
+    offsetBuffer.byteLength = static_cast<int64_t>(offsets.size());
+    offsetBuffer.cesium.data = std::move(offsets);
+    offsetBufferIndex = model.buffers.size() - 1;
+
+    BufferView& offsetBufferView = model.bufferViews.emplace_back();
+    offsetBufferView.buffer = static_cast<int32_t>(offsetBufferIndex);
+    offsetBufferView.byteOffset = 0;
+    offsetBufferView.byteLength = offsetBuffer.byteLength;
+    offsetBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::BOOLEAN;
+  testClassProperty.array = true;
+
+  ExtensionExtStructuralMetadataPropertyTable& propertyTable =
+      metadata.propertyTables.emplace_back();
+  propertyTable.classProperty = "TestClass";
+  propertyTable.count = static_cast<int64_t>(expected.size());
+
+  ExtensionExtStructuralMetadataPropertyTableProperty& propertyTableProperty =
+      propertyTable.properties["TestClassProperty"];
+  propertyTableProperty.values = static_cast<int32_t>(valueBufferViewIndex);
+  propertyTableProperty.arrayOffsets =
+      static_cast<int32_t>(offsetBufferViewIndex);
+  propertyTableProperty.arrayOffsetType =
+      ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+          UINT64;
+
+  MetadataPropertyTableView view(&model, &propertyTable);
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(
+      classProperty->type ==
+      ExtensionExtStructuralMetadataClassProperty::Type::BOOLEAN);
+  REQUIRE(classProperty->array);
+  REQUIRE(!classProperty->count);
+
+  SECTION("Access correct type") {
+    MetadataPropertyView<MetadataArrayView<bool>> boolArrayProperty =
+        view.getPropertyView<MetadataArrayView<bool>>("TestClassProperty");
+    REQUIRE(boolArrayProperty.status() == MetadataPropertyViewStatus::Valid);
+    for (size_t i = 0; i < expected.size(); ++i) {
+      MetadataArrayView<bool> arrayMember =
+          boolArrayProperty.get(static_cast<int64_t>(i));
+      REQUIRE(arrayMember.size() == static_cast<int64_t>(expected[i].size()));
+      for (size_t j = 0; j < expected[i].size(); ++j) {
+        REQUIRE(expected[i][j] == arrayMember[static_cast<int64_t>(j)]);
+      }
+    }
+  }
+
+  SECTION("Wrong offset type") {
+    propertyTableProperty.arrayOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+            UINT8;
+    MetadataPropertyView<MetadataArrayView<bool>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<bool>>("TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+
+    propertyTableProperty.arrayOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+            UINT16;
+    arrayProperty =
+        view.getPropertyView<MetadataArrayView<bool>>("TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+
+    propertyTableProperty.arrayOffsetType = "NONSENSE";
+    arrayProperty =
+        view.getPropertyView<MetadataArrayView<bool>>("TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType);
+
+    propertyTableProperty.arrayOffsetType = "";
+    propertyTableProperty.stringOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::StringOffsetType::
+            UINT64;
+    arrayProperty =
+        view.getPropertyView<MetadataArrayView<bool>>("TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType);
+  }
+
+  SECTION("Offset values are not sorted ascending") {
+    propertyTableProperty.arrayOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+            UINT64;
+    uint64_t* offset = reinterpret_cast<uint64_t*>(
+        model.buffers[offsetBufferIndex].cesium.data.data());
+    offset[propertyTable.count] = 0;
+    MetadataPropertyView<MetadataArrayView<bool>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<bool>>("TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayOffsetsNotSorted);
+  }
+
+  SECTION("Offset value points outside of value buffer") {
+    uint64_t* offset = reinterpret_cast<uint64_t*>(
+        model.buffers[offsetBufferIndex].cesium.data.data());
+    offset[propertyTable.count] = static_cast<uint32_t>(
+        model.buffers[valueBufferIndex].byteLength * 8 + 20);
+    MetadataPropertyView<MetadataArrayView<bool>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<bool>>("TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayOffsetOutOfBounds);
+  }
+
+  SECTION("Count and offset buffer both present") {
+    testClassProperty.count = 3;
+    MetadataPropertyView<MetadataArrayView<bool>> boolArrayProperty =
+        view.getPropertyView<MetadataArrayView<bool>>("TestClassProperty");
+    REQUIRE(
+        boolArrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayCountAndOffsetBufferCoexist);
+  }
+}
+
+TEST_CASE("Test StructuralMetadata fixed-length arrays of strings") {
+  Model model;
+
+  std::vector<std::string> expected{
+      "What's up",
+      "Breaking news!!! Aliens no longer attacks the US first",
+      "But they still abduct my cows! Those milk thiefs! 👽 🐮",
+      "I'm not crazy. My mother had me tested 🤪",
+      "I love you, meat bags! ❤️",
+      "Book in the freezer"};
+
+  size_t totalBytes = 0;
+  for (const std::string& expectedValue : expected) {
+    totalBytes += expectedValue.size();
+  }
+
+  std::vector<std::byte> offsets((expected.size() + 1) * sizeof(uint32_t));
+  std::vector<std::byte> values(totalBytes);
+  uint32_t* offsetValue = reinterpret_cast<uint32_t*>(offsets.data());
+  for (size_t i = 0; i < expected.size(); ++i) {
+    const std::string& expectedValue = expected[i];
+    std::memcpy(
+        values.data() + offsetValue[i],
+        expectedValue.c_str(),
+        expectedValue.size());
+    offsetValue[i + 1] =
+        offsetValue[i] + static_cast<uint32_t>(expectedValue.size());
+  }
+
+  size_t valueBufferViewIndex = 0;
+  {
+    Buffer& valueBuffer = model.buffers.emplace_back();
+    valueBuffer.byteLength = static_cast<int64_t>(values.size());
+    valueBuffer.cesium.data = std::move(values);
+
+    BufferView& valueBufferView = model.bufferViews.emplace_back();
+    valueBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
+    valueBufferView.byteOffset = 0;
+    valueBufferView.byteLength = valueBuffer.byteLength;
+    valueBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  size_t offsetBufferViewIndex = 0;
+  {
+    Buffer& offsetBuffer = model.buffers.emplace_back();
+    offsetBuffer.byteLength = static_cast<int64_t>(offsets.size());
+    offsetBuffer.cesium.data = std::move(offsets);
+
+    BufferView& offsetBufferView = model.bufferViews.emplace_back();
+    offsetBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
+    offsetBufferView.byteOffset = 0;
+    offsetBufferView.byteLength = offsetBuffer.byteLength;
+    offsetBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::STRING;
+  testClassProperty.array = true;
+  testClassProperty.count = 2;
+
+  ExtensionExtStructuralMetadataPropertyTable& propertyTable =
+      metadata.propertyTables.emplace_back();
+  propertyTable.classProperty = "TestClass";
+  propertyTable.count = static_cast<int64_t>(
+      expected.size() / static_cast<size_t>(testClassProperty.count.value()));
+
+  ExtensionExtStructuralMetadataPropertyTableProperty& propertyTableProperty =
+      propertyTable.properties["TestClassProperty"];
+  propertyTableProperty.stringOffsetType =
+      ExtensionExtStructuralMetadataPropertyTableProperty::StringOffsetType::
+          UINT32;
+  propertyTableProperty.values = static_cast<int32_t>(valueBufferViewIndex);
+  propertyTableProperty.stringOffsets =
+      static_cast<int32_t>(offsetBufferViewIndex);
+
+  MetadataPropertyTableView view(&model, &propertyTable);
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(
+      classProperty->type ==
+      ExtensionExtStructuralMetadataClassProperty::Type::STRING);
+  REQUIRE(classProperty->array);
+  REQUIRE(classProperty->count == 2);
+
+  SECTION("Access correct type") {
+    MetadataPropertyView<MetadataArrayView<std::string_view>> stringProperty =
+        view.getPropertyView<MetadataArrayView<std::string_view>>(
+            "TestClassProperty");
+    REQUIRE(stringProperty.status() == MetadataPropertyViewStatus::Valid);
+    REQUIRE(stringProperty.size() == 3);
+
+    MetadataArrayView<std::string_view> v0 = stringProperty.get(0);
+    REQUIRE(v0.size() == 2);
+    REQUIRE(v0[0] == "What's up");
+    REQUIRE(v0[1] == "Breaking news!!! Aliens no longer attacks the US first");
+
+    MetadataArrayView<std::string_view> v1 = stringProperty.get(1);
+    REQUIRE(v1.size() == 2);
+    REQUIRE(v1[0] == "But they still abduct my cows! Those milk thiefs! 👽 🐮");
+    REQUIRE(v1[1] == "I'm not crazy. My mother had me tested 🤪");
+
+    MetadataArrayView<std::string_view> v2 = stringProperty.get(2);
+    REQUIRE(v2.size() == 2);
+    REQUIRE(v2[0] == "I love you, meat bags! ❤️");
+    REQUIRE(v2[1] == "Book in the freezer");
+  }
+
+  SECTION("Array type mismatch") {
+    MetadataPropertyView<std::string_view> stringProperty =
+        view.getPropertyView<std::string_view>("TestClassProperty");
+    REQUIRE(
+        stringProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayTypeMismatch);
+  }
+
+  SECTION("Count is negative") {
+    testClassProperty.count = -1;
+    MetadataPropertyView<MetadataArrayView<std::string_view>> stringProperty =
+        view.getPropertyView<MetadataArrayView<std::string_view>>(
+            "TestClassProperty");
+    REQUIRE(
+        stringProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayCountAndOffsetBufferDontExist);
+  }
+
+  SECTION("Offset type is unknown") {
+    propertyTableProperty.stringOffsetType = "NONSENSE";
+    MetadataPropertyView<MetadataArrayView<std::string_view>> stringProperty =
+        view.getPropertyView<MetadataArrayView<std::string_view>>(
+            "TestClassProperty");
+    REQUIRE(
+        stringProperty.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidStringOffsetType);
+
+    propertyTableProperty.stringOffsetType = "";
+    propertyTableProperty.arrayOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+            UINT32;
+    stringProperty = view.getPropertyView<MetadataArrayView<std::string_view>>(
+        "TestClassProperty");
+    REQUIRE(
+        stringProperty.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidStringOffsetType);
+  }
+
+  SECTION("String offsets don't exist") {
+    propertyTableProperty.stringOffsets = -1;
+    MetadataPropertyView<MetadataArrayView<std::string_view>> stringProperty =
+        view.getPropertyView<MetadataArrayView<std::string_view>>(
+            "TestClassProperty");
+    REQUIRE(
+        stringProperty.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidStringOffsetBufferView);
+  }
+}
+
+TEST_CASE("Test StructuralMetadata variable-length arrays of strings") {
+  Model model;
+
+  std::vector<std::vector<std::string>> expected{
+      {"What's up"},
+      {"Breaking news!!! Aliens no longer attacks the US first",
+       "But they still abduct my cows! Those milk thiefs! 👽 🐮"},
+      {"I'm not crazy. My mother had me tested 🤪",
+       "I love you, meat bags! ❤️",
+       "Book in the freezer"}};
+
+  size_t totalBytes = 0;
+  size_t numOfElements = 0;
+  for (const auto& expectedValues : expected) {
+    for (const auto& value : expectedValues) {
+      totalBytes += value.size();
+    }
+
+    numOfElements += expectedValues.size();
+  }
+
+  std::vector<std::byte> offsets((expected.size() + 1) * sizeof(uint32_t));
+  std::vector<std::byte> stringOffsets((numOfElements + 1) * sizeof(uint32_t));
+  std::vector<std::byte> values(totalBytes);
+  uint32_t* offsetValue = reinterpret_cast<uint32_t*>(offsets.data());
+  uint32_t* stringOffsetValue =
+      reinterpret_cast<uint32_t*>(stringOffsets.data());
+  size_t strOffsetIdx = 0;
+  for (size_t i = 0; i < expected.size(); ++i) {
+    for (size_t j = 0; j < expected[i].size(); ++j) {
+      const std::string& expectedValue = expected[i][j];
+      std::memcpy(
+          values.data() + stringOffsetValue[strOffsetIdx],
+          expectedValue.c_str(),
+          expectedValue.size());
+
+      stringOffsetValue[strOffsetIdx + 1] =
+          stringOffsetValue[strOffsetIdx] +
+          static_cast<uint32_t>(expectedValue.size());
+      ++strOffsetIdx;
+    }
+
+    offsetValue[i + 1] =
+        offsetValue[i] +
+        static_cast<uint32_t>(expected[i].size() * sizeof(uint32_t));
+  }
+
+  size_t valueBufferViewIndex = 0;
+  {
+    Buffer& valueBuffer = model.buffers.emplace_back();
+    valueBuffer.byteLength = static_cast<int64_t>(values.size());
+    valueBuffer.cesium.data = std::move(values);
+
+    BufferView& valueBufferView = model.bufferViews.emplace_back();
+    valueBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
+    valueBufferView.byteOffset = 0;
+    valueBufferView.byteLength = valueBuffer.byteLength;
+    valueBufferViewIndex = model.bufferViews.size() - 1;
+  }
+
+  size_t arrayOffsetBuffer = 0;
+  size_t arrayOffsetBufferView = 0;
+  {
+    Buffer& offsetBuffer = model.buffers.emplace_back();
+    offsetBuffer.byteLength = static_cast<int64_t>(offsets.size());
+    offsetBuffer.cesium.data = std::move(offsets);
+    arrayOffsetBuffer = model.buffers.size() - 1;
+
+    BufferView& offsetBufferView = model.bufferViews.emplace_back();
+    offsetBufferView.buffer = static_cast<int32_t>(arrayOffsetBuffer);
+    offsetBufferView.byteOffset = 0;
+    offsetBufferView.byteLength = offsetBuffer.byteLength;
+    arrayOffsetBufferView = model.bufferViews.size() - 1;
+  }
+
+  size_t stringOffsetBuffer = 0;
+  size_t stringOffsetBufferView = 0;
+  {
+    Buffer& strOffsetBuffer = model.buffers.emplace_back();
+    strOffsetBuffer.byteLength = static_cast<int64_t>(stringOffsets.size());
+    strOffsetBuffer.cesium.data = std::move(stringOffsets);
+    stringOffsetBuffer = model.buffers.size() - 1;
+
+    BufferView& strOffsetBufferView = model.bufferViews.emplace_back();
+    strOffsetBufferView.buffer = static_cast<int32_t>(stringOffsetBuffer);
+    strOffsetBufferView.byteOffset = 0;
+    strOffsetBufferView.byteLength = strOffsetBuffer.byteLength;
+    stringOffsetBufferView = model.bufferViews.size() - 1;
+  }
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::STRING;
+  testClassProperty.array = true;
+
+  ExtensionExtStructuralMetadataPropertyTable& propertyTable =
+      metadata.propertyTables.emplace_back();
+  propertyTable.classProperty = "TestClass";
+  propertyTable.count = static_cast<int64_t>(expected.size());
+
+  ExtensionExtStructuralMetadataPropertyTableProperty& propertyTableProperty =
+      propertyTable.properties["TestClassProperty"];
+  propertyTableProperty.arrayOffsetType =
+      ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+          UINT32;
+  propertyTableProperty.stringOffsetType =
+      ExtensionExtStructuralMetadataPropertyTableProperty::StringOffsetType::
+          UINT32;
+  propertyTableProperty.values = static_cast<int32_t>(valueBufferViewIndex);
+  propertyTableProperty.arrayOffsets =
+      static_cast<int32_t>(arrayOffsetBufferView);
+  propertyTableProperty.stringOffsets =
+      static_cast<int32_t>(stringOffsetBufferView);
+
+  MetadataPropertyTableView view(&model, &propertyTable);
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(
+      classProperty->type ==
+      ExtensionExtStructuralMetadataClassProperty::Type::STRING);
+  REQUIRE(classProperty->array);
+  REQUIRE(!classProperty->componentType);
+  REQUIRE(!classProperty->count);
+
+  SECTION("Access correct type") {
+    MetadataPropertyView<MetadataArrayView<std::string_view>> stringProperty =
+        view.getPropertyView<MetadataArrayView<std::string_view>>(
+            "TestClassProperty");
+    REQUIRE(stringProperty.status() == MetadataPropertyViewStatus::Valid);
+    for (size_t i = 0; i < expected.size(); ++i) {
+      MetadataArrayView<std::string_view> stringArray =
+          stringProperty.get(static_cast<int64_t>(i));
+      for (size_t j = 0; j < expected[i].size(); ++j) {
+        REQUIRE(stringArray[static_cast<int64_t>(j)] == expected[i][j]);
+      }
+    }
+  }
+
+  SECTION("Wrong array offset type") {
+    propertyTableProperty.arrayOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+            UINT8;
+    MetadataPropertyView<MetadataArrayView<std::string_view>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<std::string_view>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+
+    propertyTableProperty.arrayOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+            UINT16;
+    arrayProperty = view.getPropertyView<MetadataArrayView<std::string_view>>(
+        "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+
+    propertyTableProperty.arrayOffsetType = "NONSENSE";
+    arrayProperty = view.getPropertyView<MetadataArrayView<std::string_view>>(
+        "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType);
+    propertyTableProperty.arrayOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
+            UINT32;
+  }
+
+  SECTION("Wrong string offset type") {
+    propertyTableProperty.stringOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::StringOffsetType::
+            UINT8;
+    MetadataPropertyView<MetadataArrayView<std::string_view>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<std::string_view>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+
+    propertyTableProperty.stringOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::StringOffsetType::
+            UINT16;
+    arrayProperty = view.getPropertyView<MetadataArrayView<std::string_view>>(
+        "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::
+            ErrorBufferViewSizeDoesNotMatchPropertyTableCount);
+
+    propertyTableProperty.stringOffsetType = "NONSENSE";
+    arrayProperty = view.getPropertyView<MetadataArrayView<std::string_view>>(
+        "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorInvalidStringOffsetType);
+    propertyTableProperty.stringOffsetType =
+        ExtensionExtStructuralMetadataPropertyTableProperty::StringOffsetType::
+            UINT32;
+  }
+
+  SECTION("Array offset values are not sorted ascending") {
+    uint32_t* offset = reinterpret_cast<uint32_t*>(
+        model.buffers[arrayOffsetBuffer].cesium.data.data());
+    offset[0] = static_cast<uint32_t>(1000);
+    MetadataPropertyView<MetadataArrayView<std::string_view>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<std::string_view>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayOffsetsNotSorted);
+    offset[0] = 0;
+  }
+
+  SECTION("String offset values are not sorted ascending") {
+    uint32_t* offset = reinterpret_cast<uint32_t*>(
+        model.buffers[stringOffsetBuffer].cesium.data.data());
+    offset[0] = static_cast<uint32_t>(1000);
+    MetadataPropertyView<MetadataArrayView<std::string_view>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<std::string_view>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted);
+    offset[0] = 0;
+  }
+
+  SECTION("Array offset value points outside of value buffer") {
+    uint32_t* offset = reinterpret_cast<uint32_t*>(
+        model.buffers[arrayOffsetBuffer].cesium.data.data());
+    uint32_t previousValue = offset[propertyTable.count];
+    offset[propertyTable.count] = static_cast<uint32_t>(100000);
+    MetadataPropertyView<MetadataArrayView<std::string_view>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<std::string_view>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayOffsetOutOfBounds);
+    offset[propertyTable.count] = previousValue;
+  }
+
+  SECTION("String offset value points outside of value buffer") {
+    uint32_t* offset = reinterpret_cast<uint32_t*>(
+        model.buffers[stringOffsetBuffer].cesium.data.data());
+    uint32_t previousValue = offset[6];
+    offset[6] = static_cast<uint32_t>(100000);
+    MetadataPropertyView<MetadataArrayView<std::string_view>> arrayProperty =
+        view.getPropertyView<MetadataArrayView<std::string_view>>(
+            "TestClassProperty");
+    REQUIRE(
+        arrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+    offset[6] = previousValue;
+  }
+
+  SECTION("Count and offset buffer both present") {
+    testClassProperty.count = 3;
+    MetadataPropertyView<MetadataArrayView<std::string_view>>
+        boolArrayProperty =
+            view.getPropertyView<MetadataArrayView<std::string_view>>(
+                "TestClassProperty");
+    REQUIRE(
+        boolArrayProperty.status() ==
+        MetadataPropertyViewStatus::ErrorArrayCountAndOffsetBufferCoexist);
+  }
+}

--- a/CesiumGltf/test/TestStructuralMetadataPropertyTableView.cpp
+++ b/CesiumGltf/test/TestStructuralMetadataPropertyTableView.cpp
@@ -56,7 +56,7 @@ TEST_CASE("Test StructuralMetadata scalar property") {
       propertyTable.properties["TestClassProperty"];
   propertyTableProperty.values = static_cast<int32_t>(valueBufferViewIndex);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -231,7 +231,7 @@ TEST_CASE("Test StructuralMetadata vecN property") {
       propertyTable.properties["TestClassProperty"];
   propertyTableProperty.values = static_cast<int32_t>(valueBufferViewIndex);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -422,7 +422,7 @@ TEST_CASE("Test StructuralMetadata matN property") {
       propertyTable.properties["TestClassProperty"];
   propertyTableProperty.values = static_cast<int32_t>(valueBufferViewIndex);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -613,7 +613,7 @@ TEST_CASE("Test StructuralMetadata boolean property") {
   propertyTableProperty.values =
       static_cast<int32_t>(model.bufferViews.size() - 1);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -724,7 +724,7 @@ TEST_CASE("Test StructuralMetadata string property") {
   propertyTableProperty.stringOffsets =
       static_cast<int32_t>(offsetBufferViewIndex);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -866,7 +866,7 @@ TEST_CASE("Test StructuralMetadata fixed-length scalar array") {
   propertyTableProperty.values =
       static_cast<int32_t>(model.bufferViews.size() - 1);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -1036,7 +1036,7 @@ TEST_CASE("Test Structural Metadata variable-length scalar array") {
       ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
           UINT64;
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -1191,7 +1191,7 @@ TEST_CASE("Test StructuralMetadata fixed-length vecN array") {
   propertyTableProperty.values =
       static_cast<int32_t>(model.bufferViews.size() - 1);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -1368,7 +1368,7 @@ TEST_CASE("Test Structural Metadata variable-length vecN array") {
       ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
           UINT64;
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -1543,7 +1543,7 @@ TEST_CASE("Test StructuralMetadata fixed-length matN array") {
   propertyTableProperty.values =
       static_cast<int32_t>(model.bufferViews.size() - 1);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -1741,7 +1741,7 @@ TEST_CASE("Test Structural Metadata variable-length matN array") {
       ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
           UINT64;
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -1914,7 +1914,7 @@ TEST_CASE("Test StructuralMetadata fixed-length boolean array") {
   propertyTableProperty.values =
       static_cast<int32_t>(model.bufferViews.size() - 1);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -2063,7 +2063,7 @@ TEST_CASE("Test StructuralMetadata variable-length boolean array") {
       ExtensionExtStructuralMetadataPropertyTableProperty::ArrayOffsetType::
           UINT64;
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -2243,7 +2243,7 @@ TEST_CASE("Test StructuralMetadata fixed-length arrays of strings") {
   propertyTableProperty.stringOffsets =
       static_cast<int32_t>(offsetBufferViewIndex);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -2444,7 +2444,7 @@ TEST_CASE("Test StructuralMetadata variable-length arrays of strings") {
   propertyTableProperty.stringOffsets =
       static_cast<int32_t>(stringOffsetBufferView);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -2623,7 +2623,7 @@ TEST_CASE("Test StructuralMetadata callback for invalid property") {
       propertyTable.properties["InvalidProperty"];
   propertyTableProperty.values = static_cast<int32_t>(-1);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("InvalidProperty");
   REQUIRE(classProperty);
@@ -2687,7 +2687,7 @@ TEST_CASE("Test StructuralMetadata callback for scalar property") {
       propertyTable.properties["TestClassProperty"];
   propertyTableProperty.values = static_cast<int32_t>(valueBufferViewIndex);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -2773,7 +2773,7 @@ TEST_CASE("Test StructuralMetadata callback for vecN property") {
       propertyTable.properties["TestClassProperty"];
   propertyTableProperty.values = static_cast<int32_t>(valueBufferViewIndex);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -2869,7 +2869,7 @@ TEST_CASE("Test StructuralMetadata callback for matN property") {
       propertyTable.properties["TestClassProperty"];
   propertyTableProperty.values = static_cast<int32_t>(valueBufferViewIndex);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -2963,7 +2963,7 @@ TEST_CASE("Test StructuralMetadata callback for boolean property") {
   propertyTableProperty.values =
       static_cast<int32_t>(model.bufferViews.size() - 1);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -3075,7 +3075,7 @@ TEST_CASE("Test StructuralMetadata callback for string property") {
   propertyTableProperty.stringOffsets =
       static_cast<int32_t>(offsetBufferViewIndex);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -3155,7 +3155,7 @@ TEST_CASE("Test StructuralMetadata callback for scalar array") {
   propertyTableProperty.values =
       static_cast<int32_t>(model.bufferViews.size() - 1);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -3242,7 +3242,7 @@ TEST_CASE("Test StructuralMetadata callback for vecN array") {
   propertyTableProperty.values =
       static_cast<int32_t>(model.bufferViews.size() - 1);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -3343,7 +3343,7 @@ TEST_CASE("Test StructuralMetadata callback for matN array") {
   propertyTableProperty.values =
       static_cast<int32_t>(model.bufferViews.size() - 1);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -3445,7 +3445,7 @@ TEST_CASE("Test StructuralMetadata callback for boolean array") {
   propertyTableProperty.values =
       static_cast<int32_t>(model.bufferViews.size() - 1);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(
@@ -3558,7 +3558,7 @@ TEST_CASE("Test StructuralMetadata callback for array of strings") {
   propertyTableProperty.stringOffsets =
       static_cast<int32_t>(offsetBufferViewIndex);
 
-  MetadataPropertyTableView view(&model, &propertyTable);
+  MetadataPropertyTableView view(model, propertyTable);
   const ExtensionExtStructuralMetadataClassProperty* classProperty =
       view.getClassProperty("TestClassProperty");
   REQUIRE(

--- a/CesiumGltf/test/TestStructuralMetadataPropertyTableView.cpp
+++ b/CesiumGltf/test/TestStructuralMetadataPropertyTableView.cpp
@@ -3104,7 +3104,6 @@ TEST_CASE("Test StructuralMetadata callback for scalar array") {
   std::vector<uint32_t> values =
       {12, 34, 30, 11, 34, 34, 11, 33, 122, 33, 223, 11};
 
-  size_t valueBufferViewIndex = 0;
   {
     Buffer& valueBuffer = model.buffers.emplace_back();
     valueBuffer.cesium.data.resize(values.size() * sizeof(uint32_t));
@@ -3119,7 +3118,6 @@ TEST_CASE("Test StructuralMetadata callback for scalar array") {
     valueBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
     valueBufferView.byteOffset = 0;
     valueBufferView.byteLength = valueBuffer.byteLength;
-    valueBufferViewIndex = model.bufferViews.size() - 1;
   }
 
   ExtensionModelExtStructuralMetadata& metadata =
@@ -3193,7 +3191,6 @@ TEST_CASE("Test StructuralMetadata callback for vecN array") {
       glm::ivec3(40, 61, 3),
   };
 
-  size_t valueBufferViewIndex = 0;
   {
     Buffer& valueBuffer = model.buffers.emplace_back();
     valueBuffer.cesium.data.resize(values.size() * sizeof(glm::ivec3));
@@ -3208,7 +3205,6 @@ TEST_CASE("Test StructuralMetadata callback for vecN array") {
     valueBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
     valueBufferView.byteOffset = 0;
     valueBufferView.byteLength = valueBuffer.byteLength;
-    valueBufferViewIndex = model.bufferViews.size() - 1;
   }
 
   ExtensionModelExtStructuralMetadata& metadata =

--- a/CesiumGltf/test/TestStructuralMetadataPropertyTableView.cpp
+++ b/CesiumGltf/test/TestStructuralMetadataPropertyTableView.cpp
@@ -3292,7 +3292,6 @@ TEST_CASE("Test StructuralMetadata callback for matN array") {
   };
   // clang-format on
 
-  size_t valueBufferViewIndex = 0;
   {
     Buffer& valueBuffer = model.buffers.emplace_back();
     valueBuffer.cesium.data.resize(values.size() * sizeof(glm::i32mat2x2));
@@ -3307,7 +3306,6 @@ TEST_CASE("Test StructuralMetadata callback for matN array") {
     valueBufferView.buffer = static_cast<int32_t>(model.buffers.size() - 1);
     valueBufferView.byteOffset = 0;
     valueBufferView.byteLength = valueBuffer.byteLength;
-    valueBufferViewIndex = model.bufferViews.size() - 1;
   }
 
   ExtensionModelExtStructuralMetadata& metadata =

--- a/CesiumGltf/test/TestStructuralMetadataPropertyView.cpp
+++ b/CesiumGltf/test/TestStructuralMetadataPropertyView.cpp
@@ -19,11 +19,6 @@ template <typename T> static void checkNumeric(const std::vector<T>& expected) {
   MetadataPropertyView<T> property(
       MetadataPropertyViewStatus::Valid,
       gsl::span<const std::byte>(data.data(), data.size()),
-      gsl::span<const std::byte>(),
-      gsl::span<const std::byte>(),
-      PropertyComponentType::None,
-      PropertyComponentType::None,
-      0,
       static_cast<int64_t>(expected.size()),
       false);
 
@@ -233,11 +228,6 @@ TEST_CASE("Check StructuralMetadata boolean property") {
   MetadataPropertyView<bool> property(
       MetadataPropertyViewStatus::Valid,
       gsl::span<const std::byte>(data.data(), data.size()),
-      gsl::span<const std::byte>(),
-      gsl::span<const std::byte>(),
-      PropertyComponentType::None,
-      PropertyComponentType::None,
-      0,
       static_cast<int64_t>(instanceCount),
       false);
   for (int64_t i = 0; i < property.size(); ++i) {


### PR DESCRIPTION
This PR adds `MetadataPropertyTableView`, the `EXT_structural_metadata` version of `MetadataFeatureTableView`. This is used to retrieve properties via a `MetadataPropertyView`. With this, all of the internal overhaul should be done, and we can actually convert the extensions themselves.