### PR TITLE
Install uriparser includes to the right location.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ endif()
 add_subdirectory(doc)
 
 # Installation of third-party libraries required to use cesium-native
-install(TARGETS uriparser OPTIONAL) # Skips headers
+install(TARGETS uriparser OPTIONAL PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/uriparser")
 
 install(DIRECTORY extern/glm/glm
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -34,7 +34,7 @@ add_subdirectory(libwebp)
 
 option(URIPARSER_BUILD_TESTS "" off)
 option(URIPARSER_BUILD_DOCS "" off)
-option(URIPARSER_ENABLE_INSTALL "" on)
+option(URIPARSER_ENABLE_INSTALL "" off)
 option(URIPARSER_BUILD_TOOLS "" off)
 add_subdirectory(uriparser)
 


### PR DESCRIPTION
In cesium-unreal, the uriparser header files were being installed to `Source/ThirdParty/include` instead of `Source/ThirdParty/include/uriparser`. This PR fixes that.