### PR TITLE
Add views for property textures and their properties

### DIFF
--- a/Cesium3DTilesSelection/src/B3dmToGltfConverter.cpp
+++ b/Cesium3DTilesSelection/src/B3dmToGltfConverter.cpp
@@ -176,7 +176,7 @@ rapidjson::Document parseFeatureTableJsonData(
   return document;
 }
 
-void convertB3dmMetadataToGltfFeatureMetadata(
+void convertB3dmMetadataToGltfStructuralMetadata(
     const gsl::span<const std::byte>& b3dmBinary,
     const B3dmHeader& header,
     uint32_t headerLength,
@@ -246,7 +246,7 @@ GltfConverterResult B3dmToGltfConverter::convert(
     return result;
   }
 
-  convertB3dmMetadataToGltfFeatureMetadata(
+  convertB3dmMetadataToGltfStructuralMetadata(
       b3dmBinary,
       header,
       headerLength,

--- a/Cesium3DTilesSelection/src/BatchTableToGltfStructuralMetadata.cpp
+++ b/Cesium3DTilesSelection/src/BatchTableToGltfStructuralMetadata.cpp
@@ -163,15 +163,15 @@ struct CompatibleTypes {
    * Merges a MaskedArrayType into this CompatibleTypes.
    */
   void operator&=(const MaskedArrayType& maskedArrayType) {
-    if (!isArray()) {
-      makeIncompatible();
+    if (isArray()) {
+      MaskedArrayType& arrayType = std::get<MaskedArrayType>(maskedType);
+      arrayType &= maskedArrayType;
       return;
     }
 
-    MaskedArrayType* pMaskedArrayType =
-        std::get_if<MaskedArrayType>(&maskedType);
-    if (pMaskedArrayType) {
-      *pMaskedArrayType &= maskedArrayType;
+    MaskedType* pMaskedType = std::get_if<MaskedType>(&maskedType);
+    if (pMaskedType) {
+      makeIncompatible();
     } else {
       maskedType = maskedArrayType;
     }

--- a/Cesium3DTilesSelection/src/BatchTableToGltfStructuralMetadata.cpp
+++ b/Cesium3DTilesSelection/src/BatchTableToGltfStructuralMetadata.cpp
@@ -1448,10 +1448,11 @@ void updateExtensionWithBatchTableHierarchy(
     ExtensionExtStructuralMetadataPropertyTable& propertyTable,
     ErrorList& result,
     const rapidjson::Value& batchTableHierarchy) {
-  // EXT_feature_metadata can't support hierarchy, so we need to flatten it.
+  // EXT_structural_metadata can't support hierarchy, so we need to flatten it.
   // It also can't support multiple classes with a single set of feature IDs.
-  // So essentially every property of every class gets added to the one class
-  // definition.
+  // (Feature IDs can only specify one property table, which only supports one class.)
+  // So essentially every property of every class gets added to
+  // the one class definition.
   auto classesIt = batchTableHierarchy.FindMember("classes");
   if (classesIt == batchTableHierarchy.MemberEnd()) {
     result.emplaceWarning(
@@ -1649,7 +1650,7 @@ ErrorList BatchTableToGltfStructuralMetadata::convertFromB3dm(
 
   ErrorList result;
 
-  // Parse the b3dm batch table and convert it to the EXT_feature_metadata
+  // Parse the b3dm batch table and convert it to the EXT_structural_metadata
   // extension.
 
   // If the feature table is missing the BATCH_LENGTH semantic, ignore the batch
@@ -1716,7 +1717,7 @@ ErrorList BatchTableToGltfStructuralMetadata::convertFromPnts(
 
   ErrorList result;
 
-  // Parse the pnts batch table and convert it to the EXT_feature_metadata
+  // Parse the pnts batch table and convert it to the EXT_structural_metadata
   // extension.
 
   const auto pointsLengthIt = featureTableJson.FindMember("POINTS_LENGTH");

--- a/Cesium3DTilesSelection/src/PntsToGltfConverter.cpp
+++ b/Cesium3DTilesSelection/src/PntsToGltfConverter.cpp
@@ -5,7 +5,6 @@
 #include <CesiumGeometry/Transforms.h>
 #include <CesiumGltf/ExtensionCesiumRTC.h>
 #include <CesiumGltf/ExtensionKhrMaterialsUnlit.h>
-#include <CesiumGltf/ExtensionMeshPrimitiveExtFeatureMetadata.h>
 #include <CesiumUtility/AttributeCompression.h>
 #include <CesiumUtility/Math.h>
 

--- a/Cesium3DTilesSelection/test/TestPntsToGltfConverter.cpp
+++ b/Cesium3DTilesSelection/test/TestPntsToGltfConverter.cpp
@@ -5,7 +5,7 @@
 #include <CesiumGltf/ExtensionCesiumRTC.h>
 #include <CesiumGltf/ExtensionExtMeshFeatures.h>
 #include <CesiumGltf/ExtensionKhrMaterialsUnlit.h>
-#include <CesiumGltf/ExtensionModelExtFeatureMetadata.h>
+#include <CesiumGltf/ExtensionModelExtStructuralMetadata.h>
 #include <CesiumUtility/Math.h>
 
 #include <catch2/catch.hpp>
@@ -654,7 +654,7 @@ getUniqueBufferIds(const std::vector<BufferView>& bufferViews) {
 }
 
 TEST_CASE(
-    "Converts point cloud with batch IDs to glTF with EXT_feature_metadata") {
+    "Converts point cloud with batch IDs to glTF with EXT_structural_metadata") {
   std::filesystem::path testFilePath = Cesium3DTilesSelection_TEST_DATA_DIR;
   testFilePath = testFilePath / "PointCloud" / "pointCloudBatched.pnts";
   const int32_t pointsLength = 8;
@@ -665,8 +665,8 @@ TEST_CASE(
   Model& gltf = *result.model;
 
   // The correctness of the model extension is thoroughly tested in
-  // TestUpgradeBatchTableToExtFeatureMetadata
-  CHECK(gltf.hasExtension<ExtensionModelExtFeatureMetadata>());
+  // TestUpgradeBatchTableToExtStructuralMetadata
+  CHECK(gltf.hasExtension<ExtensionModelExtStructuralMetadata>());
 
   CHECK(gltf.nodes.size() == 1);
   REQUIRE(gltf.meshes.size() == 1);
@@ -744,8 +744,8 @@ TEST_CASE("Converts point cloud with per-point properties to glTF with "
   Model& gltf = *result.model;
 
   // The correctness of the model extension is thoroughly tested in
-  // TestUpgradeBatchTableToExtFeatureMetadata
-  CHECK(gltf.hasExtension<ExtensionModelExtFeatureMetadata>());
+  // TestUpgradeBatchTableToExtStructuralMetadata
+  CHECK(gltf.hasExtension<ExtensionModelExtStructuralMetadata>());
 
   CHECK(gltf.nodes.size() == 1);
   REQUIRE(gltf.meshes.size() == 1);
@@ -803,8 +803,8 @@ TEST_CASE("Converts point cloud with Draco compression to glTF") {
 
   CHECK(gltf.hasExtension<CesiumGltf::ExtensionCesiumRTC>());
   // The correctness of the model extension is thoroughly tested in
-  // TestUpgradeBatchTableToExtFeatureMetadata
-  CHECK(gltf.hasExtension<ExtensionModelExtFeatureMetadata>());
+  // TestUpgradeBatchTableToExtStructuralMetadata
+  CHECK(gltf.hasExtension<ExtensionModelExtStructuralMetadata>());
 
   CHECK(gltf.nodes.size() == 1);
   REQUIRE(gltf.meshes.size() == 1);
@@ -948,7 +948,7 @@ TEST_CASE("Converts point cloud with partial Draco compression to glTF") {
   Model& gltf = *result.model;
 
   CHECK(gltf.hasExtension<CesiumGltf::ExtensionCesiumRTC>());
-  CHECK(gltf.hasExtension<ExtensionModelExtFeatureMetadata>());
+  CHECK(gltf.hasExtension<ExtensionModelExtStructuralMetadata>());
 
   CHECK(gltf.nodes.size() == 1);
   REQUIRE(gltf.meshes.size() == 1);
@@ -1087,7 +1087,7 @@ TEST_CASE("Converts batched point cloud with Draco compression to glTF") {
 
   // The correctness of the model extension is thoroughly tested in
   // TestUpgradeBatchTableToExtFeatureMetadata
-  CHECK(gltf.hasExtension<ExtensionModelExtFeatureMetadata>());
+  CHECK(gltf.hasExtension<ExtensionModelExtStructuralMetadata>());
 
   CHECK(gltf.nodes.size() == 1);
   REQUIRE(gltf.meshes.size() == 1);

--- a/Cesium3DTilesSelection/test/TestPntsToGltfConverter.cpp
+++ b/Cesium3DTilesSelection/test/TestPntsToGltfConverter.cpp
@@ -653,8 +653,8 @@ getUniqueBufferIds(const std::vector<BufferView>& bufferViews) {
   return result;
 }
 
-TEST_CASE(
-    "Converts point cloud with batch IDs to glTF with EXT_structural_metadata") {
+TEST_CASE("Converts point cloud with batch IDs to glTF with "
+          "EXT_structural_metadata") {
   std::filesystem::path testFilePath = Cesium3DTilesSelection_TEST_DATA_DIR;
   testFilePath = testFilePath / "PointCloud" / "pointCloudBatched.pnts";
   const int32_t pointsLength = 8;

--- a/Cesium3DTilesSelection/test/TestPntsToGltfConverter.cpp
+++ b/Cesium3DTilesSelection/test/TestPntsToGltfConverter.cpp
@@ -1086,7 +1086,7 @@ TEST_CASE("Converts batched point cloud with Draco compression to glTF") {
   Model& gltf = *result.model;
 
   // The correctness of the model extension is thoroughly tested in
-  // TestUpgradeBatchTableToExtFeatureMetadata
+  // TestUpgradeBatchTableToExtStructuralMetadata
   CHECK(gltf.hasExtension<ExtensionModelExtStructuralMetadata>());
 
   CHECK(gltf.nodes.size() == 1);

--- a/Cesium3DTilesSelection/test/TestUpgradeBatchTableToExtStructuralMetadata.cpp
+++ b/Cesium3DTilesSelection/test/TestUpgradeBatchTableToExtStructuralMetadata.cpp
@@ -5,8 +5,8 @@
 #include <CesiumAsync/HttpHeaders.h>
 #include <CesiumGltf/ExtensionExtMeshFeatures.h>
 #include <CesiumGltf/ExtensionModelExtStructuralMetadata.h>
-#include <CesiumGltf/StructuralMetadataPropertyTableView.h>
 #include <CesiumGltf/StructuralMetadataPropertyTablePropertyView.h>
+#include <CesiumGltf/StructuralMetadataPropertyTableView.h>
 #include <CesiumUtility/Math.h>
 
 #include <catch2/catch.hpp>

--- a/Cesium3DTilesSelection/test/TestUpgradeBatchTableToExtStructuralMetadata.cpp
+++ b/Cesium3DTilesSelection/test/TestUpgradeBatchTableToExtStructuralMetadata.cpp
@@ -6,7 +6,7 @@
 #include <CesiumGltf/ExtensionExtMeshFeatures.h>
 #include <CesiumGltf/ExtensionModelExtStructuralMetadata.h>
 #include <CesiumGltf/StructuralMetadataPropertyTableView.h>
-#include <CesiumGltf/StructuralMetadataPropertyView.h>
+#include <CesiumGltf/StructuralMetadataPropertyTablePropertyView.h>
 #include <CesiumUtility/Math.h>
 
 #include <catch2/catch.hpp>
@@ -39,13 +39,13 @@ static void checkNonArrayProperty(
   REQUIRE(!property.array);
   REQUIRE(property.count == std::nullopt);
 
-  MetadataPropertyTableView view(model, propertyTable);
-  REQUIRE(view.status() == MetadataPropertyTableViewStatus::Valid);
+  PropertyTableView view(model, propertyTable);
+  REQUIRE(view.status() == PropertyTableViewStatus::Valid);
   REQUIRE(view.size() == propertyTable.count);
 
-  MetadataPropertyView<PropertyViewType> propertyView =
+  PropertyTablePropertyView<PropertyViewType> propertyView =
       view.getPropertyView<PropertyViewType>(propertyName);
-  REQUIRE(propertyView.status() == MetadataPropertyViewStatus::Valid);
+  REQUIRE(propertyView.status() == PropertyTablePropertyViewStatus::Valid);
   REQUIRE(propertyView.size() == propertyTable.count);
   REQUIRE(propertyView.size() == static_cast<int64_t>(expectedTotalInstances));
   for (int64_t i = 0; i < propertyView.size(); ++i) {
@@ -84,13 +84,13 @@ static void checkArrayProperty(
   REQUIRE(property.array);
   REQUIRE(property.count.value_or(0) == expectedCount);
 
-  MetadataPropertyTableView view(model, propertyTable);
-  REQUIRE(view.status() == MetadataPropertyTableViewStatus::Valid);
+  PropertyTableView view(model, propertyTable);
+  REQUIRE(view.status() == PropertyTableViewStatus::Valid);
   REQUIRE(view.size() == propertyTable.count);
 
-  MetadataPropertyView<MetadataArrayView<PropertyViewType>> propertyView =
+  PropertyTablePropertyView<MetadataArrayView<PropertyViewType>> propertyView =
       view.getPropertyView<MetadataArrayView<PropertyViewType>>(propertyName);
-  REQUIRE(propertyView.status() == MetadataPropertyViewStatus::Valid);
+  REQUIRE(propertyView.status() == PropertyTablePropertyViewStatus::Valid);
   REQUIRE(propertyView.size() == propertyTable.count);
   REQUIRE(propertyView.size() == static_cast<int64_t>(expectedTotalInstances));
   for (size_t i = 0; i < expectedTotalInstances; ++i) {

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTexturePropertyView.h
@@ -58,6 +58,11 @@ enum class PropertyTexturePropertyViewStatus {
   ErrorEmptyImage,
 
   /**
+   * @brief This property texture property has a negative TEXCOORD set index.
+   */
+  ErrorInvalidTexCoordSetIndex,
+
+  /**
    * @brief The channels of this property texture property are invalid.
    * Channels must be in the range 0-3, with a minimum of one channel and a
    * maximum of four.
@@ -187,17 +192,16 @@ public:
   }
 
   /**
-   * @brief Get the count for this property.
-   *
-   * This is also how many channels a pixel value for this property will use.
+   * @brief Get the count for this property. This is equivalent to how many
+   * channels a pixel value for this property will use.
    */
   int64_t getCount() const noexcept { return this->_count; }
 
   /**
    * @brief Get the texture coordinate set index for this property.
    */
-  int64_t getTextureCoordinateSetIndex() const noexcept {
-    return this->_textureCoordinateSetIndex;
+  int64_t getTexCoordSetIndex() const noexcept {
+    return this->_texCoordSetIndex;
   }
 
   /**
@@ -233,7 +237,7 @@ private:
 
   const Sampler* _pSampler;
   const ImageCesium* _pImage;
-  int64_t _textureCoordinateSetIndex;
+  int64_t _texCoordSetIndex;
   std::vector<int64_t> _channels;
   std::string _swizzle;
   PropertyTexturePropertyComponentType _type;

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTexturePropertyView.h
@@ -89,9 +89,7 @@ enum class PropertyTexturePropertyComponentType {
  * @tparam T The component type, must correspond to a valid
  * {@link PropertyTexturePropertyComponentType}.
  */
-template <typename T> struct PropertyTexturePropertyValue {
-  T components[4];
-};
+template <typename T> struct PropertyTexturePropertyValue { T components[4]; };
 
 /**
  * @brief A view of the data specified by a

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTexturePropertyView.h
@@ -1,0 +1,245 @@
+#pragma once
+
+#include "CesiumGltf/ExtensionExtStructuralMetadataClassProperty.h"
+#include "CesiumGltf/ExtensionExtStructuralMetadataPropertyTexture.h"
+#include "CesiumGltf/ExtensionModelExtStructuralMetadata.h"
+#include "CesiumGltf/Image.h"
+#include "CesiumGltf/ImageCesium.h"
+#include "CesiumGltf/Model.h"
+#include "CesiumGltf/Sampler.h"
+#include "CesiumGltf/Texture.h"
+
+#include <cassert>
+#include <cstdint>
+#include <variant>
+
+namespace CesiumGltf {
+namespace StructuralMetadata {
+/**
+ * @brief Indicates the status of a property texture property view.
+ *
+ * The {@link PropertyTexturePropertyView} constructor always completes
+ * successfully. However it may not always reflect the actual content of the
+ * corresponding property texture property. This enumeration provides the
+ * reason.
+ */
+enum class PropertyTexturePropertyViewStatus {
+  /**
+   * @brief This view is valid and ready to use.
+   */
+  Valid,
+
+  /**
+   * @brief This view has not been initialized.
+   */
+  ErrorUninitialized,
+
+  /**
+   * @brief This property texture property has a texture index that does not
+   * exist in the glTF.
+   */
+  ErrorInvalidTexture,
+
+  /**
+   * @brief This property texture property has a texture sampler index that does
+   * not exist in the glTF.
+   */
+  ErrorInvalidTextureSampler,
+
+  /**
+   * @brief This property texture property has an image index that does not
+   * exist in the glTF.
+   */
+  ErrorInvalidImage,
+
+  /**
+   * @brief This property texture property points to an empty image.
+   */
+  ErrorEmptyImage,
+
+  /**
+   * @brief The channels of this property texture property are invalid.
+   * Channels must be in the range 0-3, with a minimum of one channel and a
+   * maximum of four.
+   */
+  ErrorInvalidChannels
+};
+
+/**
+ * @brief The supported component types that can exist in property id textures.
+ */
+enum class PropertyTexturePropertyComponentType {
+  Uint8
+  // TODO: add more types. Currently this is the only one outputted by stb,
+  // so change stb call to output more of the original types.
+};
+
+/**
+ * @brief The property texture property value for a pixel. This will contain
+ * four channels of the specified type.
+ *
+ * Only the first n components will be valid, where n is the number of channels
+ * in this property texture property.
+ *
+ * @tparam T The component type, must correspond to a valid
+ * {@link PropertyTexturePropertyComponentType}.
+ */
+template <typename T> struct PropertyTexturePropertyValue {
+  T components[4];
+};
+
+/**
+ * @brief A view of the data specified by a
+ * {@link ExtensionExtStructuralMetadataPropertyTextureProperty}.
+ *
+ * Provides utilities to sample the property texture property using texture
+ * coordinates.
+ */
+class PropertyTexturePropertyView {
+public:
+  /**
+   * @brief Construct an uninitialized, invalid view.
+   */
+  PropertyTexturePropertyView() noexcept;
+
+  /**
+   * @brief Construct a view of the data specified by the given property texture
+   * property. Assumes the model has already been validated by
+   * PropertyTextureView.
+   *
+   * @param model The glTF in which to look for the data specified by the
+   * property texture property.
+   * @param classProperty The property description.
+   * @param propertyTextureProperty The property texture property
+   */
+  PropertyTexturePropertyView(
+      const Model& model,
+      const ExtensionExtStructuralMetadataClassProperty& classProperty,
+      const ExtensionExtStructuralMetadataPropertyTextureProperty&
+          propertyTextureProperty) noexcept;
+
+  /**
+   * @brief Gets the unswizzled property for the given texture coordinates.
+   *
+   * Will return -1s when the status is not Valid or when the templated
+   * component type doesn't match the image's channel byte-size.
+   *
+   * @tparam T The component type to use when interpreting the channels of the
+   * property's pixel value.
+   * @param u The u-component of the texture coordinates. Must be within
+   * [0.0, 1.0].
+   * @param v The v-component of the texture coordinates. Must be within
+   * [0.0, 1.0].
+   * @return The property at the nearest pixel to the texture coordinates.
+   */
+  template <typename T>
+  PropertyTexturePropertyValue<T>
+  getProperty(double u, double v) const noexcept {
+    PropertyTexturePropertyValue<T> property;
+    property.components[0] = -1;
+    property.components[1] = -1;
+    property.components[2] = -1;
+    property.components[3] = -1;
+
+    if (this->_status != PropertyTexturePropertyViewStatus::Valid ||
+        sizeof(T) != this->_pImage->bytesPerChannel) {
+      return property;
+    }
+
+    // TODO: actually use the sampler??
+    int64_t x = std::clamp(
+        std::llround(u * this->_pImage->width),
+        0LL,
+        (long long)this->_pImage->width);
+    int64_t y = std::clamp(
+        std::llround(v * this->_pImage->height),
+        0LL,
+        (long long)this->_pImage->height);
+
+    int64_t pixelOffset = this->_pImage->bytesPerChannel *
+                          this->_pImage->channels *
+                          (y * this->_pImage->width + x);
+    const T* pRedChannel = reinterpret_cast<const T*>(
+        this->_pImage->pixelData.data() + pixelOffset);
+
+    for (size_t i = 0; i < this->_channels.size(); i++) {
+      const size_t channel = static_cast<size_t>(this->_channels[i]);
+      property.components[channel] = *(pRedChannel + channel);
+    }
+
+    return property;
+  }
+
+  /**
+   * @brief Get the status of this view.
+   *
+   * If invalid, it will not be safe to sample from this view.
+   */
+  PropertyTexturePropertyViewStatus status() const noexcept {
+    return this->_status;
+  }
+
+  /**
+   * @brief Get the component type for this property.
+   */
+  PropertyTexturePropertyComponentType getPropertyType() const noexcept {
+    return this->_type;
+  }
+
+  /**
+   * @brief Get the count for this property.
+   *
+   * This is also how many channels a pixel value for this property will use.
+   */
+  int64_t getCount() const noexcept { return this->_count; }
+
+  /**
+   * @brief Get the texture coordinate set index for this property.
+   */
+  int64_t getTextureCoordinateSetIndex() const noexcept {
+    return this->_textureCoordinateSetIndex;
+  }
+
+  /**
+   * @brief Whether the component type for this property should be normalized.
+   */
+  bool isNormalized() const noexcept { return this->_normalized; }
+
+  /**
+   * @brief Get the image containing this property's data.
+   *
+   * This will be nullptr if the property texture property view runs into
+   * problems during construction.
+   */
+  const ImageCesium* getImage() const noexcept { return this->_pImage; }
+
+  /**
+   * @brief Gets the channels of this property texture property.
+   */
+  const std::vector<int64_t>& getChannels() const noexcept {
+    return this->_channels;
+  }
+
+  /**
+   * @brief Gets this property's channels as a swizzle string.
+   */
+  const std::string& getSwizzle() const noexcept { return this->_swizzle; }
+
+private:
+  PropertyTexturePropertyViewStatus _status;
+  const ExtensionExtStructuralMetadataClassProperty* _pClassProperty;
+  const ExtensionExtStructuralMetadataPropertyTextureProperty*
+      _pPropertyTextureProperty;
+
+  const Sampler* _pSampler;
+  const ImageCesium* _pImage;
+  int64_t _textureCoordinateSetIndex;
+  std::vector<int64_t> _channels;
+  std::string _swizzle;
+  PropertyTexturePropertyComponentType _type;
+  int64_t _count;
+  bool _normalized;
+};
+
+} // namespace StructuralMetadata
+} // namespace CesiumGltf

--- a/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTextureView.h
+++ b/CesiumGltf/include/CesiumGltf/StructuralMetadataPropertyTextureView.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include "CesiumGltf/ExtensionExtStructuralMetadataClass.h"
+#include "CesiumGltf/ExtensionExtStructuralMetadataClassProperty.h"
+#include "CesiumGltf/ExtensionExtStructuralMetadataPropertyTexture.h"
+#include "CesiumGltf/ExtensionModelExtStructuralMetadata.h"
+#include "CesiumGltf/StructuralMetadataPropertyTexturePropertyView.h"
+#include "CesiumGltf/Texture.h"
+#include "CesiumGltf/TextureAccessor.h"
+#include "Image.h"
+#include "ImageCesium.h"
+#include "Model.h"
+
+namespace CesiumGltf {
+namespace StructuralMetadata {
+
+/**
+ * @brief Indicates the status of a property texture view.
+ *
+ * The {@link PropertyTextureView} constructor always completes successfully.
+ * However it may not always reflect the actual content of the
+ * {@link ExtensionExtStructuralMetadataPropertyTexture}. This enumeration provides the reason.
+ */
+enum class PropertyTextureViewStatus {
+  /**
+   * @brief This property texture view is valid and ready to use.
+   */
+  Valid,
+
+  /**
+   * @brief This property texture view is not initialized.
+   */
+  ErrorUninitialized,
+
+  /**
+   * @brief The glTF is missing the EXT_structural_metadata extension.
+   */
+  ErrorMissingMetadataExtension,
+
+  /**
+   * @brief The glTF EXT_structural_metadata extension doesn't contain a schema.
+   */
+  ErrorMissingSchema,
+
+  /**
+   * @brief The property texture's specified class could not be found in the
+   * extension.
+   */
+  ErrorClassNotFound,
+
+  /**
+   * @brief A property name specified in the property texture could not be found
+   * in the class.
+   */
+  ErrorClassPropertyNotFound,
+
+  /**
+   * @brief A property view for one of this property texture's properties failed
+   * to initialize successfully. Look for the invalid property view's status to
+   * find why it failed.
+   */
+  ErrorInvalidPropertyView
+};
+
+/**
+ * @brief A view on the {@link ExtensionExtStructuralMetadataPropertyTexture}.
+ *
+ * Provides access to views on the property texture properties.
+ */
+class PropertyTextureView {
+public:
+  /**
+   * @brief Construct an uninitialized, invalid property texture view.
+   */
+  PropertyTextureView() noexcept;
+
+  /**
+   * @brief Construct a view for the property texture.
+   *
+   * @param model The glTF in which to look for the property texture's data.
+   * @param propertyTexture The property texture to create a view for.
+   */
+  PropertyTextureView(
+      const Model& model,
+      const ExtensionExtStructuralMetadataPropertyTexture&
+          propertyTexture) noexcept;
+
+  /**
+   * @brief Gets the status of this property texture view.
+   *
+   * Indicates whether the view accurately reflects the property texture's data,
+   * or whether an error occurred.
+   */
+  PropertyTextureViewStatus status() const noexcept { return this->_status; }
+
+  /**
+   * @brief Finds the {@link ExtensionExtStructuralMetadataClassProperty} that
+   * describes the type information of the property with the specified name.
+   * @param propertyName The name of the property to retrieve the class for.
+   * @return A pointer to the {@link ExtensionExtStructuralMetadataClassProperty}.
+   * Return nullptr if the PropertyTextureView is invalid or if no class
+   * property was found.
+   */
+  const ExtensionExtStructuralMetadataClassProperty*
+  getClassProperty(const std::string& propertyName) const;
+
+  /**
+   * @brief Get the views for this property texture's properties.
+   */
+  const std::unordered_map<std::string, PropertyTexturePropertyView>&
+  getProperties() const noexcept {
+    return this->_propertyViews;
+  }
+
+private:
+  const Model* _pModel;
+  const ExtensionExtStructuralMetadataPropertyTexture* _pPropertyTexture;
+  const ExtensionExtStructuralMetadataClass* _pClass;
+  std::unordered_map<std::string, PropertyTexturePropertyView> _propertyViews;
+  PropertyTextureViewStatus _status;
+};
+
+} // namespace StructuralMetadata
+} // namespace CesiumGltf

--- a/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
+++ b/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
@@ -165,7 +165,8 @@ MetadataPropertyViewStatus MetadataPropertyTableView::getBufferSafe(
     return MetadataPropertyViewStatus::ErrorInvalidValueBufferView;
   }
 
-  const Buffer* pBuffer = _pModel->getSafe(&_pModel->buffers, pBufferView->buffer);
+  const Buffer* pBuffer =
+      _pModel->getSafe(&_pModel->buffers, pBufferView->buffer);
   if (!pBuffer) {
     return MetadataPropertyViewStatus::ErrorInvalidValueBuffer;
   }

--- a/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
+++ b/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
@@ -4,21 +4,21 @@ namespace CesiumGltf {
 namespace StructuralMetadata {
 
 template <typename T>
-static MetadataPropertyViewStatus checkOffsetsBuffer(
+static PropertyTablePropertyViewStatus checkOffsetsBuffer(
     const gsl::span<const std::byte>& offsetBuffer,
     size_t valueBufferSize,
     size_t instanceCount,
     bool checkBitSize,
-    MetadataPropertyViewStatus offsetsNotSortedError,
-    MetadataPropertyViewStatus offsetOutOfBoundsError) noexcept {
+    PropertyTablePropertyViewStatus offsetsNotSortedError,
+    PropertyTablePropertyViewStatus offsetOutOfBoundsError) noexcept {
   if (offsetBuffer.size() % sizeof(T) != 0) {
-    return MetadataPropertyViewStatus::
+    return PropertyTablePropertyViewStatus::
         ErrorBufferViewSizeNotDivisibleByTypeSize;
   }
 
   const size_t size = offsetBuffer.size() / sizeof(T);
   if (size != instanceCount + 1) {
-    return MetadataPropertyViewStatus::
+    return PropertyTablePropertyViewStatus::
         ErrorBufferViewSizeDoesNotMatchPropertyTableCount;
   }
 
@@ -34,21 +34,21 @@ static MetadataPropertyViewStatus checkOffsetsBuffer(
 
   if (checkBitSize) {
     if (offsetValues.back() / 8 <= valueBufferSize) {
-      return MetadataPropertyViewStatus::Valid;
+      return PropertyTablePropertyViewStatus::Valid;
     }
 
     return offsetOutOfBoundsError;
   }
 
   if (offsetValues.back() <= valueBufferSize) {
-    return MetadataPropertyViewStatus::Valid;
+    return PropertyTablePropertyViewStatus::Valid;
   }
 
   return offsetOutOfBoundsError;
 }
 
 template <typename T>
-static MetadataPropertyViewStatus checkStringAndArrayOffsetsBuffers(
+static PropertyTablePropertyViewStatus checkStringAndArrayOffsetsBuffers(
     const gsl::span<const std::byte>& arrayOffsets,
     const gsl::span<const std::byte>& stringOffsets,
     size_t valueBufferSize,
@@ -59,10 +59,10 @@ static MetadataPropertyViewStatus checkStringAndArrayOffsetsBuffers(
       stringOffsets.size(),
       propertyTableCount,
       false,
-      MetadataPropertyViewStatus::ErrorArrayOffsetsNotSorted,
-      MetadataPropertyViewStatus::ErrorArrayOffsetOutOfBounds);
+      PropertyTablePropertyViewStatus::ErrorArrayOffsetsNotSorted,
+      PropertyTablePropertyViewStatus::ErrorArrayOffsetOutOfBounds);
 
-  if (status != MetadataPropertyViewStatus::Valid) {
+  if (status != PropertyTablePropertyViewStatus::Valid) {
     return status;
   }
 
@@ -75,38 +75,38 @@ static MetadataPropertyViewStatus checkStringAndArrayOffsetsBuffers(
         valueBufferSize,
         pValue[propertyTableCount] / sizeof(T),
         false,
-        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted,
-        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+        PropertyTablePropertyViewStatus::ErrorStringOffsetsNotSorted,
+        PropertyTablePropertyViewStatus::ErrorStringOffsetOutOfBounds);
   case PropertyComponentType::Uint16:
     return checkOffsetsBuffer<uint16_t>(
         stringOffsets,
         valueBufferSize,
         pValue[propertyTableCount] / sizeof(T),
         false,
-        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted,
-        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+        PropertyTablePropertyViewStatus::ErrorStringOffsetsNotSorted,
+        PropertyTablePropertyViewStatus::ErrorStringOffsetOutOfBounds);
   case PropertyComponentType::Uint32:
     return checkOffsetsBuffer<uint32_t>(
         stringOffsets,
         valueBufferSize,
         pValue[propertyTableCount] / sizeof(T),
         false,
-        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted,
-        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+        PropertyTablePropertyViewStatus::ErrorStringOffsetsNotSorted,
+        PropertyTablePropertyViewStatus::ErrorStringOffsetOutOfBounds);
   case PropertyComponentType::Uint64:
     return checkOffsetsBuffer<uint64_t>(
         stringOffsets,
         valueBufferSize,
         pValue[propertyTableCount] / sizeof(T),
         false,
-        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted,
-        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+        PropertyTablePropertyViewStatus::ErrorStringOffsetsNotSorted,
+        PropertyTablePropertyViewStatus::ErrorStringOffsetOutOfBounds);
   default:
-    return MetadataPropertyViewStatus::ErrorInvalidStringOffsetType;
+    return PropertyTablePropertyViewStatus::ErrorInvalidStringOffsetType;
   }
 }
 
-MetadataPropertyTableView::MetadataPropertyTableView(
+PropertyTableView::PropertyTableView(
     const Model& model,
     const ExtensionExtStructuralMetadataPropertyTable& propertyTable)
     : _pModel{&model},
@@ -116,15 +116,14 @@ MetadataPropertyTableView::MetadataPropertyTableView(
   const ExtensionModelExtStructuralMetadata* pMetadata =
       model.getExtension<ExtensionModelExtStructuralMetadata>();
   if (!pMetadata) {
-    _status =
-        MetadataPropertyTableViewStatus::ErrorNoStructuralMetadataExtension;
+    _status = PropertyTableViewStatus::ErrorMissingMetadataExtension;
     return;
   }
 
   const std::optional<ExtensionExtStructuralMetadataSchema>& schema =
       pMetadata->schema;
   if (!schema) {
-    _status = MetadataPropertyTableViewStatus::ErrorNoSchema;
+    _status = PropertyTableViewStatus::ErrorMissingSchema;
     return;
   }
 
@@ -134,15 +133,14 @@ MetadataPropertyTableView::MetadataPropertyTableView(
   }
 
   if (!_pClass) {
-    _status =
-        MetadataPropertyTableViewStatus::ErrorPropertyTableClassDoesNotExist;
+    _status = PropertyTableViewStatus::ErrorClassNotFound;
   }
 }
 
 const ExtensionExtStructuralMetadataClassProperty*
-MetadataPropertyTableView::getClassProperty(
+PropertyTableView::getClassProperty(
     const std::string& propertyName) const {
-  if (_status != MetadataPropertyTableViewStatus::Valid) {
+  if (_status != PropertyTableViewStatus::Valid) {
     return nullptr;
   }
 
@@ -154,7 +152,7 @@ MetadataPropertyTableView::getClassProperty(
   return &propertyIter->second;
 }
 
-MetadataPropertyViewStatus MetadataPropertyTableView::getBufferSafe(
+PropertyTablePropertyViewStatus PropertyTableView::getBufferSafe(
     int32_t bufferViewIdx,
     gsl::span<const std::byte>& buffer) const noexcept {
   buffer = {};
@@ -162,36 +160,36 @@ MetadataPropertyViewStatus MetadataPropertyTableView::getBufferSafe(
   const BufferView* pBufferView =
       _pModel->getSafe(&_pModel->bufferViews, bufferViewIdx);
   if (!pBufferView) {
-    return MetadataPropertyViewStatus::ErrorInvalidValueBufferView;
+    return PropertyTablePropertyViewStatus::ErrorInvalidValueBufferView;
   }
 
   const Buffer* pBuffer =
       _pModel->getSafe(&_pModel->buffers, pBufferView->buffer);
   if (!pBuffer) {
-    return MetadataPropertyViewStatus::ErrorInvalidValueBuffer;
+    return PropertyTablePropertyViewStatus::ErrorInvalidValueBuffer;
   }
 
   if (pBufferView->byteOffset + pBufferView->byteLength >
       static_cast<int64_t>(pBuffer->cesium.data.size())) {
-    return MetadataPropertyViewStatus::ErrorBufferViewOutOfBounds;
+    return PropertyTablePropertyViewStatus::ErrorBufferViewOutOfBounds;
   }
 
   buffer = gsl::span<const std::byte>(
       pBuffer->cesium.data.data() + pBufferView->byteOffset,
       static_cast<size_t>(pBufferView->byteLength));
-  return MetadataPropertyViewStatus::Valid;
+  return PropertyTablePropertyViewStatus::Valid;
 }
 
-MetadataPropertyViewStatus MetadataPropertyTableView::getArrayOffsetsBufferSafe(
+PropertyTablePropertyViewStatus PropertyTableView::getArrayOffsetsBufferSafe(
     int32_t arrayOffsetsBufferView,
     PropertyComponentType arrayOffsetType,
     size_t valueBufferSize,
     size_t propertyTableCount,
     bool checkBitsSize,
     gsl::span<const std::byte>& arrayOffsetsBuffer) const noexcept {
-  const MetadataPropertyViewStatus bufferStatus =
+  const PropertyTablePropertyViewStatus bufferStatus =
       getBufferSafe(arrayOffsetsBufferView, arrayOffsetsBuffer);
-  if (bufferStatus != MetadataPropertyViewStatus::Valid) {
+  if (bufferStatus != PropertyTablePropertyViewStatus::Valid) {
     return bufferStatus;
   }
 
@@ -202,47 +200,47 @@ MetadataPropertyViewStatus MetadataPropertyTableView::getArrayOffsetsBufferSafe(
         valueBufferSize,
         propertyTableCount,
         checkBitsSize,
-        MetadataPropertyViewStatus::ErrorArrayOffsetsNotSorted,
-        MetadataPropertyViewStatus::ErrorArrayOffsetOutOfBounds);
+        PropertyTablePropertyViewStatus::ErrorArrayOffsetsNotSorted,
+        PropertyTablePropertyViewStatus::ErrorArrayOffsetOutOfBounds);
   case PropertyComponentType::Uint16:
     return checkOffsetsBuffer<uint16_t>(
         arrayOffsetsBuffer,
         valueBufferSize,
         propertyTableCount,
         checkBitsSize,
-        MetadataPropertyViewStatus::ErrorArrayOffsetsNotSorted,
-        MetadataPropertyViewStatus::ErrorArrayOffsetOutOfBounds);
+        PropertyTablePropertyViewStatus::ErrorArrayOffsetsNotSorted,
+        PropertyTablePropertyViewStatus::ErrorArrayOffsetOutOfBounds);
   case PropertyComponentType::Uint32:
     return checkOffsetsBuffer<uint32_t>(
         arrayOffsetsBuffer,
         valueBufferSize,
         propertyTableCount,
         checkBitsSize,
-        MetadataPropertyViewStatus::ErrorArrayOffsetsNotSorted,
-        MetadataPropertyViewStatus::ErrorArrayOffsetOutOfBounds);
+        PropertyTablePropertyViewStatus::ErrorArrayOffsetsNotSorted,
+        PropertyTablePropertyViewStatus::ErrorArrayOffsetOutOfBounds);
   case PropertyComponentType::Uint64:
     return checkOffsetsBuffer<uint64_t>(
         arrayOffsetsBuffer,
         valueBufferSize,
         propertyTableCount,
         checkBitsSize,
-        MetadataPropertyViewStatus::ErrorArrayOffsetsNotSorted,
-        MetadataPropertyViewStatus::ErrorArrayOffsetOutOfBounds);
+        PropertyTablePropertyViewStatus::ErrorArrayOffsetsNotSorted,
+        PropertyTablePropertyViewStatus::ErrorArrayOffsetOutOfBounds);
   default:
-    return MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType;
+    return PropertyTablePropertyViewStatus::ErrorInvalidArrayOffsetType;
   }
 }
 
-MetadataPropertyViewStatus
-MetadataPropertyTableView::getStringOffsetsBufferSafe(
+PropertyTablePropertyViewStatus
+PropertyTableView::getStringOffsetsBufferSafe(
     int32_t stringOffsetsBufferView,
     PropertyComponentType stringOffsetType,
     size_t valueBufferSize,
     size_t propertyTableCount,
     gsl::span<const std::byte>& stringOffsetsBuffer) const noexcept {
-  const MetadataPropertyViewStatus bufferStatus =
+  const PropertyTablePropertyViewStatus bufferStatus =
       getBufferSafe(stringOffsetsBufferView, stringOffsetsBuffer);
-  if (bufferStatus != MetadataPropertyViewStatus::Valid) {
+  if (bufferStatus != PropertyTablePropertyViewStatus::Valid) {
     return bufferStatus;
   }
 
@@ -253,56 +251,56 @@ MetadataPropertyTableView::getStringOffsetsBufferSafe(
         valueBufferSize,
         propertyTableCount,
         false,
-        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted,
-        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+        PropertyTablePropertyViewStatus::ErrorStringOffsetsNotSorted,
+        PropertyTablePropertyViewStatus::ErrorStringOffsetOutOfBounds);
   case PropertyComponentType::Uint16:
     return checkOffsetsBuffer<uint16_t>(
         stringOffsetsBuffer,
         valueBufferSize,
         propertyTableCount,
         false,
-        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted,
-        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+        PropertyTablePropertyViewStatus::ErrorStringOffsetsNotSorted,
+        PropertyTablePropertyViewStatus::ErrorStringOffsetOutOfBounds);
   case PropertyComponentType::Uint32:
     return checkOffsetsBuffer<uint32_t>(
         stringOffsetsBuffer,
         valueBufferSize,
         propertyTableCount,
         false,
-        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted,
-        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+        PropertyTablePropertyViewStatus::ErrorStringOffsetsNotSorted,
+        PropertyTablePropertyViewStatus::ErrorStringOffsetOutOfBounds);
   case PropertyComponentType::Uint64:
     return checkOffsetsBuffer<uint64_t>(
         stringOffsetsBuffer,
         valueBufferSize,
         propertyTableCount,
         false,
-        MetadataPropertyViewStatus::ErrorStringOffsetsNotSorted,
-        MetadataPropertyViewStatus::ErrorStringOffsetOutOfBounds);
+        PropertyTablePropertyViewStatus::ErrorStringOffsetsNotSorted,
+        PropertyTablePropertyViewStatus::ErrorStringOffsetOutOfBounds);
   default:
-    return MetadataPropertyViewStatus::ErrorInvalidStringOffsetType;
+    return PropertyTablePropertyViewStatus::ErrorInvalidStringOffsetType;
   }
 }
 
-MetadataPropertyView<std::string_view>
-MetadataPropertyTableView::getStringPropertyValues(
+PropertyTablePropertyView<std::string_view>
+PropertyTableView::getStringPropertyValues(
     const ExtensionExtStructuralMetadataClassProperty& classProperty,
     const ExtensionExtStructuralMetadataPropertyTableProperty&
         propertyTableProperty) const {
   if (classProperty.array) {
     return createInvalidPropertyView<std::string_view>(
-        MetadataPropertyViewStatus::ErrorArrayTypeMismatch);
+        PropertyTablePropertyViewStatus::ErrorArrayTypeMismatch);
   }
 
   if (classProperty.type !=
       ExtensionExtStructuralMetadataClassProperty::Type::STRING) {
     return createInvalidPropertyView<std::string_view>(
-        MetadataPropertyViewStatus::ErrorTypeMismatch);
+        PropertyTablePropertyViewStatus::ErrorTypeMismatch);
   }
 
   gsl::span<const std::byte> values;
   auto status = getBufferSafe(propertyTableProperty.values, values);
-  if (status != MetadataPropertyViewStatus::Valid) {
+  if (status != PropertyTablePropertyViewStatus::Valid) {
     return createInvalidPropertyView<std::string_view>(status);
   }
 
@@ -311,7 +309,7 @@ MetadataPropertyTableView::getStringPropertyValues(
           propertyTableProperty.stringOffsetType);
   if (offsetType == PropertyComponentType::None) {
     return createInvalidPropertyView<std::string_view>(
-        MetadataPropertyViewStatus::ErrorInvalidStringOffsetType);
+        PropertyTablePropertyViewStatus::ErrorInvalidStringOffsetType);
   }
 
   gsl::span<const std::byte> stringOffsets;
@@ -321,12 +319,12 @@ MetadataPropertyTableView::getStringPropertyValues(
       values.size(),
       static_cast<size_t>(_pPropertyTable->count),
       stringOffsets);
-  if (status != MetadataPropertyViewStatus::Valid) {
+  if (status != PropertyTablePropertyViewStatus::Valid) {
     return createInvalidPropertyView<std::string_view>(status);
   }
 
-  return MetadataPropertyView<std::string_view>(
-      MetadataPropertyViewStatus::Valid,
+  return PropertyTablePropertyView<std::string_view>(
+      PropertyTablePropertyViewStatus::Valid,
       values,
       gsl::span<const std::byte>(),
       stringOffsets,
@@ -337,25 +335,25 @@ MetadataPropertyTableView::getStringPropertyValues(
       classProperty.normalized);
 }
 
-MetadataPropertyView<MetadataArrayView<std::string_view>>
-MetadataPropertyTableView::getStringArrayPropertyValues(
+PropertyTablePropertyView<MetadataArrayView<std::string_view>>
+PropertyTableView::getStringArrayPropertyValues(
     const ExtensionExtStructuralMetadataClassProperty& classProperty,
     const ExtensionExtStructuralMetadataPropertyTableProperty&
         propertyTableProperty) const {
   if (!classProperty.array) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
-        MetadataPropertyViewStatus::ErrorArrayTypeMismatch);
+        PropertyTablePropertyViewStatus::ErrorArrayTypeMismatch);
   }
 
   if (classProperty.type !=
       ExtensionExtStructuralMetadataClassProperty::Type::STRING) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
-        MetadataPropertyViewStatus::ErrorTypeMismatch);
+        PropertyTablePropertyViewStatus::ErrorTypeMismatch);
   }
 
   gsl::span<const std::byte> values;
   auto status = getBufferSafe(propertyTableProperty.values, values);
-  if (status != MetadataPropertyViewStatus::Valid) {
+  if (status != PropertyTablePropertyViewStatus::Valid) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
         status);
   }
@@ -364,12 +362,12 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
   const int64_t fixedLengthArrayCount = classProperty.count.value_or(0);
   if (fixedLengthArrayCount > 0 && propertyTableProperty.arrayOffsets >= 0) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
-        MetadataPropertyViewStatus::ErrorArrayCountAndOffsetBufferCoexist);
+        PropertyTablePropertyViewStatus::ErrorArrayCountAndOffsetBufferCoexist);
   }
 
   if (fixedLengthArrayCount <= 0 && propertyTableProperty.arrayOffsets < 0) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
-        MetadataPropertyViewStatus::ErrorArrayCountAndOffsetBufferDontExist);
+        PropertyTablePropertyViewStatus::ErrorArrayCountAndOffsetBufferDontExist);
   }
 
   // Get string offset type
@@ -378,12 +376,12 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
           propertyTableProperty.stringOffsetType);
   if (stringOffsetType == PropertyComponentType::None) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
-        MetadataPropertyViewStatus::ErrorInvalidStringOffsetType);
+        PropertyTablePropertyViewStatus::ErrorInvalidStringOffsetType);
   }
 
   if (propertyTableProperty.stringOffsets < 0) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
-        MetadataPropertyViewStatus::ErrorInvalidStringOffsetBufferView);
+        PropertyTablePropertyViewStatus::ErrorInvalidStringOffsetBufferView);
   }
 
   // Handle fixed-length arrays
@@ -395,13 +393,13 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         values.size(),
         static_cast<size_t>(_pPropertyTable->count * fixedLengthArrayCount),
         stringOffsets);
-    if (status != MetadataPropertyViewStatus::Valid) {
+    if (status != PropertyTablePropertyViewStatus::Valid) {
       return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
           status);
     }
 
-    return MetadataPropertyView<MetadataArrayView<std::string_view>>(
-        MetadataPropertyViewStatus::Valid,
+    return PropertyTablePropertyView<MetadataArrayView<std::string_view>>(
+        PropertyTablePropertyViewStatus::Valid,
         values,
         gsl::span<const std::byte>(),
         stringOffsets,
@@ -418,25 +416,25 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
           propertyTableProperty.arrayOffsetType);
   if (arrayOffsetType == PropertyComponentType::None) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
-        MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType);
+        PropertyTablePropertyViewStatus::ErrorInvalidArrayOffsetType);
   }
 
   if (propertyTableProperty.arrayOffsets < 0) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
-        MetadataPropertyViewStatus::ErrorInvalidArrayOffsetBufferView);
+        PropertyTablePropertyViewStatus::ErrorInvalidArrayOffsetBufferView);
   }
 
   // Handle variable-length arrays
   gsl::span<const std::byte> stringOffsets;
   status = getBufferSafe(propertyTableProperty.stringOffsets, stringOffsets);
-  if (status != MetadataPropertyViewStatus::Valid) {
+  if (status != PropertyTablePropertyViewStatus::Valid) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
         status);
   }
 
   gsl::span<const std::byte> arrayOffsets;
   status = getBufferSafe(propertyTableProperty.arrayOffsets, arrayOffsets);
-  if (status != MetadataPropertyViewStatus::Valid) {
+  if (status != PropertyTablePropertyViewStatus::Valid) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
         status);
   }
@@ -475,17 +473,17 @@ MetadataPropertyTableView::getStringArrayPropertyValues(
         static_cast<size_t>(_pPropertyTable->count));
     break;
   default:
-    status = MetadataPropertyViewStatus::ErrorInvalidArrayOffsetType;
+    status = PropertyTablePropertyViewStatus::ErrorInvalidArrayOffsetType;
     break;
   }
 
-  if (status != MetadataPropertyViewStatus::Valid) {
+  if (status != PropertyTablePropertyViewStatus::Valid) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
         status);
   }
 
-  return MetadataPropertyView<MetadataArrayView<std::string_view>>(
-      MetadataPropertyViewStatus::Valid,
+  return PropertyTablePropertyView<MetadataArrayView<std::string_view>>(
+      PropertyTablePropertyViewStatus::Valid,
       values,
       arrayOffsets,
       stringOffsets,

--- a/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
+++ b/CesiumGltf/src/StructuralMetadataPropertyTableView.cpp
@@ -138,8 +138,7 @@ PropertyTableView::PropertyTableView(
 }
 
 const ExtensionExtStructuralMetadataClassProperty*
-PropertyTableView::getClassProperty(
-    const std::string& propertyName) const {
+PropertyTableView::getClassProperty(const std::string& propertyName) const {
   if (_status != PropertyTableViewStatus::Valid) {
     return nullptr;
   }
@@ -231,8 +230,7 @@ PropertyTablePropertyViewStatus PropertyTableView::getArrayOffsetsBufferSafe(
   }
 }
 
-PropertyTablePropertyViewStatus
-PropertyTableView::getStringOffsetsBufferSafe(
+PropertyTablePropertyViewStatus PropertyTableView::getStringOffsetsBufferSafe(
     int32_t stringOffsetsBufferView,
     PropertyComponentType stringOffsetType,
     size_t valueBufferSize,
@@ -367,7 +365,8 @@ PropertyTableView::getStringArrayPropertyValues(
 
   if (fixedLengthArrayCount <= 0 && propertyTableProperty.arrayOffsets < 0) {
     return createInvalidPropertyView<MetadataArrayView<std::string_view>>(
-        PropertyTablePropertyViewStatus::ErrorArrayCountAndOffsetBufferDontExist);
+        PropertyTablePropertyViewStatus::
+            ErrorArrayCountAndOffsetBufferDontExist);
   }
 
   // Get string offset type

--- a/CesiumGltf/src/StructuralMetadataPropertyTexturePropertyView.cpp
+++ b/CesiumGltf/src/StructuralMetadataPropertyTexturePropertyView.cpp
@@ -1,0 +1,102 @@
+
+#include "CesiumGltf/StructuralMetadataPropertyTexturePropertyView.h"
+
+namespace CesiumGltf {
+namespace StructuralMetadata {
+
+PropertyTexturePropertyView::PropertyTexturePropertyView() noexcept
+    : _status(PropertyTexturePropertyViewStatus::ErrorUninitialized),
+      _pClassProperty(nullptr),
+      _pPropertyTextureProperty(nullptr),
+      _pSampler(nullptr),
+      _pImage(nullptr),
+      _textureCoordinateSetIndex(-1),
+      _channels(),
+      _swizzle(""),
+      _type(PropertyTexturePropertyComponentType::Uint8),
+      _count(0),
+      _normalized(false) {}
+
+PropertyTexturePropertyView::PropertyTexturePropertyView(
+    const Model& model,
+    const ExtensionExtStructuralMetadataClassProperty& classProperty,
+    const ExtensionExtStructuralMetadataPropertyTextureProperty&
+        propertyTextureProperty) noexcept
+    : _status(PropertyTexturePropertyViewStatus::ErrorUninitialized),
+      _pClassProperty(&classProperty),
+      _pPropertyTextureProperty(&propertyTextureProperty),
+      _pSampler(nullptr),
+      _pImage(nullptr),
+      _textureCoordinateSetIndex(propertyTextureProperty.texCoord),
+      _channels(),
+      _swizzle(""),
+      _type(PropertyTexturePropertyComponentType::Uint8),
+      _count(0),
+      _normalized(false) {
+  const int64_t index = _pPropertyTextureProperty->index;
+  if (index < 0 || static_cast<size_t>(index) >= model.textures.size()) {
+    this->_status = PropertyTexturePropertyViewStatus::ErrorInvalidTexture;
+    return;
+  }
+
+  const Texture& texture = model.textures[static_cast<size_t>(index)];
+  if (texture.sampler < 0 ||
+      static_cast<size_t>(texture.sampler) >= model.samplers.size()) {
+    this->_status =
+        PropertyTexturePropertyViewStatus::ErrorInvalidTextureSampler;
+    return;
+  }
+
+  this->_pSampler = &model.samplers[static_cast<size_t>(texture.sampler)];
+
+  if (texture.source < 0 ||
+      static_cast<size_t>(texture.source) >= model.images.size()) {
+    this->_status = PropertyTexturePropertyViewStatus::ErrorInvalidImage;
+    return;
+  }
+
+  this->_pImage = &model.images[static_cast<size_t>(texture.source)].cesium;
+  if (this->_pImage->width < 1 || this->_pImage->height < 1) {
+    this->_status = PropertyTexturePropertyViewStatus::ErrorEmptyImage;
+    return;
+  }
+
+  // TODO: support more types
+  // this->_type = ...
+
+  this->_count =
+      this->_pClassProperty->count ? *this->_pClassProperty->count : 1;
+  this->_normalized = this->_pClassProperty->normalized;
+
+  const std::vector<int64_t>& channels = _pPropertyTextureProperty->channels;
+  if (channels.size() == 0 || channels.size() > 4 ||
+      channels.size() > static_cast<size_t>(this->_pImage->channels) ||
+      channels.size() != static_cast<size_t>(this->_count)) {
+    this->_status = PropertyTexturePropertyViewStatus::ErrorInvalidChannels;
+    return;
+  }
+
+  for (size_t i = 0; i < channels.size(); ++i) {
+    switch (channels[i]) {
+    case 0:
+      this->_swizzle += "r";
+      break;
+    case 1:
+      this->_swizzle += "g";
+      break;
+    case 2:
+      this->_swizzle += "b";
+      break;
+    case 3:
+      this->_swizzle += "a";
+      break;
+    default:
+      this->_status = PropertyTexturePropertyViewStatus::ErrorInvalidChannels;
+      return;
+    }
+  }
+
+  this->_status = PropertyTexturePropertyViewStatus::Valid;
+}
+} // namespace StructuralMetadata
+} // namespace CesiumGltf

--- a/CesiumGltf/src/StructuralMetadataPropertyTexturePropertyView.cpp
+++ b/CesiumGltf/src/StructuralMetadataPropertyTexturePropertyView.cpp
@@ -3,7 +3,6 @@
 
 namespace CesiumGltf {
 namespace StructuralMetadata {
-
 PropertyTexturePropertyView::PropertyTexturePropertyView() noexcept
     : _status(PropertyTexturePropertyViewStatus::ErrorUninitialized),
       _pClassProperty(nullptr),

--- a/CesiumGltf/src/StructuralMetadataPropertyTexturePropertyView.cpp
+++ b/CesiumGltf/src/StructuralMetadataPropertyTexturePropertyView.cpp
@@ -10,7 +10,7 @@ PropertyTexturePropertyView::PropertyTexturePropertyView() noexcept
       _pPropertyTextureProperty(nullptr),
       _pSampler(nullptr),
       _pImage(nullptr),
-      _textureCoordinateSetIndex(-1),
+      _texCoordSetIndex(-1),
       _channels(),
       _swizzle(""),
       _type(PropertyTexturePropertyComponentType::Uint8),
@@ -27,7 +27,7 @@ PropertyTexturePropertyView::PropertyTexturePropertyView(
       _pPropertyTextureProperty(&propertyTextureProperty),
       _pSampler(nullptr),
       _pImage(nullptr),
-      _textureCoordinateSetIndex(propertyTextureProperty.texCoord),
+      _texCoordSetIndex(propertyTextureProperty.texCoord),
       _channels(),
       _swizzle(""),
       _type(PropertyTexturePropertyComponentType::Uint8),
@@ -58,6 +58,12 @@ PropertyTexturePropertyView::PropertyTexturePropertyView(
   this->_pImage = &model.images[static_cast<size_t>(texture.source)].cesium;
   if (this->_pImage->width < 1 || this->_pImage->height < 1) {
     this->_status = PropertyTexturePropertyViewStatus::ErrorEmptyImage;
+    return;
+  }
+
+  if (this->_texCoordSetIndex < 0) {
+    this->_status =
+        PropertyTexturePropertyViewStatus::ErrorInvalidTexCoordSetIndex;
     return;
   }
 

--- a/CesiumGltf/src/StructuralMetadataPropertyTextureView.cpp
+++ b/CesiumGltf/src/StructuralMetadataPropertyTextureView.cpp
@@ -1,0 +1,84 @@
+#include "CesiumGltf/StructuralMetadataPropertyTextureView.h"
+
+namespace CesiumGltf {
+namespace StructuralMetadata {
+PropertyTextureView::PropertyTextureView() noexcept
+    : _pModel(nullptr),
+      _pPropertyTexture(nullptr),
+      _pClass(nullptr),
+      _propertyViews(),
+      _status(PropertyTextureViewStatus::ErrorUninitialized) {}
+
+PropertyTextureView::PropertyTextureView(
+    const Model& model,
+    const ExtensionExtStructuralMetadataPropertyTexture& propertyTexture) noexcept
+    : _pModel(&model),
+      _pPropertyTexture(&propertyTexture),
+      _pClass(nullptr),
+      _propertyViews(),
+      _status(PropertyTextureViewStatus::ErrorUninitialized) {
+
+  const ExtensionModelExtStructuralMetadata* pMetadata =
+      model.getExtension<ExtensionModelExtStructuralMetadata>();
+
+  if (!pMetadata) {
+    this->_status = PropertyTextureViewStatus::ErrorMissingMetadataExtension;
+    return;
+  }
+
+  if (!pMetadata->schema) {
+    this->_status = PropertyTextureViewStatus::ErrorMissingSchema;
+    return;
+  }
+
+  const auto& classIt =
+      pMetadata->schema->classes.find(propertyTexture.classProperty);
+  if (classIt == pMetadata->schema->classes.end()) {
+    this->_status = PropertyTextureViewStatus::ErrorClassNotFound;
+    return;
+  }
+
+  this->_pClass = &classIt->second;
+
+  this->_propertyViews.reserve(propertyTexture.properties.size());
+  for (const auto& property : propertyTexture.properties) {
+    auto classPropertyIt = this->_pClass->properties.find(property.first);
+
+    if (classPropertyIt == this->_pClass->properties.end()) {
+      this->_status = PropertyTextureViewStatus::ErrorClassPropertyNotFound;
+      return;
+    }
+
+    this->_propertyViews[property.first] = PropertyTexturePropertyView(
+        model,
+        classPropertyIt->second,
+        property.second);
+  }
+
+  for (const auto& propertyView : this->_propertyViews) {
+    if (propertyView.second.status() !=
+        PropertyTexturePropertyViewStatus::Valid) {
+      this->_status = PropertyTextureViewStatus::ErrorInvalidPropertyView;
+      return;
+    }
+  }
+
+  this->_status = PropertyTextureViewStatus::Valid;
+}
+
+const ExtensionExtStructuralMetadataClassProperty*
+PropertyTextureView::getClassProperty(const std::string& propertyName) const {
+  if (_status != PropertyTextureViewStatus::Valid) {
+    return nullptr;
+  }
+
+  auto propertyIter = _pClass->properties.find(propertyName);
+  if (propertyIter == _pClass->properties.end()) {
+    return nullptr;
+  }
+
+  return &propertyIter->second;
+}
+
+} // namespace StructuralMetadata
+} // namespace CesiumGltf

--- a/CesiumGltf/src/StructuralMetadataPropertyTextureView.cpp
+++ b/CesiumGltf/src/StructuralMetadataPropertyTextureView.cpp
@@ -11,7 +11,8 @@ PropertyTextureView::PropertyTextureView() noexcept
 
 PropertyTextureView::PropertyTextureView(
     const Model& model,
-    const ExtensionExtStructuralMetadataPropertyTexture& propertyTexture) noexcept
+    const ExtensionExtStructuralMetadataPropertyTexture&
+        propertyTexture) noexcept
     : _pModel(&model),
       _pPropertyTexture(&propertyTexture),
       _pClass(nullptr),

--- a/CesiumGltf/test/TestStructuralMetadataPropertyTablePropertyView.cpp
+++ b/CesiumGltf/test/TestStructuralMetadataPropertyTablePropertyView.cpp
@@ -1,4 +1,4 @@
-#include "CesiumGltf/StructuralMetadataPropertyView.h"
+#include "CesiumGltf/StructuralMetadataPropertyTablePropertyView.h"
 
 #include <catch2/catch.hpp>
 #include <gsl/span>
@@ -16,8 +16,8 @@ template <typename T> static void checkNumeric(const std::vector<T>& expected) {
   data.resize(expected.size() * sizeof(T));
   std::memcpy(data.data(), expected.data(), data.size());
 
-  MetadataPropertyView<T> property(
-      MetadataPropertyViewStatus::Valid,
+  PropertyTablePropertyView<T> property(
+      PropertyTablePropertyViewStatus::Valid,
       gsl::span<const std::byte>(data.data(), data.size()),
       static_cast<int64_t>(expected.size()),
       false);
@@ -46,8 +46,8 @@ static void checkVariableLengthArray(
       offsets.data(),
       offsets.size() * sizeof(OffsetType));
 
-  MetadataPropertyView<MetadataArrayView<DataType>> property(
-      MetadataPropertyViewStatus::Valid,
+  PropertyTablePropertyView<MetadataArrayView<DataType>> property(
+      PropertyTablePropertyViewStatus::Valid,
       gsl::span<const std::byte>(buffer.data(), buffer.size()),
       gsl::span<const std::byte>(offsetBuffer.data(), offsetBuffer.size()),
       gsl::span<const std::byte>(),
@@ -78,8 +78,8 @@ static void checkFixedLengthArray(
   buffer.resize(data.size() * sizeof(T));
   std::memcpy(buffer.data(), data.data(), data.size() * sizeof(T));
 
-  MetadataPropertyView<MetadataArrayView<T>> property(
-      MetadataPropertyViewStatus::Valid,
+  PropertyTablePropertyView<MetadataArrayView<T>> property(
+      PropertyTablePropertyViewStatus::Valid,
       gsl::span<const std::byte>(buffer.data(), buffer.size()),
       gsl::span<const std::byte>(),
       gsl::span<const std::byte>(),
@@ -225,8 +225,8 @@ TEST_CASE("Check StructuralMetadata boolean property") {
   std::memcpy(data.data(), &val, sizeof(val));
 
   size_t instanceCount = sizeof(unsigned long) * CHAR_BIT;
-  MetadataPropertyView<bool> property(
-      MetadataPropertyViewStatus::Valid,
+  PropertyTablePropertyView<bool> property(
+      PropertyTablePropertyViewStatus::Valid,
       gsl::span<const std::byte>(data.data(), data.size()),
       static_cast<int64_t>(instanceCount),
       false);
@@ -272,8 +272,8 @@ TEST_CASE("Check StructuralMetadata string property") {
       &currentOffset,
       sizeof(uint32_t));
 
-  MetadataPropertyView<std::string_view> property(
-      MetadataPropertyViewStatus::Valid,
+  PropertyTablePropertyView<std::string_view> property(
+      PropertyTablePropertyViewStatus::Valid,
       gsl::span<const std::byte>(buffer.data(), buffer.size()),
       gsl::span<const std::byte>(),
       gsl::span<const std::byte>(offsetBuffer.data(), offsetBuffer.size()),
@@ -831,8 +831,8 @@ TEST_CASE("Check StructuralMetadata fixed-length array of string") {
       &currentStringOffset,
       sizeof(uint32_t));
 
-  MetadataPropertyView<MetadataArrayView<std::string_view>> property(
-      MetadataPropertyViewStatus::Valid,
+  PropertyTablePropertyView<MetadataArrayView<std::string_view>> property(
+      PropertyTablePropertyViewStatus::Valid,
       gsl::span<const std::byte>(buffer.data(), buffer.size()),
       gsl::span<const std::byte>(),
       gsl::span<const std::byte>(stringOffsets.data(), stringOffsets.size()),
@@ -904,8 +904,8 @@ TEST_CASE(
       &currentOffset,
       sizeof(uint32_t));
 
-  MetadataPropertyView<MetadataArrayView<std::string_view>> property(
-      MetadataPropertyViewStatus::Valid,
+  PropertyTablePropertyView<MetadataArrayView<std::string_view>> property(
+      PropertyTablePropertyViewStatus::Valid,
       gsl::span<const std::byte>(buffer.data(), buffer.size()),
       gsl::span<const std::byte>(
           reinterpret_cast<const std::byte*>(arrayOffsets.data()),
@@ -936,8 +936,8 @@ TEST_CASE("Check StructuralMetadata fixed-length boolean array property") {
       static_cast<std::byte>(0b11111010),
       static_cast<std::byte>(0b11100111)};
 
-  MetadataPropertyView<MetadataArrayView<bool>> property(
-      MetadataPropertyViewStatus::Valid,
+  PropertyTablePropertyView<MetadataArrayView<bool>> property(
+      PropertyTablePropertyViewStatus::Valid,
       gsl::span<const std::byte>(buffer.data(), buffer.size()),
       gsl::span<const std::byte>(),
       gsl::span<const std::byte>(),
@@ -988,8 +988,8 @@ TEST_CASE("Check StructuralMetadata variable-length boolean array property") {
 
   std::vector<uint32_t> offsetBuffer{0, 3, 12, 28};
 
-  MetadataPropertyView<MetadataArrayView<bool>> property(
-      MetadataPropertyViewStatus::Valid,
+  PropertyTablePropertyView<MetadataArrayView<bool>> property(
+      PropertyTablePropertyViewStatus::Valid,
       gsl::span<const std::byte>(buffer.data(), buffer.size()),
       gsl::span<const std::byte>(
           reinterpret_cast<const std::byte*>(offsetBuffer.data()),

--- a/CesiumGltf/test/TestStructuralMetadataPropertyTexturePropertyView.cpp
+++ b/CesiumGltf/test/TestStructuralMetadataPropertyTexturePropertyView.cpp
@@ -1,0 +1,290 @@
+#include "CesiumGltf/StructuralMetadataPropertyTexturePropertyView.h"
+
+#include <catch2/catch.hpp>
+#include <gsl/span>
+
+#include <bitset>
+#include <climits>
+#include <cstddef>
+#include <cstring>
+#include <vector>
+
+using namespace CesiumGltf;
+using namespace CesiumGltf::StructuralMetadata;
+
+TEST_CASE(
+    "Test PropertyTexturePropertyView on property with invalid texture index") {
+  Model model;
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::SCALAR;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT8;
+
+  ExtensionExtStructuralMetadataPropertyTexture propertyTexture;
+  propertyTexture.classProperty = "TestClass";
+
+  ExtensionExtStructuralMetadataPropertyTextureProperty&
+      propertyTextureProperty = propertyTexture.properties["TestClassProperty"];
+  propertyTextureProperty.index = -1;
+  propertyTextureProperty.texCoord = 0;
+  propertyTextureProperty.channels = {0};
+
+  PropertyTexturePropertyView view(
+      model,
+      testClassProperty,
+      propertyTextureProperty);
+  REQUIRE(
+      view.status() == PropertyTexturePropertyViewStatus::ErrorInvalidTexture);
+}
+
+TEST_CASE(
+    "Test PropertyTexturePropertyView on property with invalid sampler index") {
+  Model model;
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::SCALAR;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT8;
+
+  Image& image = model.images.emplace_back();
+  image.cesium.width = 1;
+  image.cesium.height = 1;
+  Texture& texture = model.textures.emplace_back();
+  texture.sampler = -1;
+  texture.source = 0;
+
+  ExtensionExtStructuralMetadataPropertyTexture propertyTexture;
+  propertyTexture.classProperty = "TestClass";
+
+  ExtensionExtStructuralMetadataPropertyTextureProperty&
+      propertyTextureProperty = propertyTexture.properties["TestClassProperty"];
+  propertyTextureProperty.index = 0;
+  propertyTextureProperty.texCoord = 0;
+  propertyTextureProperty.channels = {0};
+
+  PropertyTexturePropertyView view(
+      model,
+      testClassProperty,
+      propertyTextureProperty);
+  REQUIRE(
+      view.status() ==
+      PropertyTexturePropertyViewStatus::ErrorInvalidTextureSampler);
+}
+
+TEST_CASE(
+    "Test PropertyTexturePropertyView on property with invalid image index") {
+  Model model;
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::SCALAR;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT8;
+
+  model.samplers.emplace_back();
+
+  Texture& texture = model.textures.emplace_back();
+  texture.sampler = 0;
+  texture.source = -1;
+
+  ExtensionExtStructuralMetadataPropertyTexture propertyTexture;
+  propertyTexture.classProperty = "TestClass";
+
+  ExtensionExtStructuralMetadataPropertyTextureProperty&
+      propertyTextureProperty = propertyTexture.properties["TestClassProperty"];
+  propertyTextureProperty.index = 0;
+  propertyTextureProperty.texCoord = 0;
+  propertyTextureProperty.channels = {0};
+
+  PropertyTexturePropertyView view(
+      model,
+      testClassProperty,
+      propertyTextureProperty);
+  REQUIRE(
+      view.status() == PropertyTexturePropertyViewStatus::ErrorInvalidImage);
+}
+
+TEST_CASE("Test PropertyTexturePropertyView on property with empty image") {
+  Model model;
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::SCALAR;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT8;
+
+  Image& image = model.images.emplace_back();
+  image.cesium.width = 0;
+  image.cesium.height = 0;
+
+  model.samplers.emplace_back();
+
+  Texture& texture = model.textures.emplace_back();
+  texture.sampler = 0;
+  texture.source = 0;
+
+  ExtensionExtStructuralMetadataPropertyTexture propertyTexture;
+  propertyTexture.classProperty = "TestClass";
+
+  ExtensionExtStructuralMetadataPropertyTextureProperty&
+      propertyTextureProperty = propertyTexture.properties["TestClassProperty"];
+  propertyTextureProperty.index = 0;
+  propertyTextureProperty.texCoord = 0;
+  propertyTextureProperty.channels = {0};
+
+  PropertyTexturePropertyView view(
+      model,
+      testClassProperty,
+      propertyTextureProperty);
+  REQUIRE(view.status() == PropertyTexturePropertyViewStatus::ErrorEmptyImage);
+}
+
+TEST_CASE("Test PropertyTextureView on model with negative texture coordinate "
+          "set index") {
+  Model model;
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::SCALAR;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT8;
+
+  Image& image = model.images.emplace_back();
+  image.cesium.width = 1;
+  image.cesium.height = 1;
+
+  model.samplers.emplace_back();
+
+  Texture& texture = model.textures.emplace_back();
+  texture.sampler = 0;
+  texture.source = 0;
+
+  ExtensionExtStructuralMetadataPropertyTexture propertyTexture;
+  propertyTexture.classProperty = "TestClass";
+
+  ExtensionExtStructuralMetadataPropertyTextureProperty&
+      propertyTextureProperty = propertyTexture.properties["TestClassProperty"];
+  propertyTextureProperty.index = 0;
+  propertyTextureProperty.texCoord = -1;
+  propertyTextureProperty.channels = {0};
+
+  PropertyTexturePropertyView view(
+      model,
+      testClassProperty,
+      propertyTextureProperty);
+  REQUIRE(
+      view.status() ==
+      PropertyTexturePropertyViewStatus::ErrorInvalidTexCoordSetIndex);
+}
+
+TEST_CASE("Test PropertyTextureView on model with zero channels") {
+  Model model;
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::SCALAR;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT8;
+
+  Image& image = model.images.emplace_back();
+  image.cesium.width = 1;
+  image.cesium.height = 1;
+  image.cesium.channels = 1;
+
+  model.samplers.emplace_back();
+
+  Texture& texture = model.textures.emplace_back();
+  texture.sampler = 0;
+  texture.source = 0;
+
+  ExtensionExtStructuralMetadataPropertyTexture propertyTexture;
+  propertyTexture.classProperty = "TestClass";
+
+  ExtensionExtStructuralMetadataPropertyTextureProperty&
+      propertyTextureProperty = propertyTexture.properties["TestClassProperty"];
+  propertyTextureProperty.index = 0;
+  propertyTextureProperty.texCoord = 0;
+  propertyTextureProperty.channels = {};
+
+  PropertyTexturePropertyView view(
+      model,
+      testClassProperty,
+      propertyTextureProperty);
+  REQUIRE(
+      view.status() == PropertyTexturePropertyViewStatus::ErrorInvalidChannels);
+}
+
+TEST_CASE("Test PropertyTextureView on model with too many channels") {
+  Model model;
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::SCALAR;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT8;
+
+  Image& image = model.images.emplace_back();
+  image.cesium.width = 1;
+  image.cesium.height = 1;
+  image.cesium.channels = 1;
+
+  model.samplers.emplace_back();
+
+  Texture& texture = model.textures.emplace_back();
+  texture.sampler = 0;
+  texture.source = 0;
+
+  ExtensionExtStructuralMetadataPropertyTexture propertyTexture;
+  propertyTexture.classProperty = "TestClass";
+
+  ExtensionExtStructuralMetadataPropertyTextureProperty&
+      propertyTextureProperty = propertyTexture.properties["TestClassProperty"];
+  propertyTextureProperty.index = 0;
+  propertyTextureProperty.texCoord = 0;
+  propertyTextureProperty.channels = {0, 1};
+
+  PropertyTexturePropertyView view(
+      model,
+      testClassProperty,
+      propertyTextureProperty);
+  REQUIRE(
+      view.status() == PropertyTexturePropertyViewStatus::ErrorInvalidChannels);
+}

--- a/CesiumGltf/test/TestStructuralMetadataPropertyTextureView.cpp
+++ b/CesiumGltf/test/TestStructuralMetadataPropertyTextureView.cpp
@@ -1,0 +1,169 @@
+#include "CesiumGltf/StructuralMetadataPropertyTextureView.h"
+
+#include <catch2/catch.hpp>
+#include <gsl/span>
+
+#include <bitset>
+#include <climits>
+#include <cstddef>
+#include <cstring>
+#include <vector>
+
+using namespace CesiumGltf;
+using namespace CesiumGltf::StructuralMetadata;
+
+TEST_CASE("Test PropertyTextureView on model without EXT_structural_metadata "
+          "extension") {
+  Model model;
+
+  // Create an erroneously isolated property texture.
+  ExtensionExtStructuralMetadataPropertyTexture propertyTexture;
+  propertyTexture.classProperty = "TestClass";
+
+  ExtensionExtStructuralMetadataPropertyTextureProperty&
+      propertyTextureProperty = propertyTexture.properties["TestClassProperty"];
+  propertyTextureProperty.index = 0;
+  propertyTextureProperty.texCoord = 0;
+  propertyTextureProperty.channels = {0};
+
+  PropertyTextureView view(model, propertyTexture);
+  REQUIRE(
+      view.status() ==
+      PropertyTextureViewStatus::ErrorMissingMetadataExtension);
+  REQUIRE(view.getProperties().empty());
+
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(!classProperty);
+}
+
+TEST_CASE("Test PropertyTextureView on model without metadata schema") {
+  Model model;
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataPropertyTexture& propertyTexture =
+      metadata.propertyTextures.emplace_back();
+  propertyTexture.classProperty = "TestClass";
+
+  ExtensionExtStructuralMetadataPropertyTextureProperty&
+      propertyTextureProperty = propertyTexture.properties["TestClassProperty"];
+  propertyTextureProperty.index = 0;
+  propertyTextureProperty.texCoord = 0;
+  propertyTextureProperty.channels = {0};
+
+  PropertyTextureView view(model, propertyTexture);
+  REQUIRE(view.status() == PropertyTextureViewStatus::ErrorMissingSchema);
+  REQUIRE(view.getProperties().empty());
+
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(!classProperty);
+}
+
+TEST_CASE("Test property texture with nonexistent class") {
+  Model model;
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::SCALAR;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT8;
+
+  ExtensionExtStructuralMetadataPropertyTexture& propertyTexture =
+      metadata.propertyTextures.emplace_back();
+  propertyTexture.classProperty = "I Don't Exist";
+
+  ExtensionExtStructuralMetadataPropertyTextureProperty&
+      propertyTextureProperty = propertyTexture.properties["TestClassProperty"];
+  propertyTextureProperty.index = 0;
+  propertyTextureProperty.texCoord = 0;
+  propertyTextureProperty.channels = {0};
+
+  PropertyTextureView view(model, propertyTexture);
+  REQUIRE(view.status() == PropertyTextureViewStatus::ErrorClassNotFound);
+  REQUIRE(view.getProperties().empty());
+
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(!classProperty);
+}
+
+TEST_CASE("Test property texture with nonexistent class property") {
+  Model model;
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::SCALAR;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT8;
+
+  ExtensionExtStructuralMetadataPropertyTexture& propertyTexture =
+      metadata.propertyTextures.emplace_back();
+  propertyTexture.classProperty = "TestClass";
+
+  ExtensionExtStructuralMetadataPropertyTextureProperty&
+      propertyTextureProperty = propertyTexture.properties["I Don't Exist"];
+  propertyTextureProperty.index = 0;
+  propertyTextureProperty.texCoord = 0;
+  propertyTextureProperty.channels = {0};
+
+  PropertyTextureView view(model, propertyTexture);
+  REQUIRE(
+      view.status() == PropertyTextureViewStatus::ErrorClassPropertyNotFound);
+  REQUIRE(view.getProperties().empty());
+
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(!classProperty);
+}
+
+TEST_CASE("Test property texture with invalid property") {
+  Model model;
+
+  ExtensionModelExtStructuralMetadata& metadata =
+      model.addExtension<ExtensionModelExtStructuralMetadata>();
+
+  ExtensionExtStructuralMetadataSchema& schema = metadata.schema.emplace();
+  ExtensionExtStructuralMetadataClass& testClass = schema.classes["TestClass"];
+  ExtensionExtStructuralMetadataClassProperty& testClassProperty =
+      testClass.properties["TestClassProperty"];
+  testClassProperty.type =
+      ExtensionExtStructuralMetadataClassProperty::Type::SCALAR;
+  testClassProperty.componentType =
+      ExtensionExtStructuralMetadataClassProperty::ComponentType::UINT8;
+
+  ExtensionExtStructuralMetadataPropertyTexture& propertyTexture =
+      metadata.propertyTextures.emplace_back();
+  propertyTexture.classProperty = "TestClass";
+
+  ExtensionExtStructuralMetadataPropertyTextureProperty&
+      propertyTextureProperty = propertyTexture.properties["TestClassProperty"];
+  propertyTextureProperty.index = -1;
+
+  PropertyTextureView view(model, propertyTexture);
+  REQUIRE(view.status() == PropertyTextureViewStatus::ErrorInvalidPropertyView);
+
+  auto properties = view.getProperties();
+  REQUIRE(properties.size() == 1);
+
+  PropertyTexturePropertyView& propertyView = properties["TestClassProperty"];
+  REQUIRE(propertyView.status() != PropertyTexturePropertyViewStatus::Valid);
+
+  const ExtensionExtStructuralMetadataClassProperty* classProperty =
+      view.getClassProperty("TestClassProperty");
+  REQUIRE(!classProperty);
+}


### PR DESCRIPTION
This adds `EXT_structural_metadata` counterparts of `FeatureTextureView` and `FeatureTexturePropertyView`. It also renames the `PropertyTableView` and `PropertyTablePropertyView` classes, and their error enums, to be consistent with the property texture naming scheme.

I kept most of the implementation of `FeatureTextureView` and `FeatureTexturePropertyView` because I'm not familiar with how it interfaces with Unreal, and I don't want to make potentially incompatible changes. But I'm not happy with the inconsistencies between property table / property texture implementations. For instance,
- `PropertyTableView` doesn't validate all of its properties on construction, but `PropertyTextureView` does.
- `PropertyTextureView` is marked invalid if one of its properties is invalid, but `PropertyTableView` does not do the same.
- `PropertyTextureProperty` is in charge of validating its own elements, but `PropertyTableView` handles all of that and simply passes the status to `PropertyTablePropertyView`.
 
Perhaps these inconsistencies are necessary / not that bad, but I'd like to revisit them once I switch Cesium for Unreal to this implementation, so that they are more standardized.