### PR TITLE
include generated headers in doxygen documentation

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -4,6 +4,7 @@ if (DOXYGEN_FOUND)
     set(
         LIB_DIRS
         ../Cesium3DTiles/include
+        ../Cesium3DTiles/generated/include
         ../Cesium3DTilesReader/include
         ../Cesium3DTilesWriter/include
         ../Cesium3DTilesSelection/include
@@ -11,6 +12,7 @@ if (DOXYGEN_FOUND)
         ../CesiumGeometry/include
         ../CesiumGeospatial/include
         ../CesiumGltf/include
+        ../CesiumGltf/generated/include
         ../CesiumGltfReader/include
         ../CesiumGltfWriter/include
         ../CesiumUtility/include


### PR DESCRIPTION
fixes #672. @kring pointed out that these missing headers just need to be added to the documentation `CMakeLists.txt`. Looking for other generated headers I found the following dirs:
```sh
Cesium3DTiles/generated/include
Cesium3DTilesReader/generated/src
Cesium3DTilesWriter/generated/src
CesiumGltf/generated/include
CesiumGltfReader/generated/src
CesiumGltfWriter/generated/src
```
Looking through the `src` dirs I didn't see anything with doxygen-style comments so I only added the two with `include` subdirs.