### PR TITLE
Add support for using external sqlite3 libraries, issue #650

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,14 @@ install(DIRECTORY ${CESIUM_NATIVE_SPDLOG_INCLUDE_DIR}/spdlog DESTINATION "${CMAK
 
 install(TARGETS ${CESIUM_NATIVE_DRACO_LIBRARY})
 
-install(TARGETS sqlite3)
+#if we're aliased then someone else has a sqlite3 lib for us to use, otherwise install our own
+get_target_property(_aliased sqlite3 ALIASED_TARGET)
+if(NOT _aliased)
+    message("sqlite3 not aliased, using ours in extern/sqlite3")
+    install(TARGETS sqlite3)
+else()
+    message("sqlite3 aliased as ${_aliased}")
+endif()
 
 install(TARGETS modp_b64)
 

--- a/CesiumAsync/CMakeLists.txt
+++ b/CesiumAsync/CMakeLists.txt
@@ -35,6 +35,7 @@ target_include_directories(
         ${CMAKE_CURRENT_LIST_DIR}/include
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/src/
+        ${CMAKE_CURRENT_LIST_DIR}/../extern/sqlite3/
 )
 
 target_link_libraries(CesiumAsync


### PR DESCRIPTION
sqlite3 is checked to see if its aliased, if so, don't attempt the install. Otherwise, we install the packaged version in extern/sqlite3

In cases where we are aliased, we need to include the extern/sqlite3 dir in our include dir list.