### PR TITLE
Tweak compute load progress

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 - Added a missing include to `FeatureTexturePropertyView.h`.
 - The CMake scripts no longer attempt to add the `Catch2` subdirectory when the tests are disabled.
+- Fixed corner cases where `Tileset::ComputeLoadProgress` can report done (100%) in error, before all work is actually complete in the current view
 
 ### v0.27.1 - 2023-09-03
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ViewUpdateResult.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ViewUpdateResult.h
@@ -55,6 +55,7 @@ public:
   uint32_t tilesCulled = 0;
   uint32_t tilesOccluded = 0;
   uint32_t tilesWaitingForOcclusionResults = 0;
+  uint32_t tilesKicked = 0;
   uint32_t maxDepthVisited = 0;
   //! @endcond
 


### PR DESCRIPTION
Addresses cases where `::ComputeLoadProgress` would report 100% done prematurely, before all work in the view had completed. 

(I noticed this in cesium-unreal performance tests, with Google 3D Tiles)

With certain tilesets and our "kicking' logic (`::_kickDescendantsAndRenderTile`), we can run into frames where all work has been kicked out of the main / worker threads, but no new work has been added yet. This could lead to a 100% value being returned, in error.

The fix is to consider frames that kicked tiles as not complete yet. This gives us at least one more view traversal to find remaining work.