### PR TITLE
Fix crash caused by redundant finishLoading call.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v0.27.1 - 2023-09-03
+
+##### Fixes :wrench:
+
+- Fixed a bug that could cause a crash when loading tiles with a raster overlay.
+
 ### v0.27.0 - 2023-09-01
 
 ##### Breaking Changes :mega:

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -880,8 +880,12 @@ void TilesetContentManager::loadTileContent(
         loadTileContent(*pParentTile, tilesetOptions);
 
         // Finalize the parent if necessary, otherwise it may never reach the
-        // Done state.
-        if (pParentTile->getState() == TileLoadState::ContentLoaded) {
+        // Done state. Also double check that we have render content in ensure
+        // we don't assert / crash in finishLoading. The latter will only ever
+        // be a problem in a pathological tileset with a non-renderable leaf
+        // tile, but that sort of thing does happen.
+        if (pParentTile->getState() == TileLoadState::ContentLoaded &&
+            pParentTile->isRenderContent()) {
           finishLoading(*pParentTile, tilesetOptions);
         }
         return;


### PR DESCRIPTION
Fixes crash reported here:
https://community.cesium.com/t/latest-update-crash/26513

In #721, I added a call to `finishLoading` in a case that it was needed. `finishLoading` switches the tile into the `Done` state, which should guarantee that `finishLoading` won't get called again later. Or so I thought. The problem is that the tile may have been added to the main thread load queue while it was in the `ContentLoaded` state, but then by the time the main thread load queue is processed, by new call to finishLoading has already happened and so the tile is in the Done state. This would cause an assertion failure in debug builds, but in release builds it tends to just crash because the game engine integration interprets the renderer resources incorrectly.

The solution in this PR is to double-check a tile is still in the ContentLoaded state when processing the load queue. I also added a bit more safety around the extra call to finishLoading for pathological tilesets with leaf tiles that have no renderable content.
