### PR TITLE
Fix Tileset::ComputeLoadProgress incorrectly reporting done, under some conditions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,8 @@
 ##### Fixes :wrench:
 
 - Fixed the handling of omitted metadata properties in `PropertyTableView`, `PropertyTextureView`, and `PropertyAttributeView` instances. Previously, if a property was not `required` and omitted, it would be initialized as invalid with the `ErrorNonexistentProperty` status. Now, it will be treated as valid as long as the property defines a valid `defaultProperty`. A special instance of `PropertyTablePropertyView`, `PropertyTexturePropertyView`, or `PropertyAttributePropertyView` will be constructed to allow the property's default value to be retrieved, either via `defaultValue` or `get`. `getRaw` may not be called on this special instance.
-
+- Fixed corner cases where `Tileset::ComputeLoadProgress` can report done (100%) in error, before all work is actually complete in the current view
+  
 ### v0.28.0 - 2023-09-08
 
 ##### Breaking Changes :mega:

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ViewUpdateResult.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ViewUpdateResult.h
@@ -55,6 +55,7 @@ public:
   uint32_t tilesCulled = 0;
   uint32_t tilesOccluded = 0;
   uint32_t tilesWaitingForOcclusionResults = 0;
+  uint32_t tilesKicked = 0;
   uint32_t maxDepthVisited = 0;
   //! @endcond
 


### PR DESCRIPTION
Addresses cases where `::ComputeLoadProgress` would report 100% done prematurely, before all work in the view had completed. 

(I noticed this in cesium-unreal performance tests, with Google 3D Tiles)

With certain tilesets and our "kicking' logic (`::_kickDescendantsAndRenderTile`), we can run into frames where all work has been kicked out of the main / worker threads, but no new work has been added yet. This could lead to a 100% value being returned, in error.

The fix is to consider frames that kicked tiles as not complete yet. This gives us at least one more view traversal to find remaining work.