### PR TITLE
Support omitted `EXT_structural_metadata` properties

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Change Log
 
+### ? - ?
+
+##### Additions :tada:
+
+- Added `getClass` to `PropertyTableView`, `PropertyTextureView`, and `PropertyAttributeView`. This can be used to retrieve the metadata `Class` associated with the view.
+- Added `PropertyViewStatus::EmptyPropertyWithDefault` to indicate when a property contains no data, but has a valid default value.
+
+##### Fixes :wrench:
+
+- Fixed the handling of omitted metadata properties in `PropertyTableView`, `PropertyTextureView`, and `PropertyAttributeView` instances. Previously, if a property was not `required` and omitted, it would be initialized as invalid with the `ErrorNonexistentProperty` status. Now, it will be treated as valid as long as the property defines a valid `defaultProperty`. Now, a special instance of `PropertyTablePropertyView`, `PropertyTexturePropertyView`, or `PropertyAttributePropertyView` will be constructed to allow the property's default value to be retrieved, either via `defaultValue` or `get`. `getRaw` may not be called on this special instance.
+
 ### v0.28.0 - 2023-09-08
 
 ##### Breaking Changes :mega:

--- a/CesiumGltf/include/CesiumGltf/PropertyAttributePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyAttributePropertyView.h
@@ -127,7 +127,7 @@ public:
   /**
    * @brief Constructs an invalid instance for an erroneous property.
    *
-   * @param status The value of {@link PropertyAttributePropertyViewStatus} indicating the error with the property.
+   * @param status The code from {@link PropertyAttributePropertyViewStatus} indicating the error with the property.
    */
   PropertyAttributePropertyView(PropertyViewStatusType status) noexcept
       : PropertyView<ElementType, false>(status), _accessor{}, _size{0} {

--- a/CesiumGltf/include/CesiumGltf/PropertyAttributePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyAttributePropertyView.h
@@ -25,66 +25,66 @@ public:
    * @brief This property view was initialized from an invalid
    * {@link PropertyAttribute}.
    */
-  static const int ErrorInvalidPropertyAttribute = 13;
+  static const int ErrorInvalidPropertyAttribute = 14;
 
   /**
    * @brief This property view is associated with a {@link ClassProperty} of an
    * unsupported type.
    */
-  static const int ErrorUnsupportedProperty = 14;
+  static const int ErrorUnsupportedProperty = 15;
 
   /**
    * @brief This property view was initialized with a primitive that does not
    * contain the specified attribute.
    */
-  static const int ErrorMissingAttribute = 15;
+  static const int ErrorMissingAttribute = 16;
 
   /**
    * @brief This property view's attribute does not have a valid accessor index.
    */
-  static const int ErrorInvalidAccessor = 16;
+  static const int ErrorInvalidAccessor = 17;
 
   /**
    * @brief This property view's type does not match the type of the accessor it
    * uses.
    */
-  static const int ErrorAccessorTypeMismatch = 17;
+  static const int ErrorAccessorTypeMismatch = 18;
 
   /**
    * @brief This property view's component type does not match the type of the
    * accessor it uses.
    */
-  static const int ErrorAccessorComponentTypeMismatch = 18;
+  static const int ErrorAccessorComponentTypeMismatch = 19;
 
   /**
    * @brief This property view's normalization does not match the normalization
    * of the accessor it uses.
    */
-  static const int ErrorAccessorNormalizationMismatch = 19;
+  static const int ErrorAccessorNormalizationMismatch = 20;
 
   /**
    * @brief This property view uses an accessor that does not have a valid
    * buffer view index.
    */
-  static const int ErrorInvalidBufferView = 20;
+  static const int ErrorInvalidBufferView = 21;
 
   /**
    * @brief This property view uses a buffer view that does not have a valid
    * buffer index.
    */
-  static const int ErrorInvalidBuffer = 21;
+  static const int ErrorInvalidBuffer = 22;
 
   /**
    * @brief This property view uses an accessor that points outside the bounds
    * of its target buffer view.
    */
-  static const PropertyViewStatusType ErrorAccessorOutOfBounds = 22;
+  static const PropertyViewStatusType ErrorAccessorOutOfBounds = 23;
 
   /**
    * @brief This property view uses a buffer view that points outside the bounds
    * of its target buffer.
    */
-  static const PropertyViewStatusType ErrorBufferViewOutOfBounds = 23;
+  static const PropertyViewStatusType ErrorBufferViewOutOfBounds = 24;
 };
 
 /**
@@ -122,18 +122,48 @@ public:
    * @brief Constructs an invalid instance for a non-existent property.
    */
   PropertyAttributePropertyView() noexcept
-      : PropertyView<ElementType, false>(), _accessor{} {}
+      : PropertyView<ElementType, false>(), _accessor{}, _size{0} {}
 
   /**
    * @brief Constructs an invalid instance for an erroneous property.
    *
-   * @param status The code from {@link PropertyAttributePropertyViewStatus} indicating the error with the property.
+   * @param status The value of {@link PropertyAttributePropertyViewStatus} indicating the error with the property.
    */
   PropertyAttributePropertyView(PropertyViewStatusType status) noexcept
