### PR TITLE
Convert batch tables to `EXT_structural_metadata`

### DIFF
--- a/Cesium3DTilesSelection/src/B3dmToGltfConverter.cpp
+++ b/Cesium3DTilesSelection/src/B3dmToGltfConverter.cpp
@@ -176,7 +176,7 @@ rapidjson::Document parseFeatureTableJsonData(
   return document;
 }
 
-void convertB3dmMetadataToGltfFeatureMetadata(
+void convertB3dmMetadataToGltfStructuralMetadata(
     const gsl::span<const std::byte>& b3dmBinary,
     const B3dmHeader& header,
     uint32_t headerLength,
@@ -246,7 +246,7 @@ GltfConverterResult B3dmToGltfConverter::convert(
     return result;
   }
 
-  convertB3dmMetadataToGltfFeatureMetadata(
+  convertB3dmMetadataToGltfStructuralMetadata(
       b3dmBinary,
       header,
       headerLength,

--- a/Cesium3DTilesSelection/src/B3dmToGltfConverter.cpp
+++ b/Cesium3DTilesSelection/src/B3dmToGltfConverter.cpp
@@ -219,7 +219,7 @@ void convertB3dmMetadataToGltfFeatureMetadata(
         return;
       }
 
-      // upgrade batch table to glTF feature metadata and append the result
+      // upgrade batch table to glTF structural metadata and append the result
       result.errors.merge(BatchTableToGltfStructuralMetadata::convertFromB3dm(
           featureTableJson,
           batchTableJson,

--- a/Cesium3DTilesSelection/src/BatchTableToGltfStructuralMetadata.cpp
+++ b/Cesium3DTilesSelection/src/BatchTableToGltfStructuralMetadata.cpp
@@ -163,15 +163,15 @@ struct CompatibleTypes {
    * Merges a MaskedArrayType into this CompatibleTypes.
    */
   void operator&=(const MaskedArrayType& maskedArrayType) {
-    if (!isArray()) {
-      makeIncompatible();
+    if (isArray()) {
+      MaskedArrayType& arrayType = std::get<MaskedArrayType>(maskedType);
+      arrayType &= maskedArrayType;
       return;
     }
 
-    MaskedArrayType* pMaskedArrayType =
-        std::get_if<MaskedArrayType>(&maskedType);
-    if (pMaskedArrayType) {
-      *pMaskedArrayType &= maskedArrayType;
+    MaskedType* pMaskedType = std::get_if<MaskedType>(&maskedType);
+    if (pMaskedType) {
+      makeIncompatible();
     } else {
       maskedType = maskedArrayType;
     }

--- a/Cesium3DTilesSelection/src/BatchTableToGltfStructuralMetadata.cpp
+++ b/Cesium3DTilesSelection/src/BatchTableToGltfStructuralMetadata.cpp
@@ -1448,10 +1448,11 @@ void updateExtensionWithBatchTableHierarchy(
     ExtensionExtStructuralMetadataPropertyTable& propertyTable,
     ErrorList& result,
     const rapidjson::Value& batchTableHierarchy) {
-  // EXT_feature_metadata can't support hierarchy, so we need to flatten it.
+  // EXT_structural_metadata can't support hierarchy, so we need to flatten it.
   // It also can't support multiple classes with a single set of feature IDs.
-  // So essentially every property of every class gets added to the one class
-  // definition.
+  // (Feature IDs can only specify one property table, which only supports one class.)
+  // So essentially every property of every class gets added to
+  // the one class definition.
   auto classesIt = batchTableHierarchy.FindMember("classes");
   if (classesIt == batchTableHierarchy.MemberEnd()) {
     result.emplaceWarning(
@@ -1649,7 +1650,7 @@ ErrorList BatchTableToGltfStructuralMetadata::convertFromB3dm(
 
   ErrorList result;
 
-  // Parse the b3dm batch table and convert it to the EXT_feature_metadata
+  // Parse the b3dm batch table and convert it to the EXT_structural_metadata
   // extension.
 
   // If the feature table is missing the BATCH_LENGTH semantic, ignore the batch
@@ -1716,7 +1717,7 @@ ErrorList BatchTableToGltfStructuralMetadata::convertFromPnts(
 
   ErrorList result;
 
-  // Parse the pnts batch table and convert it to the EXT_feature_metadata
+  // Parse the pnts batch table and convert it to the EXT_structural_metadata
   // extension.
 
   const auto pointsLengthIt = featureTableJson.FindMember("POINTS_LENGTH");

--- a/Cesium3DTilesSelection/src/PntsToGltfConverter.cpp
+++ b/Cesium3DTilesSelection/src/PntsToGltfConverter.cpp
@@ -5,7 +5,6 @@
 #include <CesiumGeometry/Transforms.h>
 #include <CesiumGltf/ExtensionCesiumRTC.h>
 #include <CesiumGltf/ExtensionKhrMaterialsUnlit.h>
-#include <CesiumGltf/ExtensionMeshPrimitiveExtFeatureMetadata.h>
 #include <CesiumUtility/AttributeCompression.h>
 #include <CesiumUtility/Math.h>
 

--- a/Cesium3DTilesSelection/test/TestPntsToGltfConverter.cpp
+++ b/Cesium3DTilesSelection/test/TestPntsToGltfConverter.cpp
@@ -5,7 +5,7 @@
 #include <CesiumGltf/ExtensionCesiumRTC.h>
 #include <CesiumGltf/ExtensionExtMeshFeatures.h>
 #include <CesiumGltf/ExtensionKhrMaterialsUnlit.h>
-#include <CesiumGltf/ExtensionModelExtFeatureMetadata.h>
+#include <CesiumGltf/ExtensionModelExtStructuralMetadata.h>
 #include <CesiumUtility/Math.h>
 
 #include <catch2/catch.hpp>
@@ -654,7 +654,7 @@ getUniqueBufferIds(const std::vector<BufferView>& bufferViews) {
 }
 
 TEST_CASE(
-    "Converts point cloud with batch IDs to glTF with EXT_feature_metadata") {
+    "Converts point cloud with batch IDs to glTF with EXT_structural_metadata") {
   std::filesystem::path testFilePath = Cesium3DTilesSelection_TEST_DATA_DIR;
   testFilePath = testFilePath / "PointCloud" / "pointCloudBatched.pnts";
   const int32_t pointsLength = 8;
@@ -665,8 +665,8 @@ TEST_CASE(
   Model& gltf = *result.model;
 
   // The correctness of the model extension is thoroughly tested in
-  // TestUpgradeBatchTableToExtFeatureMetadata
-  CHECK(gltf.hasExtension<ExtensionModelExtFeatureMetadata>());
+  // TestUpgradeBatchTableToExtStructuralMetadata
+  CHECK(gltf.hasExtension<ExtensionModelExtStructuralMetadata>());
 
   CHECK(gltf.nodes.size() == 1);
   REQUIRE(gltf.meshes.size() == 1);
@@ -744,8 +744,8 @@ TEST_CASE("Converts point cloud with per-point properties to glTF with "
   Model& gltf = *result.model;
 
   // The correctness of the model extension is thoroughly tested in
-  // TestUpgradeBatchTableToExtFeatureMetadata
-  CHECK(gltf.hasExtension<ExtensionModelExtFeatureMetadata>());
+  // TestUpgradeBatchTableToExtStructuralMetadata
+  CHECK(gltf.hasExtension<ExtensionModelExtStructuralMetadata>());
 
   CHECK(gltf.nodes.size() == 1);
   REQUIRE(gltf.meshes.size() == 1);
@@ -803,8 +803,8 @@ TEST_CASE("Converts point cloud with Draco compression to glTF") {
 
   CHECK(gltf.hasExtension<CesiumGltf::ExtensionCesiumRTC>());
   // The correctness of the model extension is thoroughly tested in
-  // TestUpgradeBatchTableToExtFeatureMetadata
-  CHECK(gltf.hasExtension<ExtensionModelExtFeatureMetadata>());
+  // TestUpgradeBatchTableToExtStructuralMetadata
+  CHECK(gltf.hasExtension<ExtensionModelExtStructuralMetadata>());
 
   CHECK(gltf.nodes.size() == 1);
   REQUIRE(gltf.meshes.size() == 1);
@@ -948,7 +948,7 @@ TEST_CASE("Converts point cloud with partial Draco compression to glTF") {
   Model& gltf = *result.model;
 
   CHECK(gltf.hasExtension<CesiumGltf::ExtensionCesiumRTC>());
-  CHECK(gltf.hasExtension<ExtensionModelExtFeatureMetadata>());
+  CHECK(gltf.hasExtension<ExtensionModelExtStructuralMetadata>());
 
   CHECK(gltf.nodes.size() == 1);
   REQUIRE(gltf.meshes.size() == 1);
@@ -1087,7 +1087,7 @@ TEST_CASE("Converts batched point cloud with Draco compression to glTF") {
 
   // The correctness of the model extension is thoroughly tested in
   // TestUpgradeBatchTableToExtFeatureMetadata
-  CHECK(gltf.hasExtension<ExtensionModelExtFeatureMetadata>());
+  CHECK(gltf.hasExtension<ExtensionModelExtStructuralMetadata>());
 
   CHECK(gltf.nodes.size() == 1);
   REQUIRE(gltf.meshes.size() == 1);

--- a/Cesium3DTilesSelection/test/TestPntsToGltfConverter.cpp
+++ b/Cesium3DTilesSelection/test/TestPntsToGltfConverter.cpp
@@ -653,8 +653,8 @@ getUniqueBufferIds(const std::vector<BufferView>& bufferViews) {
   return result;
 }
 
-TEST_CASE(
-    "Converts point cloud with batch IDs to glTF with EXT_structural_metadata") {
+TEST_CASE("Converts point cloud with batch IDs to glTF with "
+          "EXT_structural_metadata") {
   std::filesystem::path testFilePath = Cesium3DTilesSelection_TEST_DATA_DIR;
   testFilePath = testFilePath / "PointCloud" / "pointCloudBatched.pnts";
   const int32_t pointsLength = 8;

--- a/Cesium3DTilesSelection/test/TestPntsToGltfConverter.cpp
+++ b/Cesium3DTilesSelection/test/TestPntsToGltfConverter.cpp
@@ -1086,7 +1086,7 @@ TEST_CASE("Converts batched point cloud with Draco compression to glTF") {
   Model& gltf = *result.model;
 
   // The correctness of the model extension is thoroughly tested in
-  // TestUpgradeBatchTableToExtFeatureMetadata
+  // TestUpgradeBatchTableToExtStructuralMetadata
   CHECK(gltf.hasExtension<ExtensionModelExtStructuralMetadata>());
 
   CHECK(gltf.nodes.size() == 1);

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTableView.h
@@ -83,7 +83,7 @@ public:
    */
   int64_t size() const noexcept {
     return _status == MetadataPropertyTableViewStatus::Valid
-               ? _propertyTable.count
+               ? _pPropertyTable->count
                : 0;
   }
 
@@ -973,8 +973,8 @@ private:
       const std::string& propertyName,
       const ExtensionExtStructuralMetadataClassProperty& classProperty) const {
     auto propertyTablePropertyIter =
-        _propertyTable.properties.find(propertyName);
-    if (propertyTablePropertyIter == _propertyTable.properties.end()) {
+        _pPropertyTable->properties.find(propertyName);
+    if (propertyTablePropertyIter == _pPropertyTable->properties.end()) {
       return createInvalidPropertyView<T>(
           MetadataPropertyViewStatus::ErrorPropertyDoesNotExist);
     }
@@ -1043,9 +1043,9 @@ private:
     size_t maxRequiredBytes = 0;
     if (IsMetadataBoolean<T>::value) {
       maxRequiredBytes = static_cast<size_t>(
-          glm::ceil(static_cast<double>(_propertyTable.count) / 8.0));
+          glm::ceil(static_cast<double>(_pPropertyTable->count) / 8.0));
     } else {
-      maxRequiredBytes = _propertyTable.count * sizeof(T);
+      maxRequiredBytes = _pPropertyTable->count * sizeof(T);
     }
 
     if (values.size() < maxRequiredBytes) {
@@ -1057,7 +1057,7 @@ private:
     return MetadataPropertyView<T>(
         MetadataPropertyViewStatus::Valid,
         values,
-        _propertyTable.count,
+        _pPropertyTable->count,
         classProperty.normalized);
   }
 
@@ -1118,11 +1118,12 @@ private:
       size_t maxRequiredBytes = 0;
       if constexpr (IsMetadataBoolean<T>::value) {
         maxRequiredBytes = static_cast<size_t>(glm::ceil(
-            static_cast<double>(_propertyTable.count * fixedLengthArrayCount) /
+            static_cast<double>(
+                _pPropertyTable->count * fixedLengthArrayCount) /
             8.0));
       } else {
         maxRequiredBytes = static_cast<size_t>(
-            _propertyTable.count * fixedLengthArrayCount * sizeof(T));
+            _pPropertyTable->count * fixedLengthArrayCount * sizeof(T));
       }
 
       if (values.size() < maxRequiredBytes) {
@@ -1139,7 +1140,7 @@ private:
           PropertyComponentType::None,
           PropertyComponentType::None,
           static_cast<size_t>(fixedLengthArrayCount),
-          static_cast<size_t>(_propertyTable.count),
+          static_cast<size_t>(_pPropertyTable->count),
           classProperty.normalized);
     }
 
@@ -1158,7 +1159,7 @@ private:
         propertyTableProperty.arrayOffsets,
         arrayOffsetType,
         values.size(),
-        static_cast<size_t>(_propertyTable.count),
+        static_cast<size_t>(_pPropertyTable->count),
         checkBitsSize,
         arrayOffsets);
     if (status != MetadataPropertyViewStatus::Valid) {
@@ -1173,7 +1174,7 @@ private:
         arrayOffsetType,
         PropertyComponentType::None,
         0,
-        static_cast<size_t>(_propertyTable.count),
+        static_cast<size_t>(_pPropertyTable->count),
         classProperty.normalized);
   }
 
@@ -1212,8 +1213,8 @@ private:
         false);
   }
 
-  const Model& _model;
-  const ExtensionExtStructuralMetadataPropertyTable& _propertyTable;
+  const Model* _pModel;
+  const ExtensionExtStructuralMetadataPropertyTable* _pPropertyTable;
   const ExtensionExtStructuralMetadataClass* _pClass;
   MetadataPropertyTableViewStatus _status;
 };

--- a/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
+++ b/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
@@ -109,8 +109,8 @@ static MetadataPropertyViewStatus checkStringAndArrayOffsetsBuffers(
 MetadataPropertyTableView::MetadataPropertyTableView(
     const Model& model,
     const ExtensionExtStructuralMetadataPropertyTable& propertyTable)
-    : _model{model},
-      _propertyTable{propertyTable},
+    : _pModel{&model},
+      _pPropertyTable{&propertyTable},
       _pClass{nullptr},
       _status() {
   const ExtensionModelExtStructuralMetadata* pMetadata =
@@ -128,7 +128,7 @@ MetadataPropertyTableView::MetadataPropertyTableView(
     return;
   }
 
-  auto classIter = schema->classes.find(_propertyTable.classProperty);
+  auto classIter = schema->classes.find(_pPropertyTable->classProperty);
   if (classIter != schema->classes.end()) {
     _pClass = &classIter->second;
   }
@@ -160,12 +160,12 @@ MetadataPropertyViewStatus MetadataPropertyTableView::getBufferSafe(
   buffer = {};
 
   const BufferView* pBufferView =
-      _model.getSafe(&_model.bufferViews, bufferViewIdx);
+      _pModel->getSafe(&_pModel->bufferViews, bufferViewIdx);
   if (!pBufferView) {
     return MetadataPropertyViewStatus::ErrorInvalidValueBufferView;
   }
 
-  const Buffer* pBuffer = _model.getSafe(&_model.buffers, pBufferView->buffer);
+  const Buffer* pBuffer = _pModel->getSafe(&_pModel->buffers, pBufferView->buffer);
   if (!pBuffer) {
     return MetadataPropertyViewStatus::ErrorInvalidValueBuffer;
   }
@@ -318,7 +318,7 @@ MetadataPropertyTableView::getStringPropertyValues(
       propertyTableProperty.stringOffsets,
       offsetType,
       values.size(),
-      static_cast<size_t>(_propertyTable.count),
+      static_cast<size_t>(_pPropertyTable->count),
       stringOffsets);
   if (status != MetadataPropertyViewStatus::Valid) {
     return createInvalidPropertyView<std::string_view>(status);
@@ -332,7 +332,7 @@ MetadataPropertyTableView::getStringPropertyValues(
       PropertyComponentType::None,
       offsetType,
       0,
-      _propertyTable.count,
+      _pPropertyTable->count,
       classProperty.normalized);
 }
 
@@ -392,7 +392,7 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         propertyTableProperty.stringOffsets,
         stringOffsetType,
         values.size(),
-        static_cast<size_t>(_propertyTable.count * fixedLengthArrayCount),
+        static_cast<size_t>(_pPropertyTable->count * fixedLengthArrayCount),
         stringOffsets);
     if (status != MetadataPropertyViewStatus::Valid) {
       return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
@@ -407,7 +407,7 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         PropertyComponentType::None,
         stringOffsetType,
         fixedLengthArrayCount,
-        _propertyTable.count,
+        _pPropertyTable->count,
         classProperty.normalized);
   }
 
@@ -447,7 +447,7 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         stringOffsets,
         values.size(),
         stringOffsetType,
-        static_cast<size_t>(_propertyTable.count));
+        static_cast<size_t>(_pPropertyTable->count));
     break;
   case PropertyComponentType::Uint16:
     status = checkStringAndArrayOffsetsBuffers<uint16_t>(
@@ -455,7 +455,7 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         stringOffsets,
         values.size(),
         stringOffsetType,
-        static_cast<size_t>(_propertyTable.count));
+        static_cast<size_t>(_pPropertyTable->count));
     break;
   case PropertyComponentType::Uint32:
     status = checkStringAndArrayOffsetsBuffers<uint32_t>(
@@ -463,7 +463,7 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         stringOffsets,
         values.size(),
         stringOffsetType,
-        static_cast<size_t>(_propertyTable.count));
+        static_cast<size_t>(_pPropertyTable->count));
     break;
   case PropertyComponentType::Uint64:
     status = checkStringAndArrayOffsetsBuffers<uint64_t>(
@@ -471,7 +471,7 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         stringOffsets,
         values.size(),
         stringOffsetType,
-        static_cast<size_t>(_propertyTable.count));
+        static_cast<size_t>(_pPropertyTable->count));
     break;
   default:
     status = MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType;
@@ -491,7 +491,7 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
       arrayOffsetType,
       stringOffsetType,
       0,
-      _propertyTable.count,
+      _pPropertyTable->count,
       classProperty.normalized);
 }
 

--- a/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
+++ b/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
@@ -165,7 +165,8 @@ MetadataPropertyViewStatus MetadataPropertyTableView::getBufferSafe(
     return MetadataPropertyViewStatus::ErrorInvalidValueBufferView;
   }
 
-  const Buffer* pBuffer = _pModel->getSafe(&_pModel->buffers, pBufferView->buffer);
+  const Buffer* pBuffer =
+      _pModel->getSafe(&_pModel->buffers, pBufferView->buffer);
   if (!pBuffer) {
     return MetadataPropertyViewStatus::ErrorInvalidValueBuffer;
   }


### PR DESCRIPTION
This PR rewrites how batch tables in `b3dm` and `pnts` formats are parsed. They are now stored as a property table in a glTF with the `EXT_mesh_features` and `EXT_structural_metadata` extensions. The tests have also been rewritten to accommodate this difference.