### PR TITLE
Don't let zlib dirty its repo on configure

### DIFF
--- a/CesiumUtility/CMakeLists.txt
+++ b/CesiumUtility/CMakeLists.txt
@@ -35,8 +35,8 @@ target_include_directories(
         ${CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR}
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/src
-        ${CMAKE_CURRENT_LIST_DIR}/../extern/zlib
         ${CMAKE_CURRENT_BINARY_DIR}/../extern/zlib
+        ${CMAKE_CURRENT_BINARY_DIR}/../extern/zlib-src
 )
 
 # GLM erroneously does not declare its include a `SYSTEM` include, so

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -158,7 +158,12 @@ set(CESIUM_NATIVE_LIBMORTON_INCUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/libmorton/incl
 set(BUILD_TESTING OFF CACHE INTERNAL "Disable libmorton Testing")
 add_subdirectory(libmorton)
 
+# Be sure the include directories zlib adds are added before any existing directories.
+# We need to make sure it finds zconf.h in the build directory not the source directory.
+set(ORIGINAL_CMAKE_INCLUDE_DIRECTORIES_BEFORE ${CMAKE_INCLUDE_DIRECTORIES_BEFORE})
+set(CMAKE_INCLUDE_DIRECTORIES_BEFORE ON)
 add_subdirectory(zlib)
+set(CMAKE_INCLUDE_DIRECTORIES_BEFORE ${ORIGINAL_CMAKE_INCLUDE_DIRECTORIES_BEFORE})
 
 # Undo zlib's unnecessary and repo-dirtying rename.
 file(RENAME ${CMAKE_CURRENT_SOURCE_DIR}/zlib/zconf.h.included ${CMAKE_CURRENT_SOURCE_DIR}/zlib/zconf.h)

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -160,6 +160,9 @@ add_subdirectory(libmorton)
 
 add_subdirectory(zlib)
 
+# Undo zlib's unnecessary and repo-dirtying rename.
+file(RENAME ${CMAKE_CURRENT_SOURCE_DIR}/zlib/zconf.h.included ${CMAKE_CURRENT_SOURCE_DIR}/zlib/zconf.h)
+
 if(DEFINED CMAKE_TOOLCHAIN_FILE)
     if(NOT IS_ABSOLUTE ${CMAKE_TOOLCHAIN_FILE})
         set(TJ_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/${CMAKE_TOOLCHAIN_FILE})

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -158,15 +158,10 @@ set(CESIUM_NATIVE_LIBMORTON_INCUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/libmorton/incl
 set(BUILD_TESTING OFF CACHE INTERNAL "Disable libmorton Testing")
 add_subdirectory(libmorton)
 
-# Be sure the include directories zlib adds are added before any existing directories.
-# We need to make sure it finds zconf.h in the build directory not the source directory.
-set(ORIGINAL_CMAKE_INCLUDE_DIRECTORIES_BEFORE ${CMAKE_INCLUDE_DIRECTORIES_BEFORE})
-set(CMAKE_INCLUDE_DIRECTORIES_BEFORE ON)
-add_subdirectory(zlib)
-set(CMAKE_INCLUDE_DIRECTORIES_BEFORE ${ORIGINAL_CMAKE_INCLUDE_DIRECTORIES_BEFORE})
-
-# Undo zlib's unnecessary and repo-dirtying rename.
-file(RENAME ${CMAKE_CURRENT_SOURCE_DIR}/zlib/zconf.h.included ${CMAKE_CURRENT_SOURCE_DIR}/zlib/zconf.h)
+# The zlib cmake build makes its working directory dirty.
+# So we make a copy of it to avoid that annoyance.
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/zlib/" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/zlib-src")
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/zlib-src ${CMAKE_CURRENT_BINARY_DIR}/zlib)
 
 if(DEFINED CMAKE_TOOLCHAIN_FILE)
     if(NOT IS_ABSOLUTE ${CMAKE_TOOLCHAIN_FILE})


### PR DESCRIPTION
On configure, zlib renames `zconf.h` to `zconf.h.included` for no good reason, causing git to report its repo as dirty. The dirty repo then propagates up through cesium-native into whatever projects are using it via submodule, which is really annoying. There are a [bunch of issues](https://github.com/madler/zlib/issues?q=is%3Aissue+is%3Aopen+zconf.h.included) written for this, along with multiple PRs to fix it in different ways, but seemingly no interest from the maintainers.

So the hacky approach I used here is to simply rename it back after the zlib `add_subdirectory`. Since the rename was pointless to begin with, this doesn't do any harm and avoids a dirty repo.