-      : PropertyView<ElementType, false>(status), _accessor{} {
+      : PropertyView<ElementType, false>(status), _accessor{}, _size{0} {
     assert(
         this->_status != PropertyAttributePropertyViewStatus::Valid &&
         "An empty property view should not be constructed with a valid status");
+  }
+
+  /**
+   * @brief Constructs an instance of an empty property that specifies a default
+   * value. Although this property has no data, it can return the default value
+   * when {@link PropertyAttributePropertyView::get} is called. However,
+   * {@link PropertyAttributePropertyView::getRaw} cannot be used.
+   *
+   * @param classProperty The {@link ClassProperty} this property conforms to.
+   * @param size The number of elements in the primitive's POSITION accessor.
+   * Used as a substitute since no actual accessor is defined.
+   */
+  PropertyAttributePropertyView(
+      const ClassProperty& classProperty,
+      int64_t size) noexcept
+      : PropertyView<ElementType, false>(classProperty), _accessor{}, _size{0} {
+    // Don't override the status / size if something is wrong with the class
+    // property's definition.
+    if (this->_status != PropertyAttributePropertyViewStatus::Valid) {
+      return;
+    }
+
+    assert(
+        classProperty.defaultProperty &&
+        "Cannot construct a valid property view for an empty property with no "
+        "default value.");
+
+    this->_status =
+        PropertyAttributePropertyViewStatus::EmptyPropertyWithDefault;
+    this->_size = size;
   }
 
   /**
@@ -141,7 +171,7 @@ public:
    *
    * @param property The {@link PropertyAttributeProperty}
    * @param classProperty The {@link ClassProperty} this property conforms to.
-   * @param accsesorView The {@link AccessorView} for the data that this property is
+   * @param accessorView The {@link AccessorView} for the data that this property is
    * associated with.
    */
   PropertyAttributePropertyView(
@@ -149,7 +179,11 @@ public:
       const ClassProperty& classProperty,
       const AccessorView<ElementType>& accessorView) noexcept
       : PropertyView<ElementType, false>(classProperty, property),
-        _accessor{accessorView} {}
+        _accessor{accessorView},
+        _size{
+            this->_status == PropertyAttributePropertyViewStatus::Valid
+                ? accessorView.size()
+                : 0} {}
 
   /**
    * @brief Gets the value of the property for the given texture coordinates
@@ -167,6 +201,11 @@ public:
    * it matches the "no data" value
    */
   std::optional<ElementType> get(int64_t index) const noexcept {
+    if (this->_status ==
+        PropertyAttributePropertyViewStatus::EmptyPropertyWithDefault) {
+      return this->defaultValue();
+    }
+
     ElementType value = getRaw(index);
 
     if (value == this->noData()) {
@@ -206,16 +245,11 @@ public:
    *
    * @return The number of elements in this PropertyAttributePropertyView.
    */
-  int64_t size() const noexcept {
-    if (this->_status != PropertyAttributePropertyViewStatus::Valid) {
-      return 0;
-    }
-
-    return _accessor.size();
-  }
+  int64_t size() const noexcept { return _size; }
 
 private:
   AccessorView<ElementType> _accessor;
+  int64_t _size;
 };
 
 /**
@@ -240,7 +274,7 @@ public:
    * @brief Constructs an invalid instance for a non-existent property.
    */
   PropertyAttributePropertyView() noexcept
-      : PropertyView<ElementType, true>(), _accessor{} {}
+      : PropertyView<ElementType, true>(), _accessor{}, _size{0} {}
 
   /**
    * @brief Constructs an invalid instance for an erroneous property.
@@ -248,10 +282,40 @@ public:
    * @param status The code from {@link PropertyAttributePropertyViewStatus} indicating the error with the property.
    */
   PropertyAttributePropertyView(PropertyViewStatusType status) noexcept
-      : PropertyView<ElementType, true>(status), _accessor{} {
+      : PropertyView<ElementType, true>(status), _accessor{}, _size{0} {
     assert(
         this->_status != PropertyAttributePropertyViewStatus::Valid &&
         "An empty property view should not be constructed with a valid status");
+  }
+
+  /**
+   * @brief Constructs an instance of an empty property that specifies a default
+   * value. Although this property has no data, it can return the default value
+   * when {@link PropertyAttributePropertyView::get} is called. However,
+   * {@link PropertyAttributePropertyView::getRaw} cannot be used.
+   *
+   * @param classProperty The {@link ClassProperty} this property conforms to.
+   * @param size The number of elements in the primitive's POSITION accessor.
+   * Used as a substitute since no actual accessor is defined.
+   */
+  PropertyAttributePropertyView(
+      const ClassProperty& classProperty,
+      int64_t size) noexcept
+      : PropertyView<ElementType, true>(classProperty), _accessor{}, _size{0} {
+    // Don't override the status / size if something is wrong with the class
+    // property's definition.
+    if (this->_status != PropertyAttributePropertyViewStatus::Valid) {
+      return;
+    }
+
+    assert(
+        classProperty.defaultProperty &&
+        "Cannot construct a valid property view for an empty property with no "
+        "default value.");
+
+    this->_status =
+        PropertyAttributePropertyViewStatus::EmptyPropertyWithDefault;
+    this->_size = size;
   }
 
   /**
@@ -259,7 +323,7 @@ public:
    *
    * @param property The {@link PropertyAttributeProperty}
    * @param classProperty The {@link ClassProperty} this property conforms to.
-   * @param accsesorView The {@link AccessorView} for the data that this property is
+   * @param accessorView The {@link AccessorView} for the data that this property is
    * associated with.
    */
   PropertyAttributePropertyView(
@@ -267,7 +331,11 @@ public:
       const ClassProperty& classProperty,
       const AccessorView<ElementType>& accessorView) noexcept
       : PropertyView<ElementType, true>(classProperty, property),
-        _accessor{accessorView} {}
+        _accessor{accessorView},
+        _size{
+            this->_status == PropertyAttributePropertyViewStatus::Valid
+                ? accessorView.size()
+                : 0} {}
 
   /**
    * @brief Gets the value of the property for the given texture coordinates
@@ -285,6 +353,11 @@ public:
    * it matches the "no data" value
    */
   std::optional<NormalizedType> get(int64_t index) const noexcept {
+    if (this->_status ==
+        PropertyAttributePropertyViewStatus::EmptyPropertyWithDefault) {
+      return this->defaultValue();
+    }
+
     ElementType value = getRaw(index);
 
     if (value == this->noData()) {
@@ -349,16 +422,11 @@ public:
    *
    * @return The number of elements in this PropertyAttributePropertyView.
    */
-  int64_t size() const noexcept {
-    if (this->_status != PropertyAttributePropertyViewStatus::Valid) {
-      return 0;
-    }
-
-    return _accessor.size();
-  }
+  int64_t size() const noexcept { return _size; }
 
 private:
   AccessorView<ElementType> _accessor;
+  int64_t _size;
 };
 
 } // namespace CesiumGltf

--- a/CesiumGltf/include/CesiumGltf/PropertyAttributeView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyAttributeView.h
@@ -81,6 +81,14 @@ public:
   }
 
   /**
+   * @brief Gets the {@link Class} that this property attribute conforms to.
+   *
+   * @return A pointer to the {@link Class}. Returns nullptr if the
+   * PropertyAttribute did not specify a valid class.
+   */
+  const Class* getClass() const noexcept { return _pClass; }
+
+  /**
    * @brief Finds the {@link ClassProperty} that
    * describes the type information of the property with the specified name.
    * @param propertyName The name of the property to retrieve the class for.

--- a/CesiumGltf/include/CesiumGltf/PropertyAttributeView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyAttributeView.h
@@ -316,6 +316,31 @@ public:
 
 private:
   template <typename T, bool Normalized>
+  PropertyAttributePropertyView<T, Normalized> getEmptyPropertyViewWithDefault(
+      const MeshPrimitive& primitive,
+      const ClassProperty& classProperty) const {
+    // To make the view have a nonzero size, find the POSITION attribute and get
+    // its accessor count. If it doesn't exist or is somehow erroneous, just
+    // mark the property as nonexistent.
+    if (primitive.attributes.find("POSITION") == primitive.attributes.end()) {
+      return PropertyAttributePropertyView<T, Normalized>(
+          PropertyAttributePropertyViewStatus::ErrorNonexistentProperty);
+    }
+
+    const Accessor* pAccessor = _pModel->getSafe<Accessor>(
+        &_pModel->accessors,
+        primitive.attributes.at("POSITION"));
+    if (!pAccessor) {
+      return PropertyAttributePropertyView<T, Normalized>(
+          PropertyAttributePropertyViewStatus::ErrorNonexistentProperty);
+    }
+
+    return PropertyAttributePropertyView<T, Normalized>(
+        classProperty,
+        pAccessor->count);
+  }
+
+  template <typename T, bool Normalized>
   PropertyAttributePropertyView<T, Normalized> getPropertyViewImpl(
       const MeshPrimitive& primitive,
       const std::string& propertyName,
@@ -324,6 +349,16 @@ private:
         _pPropertyAttribute->properties.find(propertyName);
     if (propertyAttributePropertyIter ==
         _pPropertyAttribute->properties.end()) {
+      if (!classProperty.required && classProperty.defaultProperty) {
+        // If the property was omitted from the property attribute, it is still
+        // technically valid if it specifies a default value. Try to create a
+        // view that just returns the default value.
+        return getEmptyPropertyViewWithDefault<T, Normalized>(
+            primitive,
+            classProperty);
+      }
+
+      // Otherwise, the property is erroneously nonexistent.
       return PropertyAttributePropertyView<T, Normalized>(
           PropertyAttributePropertyViewStatus::ErrorNonexistentProperty);
     }

--- a/CesiumGltf/include/CesiumGltf/PropertyTableView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTableView.h
@@ -93,10 +93,10 @@ public:
   /**
    * @brief Gets the {@link Class} that this property table conforms to.
    *
-   * @return A pointer to the {@link Class}. Returns nullptr if the PropertyTable did not
-   * specify a valid class.
+   * @return A pointer to the {@link Class}. Returns nullptr if the PropertyTable
+   * did not specify a valid class.
    */
-  const Class* getClass() const;
+  const Class* getClass() const noexcept { return _pClass; }
 
   /**
    * @brief Finds the {@link ClassProperty} that

--- a/CesiumGltf/include/CesiumGltf/PropertyTableView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTableView.h
@@ -1054,6 +1054,16 @@ private:
     auto propertyTablePropertyIter =
         _pPropertyTable->properties.find(propertyName);
     if (propertyTablePropertyIter == _pPropertyTable->properties.end()) {
+      if (!classProperty.required && classProperty.defaultProperty) {
+        // If the property was omitted from the property table, it is still
+        // technically valid if it specifies a default value. Create a view that
+        // just returns the default value.
+        return PropertyTablePropertyView<T, Normalized>(
+            classProperty,
+            _pPropertyTable->count);
+      }
+
+      // Otherwise, the property is erroneously nonexistent.
       return PropertyTablePropertyView<T, Normalized>(
           PropertyTablePropertyViewStatus::ErrorNonexistentProperty);
     }

--- a/CesiumGltf/include/CesiumGltf/PropertyTableView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTableView.h
@@ -91,12 +91,19 @@ public:
   }
 
   /**
+   * @brief Gets the {@link Class} that this property table conforms to.
+   *
+   * @return A pointer to the {@link Class}. Returns nullptr if the PropertyTable did not
+   * specify a valid class.
+   */
+  const Class* getClass() const;
+
+  /**
    * @brief Finds the {@link ClassProperty} that
    * describes the type information of the property with the specified name.
    * @param propertyName The name of the property to retrieve the class for.
-   * @return A pointer to the {@link ClassProperty}.
-   * Return nullptr if the PropertyTableView is invalid or if no class
-   * property was found.
+   * @return A pointer to the {@link ClassProperty}. Returns nullptr if the
+   * PropertyTableView is invalid or if no class property was found.
    */
   const ClassProperty* getClassProperty(const std::string& propertyName) const;
 

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -298,13 +298,12 @@ public:
       const PropertyTextureProperty& property,
       const ClassProperty& classProperty,
       const Sampler& sampler,
-      const ImageCesium& image,
-      const std::vector<int64_t>& channels) noexcept
+      const ImageCesium& image) noexcept
       : PropertyView<ElementType, false>(classProperty, property),
         _pSampler(&sampler),
         _pImage(&image),
         _texCoordSetIndex(property.texCoord),
