### PR TITLE
Remove hardcoded size logic

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
@@ -163,6 +163,20 @@ public:
   void setRenderResources(void* pRenderResources) noexcept;
 
   /**
+   * @brief Set the byte size of the render content
+   *
+   * @param byteSize The size of the render content
+   */
+  void setByteSize(int64_t byteSize) noexcept;
+
+  /**
+   * @brief Get the size in bytes of the render content
+   *
+   * @return The render content's size in bytes
+   */
+  int64_t getByteSize() const noexcept;
+
+  /**
    * @brief Get the fade percentage that this tile during an LOD transition.
    *
    * This will be used when {@link TilesetOptions::enableLodTransitionPeriod}
@@ -188,6 +202,7 @@ private:
   RasterOverlayDetails _rasterOverlayDetails;
   std::vector<Credit> _credits;
   float _lodTransitionFadePercentage;
+  int64_t _byteSize;
 };
 
 /**

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -152,31 +152,11 @@ double Tile::getNonZeroGeometricError() const noexcept {
 
 int64_t Tile::computeByteSize() const noexcept {
   int64_t bytes = 0;
-
   const TileContent& content = this->getContent();
   const TileRenderContent* pRenderContent = content.getRenderContent();
   if (pRenderContent) {
-    const CesiumGltf::Model& model = pRenderContent->getModel();
-
-    // Add up the glTF buffers
-    for (const CesiumGltf::Buffer& buffer : model.buffers) {
-      bytes += int64_t(buffer.cesium.data.size());
-    }
-
-    const std::vector<CesiumGltf::BufferView>& bufferViews = model.bufferViews;
-    for (const CesiumGltf::Image& image : model.images) {
-      const int32_t bufferView = image.bufferView;
-      // For images loaded from buffers, subtract the buffer size before adding
-      // the decoded image size.
-      if (bufferView >= 0 &&
-          bufferView < static_cast<int32_t>(bufferViews.size())) {
-        bytes -= bufferViews[size_t(bufferView)].byteLength;
-      }
-
-      bytes += int64_t(image.cesium.pixelData.size());
-    }
+    bytes = pRenderContent->getByteSize();
   }
-
   return bytes;
 }
 

--- a/Cesium3DTilesSelection/src/TileContent.cpp
+++ b/Cesium3DTilesSelection/src/TileContent.cpp
@@ -6,6 +6,7 @@ TileRenderContent::TileRenderContent(CesiumGltf::Model&& model)
       _pRenderResources{nullptr},
       _rasterOverlayDetails{},
       _credits{},
+      _byteSize(0),
       _lodTransitionFadePercentage{0.0f} {}
 
 const CesiumGltf::Model& TileRenderContent::getModel() const noexcept {
@@ -64,6 +65,12 @@ void* TileRenderContent::getRenderResources() const noexcept {
 void TileRenderContent::setRenderResources(void* pRenderResources) noexcept {
   this->_pRenderResources = pRenderResources;
 }
+
+void TileRenderContent::setByteSize(int64_t byteSize) noexcept {
+  this->_byteSize = byteSize;
+}
+
+int64_t TileRenderContent::getByteSize() const noexcept { return _byteSize; }
 
 float TileRenderContent::getLodTransitionFadePercentage() const noexcept {
   return _lodTransitionFadePercentage;

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -1272,6 +1272,7 @@ void TilesetContentManager::finishLoading(
           pWorkerRenderResources);
 
   pRenderContent->setRenderResources(pMainThreadRenderResources);
+  this->_tilesDataUsed += pRenderContent->getByteSize();
   tile.setState(TileLoadState::Done);
 
   // This allows the raster tile to be updated and children to be created, if
@@ -1419,10 +1420,6 @@ void TilesetContentManager::notifyTileDoneLoading(const Tile* pTile) noexcept {
       "There are no tile loads currently in flight");
   --this->_tilesLoadOnProgress;
   ++this->_loadedTilesCount;
-
-  if (pTile) {
-    this->_tilesDataUsed += pTile->computeByteSize();
-  }
 }
 
 void TilesetContentManager::notifyTileUnloading(const Tile* pTile) noexcept {


### PR DESCRIPTION
Right now the size of each tile is hardcoded to the size of the gltf model. Specifically in Unity but probably Unreal too there is no real reason to keep the gltf model in memory after the IPrepareRendererResources runs and you have created your game engine-specific resources. Our devices have very little working memory so it is imperative we free the gltf model immediately after using it to create the Unity meshes and textures.
I wanted to present the proposed changes as a pr but this is actually a bigger change than I thought and would love to discuss different solutions.
Right now I'm working with the idea that TileRenderContent now has a byteSize that can be set by the end user inside the IPrepareRenderResources. This can still be set to the gltf model like before or something else, this allows more flexibility as I can set it to a calculated value I get from my Unity resources as well as the size of  RenderResources, in my case a collision mesh for each tile. 
This works well except the notifyTileDoneLoading() which increments the TilesetContentManager _tilesDataUsed after the prepareInLoadThread but before the prepareInMainThread which is a problem as the final true size of the tile may not be known until after prepareInMainThread.

I attached an example of how I'm using setByteSize at the end of my prepareInMainThread
![example](https://github.com/CesiumGS/cesium-native/assets/13579475/953a985a-1489-4fd1-b7bb-d2ca277843b3)
