### PR TITLE
Fix in response to unused but set var

### DIFF
--- a/Cesium3DTilesSelection/test/TestQuadtreeRasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/test/TestQuadtreeRasterOverlayTileProvider.cpp
@@ -159,9 +159,8 @@ TEST_CASE("QuadtreeRasterOverlayTileProvider getTile") {
         pProvider->getTile(rectangle, glm::dvec2(256));
     pProvider->loadTile(*pTile);
 
-    for (int i = 0; pTile->getState() != RasterOverlayTile::LoadState::Loaded;
-         ++i) {
-      asyncSystem.dispatchMainThreadTasks();
+    while (pTile->getState() != RasterOverlayTile::LoadState::Loaded) {
+        asyncSystem.dispatchMainThreadTasks();
     }
 
     CHECK(pTile->getState() == RasterOverlayTile::LoadState::Loaded);
@@ -214,9 +213,8 @@ TEST_CASE("QuadtreeRasterOverlayTileProvider getTile") {
         pProvider->getTile(tileRectangle, targetScreenPixels);
     pProvider->loadTile(*pTile);
 
-    for (int i = 0; pTile->getState() != RasterOverlayTile::LoadState::Loaded;
-         ++i) {
-      asyncSystem.dispatchMainThreadTasks();
+    while (pTile->getState() != RasterOverlayTile::LoadState::Loaded) {
+        asyncSystem.dispatchMainThreadTasks();
     }
 
     CHECK(pTile->getState() == RasterOverlayTile::LoadState::Loaded);

--- a/Cesium3DTilesSelection/test/TestQuadtreeRasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/test/TestQuadtreeRasterOverlayTileProvider.cpp
@@ -160,7 +160,7 @@ TEST_CASE("QuadtreeRasterOverlayTileProvider getTile") {
     pProvider->loadTile(*pTile);
 
     while (pTile->getState() != RasterOverlayTile::LoadState::Loaded) {
-        asyncSystem.dispatchMainThreadTasks();
+      asyncSystem.dispatchMainThreadTasks();
     }
 
     CHECK(pTile->getState() == RasterOverlayTile::LoadState::Loaded);
@@ -214,7 +214,7 @@ TEST_CASE("QuadtreeRasterOverlayTileProvider getTile") {
     pProvider->loadTile(*pTile);
 
     while (pTile->getState() != RasterOverlayTile::LoadState::Loaded) {
-        asyncSystem.dispatchMainThreadTasks();
+      asyncSystem.dispatchMainThreadTasks();
     }
 
     CHECK(pTile->getState() == RasterOverlayTile::LoadState::Loaded);


### PR DESCRIPTION
Trying to fool around with cesium using the new C++ intrerop with swift and ran into the following errors building with cmake on macOS. 

[ 86%] Built target csprng
[ 88%] Built target CesiumIonClient
[ 88%] Building CXX object CesiumNativeTests/CMakeFiles/cesium-native-tests.dir/__/Cesium3DTilesSelection/test/TestQuadtreeRasterOverlayTileProvider.cpp.o
/Users/jacobmartin/Documents/Development/cesium-native/Cesium3DTilesSelection/test/TestQuadtreeRasterOverlayTileProvider.cpp:162:14: error: variable 'i' set but not used [-Werror,-Wunused-but-set-variable]
    for (int i = 0; pTile->getState() != RasterOverlayTile::LoadState::Loaded;
             ^
/Users/jacobmartin/Documents/Development/cesium-native/Cesium3DTilesSelection/test/TestQuadtreeRasterOverlayTileProvider.cpp:217:14: error: variable 'i' set but not used [-Werror,-Wunused-but-set-variable]
    for (int i = 0; pTile->getState() != RasterOverlayTile::LoadState::Loaded;
             ^
2 errors generated.
make[2]: *** [CesiumNativeTests/CMakeFiles/cesium-native-tests.dir/__/Cesium3DTilesSelection/test/TestQuadtreeRasterOverlayTileProvider.cpp.o] Error 1
make[1]: *** [CesiumNativeTests/CMakeFiles/cesium-native-tests.dir/all] Error 2
make: *** [all] Error 2
jacobmartin@Jacobs-MacBook-Pro cesium-native % 


rather than fix with a 
```
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
```
I just rewrote to use a while loop.