-        _channels(channels),
+        _channels(property.channels),
         _swizzle() {
     if (this->_status != PropertyTexturePropertyViewStatus::Valid) {
       return;
@@ -519,13 +518,12 @@ public:
       const PropertyTextureProperty& property,
       const ClassProperty& classProperty,
       const Sampler& sampler,
-      const ImageCesium& image,
-      const std::vector<int64_t>& channels) noexcept
+      const ImageCesium& image) noexcept
       : PropertyView<ElementType, true>(classProperty, property),
         _pSampler(&sampler),
         _pImage(&image),
         _texCoordSetIndex(property.texCoord),
-        _channels(channels),
+        _channels(property.channels),
         _swizzle() {
     if (this->_status != PropertyTexturePropertyViewStatus::Valid) {
       return;

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -407,6 +407,15 @@ public:
   }
 
   /**
+   * @brief Get the sampler describing how to sample the data from the
+   * property's texture.
+   *
+   * This will be nullptr if the property texture property view runs into
+   * problems during construction.
+   */
+  const Sampler* getSampler() const noexcept { return this->_pSampler; }
+
+  /**
    * @brief Get the image containing this property's data.
    *
    * This will be nullptr if the property texture property view runs into
@@ -652,6 +661,15 @@ public:
   int64_t getTexCoordSetIndex() const noexcept {
     return this->_texCoordSetIndex;
   }
+
+  /**
+   * @brief Get the sampler describing how to sample the data from the
+   * property's texture.
+   *
+   * This will be nullptr if the property texture property view runs into
+   * problems during construction.
+   */
+  const Sampler* getSampler() const noexcept { return this->_pSampler; }
 
   /**
    * @brief Get the image containing this property's data.

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -27,39 +27,39 @@ public:
    * @brief This property view was initialized from an invalid
    * {@link PropertyTexture}.
    */
-  static const int ErrorInvalidPropertyTexture = 13;
+  static const int ErrorInvalidPropertyTexture = 14;
 
   /**
    * @brief This property view is associated with a {@link ClassProperty} of an
    * unsupported type.
    */
-  static const int ErrorUnsupportedProperty = 14;
+  static const int ErrorUnsupportedProperty = 15;
 
   /**
    * @brief This property view does not have a valid texture index.
    */
-  static const int ErrorInvalidTexture = 15;
+  static const int ErrorInvalidTexture = 16;
 
   /**
    * @brief This property view does not have a valid sampler index.
    */
-  static const int ErrorInvalidSampler = 16;
+  static const int ErrorInvalidSampler = 17;
 
   /**
    * @brief This property view does not have a valid image index.
    */
-  static const int ErrorInvalidImage = 17;
+  static const int ErrorInvalidImage = 18;
 
   /**
    * @brief This property is viewing an empty image.
    */
-  static const int ErrorEmptyImage = 18;
+  static const int ErrorEmptyImage = 19;
 
   /**
    * @brief This property uses an image with multi-byte channels. Only
    * single-byte channels are supported.
    */
-  static const int ErrorInvalidBytesPerChannel = 19;
+  static const int ErrorInvalidBytesPerChannel = 20;
 
   /**
    * @brief The channels of this property texture property are invalid.
@@ -68,7 +68,7 @@ public:
    * more than four channels can be defined for specialized texture
    * formats, this implementation only supports four channels max.
    */
-  static const int ErrorInvalidChannels = 20;
+  static const int ErrorInvalidChannels = 21;
 
   /**
    * @brief The channels of this property texture property do not provide
@@ -76,7 +76,7 @@ public:
    * because an incorrect number of channels was provided, or because the
    * image itself has a different channel count / byte size than expected.
    */
-  static const int ErrorChannelsAndTypeMismatch = 21;
+  static const int ErrorChannelsAndTypeMismatch = 22;
 };
 
 template <typename ElementType>
