### PR TITLE
Updated ion authorization url to the current url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ CMakeSettings.json
 *.DS_Store
 test.db
 build-wsl
+.idea

--- a/CesiumIonClient/include/CesiumIonClient/Connection.h
+++ b/CesiumIonClient/include/CesiumIonClient/Connection.h
@@ -103,7 +103,7 @@ public:
       const std::vector<std::string>& scopes,
       std::function<void(const std::string&)>&& openUrlCallback,
       const std::string& ionApiUrl = "https://api.cesium.com/",
-      const std::string& ionAuthorizeUrl = "https://cesium.com/ion/oauth");
+      const std::string& ionAuthorizeUrl = "https://ion.cesium.com/oauth");
 
   /**
    * @brief Creates a connection to Cesium ion using the provided access token.


### PR DESCRIPTION
I noticed that the authorization URL used in cesium-native is an old one that's doing a redirect last week. I checked with @mramato and confirmed that we should be using `https://ion.cesium.com/oauth`. This is just a PR to make this update.

P.S. I also added `.idea` to the `.gitignore` to prevent git from trying to scoop up the Clion prefs on my machine.