### PR TITLE
Add missing include.

### DIFF
--- a/CesiumGltf/include/CesiumGltf/FeatureTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/FeatureTexturePropertyView.h
@@ -11,6 +11,7 @@
 #include "ImageCesium.h"
 #include "Model.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <variant>


### PR DESCRIPTION
Needed by `std::clamp`. This showed up in the Unreal Engine 5.3 build.