@@ -257,13 +257,42 @@ public:
   }
 
   /**
+   * @brief Constructs an instance of an empty property that specifies a default
+   * value. Although this property has no data, it can return the default value
+   * when {@link PropertyTexturePropertyView::get} is called. However,
+   * {@link PropertyTexturePropertyView::getRaw} cannot be used.
+   *
+   * @param classProperty The {@link ClassProperty} this property conforms to.
+   */
+  PropertyTexturePropertyView(const ClassProperty& classProperty) noexcept
+      : PropertyView<ElementType, false>(classProperty),
+        _pSampler(nullptr),
+        _pImage(nullptr),
+        _texCoordSetIndex(0),
+        _channels(),
+        _swizzle() {
+    // Don't override the status / size if something is wrong with the class
+    // property's definition.
+    if (this->_status != PropertyTexturePropertyViewStatus::Valid) {
+      return;
+    }
+
+    assert(
+        classProperty.defaultProperty &&
+        "Cannot construct a valid property view for an empty property with no "
+        "default value.");
+
+    this->_status = PropertyTexturePropertyViewStatus::EmptyPropertyWithDefault;
+  }
+
+  /**
    * @brief Construct a view of the data specified by a {@link PropertyTextureProperty}.
    *
    * @param property The {@link PropertyTextureProperty}
    * @param classProperty The {@link ClassProperty} this property conforms to.
    * @param sampler The {@link Sampler} used by the property.
    * @param image The {@link ImageCesium} used by the property.
-   * @param channels The value of {@link PropertyTextureProperty::channels}.
+   * @param channels The code from {@link PropertyTextureProperty::channels}.
    */
   PropertyTexturePropertyView(
       const PropertyTextureProperty& property,
@@ -321,6 +350,11 @@ public:
    * data" value
    */
   std::optional<ElementType> get(double u, double v) const noexcept {
+    if (this->_status ==
+        PropertyTexturePropertyViewStatus::EmptyPropertyWithDefault) {
+      return this->defaultValue();
+    }
+
     ElementType value = getRaw(u, v);
 
     if (value == this->noData()) {
@@ -444,6 +478,35 @@ public:
   }
 
   /**
+   * @brief Constructs an instance of an empty property that specifies a default
+   * value. Although this property has no data, it can return the default value
+   * when {@link PropertyTexturePropertyView::get} is called. However,
+   * {@link PropertyTexturePropertyView::getRaw} cannot be used.
+   *
+   * @param classProperty The {@link ClassProperty} this property conforms to.
+   */
+  PropertyTexturePropertyView(const ClassProperty& classProperty) noexcept
+      : PropertyView<ElementType, true>(classProperty),
+        _pSampler(nullptr),
+        _pImage(nullptr),
+        _texCoordSetIndex(0),
+        _channels(),
+        _swizzle() {
+    // Don't override the status / size if something is wrong with the class
+    // property's definition.
+    if (this->_status != PropertyTexturePropertyViewStatus::Valid) {
+      return;
+    }
+
+    assert(
+        classProperty.defaultProperty &&
+        "Cannot construct a valid property view for an empty property with no "
+        "default value.");
+
+    this->_status = PropertyTexturePropertyViewStatus::EmptyPropertyWithDefault;
+  }
+
+  /**
    * @brief Construct a view of the data specified by a {@link PropertyTextureProperty}.
    *
    * @param property The {@link PropertyTextureProperty}
@@ -508,6 +571,11 @@ public:
    * data" value
    */
   std::optional<NormalizedType> get(double u, double v) const noexcept {
+    if (this->_status ==
+        PropertyTexturePropertyViewStatus::EmptyPropertyWithDefault) {
+      return this->defaultValue();
+    }
+
     ElementType value = getRaw(u, v);
 
     if (value == this->noData()) {

--- a/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
@@ -285,6 +285,13 @@ private:
     auto propertyTexturePropertyIter =
         _pPropertyTexture->properties.find(propertyName);
     if (propertyTexturePropertyIter == _pPropertyTexture->properties.end()) {
+      if (!classProperty.required && classProperty.defaultProperty) {
+        // If the property was omitted from the property texture, it is still
+        // technically valid if it specifies a default value. Create a view that
+        // just returns the default value.
+        return PropertyTexturePropertyView<T, Normalized>(classProperty);
+      }
+
       return PropertyTexturePropertyView<T, Normalized>(
           PropertyTexturePropertyViewStatus::ErrorNonexistentProperty);
     }

--- a/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
@@ -77,6 +77,14 @@ public:
   }
 
   /**
+   * @brief Gets the {@link Class} that this property texture conforms to.
+   *
+   * @return A pointer to the {@link Class}. Returns nullptr if the PropertyTexture
+   * did not specify a valid class.
+   */
+  const Class* getClass() const noexcept { return _pClass; }
+
+  /**
    * @brief Finds the {@link ClassProperty} that
    * describes the type information of the property with the specified name.
    * @param propertyName The name of the property to retrieve the class for.

--- a/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
@@ -709,8 +709,7 @@ private:
         propertyTextureProperty,
         classProperty,
         _pModel->samplers[samplerIndex],
-        image,
-        channels);
+        image);
   }
 
   PropertyViewStatusType getTextureSafe(

--- a/CesiumGltf/include/CesiumGltf/PropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyView.h
@@ -32,70 +32,79 @@ public:
   static const PropertyViewStatusType Valid = 0;
 
   /**
+   * @brief This property view does not contain any data, but specifies a
+   * default value. This happens when a class property is defined with a default
+   * value and omitted from an instance of the class's collective properties. In
+   * this case, it is not possible to retrieve the raw data from a property, but
+   * its default value will be accessible.
+   */
+  static const PropertyViewStatusType EmptyPropertyWithDefault = 1;
+
+  /**
    * @brief This property view is trying to view a property that does not
    * exist.
    */
-  static const PropertyViewStatusType ErrorNonexistentProperty = 1;
+  static const PropertyViewStatusType ErrorNonexistentProperty = 2;
 
   /**
    * @brief This property view's type does not match what is
    * specified in {@link ClassProperty::type}.
    */
-  static const PropertyViewStatusType ErrorTypeMismatch = 2;
+  static const PropertyViewStatusType ErrorTypeMismatch = 3;
 
   /**
    * @brief This property view's component type does not match what
    * is specified in {@link ClassProperty::componentType}.
    */
-  static const PropertyViewStatusType ErrorComponentTypeMismatch = 3;
+  static const PropertyViewStatusType ErrorComponentTypeMismatch = 4;
 
   /**
    * @brief This property view differs from what is specified in
    * {@link ClassProperty::array}.
    */
-  static const PropertyViewStatusType ErrorArrayTypeMismatch = 4;
+  static const PropertyViewStatusType ErrorArrayTypeMismatch = 5;
 
   /**
    * @brief This property says it is normalized, but it does not have an integer
    * component type.
    */
-  static const PropertyViewStatusType ErrorInvalidNormalization = 5;
+  static const PropertyViewStatusType ErrorInvalidNormalization = 6;
 
   /**
    * @brief This property view's normalization differs from what
    * is specified in {@link ClassProperty::normalized}
    */
-  static const PropertyViewStatusType ErrorNormalizationMismatch = 6;
+  static const PropertyViewStatusType ErrorNormalizationMismatch = 7;
 
   /**
    * @brief The property provided an invalid offset value.
    */
-  static const PropertyViewStatusType ErrorInvalidOffset = 7;
+  static const PropertyViewStatusType ErrorInvalidOffset = 8;
 
   /**
    * @brief The property provided an invalid scale value.
    */
-  static const PropertyViewStatusType ErrorInvalidScale = 8;
+  static const PropertyViewStatusType ErrorInvalidScale = 9;
 
   /**
    * @brief The property provided an invalid maximum value.
    */
-  static const PropertyViewStatusType ErrorInvalidMax = 9;
+  static const PropertyViewStatusType ErrorInvalidMax = 10;
 
   /**
    * @brief The property provided an invalid minimum value.
    */
-  static const PropertyViewStatusType ErrorInvalidMin = 10;
+  static const PropertyViewStatusType ErrorInvalidMin = 11;
 
   /**
    * @brief The property provided an invalid "no data" value.
    */
-  static const PropertyViewStatusType ErrorInvalidNoDataValue = 11;
+  static const PropertyViewStatusType ErrorInvalidNoDataValue = 12;
 
   /**
    * @brief The property provided an invalid default value.
    */
-  static const PropertyViewStatusType ErrorInvalidDefaultValue = 12;
+  static const PropertyViewStatusType ErrorInvalidDefaultValue = 13;
 };
 
 template <typename T>

--- a/CesiumGltf/src/PropertyTableView.cpp
+++ b/CesiumGltf/src/PropertyTableView.cpp
@@ -133,6 +133,8 @@ PropertyTableView::PropertyTableView(
   _pClass = &classIter->second;
 }
 
+const Class* PropertyTableView::getClass() const { return _pClass; }
+
 const ClassProperty*
 PropertyTableView::getClassProperty(const std::string& propertyName) const {
   if (_status != PropertyTableViewStatus::Valid) {

--- a/CesiumGltf/src/PropertyTableView.cpp
+++ b/CesiumGltf/src/PropertyTableView.cpp
@@ -133,8 +133,6 @@ PropertyTableView::PropertyTableView(
   _pClass = &classIter->second;
 }
 
-const Class* PropertyTableView::getClass() const { return _pClass; }
-
 const ClassProperty*
 PropertyTableView::getClassProperty(const std::string& propertyName) const {
   if (_status != PropertyTableViewStatus::Valid) {

--- a/CesiumGltf/src/PropertyView.cpp
+++ b/CesiumGltf/src/PropertyView.cpp
@@ -5,6 +5,7 @@ using namespace CesiumGltf;
 // Re-initialize consts here to avoid "undefined reference" errors with GCC /
 // Clang.
 const PropertyViewStatusType PropertyViewStatus::Valid;
+const PropertyViewStatusType PropertyViewStatus::EmptyPropertyWithDefault;
 const PropertyViewStatusType PropertyViewStatus::ErrorNonexistentProperty;
 const PropertyViewStatusType PropertyViewStatus::ErrorTypeMismatch;
 const PropertyViewStatusType PropertyViewStatus::ErrorComponentTypeMismatch;

--- a/CesiumGltf/test/TestPropertyTexturePropertyView.cpp
+++ b/CesiumGltf/test/TestPropertyTexturePropertyView.cpp
@@ -35,13 +35,12 @@ void checkTextureValues(
   imageData.resize(data.size());
   std::memcpy(imageData.data(), data.data(), data.size());
 
-  std::vector<int64_t> channels;
-  for (int32_t i = 0; i < image.channels; i++) {
-    channels.push_back(i);
+  property.channels.resize(static_cast<size_t>(image.channels));
+  for (size_t i = 0; i < property.channels.size(); i++) {
+    property.channels[i] = static_cast<int64_t>(i);
   }
 
-  PropertyTexturePropertyView<T>
-      view(property, classProperty, sampler, image, channels);
+  PropertyTexturePropertyView<T> view(property, classProperty, sampler, image);
   switch (sizeof(T)) {
   case 1:
     CHECK(view.getSwizzle() == "r");
@@ -108,13 +107,12 @@ void checkTextureValues(
   imageData.resize(data.size());
   std::memcpy(imageData.data(), data.data(), data.size());
 
-  std::vector<int64_t> channels;
-  for (int32_t i = 0; i < image.channels; i++) {
-    channels.push_back(i);
+  property.channels.resize(static_cast<size_t>(image.channels));
+  for (size_t i = 0; i < property.channels.size(); i++) {
+    property.channels[i] = static_cast<int64_t>(i);
   }
 
-  PropertyTexturePropertyView<T>
-      view(property, classProperty, sampler, image, channels);
+  PropertyTexturePropertyView<T> view(property, classProperty, sampler, image);
   switch (sizeof(T)) {
   case 1:
     CHECK(view.getSwizzle() == "r");
@@ -183,13 +181,16 @@ void checkNormalizedTextureValues(
   imageData.resize(data.size());
   std::memcpy(imageData.data(), data.data(), data.size());
 
-  std::vector<int64_t> channels;
-  for (int32_t i = 0; i < image.channels; i++) {
-    channels.push_back(i);
+  property.channels.resize(static_cast<size_t>(image.channels));
+  for (size_t i = 0; i < property.channels.size(); i++) {
+    property.channels[i] = static_cast<int64_t>(i);
   }
 
-  PropertyTexturePropertyView<T, true>
-      view(property, classProperty, sampler, image, channels);
+  PropertyTexturePropertyView<T, true> view(
+      property,
+      classProperty,
+      sampler,
+      image);
   switch (sizeof(T)) {
   case 1:
     CHECK(view.getSwizzle() == "r");
@@ -251,13 +252,16 @@ void checkTextureArrayValues(
   imageData.resize(data.size());
   std::memcpy(imageData.data(), data.data(), data.size());
 
-  std::vector<int64_t> channels;
-  for (int32_t i = 0; i < image.channels; i++) {
-    channels.push_back(i);
+  property.channels.resize(static_cast<size_t>(image.channels));
+  for (size_t i = 0; i < property.channels.size(); i++) {
+    property.channels[i] = static_cast<int64_t>(i);
   }
 
-  PropertyTexturePropertyView<PropertyArrayView<T>>
-      view(property, classProperty, sampler, image, channels);
+  PropertyTexturePropertyView<PropertyArrayView<T>> view(
+      property,
+      classProperty,
+      sampler,
+      image);
   switch (image.channels) {
   case 1:
     CHECK(view.getSwizzle() == "r");
@@ -334,13 +338,16 @@ void checkTextureArrayValues(
   imageData.resize(data.size());
   std::memcpy(imageData.data(), data.data(), data.size());
 
-  std::vector<int64_t> channels;
-  for (int32_t i = 0; i < image.channels; i++) {
-    channels.push_back(i);
+  property.channels.resize(static_cast<size_t>(image.channels));
+  for (size_t i = 0; i < property.channels.size(); i++) {
+    property.channels[i] = static_cast<int64_t>(i);
   }
 
-  PropertyTexturePropertyView<PropertyArrayView<T>>
-      view(property, classProperty, sampler, image, channels);
+  PropertyTexturePropertyView<PropertyArrayView<T>> view(
+      property,
+      classProperty,
+      sampler,
+      image);
   switch (count) {
   case 1:
     CHECK(view.getSwizzle() == "r");
@@ -431,13 +438,16 @@ void checkNormalizedTextureArrayValues(
   imageData.resize(data.size());
   std::memcpy(imageData.data(), data.data(), data.size());
 
-  std::vector<int64_t> channels;
-  for (int32_t i = 0; i < image.channels; i++) {
-    channels.push_back(i);
+  property.channels.resize(static_cast<size_t>(image.channels));
+  for (size_t i = 0; i < property.channels.size(); i++) {
+    property.channels[i] = static_cast<int64_t>(i);
   }
 
-  PropertyTexturePropertyView<PropertyArrayView<T>, true>
-      view(property, classProperty, sampler, image, channels);
+  PropertyTexturePropertyView<PropertyArrayView<T>, true> view(
+      property,
+      classProperty,
+      sampler,
+      image);
   switch (image.channels) {
   case 1:
     CHECK(view.getSwizzle() == "r");
@@ -1414,16 +1424,18 @@ TEST_CASE("Check that PropertyTextureProperty values override class property "
   imageData.resize(data.size());
   std::memcpy(imageData.data(), data.data(), data.size());
 
-  std::vector<int64_t> channels{0, 1, 2, 3};
-
   PropertyTextureProperty property;
   property.offset = offset;
   property.scale = scale;
   property.min = std::numeric_limits<float>::lowest();
   property.max = std::numeric_limits<float>::max();
+  property.channels = {0, 1, 2, 3};
 
-  PropertyTexturePropertyView<float>
-      view(property, classProperty, sampler, image, channels);
+  PropertyTexturePropertyView<float> view(
+      property,
+      classProperty,
+      sampler,
+      image);
   CHECK(view.getSwizzle() == "rgba");
 
   REQUIRE(view.offset() == offset);
@@ -1453,6 +1465,8 @@ TEST_CASE("Check that non-adjacent channels resolve to expected output") {
 
   SECTION("single-byte scalar") {
     PropertyTextureProperty property;
+    property.channels = {3};
+
     ClassProperty classProperty;
     classProperty.type = ClassProperty::Type::SCALAR;
     classProperty.componentType = ClassProperty::ComponentType::UINT8;
@@ -1476,10 +1490,11 @@ TEST_CASE("Check that non-adjacent channels resolve to expected output") {
     imageData.resize(data.size());
     std::memcpy(imageData.data(), data.data(), data.size());
 
-    std::vector<int64_t> channels{3};
-
-    PropertyTexturePropertyView<uint8_t>
-        view(property, classProperty, sampler, image, channels);
+    PropertyTexturePropertyView<uint8_t> view(
+        property,
+        classProperty,
+        sampler,
+        image);
     CHECK(view.getSwizzle() == "a");
 
     std::vector<uint8_t> expected{3, 4, 0, 1};
@@ -1492,6 +1507,8 @@ TEST_CASE("Check that non-adjacent channels resolve to expected output") {
 
   SECTION("multi-byte scalar") {
     PropertyTextureProperty property;
+    property.channels = {2, 0};
+
     ClassProperty classProperty;
     classProperty.type = ClassProperty::Type::SCALAR;
     classProperty.componentType = ClassProperty::ComponentType::UINT16;
@@ -1514,10 +1531,11 @@ TEST_CASE("Check that non-adjacent channels resolve to expected output") {
     imageData.resize(data.size());
     std::memcpy(imageData.data(), data.data(), data.size());
 
-    std::vector<int64_t> channels{2, 0};
-
-    PropertyTexturePropertyView<uint16_t>
-        view(property, classProperty, sampler, image, channels);
+    PropertyTexturePropertyView<uint16_t> view(
+        property,
+        classProperty,
+        sampler,
+        image);
     CHECK(view.getSwizzle() == "br");
 
     std::vector<uint16_t> expected{2, 259, 257, 520};
@@ -1530,6 +1548,8 @@ TEST_CASE("Check that non-adjacent channels resolve to expected output") {
 
   SECTION("vecN") {
     PropertyTextureProperty property;
+    property.channels = {3, 2, 1};
+
     ClassProperty classProperty;
     classProperty.type = ClassProperty::Type::VEC3;
     classProperty.componentType = ClassProperty::ComponentType::UINT8;
@@ -1552,10 +1572,11 @@ TEST_CASE("Check that non-adjacent channels resolve to expected output") {
     imageData.resize(data.size());
     std::memcpy(imageData.data(), data.data(), data.size());
 
-    std::vector<int64_t> channels{3, 2, 1};
-
-    PropertyTexturePropertyView<glm::u8vec3>
-        view(property, classProperty, sampler, image, channels);
+    PropertyTexturePropertyView<glm::u8vec3> view(
+        property,
+        classProperty,
+        sampler,
+        image);
     CHECK(view.getSwizzle() == "abg");
 
     std::vector<glm::u8vec3> expected{
@@ -1572,6 +1593,8 @@ TEST_CASE("Check that non-adjacent channels resolve to expected output") {
 
   SECTION("array") {
     PropertyTextureProperty property;
+    property.channels = {1, 0, 3, 2};
+
     ClassProperty classProperty;
     classProperty.type = ClassProperty::Type::SCALAR;
     classProperty.componentType = ClassProperty::ComponentType::UINT8;
@@ -1596,10 +1619,11 @@ TEST_CASE("Check that non-adjacent channels resolve to expected output") {
     imageData.resize(data.size());
     std::memcpy(imageData.data(), data.data(), data.size());
 
-    std::vector<int64_t> channels{1, 0, 3, 2};
-
-    PropertyTexturePropertyView<PropertyArrayView<uint8_t>>
-        view(property, classProperty, sampler, image, channels);
+    PropertyTexturePropertyView<PropertyArrayView<uint8_t>> view(
+        property,
+        classProperty,
+        sampler,
+        image);
     CHECK(view.getSwizzle() == "grab");
 
     std::vector<std::vector<uint8_t>> expected{
@@ -1628,6 +1652,8 @@ TEST_CASE("Check that non-adjacent channels resolve to expected output") {
 
 TEST_CASE("Check sampling with different sampler values") {
   PropertyTextureProperty property;
+  property.channels = {0};
+
   ClassProperty classProperty;
   classProperty.type = ClassProperty::Type::SCALAR;
   classProperty.componentType = ClassProperty::ComponentType::UINT8;
@@ -1643,15 +1669,16 @@ TEST_CASE("Check sampling with different sampler values") {
   imageData.resize(data.size());
   std::memcpy(imageData.data(), data.data(), data.size());
 
-  std::vector<int64_t> channels{0};
-
   SECTION("REPEAT") {
     Sampler sampler;
     sampler.wrapS = Sampler::WrapS::REPEAT;
     sampler.wrapT = Sampler::WrapT::REPEAT;
 
-    PropertyTexturePropertyView<uint8_t>
-        view(property, classProperty, sampler, image, channels);
+    PropertyTexturePropertyView<uint8_t> view(
+        property,
+        classProperty,
+        sampler,
+        image);
     CHECK(view.getSwizzle() == "r");
 
     std::vector<glm::dvec2> uvs{
@@ -1674,8 +1701,11 @@ TEST_CASE("Check sampling with different sampler values") {
     // MIRRORED: | 1 2 3 | 3 2 1 |
     // Sampling 0.6 is equal to sampling 1.4 or -0.6.
 
-    PropertyTexturePropertyView<uint8_t>
-        view(property, classProperty, sampler, image, channels);
+    PropertyTexturePropertyView<uint8_t> view(
+        property,
+        classProperty,
+        sampler,
+        image);
     CHECK(view.getSwizzle() == "r");
 
     std::vector<glm::dvec2> uvs{
@@ -1695,8 +1725,11 @@ TEST_CASE("Check sampling with different sampler values") {
     sampler.wrapS = Sampler::WrapS::CLAMP_TO_EDGE;
     sampler.wrapT = Sampler::WrapT::CLAMP_TO_EDGE;
 
-    PropertyTexturePropertyView<uint8_t>
-        view(property, classProperty, sampler, image, channels);
+    PropertyTexturePropertyView<uint8_t> view(
+        property,
+        classProperty,
+        sampler,
+        image);
     CHECK(view.getSwizzle() == "r");
 
     std::vector<glm::dvec2> uvs{
@@ -1716,8 +1749,11 @@ TEST_CASE("Check sampling with different sampler values") {
     sampler.wrapS = Sampler::WrapS::REPEAT;
     sampler.wrapT = Sampler::WrapT::CLAMP_TO_EDGE;
 
-    PropertyTexturePropertyView<uint8_t>
-        view(property, classProperty, sampler, image, channels);
+    PropertyTexturePropertyView<uint8_t> view(
+        property,
+        classProperty,
+        sampler,
+        image);
     CHECK(view.getSwizzle() == "r");
 
     std::vector<glm::dvec2> uvs{


### PR DESCRIPTION
This PR adds support for properties that are omitted from a property table / texture / attribute instance. This is allowed by the spec so long as the `ClassProperty` is not `required`. A special case happens if an omitted `ClassProperty` defines a default value; ideally, this value should be used by for metadata picking / styling in our runtime engines. However, in the current implementation it creates `ErrorNonexistentProperty` instances for these omitted properties. Technically, this is not wrong, but it may be confusing when trying to convey what data is actually available to users. 

My initial approach was to restrict the `forEachProperty` functions in `PropertyTable`, `PropertyTexture` and `PropertyAttribute`. They would only handle properties that were actually defined in the instance, and ignore anything else in the metadata `Class`. It would be up to the runtime engine to cross-reference this with the `Class` definition using the `getClass` functions. This also implied that `Class` and `ClassProperty` should be made accessible to users in the runtime engines, since they'd need the `Class` definition to know if properties were omitted. It would also reduce the need for `forEachProperty`, since we'd prefer to iterate over all of the `ClassProperty`s instead.

I thought about this some more today, and realized the approach would put more work on the runtime implementations than necessary. Fundamentally, `PropertyTable`, `PropertyTexture`, and `PropertyAttribute` are just ways of implementing a metadata `Class` with a certain data storage. The views we create on their properties already consolidate the `ClassProperty` information with the `PropertyView`s. So I think it is fitting to fold in the omitted property definitions into the `PropertyTableView`, etc. classes. Because even if they omit properties that are included in the `Class`, there should still be some way to quickly indicate that the property has data.

That's my thinking, anyways. Feel free to push back on it if the design is questionable. If we want, we still can expose `Class` and `ClassProperty` to users in the runtime engines, but at least this doesn't mandate it. You can still get the full picture of a metadata entity even if it has omitted properties. Ultimately, there is a distinction between a property that *should* be found but wasn't, and a property that is okay to omit.