### PR TITLE
Prevent empty error message from getting propagated to loadErrorCallback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v0.27.0 - 2023-09-01
+
+##### Fixes :wrench:
+
+- Fixed a bug where an empty error message would get propagated to a tileset's `loadErrorCallback`.
+
 ### v0.26.0 - 2023-08-01
 
 ##### Additions :tada:

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -1425,12 +1425,14 @@ void TilesetContentManager::propagateTilesetContentLoaderResult(
       this->_externals.pLogger,
       "Warnings when loading tileset");
 
-  if (loadErrorCallback) {
-    loadErrorCallback(TilesetLoadFailureDetails{
-        nullptr,
-        type,
-        result.statusCode,
-        CesiumUtility::joinToString(result.errors.errors, "\n- ")});
+  if (result.errors) {
+    if (loadErrorCallback) {
+      loadErrorCallback(TilesetLoadFailureDetails{
+          nullptr,
+          type,
+          result.statusCode,
+          CesiumUtility::joinToString(result.errors.errors, "\n- ")});
+    }
   }
 
   if (!result.errors) {


### PR DESCRIPTION
There was a small regression in https://github.com/CesiumGS/cesium-native/pull/646 where an invalid error would get propagated to the tileset's `loadErrorCallback`. Fixed by wrapping in a `if (result.errors)` check.

Feel to free to tweak for style as needed (e.g. maybe the if statements should be combined into one?).