### PR TITLE
Finish loading parent tile when needed for upsampling.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
 - Fixed several small build script issues to allow cesium-native to be used in Univeral Windows Platform (UWP) applications, such as those that run on Holo Lens 2.
 - When KTX transcoding fails, the image will now be fully decompressed instead of returning an error.
 - Fixed a bug that could cause higher-detail tiles to continue showing when zooming out quickly on a tileset that uses "additive" refinement.
+- Fixed a bug that could cause a tile to never finish upsampling because its non-rendered parent never finishes loading.
 
 ### v0.26.0 - 2023-08-01
 

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -808,10 +808,7 @@ Tileset::TraversalDetails Tileset::_visitTileIfNeeded(
   double tilePriority =
       computeTilePriority(tile, frameState.frustums, distances);
 
-  this->_pTilesetContentManager->updateTileContent(
-      tile,
-      tilePriority,
-      _options);
+  this->_pTilesetContentManager->updateTileContent(tile, _options);
   this->_markTileVisited(tile);
 
   CullResult cullResult{};

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -878,6 +878,12 @@ void TilesetContentManager::loadTileContent(
     if (pParentTile) {
       if (pParentTile->getState() != TileLoadState::Done) {
         loadTileContent(*pParentTile, tilesetOptions);
+
+        // Finalize the parent if necessary, otherwise it may never reach the
+        // Done state.
+        if (pParentTile->getState() == TileLoadState::ContentLoaded) {
+          finishLoading(*pParentTile, tilesetOptions);
+        }
         return;
       }
     } else {
@@ -970,14 +976,13 @@ void TilesetContentManager::loadTileContent(
 
 void TilesetContentManager::updateTileContent(
     Tile& tile,
-    double priority,
     const TilesetOptions& tilesetOptions) {
   if (tile.getState() == TileLoadState::Unloading) {
     unloadTileContent(tile);
   }
 
   if (tile.getState() == TileLoadState::ContentLoaded) {
-    updateContentLoadedState(tile, priority, tilesetOptions);
+    updateContentLoadedState(tile, tilesetOptions);
   }
 
   if (tile.getState() == TileLoadState::Done) {
@@ -1188,8 +1193,7 @@ void TilesetContentManager::finishLoading(
 
   // This allows the raster tile to be updated and children to be created, if
   // necessary.
-  // Priority doesn't matter here since loading is complete.
-  updateTileContent(tile, 0.0, tilesetOptions);
+  updateTileContent(tile, tilesetOptions);
 }
 
 void TilesetContentManager::setTileContent(
@@ -1230,7 +1234,6 @@ void TilesetContentManager::setTileContent(
 
 void TilesetContentManager::updateContentLoadedState(
     Tile& tile,
-    double /*priority*/,
     const TilesetOptions& tilesetOptions) {
   // initialize this tile content first
   TileContent& content = tile.getContent();

--- a/Cesium3DTilesSelection/src/TilesetContentManager.h
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.h
@@ -62,10 +62,7 @@ public:
 
   void loadTileContent(Tile& tile, const TilesetOptions& tilesetOptions);
 
-  void updateTileContent(
-      Tile& tile,
-      double priority,
-      const TilesetOptions& tilesetOptions);
+  void updateTileContent(Tile& tile, const TilesetOptions& tilesetOptions);
 
   bool unloadTileContent(Tile& tile);
 
@@ -115,10 +112,8 @@ private:
       TileLoadResult&& result,
       void* pWorkerRenderResources);
 
-  void updateContentLoadedState(
-      Tile& tile,
-      double priority,
-      const TilesetOptions& tilesetOptions);
+  void
+  updateContentLoadedState(Tile& tile, const TilesetOptions& tilesetOptions);
 
   void updateDoneState(Tile& tile, const TilesetOptions& tilesetOptions);
 

--- a/Cesium3DTilesSelection/test/TestTilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/test/TestTilesetContentManager.cpp
@@ -372,7 +372,7 @@ TEST_CASE("Test tile state machine") {
 
       // ContentLoaded -> Done
       // update tile content to move from ContentLoaded -> Done
-      pManager->updateTileContent(tile, 0.0, options);
+      pManager->updateTileContent(tile, options);
       CHECK(tile.getState() == TileLoadState::Done);
       CHECK(tile.getChildren().size() == 1);
       CHECK(tile.getChildren().front().getContent().isEmptyContent());
@@ -473,7 +473,7 @@ TEST_CASE("Test tile state machine") {
 
     // FailedTemporarily -> FailedTemporarily
     // tile is failed temporarily but the loader can still add children to it
-    pManager->updateTileContent(tile, 0.0, options);
+    pManager->updateTileContent(tile, options);
     CHECK(pManager->getNumberOfTilesLoading() == 0);
     CHECK(tile.getChildren().size() == 1);
     CHECK(tile.getChildren().front().isEmptyContent());
@@ -548,7 +548,7 @@ TEST_CASE("Test tile state machine") {
 
     // Failed -> Failed
     // tile is failed but the loader can still add children to it
-    pManager->updateTileContent(tile, 0.0, options);
+    pManager->updateTileContent(tile, options);
     CHECK(pManager->getNumberOfTilesLoading() == 0);
     CHECK(tile.getChildren().size() == 1);
     CHECK(tile.getChildren().front().isEmptyContent());
@@ -648,7 +648,7 @@ TEST_CASE("Test tile state machine") {
     CHECK(upsampledTile.getState() == TileLoadState::Unloaded);
 
     // parent moves from ContentLoaded -> Done
-    pManager->updateTileContent(tile, 0.0, options);
+    pManager->updateTileContent(tile, options);
     CHECK(tile.getState() == TileLoadState::Done);
     CHECK(tile.getChildren().size() == 1);
     CHECK(&tile.getChildren().back() == &upsampledTile);


### PR DESCRIPTION
This fixes the Unreal Movie Render Queue freezing that several users have noticed in Cesium for Unreal v1.29.0:
https://community.cesium.com/t/movie-render-queue-freeze-at-lower-values-for-maximum-screen-space-error/26331

Here's what's happening:

1. A tile needs to be upsampled in order to hang more detailed raster overlays on it.
2. That tile can't be upsampled until its parent enters the Done state, because we need the parent geometry in order to do the upsampling.
3. `TilesetContentManager::loadTileContent` detects this case, and explicitly calls `loadTileContent` on the parent tile. Because there's no guarantee the parent tile would ever load otherwise.
4. `loadTileContent` allows the parent tile to complete its request and worker thread work, but by itself it will only get the tile as far as the `ContentLoaded` state. The transition from `ContentLoaded` to `Done` happens in the course of visiting the tile during the main traversal.
5. Except (4) isn't quite true. It used to work that way, but after #565 this transition is throttled and prioritized, in order to avoid tanking the frame rate by loading too many tiles at once. We'll only do this work for tiles that we actually want to render.
6. Because the parent tile in this scenario isn't actually selected for rendering, it never transitions from `ContentLoaded` to `Done`.
7. So the parent tile's failure to load blocks loading of the upsampled tile, which blocks the movie rendering from advancing to the next frame because loading isn't completed.

This is quite an old problem. However it just became apparent to users in Cesium for Unreal v1.29.0 because we tightened up the logic for waiting for tiles to load when rendering movies. Previously it wouldn't have waited, now it does (forever).