### PR TITLE
Add support for Cesium ion "externalType" assets.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v0.27.x - ?
+
+##### Additions :tada:
+
+- Added support for Cesium ion `"externalType"` assets.
+
 ### v0.27.2 - 2023-09-20
 
 ##### Additions :tada:

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
@@ -272,18 +272,33 @@ mainThreadHandleEndpointResponse(
     }
   }
 
+  std::string type =
+      CesiumUtility::JsonHelpers::getStringOrDefault(ionResponse, "type", "");
   std::string url =
       CesiumUtility::JsonHelpers::getStringOrDefault(ionResponse, "url", "");
   std::string accessToken = CesiumUtility::JsonHelpers::getStringOrDefault(
       ionResponse,
       "accessToken",
       "");
+  std::string externalType = CesiumUtility::JsonHelpers::getStringOrDefault(
+      ionResponse,
+      "externalType",
+      "");
+  const auto optionsIt = ionResponse.FindMember("options");
 
-  std::string type =
-      CesiumUtility::JsonHelpers::getStringOrDefault(ionResponse, "type", "");
+  if (!externalType.empty()) {
+    type = externalType;
+    if (optionsIt != ionResponse.MemberEnd()) {
+      url = CesiumUtility::JsonHelpers::getStringOrDefault(
+          optionsIt->value,
+          "url",
+          url);
+    }
+  }
+
   if (type == "TERRAIN") {
-    // For terrain resources, we need to append `/layer.json` to the end of the
-    // URL.
+    // For terrain resources, we need to append `/layer.json` to the end of
+    // the URL.
     url = CesiumUtility::Uri::resolve(url, "layer.json", true);
     endpoint.type = type;
     endpoint.url = url;

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
@@ -284,11 +284,11 @@ mainThreadHandleEndpointResponse(
       ionResponse,
       "externalType",
       "");
-  const auto optionsIt = ionResponse.FindMember("options");
 
   if (!externalType.empty()) {
     type = externalType;
-    if (optionsIt != ionResponse.MemberEnd()) {
+    const auto optionsIt = ionResponse.FindMember("options");
+    if (optionsIt != ionResponse.MemberEnd() && optionsIt->value.IsObject()) {
       url = CesiumUtility::JsonHelpers::getStringOrDefault(
           optionsIt->value,
           "url",


### PR DESCRIPTION
This is a PR into the v0.27.x branch so that we can ship it in the next Cesium for Unreal v1.x release. v0.28 and main have the new metadata architecture that are targeted for v2.0.