### PR TITLE
Material variants support

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/MaterialVariants.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/MaterialVariants.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "Library.h"
+
+#include <string>
+#include <vector>
+
+namespace Cesium3DTilesSelection {
+
+/**
+ */
+struct CESIUM3DTILESSELECTION_API MaterialVariants {
+public:
+  std::vector<std::string> tilesetMaterialVariantNames;
+  std::vector<std::vector<std::string>> groupsMaterialVariantNames;
+};
+
+} // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Library.h"
+#include "MaterialVariants.h";
 #include "RasterOverlayCollection.h"
 #include "Tile.h"
 #include "TilesetContentLoader.h"
@@ -153,6 +154,8 @@ public:
 
   /** @copydoc Tileset::getOverlays() */
   const RasterOverlayCollection& getOverlays() const noexcept;
+
+  const MaterialVariants& getMaterialVariants() const noexcept;
 
   /**
    * @brief Updates this view but waits for all tiles that meet sse to finish

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
@@ -124,6 +124,7 @@ convertToTilesetContentLoaderResult(LoadLayersResult&& loadLayersResult) {
       std::move(pLoader),
       std::move(pRootTile),
       std::move(credits),
+      MaterialVariants{},
       std::vector<IAssetAccessor::THeader>{},
       std::move(loadLayersResult.errors)};
 }

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -127,6 +127,10 @@ const RasterOverlayCollection& Tileset::getOverlays() const noexcept {
   return this->_pTilesetContentManager->getRasterOverlayCollection();
 }
 
+const MaterialVariants& Tileset::getMaterialVariants() const noexcept {
+  return this->_pTilesetContentManager->getMaterialVariants();
+}
+
 static bool
 operator<(const FogDensityAtHeight& fogDensity, double height) noexcept {
   return fogDensity.cameraHeight < height;

--- a/Cesium3DTilesSelection/src/TilesetContentLoaderResult.h
+++ b/Cesium3DTilesSelection/src/TilesetContentLoaderResult.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Cesium3DTilesSelection/ErrorList.h>
+#include <Cesium3DTilesSelection/MaterialVariants.h>
 #include <Cesium3DTilesSelection/Tile.h>
 #include <CesiumAsync/IAssetAccessor.h>
 #include <CesiumGeometry/Axis.h>
@@ -23,11 +24,13 @@ template <class TilesetContentLoaderType> struct TilesetContentLoaderResult {
       std::unique_ptr<TilesetContentLoaderType>&& pLoader_,
       std::unique_ptr<Tile>&& pRootTile_,
       std::vector<LoaderCreditResult>&& credits_,
+      MaterialVariants&& materialVariants_,
       std::vector<CesiumAsync::IAssetAccessor::THeader>&& requestHeaders_,
       ErrorList&& errors_)
       : pLoader{std::move(pLoader_)},
         pRootTile{std::move(pRootTile_)},
         credits{std::move(credits_)},
+        materialVariants{std::move(materialVariants_)},
         requestHeaders{std::move(requestHeaders_)},
         errors{std::move(errors_)} {}
 
@@ -54,6 +57,7 @@ template <class TilesetContentLoaderType> struct TilesetContentLoaderResult {
       : pLoader{std::move(rhs.pLoader)},
         pRootTile{std::move(rhs.pRootTile)},
         credits{std::move(rhs.credits)},
+        materialVariants{std::move(rhs.materialVariants)},
         requestHeaders{std::move(rhs.requestHeaders)},
         errors{std::move(rhs.errors)} {}
 
@@ -71,6 +75,7 @@ template <class TilesetContentLoaderType> struct TilesetContentLoaderResult {
     swap(this->pLoader, rhs.pLoader);
     swap(this->pRootTile, rhs.pRootTile);
     swap(this->credits, rhs.credits);
+    swap(this->materialVariants, rhs.materialVariants);
     swap(this->requestHeaders, rhs.requestHeaders);
     swap(this->errors, rhs.errors);
 
@@ -82,6 +87,8 @@ template <class TilesetContentLoaderType> struct TilesetContentLoaderResult {
   std::unique_ptr<Tile> pRootTile;
 
   std::vector<LoaderCreditResult> credits;
+
+  MaterialVariants materialVariants;
 
   std::vector<CesiumAsync::IAssetAccessor::THeader> requestHeaders;
 

--- a/Cesium3DTilesSelection/src/TilesetContentManager.h
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.h
@@ -4,6 +4,7 @@
 #include "TilesetContentLoaderResult.h"
 
 #include <Cesium3DTilesSelection/CreditSystem.h>
+#include <Cesium3DTilesSelection/MaterialVariants.h>
 #include <Cesium3DTilesSelection/RasterOverlayCollection.h>
 #include <Cesium3DTilesSelection/Tile.h>
 #include <Cesium3DTilesSelection/TileContent.h>
@@ -76,6 +77,8 @@ public:
 
   Tile* getRootTile() noexcept;
 
+  const MaterialVariants& getMaterialVariants() const noexcept;
+
   const std::vector<CesiumAsync::IAssetAccessor::THeader>&
   getRequestHeaders() const noexcept;
 
@@ -143,6 +146,8 @@ private:
   int32_t _tileLoadsInProgress;
   int32_t _loadedTilesCount;
   int64_t _tilesDataUsed;
+
+  MaterialVariants _materialVariants;
 
   CesiumAsync::Promise<void> _destructionCompletePromise;
   CesiumAsync::SharedFuture<void> _destructionCompleteFuture;

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -17,6 +17,7 @@
 #include <CesiumUtility/joinToString.h>
 
 #include <rapidjson/document.h>
+#include <rapidjson/pointer.h>
 #include <spdlog/logger.h>
 
 #include <cctype>
@@ -614,6 +615,7 @@ TilesetContentLoaderResult<TilesetJsonLoader> parseTilesetJson(
       std::move(pLoader),
       std::move(pRootTile),
       std::vector<LoaderCreditResult>{},
+      MaterialVariants{},
       std::vector<CesiumAsync::IAssetAccessor::THeader>{},
       ErrorList{}};
 }

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.h
@@ -2,6 +2,7 @@
 
 #include "TilesetContentLoaderResult.h"
 
+#include <Cesium3DTilesSelection/MaterialVariants.h>
 #include <Cesium3DTilesSelection/TilesetContentLoader.h>
 #include <Cesium3DTilesSelection/TilesetExternals.h>
 #include <CesiumAsync/Future.h>


### PR DESCRIPTION
Addressing https://github.com/CesiumGS/cesium-native/issues/676

Maybe it is possible to split the _conceptual_ questions from some lower-level questions. I'll add a comment with some _conceptual_ questions in the issue. 

The lower-level questions: 

I tried to find the right place for extracting the (metadata) information from the tileset JSON, and pass it on to the `Tileset` class. The right place for _parsing_ it may be a bit arbitrary. Since this is currently solely operating on the `rapidjson` document for the tileset, the magic 
`MaterialVariants parseMaterialVariants(const rapidjson::Document& tileset)`
function can basically be inserted anywhere (currently in an anonymous namespace of the `TilesetContentManager`). **But**... this has to be changed for the case that the metadata `schema` is **not** contained in the tileset JSON, but referred to via a `schemaUri`. This is related the the question about the "proper way" for passing this information from the place where it is loaded (or where it has to be loaded in the future) to the `Tileset` object. Having short descriptions about what a `TilesetContentManager` actually **is** (beyond `/* A class that manages tileset content */`), or the role that a `TilesetContentLoaderResult` plays (beyond that it is `/* The result of loading tileset content */`) could be really, really, really helpful. 

