### PR TITLE
Add LocalHorizontalCoordinateSystem constructors taking ECEF<->Local matrices.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - Add caching support for Google 3d Photorealistic Tiles. Fixes cases where the origin server is using combinations of HTTP header directives that would cause tiles to not go to disk cache (`max-age-0`, `stale-while-revalidate`, and `Expires`).
+- Added new constructors to `LocalHorizontalCoordinateSystem` taking ECEF<->Local transformation matrices directly.
 
 ##### Fixes :wrench:
 

--- a/CesiumGeospatial/include/CesiumGeospatial/LocalHorizontalCoordinateSystem.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/LocalHorizontalCoordinateSystem.h
@@ -73,6 +73,30 @@ public:
       const Ellipsoid& ellipsoid = Ellipsoid::WGS84);
 
   /**
+   * @brief Create a new coordinate system with a specified transformation to
+   * the Earth-Centered, Earth-Fixed frame. This is an advanced constructor and
+   * should be avoided in most cases.
+   *
+   * @param localToEcef The transformation matrix from this coordinate system to
+   * the ECEF frame.
+   */
+  explicit LocalHorizontalCoordinateSystem(const glm::dmat4& localToEcef);
+
+  /**
+   * @brief Create a new coordinate system with the specified transformations
+   * between the local frame and the Earth-Centered, Earth-Fixed frame. This is
+   * an advanced constructor and should be avoided in most cases.
+   *
+   * @param localToEcef The transformation matrix from this coordinate system to
+   * the ECEF frame. This must be the inverse of `ecefToLocal`.
+   * @param ecefToLocal The transformation matrix from the ECEF frame to this
+   * coordinate system. This must be the inverse of `localToEcef`.
+   */
+  LocalHorizontalCoordinateSystem(
+      const glm::dmat4& localToEcef,
+      const glm::dmat4& ecefToLocal);
+
+  /**
    * @brief Gets the transformation matrix from the local horizontal coordinate
    * system managed by this instance to the Earth-Centered, Earth-fixed
    * coordinate system.

--- a/CesiumGeospatial/src/LocalHorizontalCoordinateSystem.cpp
+++ b/CesiumGeospatial/src/LocalHorizontalCoordinateSystem.cpp
@@ -86,6 +86,17 @@ LocalHorizontalCoordinateSystem::LocalHorizontalCoordinateSystem(
   this->_ecefToLocal = glm::affineInverse(this->_localToEcef);
 }
 
+CesiumGeospatial::LocalHorizontalCoordinateSystem::
+    LocalHorizontalCoordinateSystem(const glm::dmat4& localToEcef)
+    : _localToEcef(localToEcef),
+      _ecefToLocal(glm::affineInverse(localToEcef)) {}
+
+CesiumGeospatial::LocalHorizontalCoordinateSystem::
+    LocalHorizontalCoordinateSystem(
+        const glm::dmat4& localToEcef,
+        const glm::dmat4& ecefToLocal)
+    : _localToEcef(localToEcef), _ecefToLocal(ecefToLocal) {}
+
 glm::dvec3 LocalHorizontalCoordinateSystem::localPositionToEcef(
     const glm::dvec3& localPosition) const noexcept {
   return glm::dvec3(this->_localToEcef * glm::dvec4(localPosition, 1.0));


### PR DESCRIPTION
These matrices are the actual data representation of the class. It's helpful to have these for some refactoring I'm doing in Cesium for Unreal.