### PR TITLE
Fully decompress KTX images if transcoding fails.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 ##### Fixes :wrench:
 
 - When KTX transcoding fails, the image will now be fully decompressed instead of returning an error.
-- Fixed texture format selection for KTX on mobile platforms. Specifically, it will select ASTC if it is available and fall back to PVRTC if it is not.
+
 ### v0.26.0 - 2023-08-01
 
 ##### Additions :tada:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- When KTX transcoding fails, the image will now be fully decompressed instead of returning an error.
+
 ### v0.26.0 - 2023-08-01
 
 ##### Additions :tada:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 ##### Fixes :wrench:
 
 - When KTX transcoding fails, the image will now be fully decompressed instead of returning an error.
-
+- Fixed texture format selection for KTX on mobile platforms. Specifically, it will select ASTC if it is available and fall back to PVRTC if it is not.
 ### v0.26.0 - 2023-08-01
 
 ##### Additions :tada:

--- a/CesiumGltf/src/Ktx2TranscodeTargets.cpp
+++ b/CesiumGltf/src/Ktx2TranscodeTargets.cpp
@@ -22,6 +22,8 @@ Ktx2TranscodeTargets::Ktx2TranscodeTargets(
     this->ETC1S_RGBA = GpuCompressedPixelFormat::BC7_RGBA;
   } else if (supportedFormats.BC3_RGBA) {
     this->ETC1S_RGBA = GpuCompressedPixelFormat::BC3_RGBA;
+  } else if (supportedFormats.ASTC_4x4_RGBA) {
+    this->ETC1S_RGBA = GpuCompressedPixelFormat::ASTC_4x4_RGBA;
   } else if (supportedFormats.PVRTC1_4_RGBA) {
     this->ETC1S_RGBA = GpuCompressedPixelFormat::PVRTC1_4_RGBA;
   }
@@ -33,6 +35,8 @@ Ktx2TranscodeTargets::Ktx2TranscodeTargets(
     this->ETC1S_RGB = GpuCompressedPixelFormat::BC7_RGBA;
   } else if (supportedFormats.BC1_RGB) {
     this->ETC1S_RGB = GpuCompressedPixelFormat::BC1_RGB;
+  } else if (supportedFormats.ASTC_4x4_RGBA) {
+    this->ETC1S_RGBA = GpuCompressedPixelFormat::ASTC_4x4_RGBA;
   } else if (supportedFormats.PVRTC1_4_RGB) {
     this->ETC1S_RGB = GpuCompressedPixelFormat::PVRTC1_4_RGB;
   }

--- a/CesiumGltf/src/Ktx2TranscodeTargets.cpp
+++ b/CesiumGltf/src/Ktx2TranscodeTargets.cpp
@@ -22,8 +22,6 @@ Ktx2TranscodeTargets::Ktx2TranscodeTargets(
     this->ETC1S_RGBA = GpuCompressedPixelFormat::BC7_RGBA;
   } else if (supportedFormats.BC3_RGBA) {
     this->ETC1S_RGBA = GpuCompressedPixelFormat::BC3_RGBA;
-  } else if (supportedFormats.ASTC_4x4_RGBA) {
-    this->ETC1S_RGBA = GpuCompressedPixelFormat::ASTC_4x4_RGBA;
   } else if (supportedFormats.PVRTC1_4_RGBA) {
     this->ETC1S_RGBA = GpuCompressedPixelFormat::PVRTC1_4_RGBA;
   }
@@ -35,8 +33,6 @@ Ktx2TranscodeTargets::Ktx2TranscodeTargets(
     this->ETC1S_RGB = GpuCompressedPixelFormat::BC7_RGBA;
   } else if (supportedFormats.BC1_RGB) {
     this->ETC1S_RGB = GpuCompressedPixelFormat::BC1_RGB;
-  } else if (supportedFormats.ASTC_4x4_RGBA) {
-    this->ETC1S_RGBA = GpuCompressedPixelFormat::ASTC_4x4_RGBA;
   } else if (supportedFormats.PVRTC1_4_RGB) {
     this->ETC1S_RGB = GpuCompressedPixelFormat::PVRTC1_4_RGB;
   }

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -612,6 +612,12 @@ ImageReaderResult GltfReader::readImage(
 
         errorCode =
             ktxTexture2_TranscodeBasis(pTexture, transcodeTargetFormat_, 0);
+        if (errorCode != KTX_SUCCESS){
+          transcodeTargetFormat_ = KTX_TTF_RGBA32;
+          transcodeTargetFormat = GpuCompressedPixelFormat::NONE;
+          errorCode =
+              ktxTexture2_TranscodeBasis(pTexture, transcodeTargetFormat_, 0);
+        }
         if (errorCode == KTX_SUCCESS) {
           image.compressedPixelFormat = transcodeTargetFormat;
           image.width = static_cast<int32_t>(pTexture->baseWidth);
@@ -688,7 +694,7 @@ ImageReaderResult GltfReader::readImage(
     }
 
     result.image.reset();
-    result.errors.emplace_back("KTX2 loading failed");
+    result.errors.emplace_back("KTX2 loading failed with error: " + std::string(ktxErrorString(errorCode)));
 
     return result;
   } else if (isWebP(data)) {

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -612,7 +612,7 @@ ImageReaderResult GltfReader::readImage(
 
         errorCode =
             ktxTexture2_TranscodeBasis(pTexture, transcodeTargetFormat_, 0);
-        if (errorCode != KTX_SUCCESS){
+        if (errorCode != KTX_SUCCESS) {
           transcodeTargetFormat_ = KTX_TTF_RGBA32;
           transcodeTargetFormat = GpuCompressedPixelFormat::NONE;
           errorCode =
@@ -694,7 +694,9 @@ ImageReaderResult GltfReader::readImage(
     }
 
     result.image.reset();
-    result.errors.emplace_back("KTX2 loading failed with error: " + std::string(ktxErrorString(errorCode)));
+    result.errors.emplace_back(
+        "KTX2 loading failed with error: " +
+        std::string(ktxErrorString(errorCode)));
 
     return result;
   } else if (isWebP(data)) {


### PR DESCRIPTION
When KTX transcoding fails, the image will now be fully decompressed instead of returning an error.