### PR TITLE
Fix `EmptyPropertyWithDefault` constructors

### DIFF
--- a/CesiumGltf/include/CesiumGltf/PropertyAttributePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyAttributePropertyView.h
@@ -150,16 +150,20 @@ public:
       const ClassProperty& classProperty,
       int64_t size) noexcept
       : PropertyView<ElementType, false>(classProperty), _accessor{}, _size{0} {
-    // Don't override the status / size if something is wrong with the class
-    // property's definition.
     if (this->_status != PropertyAttributePropertyViewStatus::Valid) {
+      // Don't override the status / size if something is wrong with the class
+      // property's definition.
       return;
     }
 
-    assert(
-        classProperty.defaultProperty &&
-        "Cannot construct a valid property view for an empty property with no "
-        "default value.");
+    if (!classProperty.defaultProperty) {
+      // This constructor should only be called if the class property *has* a
+      // default value. But in the case that it does not, this property view
+      // becomes invalid.
+      this->_status =
+          PropertyAttributePropertyViewStatus::ErrorNonexistentProperty;
+      return;
+    }
 
     this->_status =
         PropertyAttributePropertyViewStatus::EmptyPropertyWithDefault;
@@ -302,16 +306,20 @@ public:
       const ClassProperty& classProperty,
       int64_t size) noexcept
       : PropertyView<ElementType, true>(classProperty), _accessor{}, _size{0} {
-    // Don't override the status / size if something is wrong with the class
-    // property's definition.
     if (this->_status != PropertyAttributePropertyViewStatus::Valid) {
+      // Don't override the status / size if something is wrong with the class
+      // property's definition.
       return;
     }
 
-    assert(
-        classProperty.defaultProperty &&
-        "Cannot construct a valid property view for an empty property with no "
-        "default value.");
+    if (!classProperty.defaultProperty) {
+      // This constructor should only be called if the class property *has* a
+      // default value. But in the case that it does not, this property view
+      // becomes invalid.
+      this->_status =
+          PropertyAttributePropertyViewStatus::ErrorNonexistentProperty;
+      return;
+    }
 
     this->_status =
         PropertyAttributePropertyViewStatus::EmptyPropertyWithDefault;

--- a/CesiumGltf/include/CesiumGltf/PropertyTablePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTablePropertyView.h
@@ -213,16 +213,19 @@ public:
         _stringOffsets{},
         _stringOffsetType{PropertyComponentType::None},
         _stringOffsetTypeSize{0} {
-    // Don't override the status / size if something is wrong with the class
-    // property's definition.
     if (this->_status != PropertyTablePropertyViewStatus::Valid) {
+      // Don't override the status / size if something is wrong with the class
+      // property's definition.
       return;
     }
 
-    assert(
-        classProperty.defaultProperty &&
-        "Cannot construct a valid property view for an empty property with no "
-        "default value.");
+    if (!classProperty.defaultProperty) {
+      // This constructor should only be called if the class property *has* a
+      // default value. But in the case that it does not, this property view
+      // becomes invalid.
+      this->_status = PropertyTablePropertyViewStatus::ErrorNonexistentProperty;
+      return;
+    }
 
     this->_status = PropertyTablePropertyViewStatus::EmptyPropertyWithDefault;
     this->_size = size;
@@ -562,16 +565,19 @@ public:
         _arrayOffsets{},
         _arrayOffsetType{PropertyComponentType::None},
         _arrayOffsetTypeSize{0} {
-    // Don't override the status / size if something is wrong with the class
-    // property's definition.
     if (this->_status != PropertyTablePropertyViewStatus::Valid) {
+      // Don't override the status / size if something is wrong with the class
+      // property's definition.
       return;
     }
 
-    assert(
-        classProperty.defaultProperty &&
-        "Cannot construct a valid property view for an empty property with no "
-        "default value.");
+    if (!classProperty.defaultProperty) {
+      // This constructor should only be called if the class property *has* a
+      // default value. But in the case that it does not, this property view
+      // becomes invalid.
+      this->_status = PropertyTablePropertyViewStatus::ErrorNonexistentProperty;
+      return;
+    }
 
     this->_status = PropertyTablePropertyViewStatus::EmptyPropertyWithDefault;
     this->_size = size;

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -271,16 +271,20 @@ public:
         _texCoordSetIndex(0),
         _channels(),
         _swizzle() {
-    // Don't override the status / size if something is wrong with the class
-    // property's definition.
     if (this->_status != PropertyTexturePropertyViewStatus::Valid) {
+      // Don't override the status / size if something is wrong with the class
+      // property's definition.
       return;
     }
 
-    assert(
-        classProperty.defaultProperty &&
-        "Cannot construct a valid property view for an empty property with no "
-        "default value.");
+    if (!classProperty.defaultProperty) {
+      // This constructor should only be called if the class property *has* a
+      // default value. But in the case that it does not, this property view
+      // becomes invalid.
+      this->_status =
+          PropertyTexturePropertyViewStatus::ErrorNonexistentProperty;
+      return;
+    }
 
     this->_status = PropertyTexturePropertyViewStatus::EmptyPropertyWithDefault;
   }
@@ -500,16 +504,20 @@ public:
         _texCoordSetIndex(0),
         _channels(),
         _swizzle() {
-    // Don't override the status / size if something is wrong with the class
-    // property's definition.
     if (this->_status != PropertyTexturePropertyViewStatus::Valid) {
+      // Don't override the status / size if something is wrong with the class
+      // property's definition.
       return;
     }
 
-    assert(
-        classProperty.defaultProperty &&
-        "Cannot construct a valid property view for an empty property with no "
-        "default value.");
+    if (!classProperty.defaultProperty) {
+      // This constructor should only be called if the class property *has* a
+      // default value. But in the case that it does not, this property view
+      // becomes invalid.
+      this->_status =
+          PropertyTexturePropertyViewStatus::ErrorNonexistentProperty;
+      return;
+    }
 
     this->_status = PropertyTexturePropertyViewStatus::EmptyPropertyWithDefault;
   }


### PR DESCRIPTION
Followup to #726. This addresses @kring 's suggestion for improving the `EmptyPropertyWithDefault` constructor. Now when the constructor is called and `classProperty.defaultProperty` is not defined, the property view status is set to `ErrorNonexistentProperty`.