### PR TITLE
Remove logs when registering magic headers of file extensions

### DIFF
--- a/Cesium3DTilesSelection/src/GltfConverters.cpp
+++ b/Cesium3DTilesSelection/src/GltfConverters.cpp
@@ -12,14 +12,12 @@ std::unordered_map<std::string, GltfConverters::ConverterFunction>
 void GltfConverters::registerMagic(
     const std::string& magic,
     ConverterFunction converter) {
-  SPDLOG_INFO("Registering magic header {}", magic);
   _loadersByMagic[magic] = converter;
 }
 
 void GltfConverters::registerFileExtension(
     const std::string& fileExtension,
     ConverterFunction converter) {
-  SPDLOG_INFO("Registering file extension {}", fileExtension);
 
   std::string lowerCaseFileExtension = toLowerCase(fileExtension);
   _loadersByFileExtension[lowerCaseFileExtension] = converter;


### PR DESCRIPTION
These logs appear to be informational in nature and are visible in the console when using Cesium for Unity. I've also noticed these in the unit tests output for Cesium for Unreal.

Ultimately, I decided to remove these completely. In the context our official releases, I didn't see much use. Our supported magic headers and file extensions are not configurable by a user. So really it's just verifying the call to `Cesium3DTilesSelection::registerAllTileContentTypes()`, which is informative, but isn't particularly complicated. For example, in the Cesium for Unreal plugin, this call only happens once, and always during plugin startup.

Fixes #679 