### PR TITLE
Remove credits argument

### DIFF
--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
@@ -167,8 +167,7 @@ mainThreadLoadLayerJsonFromAssetEndpoint(
              externals,
              contentOptions,
              url,
-             requestHeaders,
-             showCreditsOnScreen)
+             requestHeaders)
       .thenImmediately([credits = std::move(credits),
                         requestHeaders,
                         ionAssetID,

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
@@ -34,8 +34,7 @@ public:
       const TilesetExternals& externals,
       const TilesetContentOptions& contentOptions,
       const std::string& layerJsonUrl,
-      const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders,
-      bool showCreditsOnScreen);
+      const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders);
 
   static CesiumAsync::Future<TilesetContentLoaderResult<LayerJsonTerrainLoader>>
   createLoader(
@@ -44,7 +43,6 @@ public:
       const TilesetContentOptions& contentOptions,
       const std::string& layerJsonUrl,
       const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders,
-      bool showCreditsOnScreen,
       const rapidjson::Document& layerJson);
 
   struct Layer {

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -702,7 +702,6 @@ TilesetContentManager::TilesetContentManager(
                              contentOptions,
                              url,
                              flatHeaders,
-                             showCreditsOnScreen,
                              tilesetJson)
                       .thenImmediately(
                           [](TilesetContentLoaderResult<TilesetContentLoader>&&

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -634,8 +634,7 @@ TilesetContentManager::TilesetContentManager(
             [pLogger = externals.pLogger,
              asyncSystem = externals.asyncSystem,
              pAssetAccessor = externals.pAssetAccessor,
-             contentOptions = tilesetOptions.contentOptions,
-             showCreditsOnScreen = tilesetOptions.showCreditsOnScreen](
+             contentOptions = tilesetOptions.contentOptions](
                 const std::shared_ptr<CesiumAsync::IAssetRequest>&
                     pCompletedRequest) {
               // Check if request is successful

--- a/Cesium3DTilesSelection/test/TestLayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/test/TestLayerJsonTerrainLoader.cpp
@@ -94,12 +94,8 @@ TEST_CASE("Test create layer json terrain loader") {
     pMockedAssetAccessor->mockCompletedRequests.insert(
         {"layer.json", createMockAssetRequest(layerJsonPath)});
 
-    auto loaderFuture = LayerJsonTerrainLoader::createLoader(
-        externals,
-        {},
-        "layer.json",
-        {},
-        true);
+    auto loaderFuture =
+        LayerJsonTerrainLoader::createLoader(externals, {}, "layer.json", {});
 
     asyncSystem.dispatchMainThreadTasks();
 
@@ -183,12 +179,8 @@ TEST_CASE("Test create layer json terrain loader") {
     pMockedAssetAccessor->mockCompletedRequests.insert(
         {"layer.json", createMockAssetRequest(layerJsonPath)});
 
-    auto loaderFuture = LayerJsonTerrainLoader::createLoader(
-        externals,
-        {},
-        "layer.json",
-        {},
-        true);
+    auto loaderFuture =
+        LayerJsonTerrainLoader::createLoader(externals, {}, "layer.json", {});
 
     asyncSystem.dispatchMainThreadTasks();
 
@@ -207,12 +199,8 @@ TEST_CASE("Test create layer json terrain loader") {
     pMockedAssetAccessor->mockCompletedRequests.insert(
         {"layer.json", createMockAssetRequest(layerJsonPath)});
 
-    auto loaderFuture = LayerJsonTerrainLoader::createLoader(
-        externals,
-        {},
-        "layer.json",
-        {},
-        true);
+    auto loaderFuture =
+        LayerJsonTerrainLoader::createLoader(externals, {}, "layer.json", {});
 
     asyncSystem.dispatchMainThreadTasks();
 
@@ -231,12 +219,8 @@ TEST_CASE("Test create layer json terrain loader") {
     pMockedAssetAccessor->mockCompletedRequests.insert(
         {"layer.json", createMockAssetRequest(layerJsonPath)});
 
-    auto loaderFuture = LayerJsonTerrainLoader::createLoader(
-        externals,
-        {},
-        "layer.json",
-        {},
-        true);
+    auto loaderFuture =
+        LayerJsonTerrainLoader::createLoader(externals, {}, "layer.json", {});
 
     asyncSystem.dispatchMainThreadTasks();
 
@@ -264,12 +248,8 @@ TEST_CASE("Test create layer json terrain loader") {
     pMockedAssetAccessor->mockCompletedRequests.insert(
         {"layer.json", createMockAssetRequest(layerJsonPath)});
 
-    auto loaderFuture = LayerJsonTerrainLoader::createLoader(
-        externals,
-        {},
-        "layer.json",
-        {},
-        true);
+    auto loaderFuture =
+        LayerJsonTerrainLoader::createLoader(externals, {}, "layer.json", {});
 
     asyncSystem.dispatchMainThreadTasks();
 
@@ -311,12 +291,8 @@ TEST_CASE("Test create layer json terrain loader") {
     pMockedAssetAccessor->mockCompletedRequests.insert(
         {"./Parent/layer.json", createMockAssetRequest(parentJsonPath)});
 
-    auto loaderFuture = LayerJsonTerrainLoader::createLoader(
-        externals,
-        {},
-        "layer.json",
-        {},
-        true);
+    auto loaderFuture =
+        LayerJsonTerrainLoader::createLoader(externals, {}, "layer.json", {});
 
     asyncSystem.dispatchMainThreadTasks();
 
@@ -349,12 +325,8 @@ TEST_CASE("Test create layer json terrain loader") {
     pMockedAssetAccessor->mockCompletedRequests.insert(
         {"layer.json", createMockAssetRequest(layerJsonPath)});
 
-    auto loaderFuture = LayerJsonTerrainLoader::createLoader(
-        externals,
-        {},
-        "layer.json",
-        {},
-        true);
+    auto loaderFuture =
+        LayerJsonTerrainLoader::createLoader(externals, {}, "layer.json", {});
 
     asyncSystem.dispatchMainThreadTasks();
 
@@ -376,12 +348,8 @@ TEST_CASE("Test create layer json terrain loader") {
     pMockedAssetAccessor->mockCompletedRequests.insert(
         {"layer.json", createMockAssetRequest(layerJsonPath)});
 
-    auto loaderFuture = LayerJsonTerrainLoader::createLoader(
-        externals,
-        {},
-        "layer.json",
-        {},
-        true);
+    auto loaderFuture =
+        LayerJsonTerrainLoader::createLoader(externals, {}, "layer.json", {});
 
     asyncSystem.dispatchMainThreadTasks();
 
@@ -406,8 +374,7 @@ TEST_CASE("Test create layer json terrain loader") {
         externals,
         options,
         "layer.json",
-        {},
-        true);
+        {});
 
     asyncSystem.dispatchMainThreadTasks();
 


### PR DESCRIPTION
The `showCreditsOnScreen` argument was passed all the way down through the call chains in `LayerJsonTerrainLoader`, and apparently, it was not used.

Opening this as a DRAFT, because I don't know whether...
- the fact that it was passed on was unintentional
- the fact that it was not used was unintentional
- (Maybe I overlooked some place where it was used, but if this is the case, then there was no test that took this flag into account - all tests still seem to be passing...)


Maybe someone wants to have a look...
