### PR TITLE
Install meshoptimizer targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,3 +206,5 @@ install(TARGETS s2geometry)
 
 install(TARGETS expected-lite)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/extern/expected-lite/include/nonstd TYPE INCLUDE)
+
+install(TARGETS meshoptimizer)


### PR DESCRIPTION
This is needed to make the meshoptimizer lib available to cesium-unreal.