### PR TITLE
Improve support for reading implicit tiling subtrees, and manipulating them after they're loaded

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 - Moved `GltfUtilities` from `Cesium3DTilesSelection` to `Cesium3DTilesContent`.
 - Moved `createRasterOverlayTextureCoordinates` method from `GltfUtilities` to a new `RasterOverlayUtilities` class in the `Cesium3DTilesSelection` library.
 - `GltfUtilities::parseGltfCopyright` now returns the credits as a vector of string_views. Previously it took a `CreditSystem` and created credits directly.
+- The `SubtreeAvailability` constructor and `loadSubtree` static method now take an `ImplicitTileSubdivisionScheme` enumeration parameter instead of a `powerOf2` parameter. They also now require a `levelsInSubtree` parameter, which is needed when switching from constant to bitstream availability. Lastly, the constructor now takes a `Subtree` parameter instead of a `std::vector<std::vector<std::byte>>` representing the buffers.
+- `SubtreeConstantAvailability`, `SubtreeBufferViewAvailability`, and `AvailabilityView` are now members of `SubtreeAvailability`.
 
 ##### Additions :tada:
 
@@ -17,7 +19,10 @@
 - Added `toSphere`, `fromSphere`, and `fromAxisAligned` methods to `CesiumGeometry::OrientedBoundingBox`.
 - Added `TileTransform` class to `Cesium3DTilesContent`, making it easier to create a `glm::dmat4` from the `transform` property of a `Cesium3DTiles::Tile`.
 - Added `ImplicitTilingUtilities` class to `Cesium3DTilesContent`.
-- Added overloads of `isTileAvailable` and `isContentAvailable` on the `SubtreeAvailability` class that take the subtree root tile ID and the tile ID of interest, instead of a relative level and Morton index.
+- Added overloads of `isTileAvailable`, `isContentAvailable`, and `isSubtreeAvailable` on the `SubtreeAvailability` class that take the subtree root tile ID and the tile ID of interest, instead of a relative level and Morton index.
+- Added `fromSubtree` and `createEmpty` static methods to `SubtreeAvailability`.
+- Added new `set` methods to `SubtreeAvailability`, allowing the availability information to be modified.
+- Added `SubtreeFileReader` class, used to read `Cesium3DTiles::Subtree` from a binary or JSON subtree file.
 
 ##### Fixes :wrench:
 

--- a/Cesium3DTiles/generated/include/Cesium3DTiles/BufferSpec.h
+++ b/Cesium3DTiles/generated/include/Cesium3DTiles/BufferSpec.h
@@ -15,7 +15,7 @@ namespace Cesium3DTiles {
  * @brief A buffer is a binary blob. It is either the binary chunk of the
  * subtree file, or an external buffer referenced by a URI.
  */
-struct CESIUM3DTILES_API Buffer final : public CesiumUtility::ExtensibleObject {
+struct CESIUM3DTILES_API BufferSpec : public CesiumUtility::ExtensibleObject {
   static inline constexpr const char* TypeName = "Buffer";
 
   /**
@@ -36,5 +36,12 @@ struct CESIUM3DTILES_API Buffer final : public CesiumUtility::ExtensibleObject {
    * @brief The name of the buffer.
    */
   std::optional<std::string> name;
+
+private:
+  /**
+   * @brief This class is not meant to be instantiated directly. Use {@link Buffer} instead.
+   */
+  BufferSpec() = default;
+  friend struct Buffer;
 };
 } // namespace Cesium3DTiles

--- a/Cesium3DTiles/generated/include/Cesium3DTiles/Properties.h
+++ b/Cesium3DTiles/generated/include/Cesium3DTiles/Properties.h
@@ -16,13 +16,13 @@ struct CESIUM3DTILES_API Properties final
 
   /**
    * @brief The maximum value of this property of all the features in the
-   * tileset. The maximum value shall not be larger than the minimum value.
+   * tileset. The maximum value shall not be smaller than the minimum value.
    */
   double maximum = double();
 
   /**
    * @brief The minimum value of this property of all the features in the
-   * tileset. The maximum value shall not be larger than the minimum value.
+   * tileset. The maximum value shall not be smaller than the minimum value.
    */
   double minimum = double();
 };

--- a/Cesium3DTiles/generated/include/Cesium3DTiles/Tile.h
+++ b/Cesium3DTiles/generated/include/Cesium3DTiles/Tile.h
@@ -104,7 +104,7 @@ struct CESIUM3DTILES_API Tile final : public CesiumUtility::ExtensibleObject {
    * @brief An array of objects that define child tiles. Each child tile content
    * is fully enclosed by its parent tile's bounding volume and, generally, has
    * a geometricError less than its parent tile's geometricError. For leaf
-   * tiles, the length of this array is zero, and children may not be defined.
+   * tiles, there are no children, and this property may not be defined.
    */
   std::vector<Cesium3DTiles::Tile> children;
 };

--- a/Cesium3DTiles/include/Cesium3DTiles/Buffer.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/Buffer.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "Cesium3DTiles/BufferCesium.h"
+#include "Cesium3DTiles/BufferSpec.h"
+#include "Cesium3DTiles/Library.h"
+
+namespace Cesium3DTiles {
+/** @copydoc BufferSpec */
+struct CESIUM3DTILES_API Buffer final : public BufferSpec {
+  /**
+   * @brief Holds properties that are specific to the 3D Tiles loader rather
+   * than part of the 3D Tiles spec.
+   */
+  BufferCesium cesium;
+};
+} // namespace Cesium3DTiles

--- a/Cesium3DTiles/include/Cesium3DTiles/Buffer.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/Buffer.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "Cesium3DTiles/BufferCesium.h"
-#include "Cesium3DTiles/BufferSpec.h"
-#include "Cesium3DTiles/Library.h"
+#include <Cesium3DTiles/BufferCesium.h>
+#include <Cesium3DTiles/BufferSpec.h>
+#include <Cesium3DTiles/Library.h>
 
 namespace Cesium3DTiles {
 /** @copydoc BufferSpec */

--- a/Cesium3DTiles/include/Cesium3DTiles/BufferCesium.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/BufferCesium.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Cesium3DTiles/Library.h"
+#include <Cesium3DTiles/Library.h>
 
 #include <cstddef>
 #include <vector>

--- a/Cesium3DTiles/include/Cesium3DTiles/BufferCesium.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/BufferCesium.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "Cesium3DTiles/Library.h"
+
+#include <cstddef>
+#include <vector>
+
+namespace Cesium3DTiles {
+/**
+ * @brief Holds {@link Buffer} properties that are specific to the 3D Tiles loader
+ * rather than part of the 3D Tiles spec.
+ */
+struct CESIUM3DTILES_API BufferCesium final {
+  /**
+   * @brief The buffer's data.
+   */
+  std::vector<std::byte> data;
+};
+} // namespace Cesium3DTiles

--- a/Cesium3DTilesContent/CMakeLists.txt
+++ b/Cesium3DTilesContent/CMakeLists.txt
@@ -54,6 +54,7 @@ target_include_directories(
 target_link_libraries(Cesium3DTilesContent
     PUBLIC
         Cesium3DTiles
+        Cesium3DTilesReader
         CesiumAsync
         CesiumGeometry
         CesiumGeospatial

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
@@ -77,7 +77,7 @@ public:
    * @param asyncSystem The async system with which to do background work.
    * @param pAssetAccessor The asset accessor to use to retrieve the subtree
    * resource from the URL.
-   * @param pLogger The logger to which to load errors and warnings and occur
+   * @param pLogger The logger to which to load errors and warnings that occur
    * during subtree load.
    * @param subtreeUrl The URL from which to retrieve the subtree file.
    * @param requestHeaders HTTP headers to include in the request for the
@@ -95,19 +95,19 @@ public:
       const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders);
 
   /**
-   * @brief An AvailibilityView that indicates all tiles are either available or
-   * all tiles are unavailable.
+   * @brief An AvailibilityView that indicates that either all tiles are
+   * available or all tiles are unavailable.
    */
   struct SubtreeConstantAvailability {
     /**
-     * @brief True if all tiles are availability, false if all tiles are
+     * @brief True if all tiles are availabile, false if all tiles are
      * unavailable.
      */
     bool constant;
   };
 
   /**
-   * @brief An AvailabilityView that access availability information from a
+   * @brief An AvailabilityView that accesses availability information from a
    * bitstream.
    */
   struct SubtreeBufferViewAvailability {
@@ -148,7 +148,7 @@ public:
       Cesium3DTiles::Subtree&& subtree);
 
   /**
-   * @brief Determines if a given tile in the subtree is available.
+   * @brief Determines if a given tile in the quadtree is available.
    *
    * @param subtreeID The ID of the root tile of the subtree.
    * @param tileID The ID of the tile to query.
@@ -159,7 +159,7 @@ public:
       const CesiumGeometry::QuadtreeTileID& tileID) const noexcept;
 
   /**
-   * @brief Determines if a given tile in the subtree is available.
+   * @brief Determines if a given tile in the octree is available.
    *
    * @param subtreeID The ID of the root tile of the subtree.
    * @param tileID The ID of the tile to query.
@@ -183,7 +183,7 @@ public:
       uint64_t relativeTileMortonId) const noexcept;
 
   /**
-   * @brief Sets the availability state of a given tile in the subtree.
+   * @brief Sets the availability state of a given tile in the quadtree.
    *
    * @param subtreeID The ID of the root tile of the subtree.
    * @param tileID The ID of the tile for which to set availability.
@@ -195,7 +195,7 @@ public:
       bool isAvailable) noexcept;
 
   /**
-   * @brief Sets the availability state of a given tile in the subtree.
+   * @brief Sets the availability state of a given tile in the octree.
    *
    * @param subtreeID The ID of the root tile of the subtree.
    * @param tileID The ID of the tile for which to set availability.
@@ -222,10 +222,11 @@ public:
       bool isAvailable) noexcept;
 
   /**
-   * @brief Determines if content for a given tile in the subtree is available.
+   * @brief Determines if content for a given tile in the quadtree is available.
    *
    * @param subtreeID The ID of the root tile of the subtree.
    * @param tileID The ID of the tile to query.
+   * @param contentId The ID of the content to query.
    * @return True if the tile's content is available; otherwise, false.
    */
   bool isContentAvailable(
@@ -234,10 +235,11 @@ public:
       uint64_t contentId) const noexcept;
 
   /**
-   * @brief Determines if content for a given tile in the subtree is available.
+   * @brief Determines if content for a given tile in the octree is available.
    *
    * @param subtreeID The ID of the root tile of the subtree.
    * @param tileID The ID of the tile to query.
+   * @param contentId The ID of the content to query.
    * @return True if the tile's content is available; otherwise, false.
    */
   bool isContentAvailable(
@@ -252,6 +254,7 @@ public:
    * root of the subtree.
    * @param relativeTileMortonId The Morton ID of the tile to query. See
    * {@link ImplicitTilingUtilities::computeRelativeMortonIndex}.
+   * @param contentId The ID of the content to query.
    * @return True if the tile's content is available; otherwise, false.
    */
   bool isContentAvailable(
@@ -261,10 +264,11 @@ public:
 
   /**
    * @brief Sets the availability state of the content for a given tile in the
-   * subtree.
+   * quadtree.
    *
    * @param subtreeID The ID of the root tile of the subtree.
    * @param tileID The ID of the tile for which to set content availability.
+   * @param contentId The ID of the content to query.
    * @param isAvailable The new availability state for the tile's content.
    */
   void setContentAvailable(
@@ -275,10 +279,11 @@ public:
 
   /**
    * @brief Sets the availability state of the content for a given tile in the
-   * subtree.
+   * octree.
    *
    * @param subtreeID The ID of the root tile of the subtree.
    * @param tileID The ID of the tile for which to set content availability.
+   * @param contentId The ID of the content to query.
    * @param isAvailable The new availability state for the tile's content.
    */
   void setContentAvailable(
@@ -296,6 +301,7 @@ public:
    * @param relativeTileMortonId The Morton ID of the tile for which to set
    * content availability. See
    * {@link ImplicitTilingUtilities::computeRelativeMortonIndex}.
+   * @param contentId The ID of the content to query.
    * @param isAvailable The new availability state for the tile's content.
    */
   void setContentAvailable(
@@ -313,7 +319,7 @@ public:
    * @param thisSubtreeID The ID of the root tile of this subtree.
    * @param checkSubtreeID The ID of the tile to query to see if its subtree is
    * available.
-   * @return True if the tile's content is available; otherwise, false.
+   * @return True if the subtree is available; otherwise, false.
    */
   bool isSubtreeAvailable(
       const CesiumGeometry::QuadtreeTileID& thisSubtreeID,
@@ -328,7 +334,7 @@ public:
    * @param thisSubtreeID The ID of the root tile of this subtree.
    * @param checkSubtreeID The ID of the tile to query to see if its subtree is
    * available.
-   * @return True if the tile's content is available; otherwise, false.
+   * @return True if the subtree is available; otherwise, false.
    */
   bool isSubtreeAvailable(
       const CesiumGeometry::OctreeTileID& thisSubtreeID,
@@ -343,13 +349,13 @@ public:
    * @param relativeTileMortonId The Morton ID of the tile for which to check
    * subtree availability. See
    * {@link ImplicitTilingUtilities::computeRelativeMortonIndex}.
-   * @return True if the tile's subtree is available; otherwise, false.
+   * @return True if the subtree is available; otherwise, false.
    */
   bool isSubtreeAvailable(uint64_t relativeSubtreeMortonId) const noexcept;
 
   /**
-   * @brief Sets the availability state of the child subtree rooted at the given
-   * tile.
+   * @brief Sets the availability state of the child quadtree rooted at the
+   * given tile.
    *
    * The provided `setSubtreeID` must be a child of the leaves of this
    * subtree.
@@ -357,7 +363,7 @@ public:
    * @param thisSubtreeID The ID of the root tile of this subtree.
    * @param setSubtreeID The ID of the tile to query to see if its subtree is
    * available.
-   * @return True if the tile's subtree is available; otherwise, false.
+   * @param isAvailable The new availability state for the subtree.
    */
   void setSubtreeAvailable(
       const CesiumGeometry::QuadtreeTileID& thisSubtreeID,
@@ -365,7 +371,7 @@ public:
       bool isAvailable) noexcept;
 
   /**
-   * @brief Sets the availability state of the child subtree rooted at the given
+   * @brief Sets the availability state of the child octree rooted at the given
    * tile.
    *
    * The provided `setSubtreeID` must be a child of the leaves of this
@@ -374,7 +380,7 @@ public:
    * @param thisSubtreeID The ID of the root tile of this subtree.
    * @param setSubtreeID The ID of the tile to query to see if its subtree is
    * available.
-   * @return True if the tile's subtree is available; otherwise, false.
+   * @param isAvailable The new availability state for the subtree.
    */
   void setSubtreeAvailable(
       const CesiumGeometry::OctreeTileID& thisSubtreeID,

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
@@ -21,7 +21,7 @@ struct SubtreeConstantAvailability {
 };
 
 struct SubtreeBufferViewAvailability {
-  gsl::span<const std::byte> view;
+  gsl::span<std::byte> view;
 };
 
 using AvailabilityView =
@@ -29,11 +29,25 @@ using AvailabilityView =
 
 class SubtreeAvailability {
 public:
+  static std::optional<SubtreeAvailability> fromSubtree(
+      uint32_t powerOfTwo,
+      uint32_t levelsInSubtree,
+      Cesium3DTiles::Subtree&& subtree) noexcept;
+
+  /**
+   * @brief Creates an empty instance with all tiles initially available, while
+   * all content and subtrees are initially unavailable.
+   *
+   * @param powerOfTwo
+   * @param levelsInSubtree
+   * @return SubtreeAvailability
+   */
   static std::optional<SubtreeAvailability>
-  fromSubtree(uint32_t powerOfTwo, Cesium3DTiles::Subtree&& subtree) noexcept;
+  createEmpty(uint32_t powerOfTwo, uint32_t levelsInSubtree) noexcept;
 
   static CesiumAsync::Future<std::optional<SubtreeAvailability>> loadSubtree(
       uint32_t powerOf2,
+      uint32_t levelsInSubtree,
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const std::shared_ptr<spdlog::logger>& pLogger,
@@ -42,6 +56,7 @@ public:
 
   SubtreeAvailability(
       uint32_t powerOf2,
+      uint32_t levelsInSubtree,
       AvailabilityView tileAvailability,
       AvailabilityView subtreeAvailability,
       std::vector<AvailabilityView>&& contentAvailability,
@@ -59,6 +74,21 @@ public:
       uint32_t relativeTileLevel,
       uint64_t relativeTileMortonId) const noexcept;
 
+  void setTileAvailable(
+      const CesiumGeometry::QuadtreeTileID& subtreeID,
+      const CesiumGeometry::QuadtreeTileID& tileID,
+      bool isAvailable) noexcept;
+
+  void setTileAvailable(
+      const CesiumGeometry::OctreeTileID& subtreeID,
+      const CesiumGeometry::OctreeTileID& tileID,
+      bool isAvailable) noexcept;
+
+  void setTileAvailable(
+      uint32_t relativeTileLevel,
+      uint64_t relativeTileMortonId,
+      bool isAvailable) noexcept;
+
   bool isContentAvailable(
       const CesiumGeometry::QuadtreeTileID& subtreeID,
       const CesiumGeometry::QuadtreeTileID& tileID,
@@ -74,22 +104,78 @@ public:
       uint64_t relativeTileMortonId,
       uint64_t contentId) const noexcept;
 
+  void setContentAvailable(
+      const CesiumGeometry::QuadtreeTileID& subtreeID,
+      const CesiumGeometry::QuadtreeTileID& tileID,
+      uint64_t contentId,
+      bool isAvailable) noexcept;
+
+  void setContentAvailable(
+      const CesiumGeometry::OctreeTileID& subtreeID,
+      const CesiumGeometry::OctreeTileID& tileID,
+      uint64_t contentId,
+      bool isAvailable) noexcept;
+
+  void setContentAvailable(
+      uint32_t relativeTileLevel,
+      uint64_t relativeTileMortonId,
+      uint64_t contentId,
+      bool isAvailable) noexcept;
+
   bool isSubtreeAvailable(uint64_t relativeSubtreeMortonId) const noexcept;
+
+  bool isSubtreeAvailable(
+      const CesiumGeometry::QuadtreeTileID& thisSubtreeID,
+      const CesiumGeometry::QuadtreeTileID& checkSubtreeID) const noexcept;
+
+  bool isSubtreeAvailable(
+      const CesiumGeometry::OctreeTileID& thisSubtreeID,
+      const CesiumGeometry::OctreeTileID& checkSubtreeID) const noexcept;
+
+  void setSubtreeAvailable(
+      uint64_t relativeSubtreeMortonId,
+      bool isAvailable) noexcept;
+
+  void setSubtreeAvailable(
+      const CesiumGeometry::QuadtreeTileID& thisSubtreeID,
+      const CesiumGeometry::QuadtreeTileID& setSubtreeID,
+      bool isAvailable) noexcept;
+
+  void setSubtreeAvailable(
+      const CesiumGeometry::OctreeTileID& thisSubtreeID,
+      const CesiumGeometry::OctreeTileID& setSubtreeID,
+      bool isAvailable) noexcept;
+
+  Cesium3DTiles::Subtree& getSubtree() noexcept { return this->_subtree; }
+  const Cesium3DTiles::Subtree& getSubtree() const noexcept {
+    return this->_subtree;
+  }
 
 private:
   bool isAvailable(
       uint32_t relativeTileLevel,
       uint64_t relativeTileMortonId,
       const AvailabilityView& availabilityView) const noexcept;
+  void setAvailable(
+      uint32_t relativeTileLevel,
+      uint64_t relativeTileMortonId,
+      AvailabilityView& availabilityView,
+      bool isAvailable) noexcept;
 
   bool isAvailableUsingBufferView(
       uint64_t numOfTilesFromRootToParentLevel,
       uint64_t relativeTileMortonId,
       const AvailabilityView& availabilityView) const noexcept;
+  void setAvailableUsingBufferView(
+      uint64_t numOfTilesFromRootToParentLevel,
+      uint64_t relativeTileMortonId,
+      AvailabilityView& availabilityView,
+      bool isAvailable) noexcept;
 
+  uint32_t _powerOf2;
+  uint32_t _levelsInSubtree;
   Cesium3DTiles::Subtree _subtree;
   uint32_t _childCount;
-  uint32_t _powerOf2;
   AvailabilityView _tileAvailability;
   AvailabilityView _subtreeAvailability;
   std::vector<AvailabilityView> _contentAvailability;

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
@@ -150,24 +150,24 @@ public:
   /**
    * @brief Determines if a given tile in the quadtree is available.
    *
-   * @param subtreeID The ID of the root tile of the subtree.
-   * @param tileID The ID of the tile to query.
+   * @param subtreeId The ID of the root tile of the subtree.
+   * @param tileId The ID of the tile to query.
    * @return True if the tile is available; otherwise, false.
    */
   bool isTileAvailable(
-      const CesiumGeometry::QuadtreeTileID& subtreeID,
-      const CesiumGeometry::QuadtreeTileID& tileID) const noexcept;
+      const CesiumGeometry::QuadtreeTileID& subtreeId,
+      const CesiumGeometry::QuadtreeTileID& tileId) const noexcept;
 
   /**
    * @brief Determines if a given tile in the octree is available.
    *
-   * @param subtreeID The ID of the root tile of the subtree.
-   * @param tileID The ID of the tile to query.
+   * @param subtreeId The ID of the root tile of the subtree.
+   * @param tileId The ID of the tile to query.
    * @return True if the tile is available; otherwise, false.
    */
   bool isTileAvailable(
-      const CesiumGeometry::OctreeTileID& subtreeID,
-      const CesiumGeometry::OctreeTileID& tileID) const noexcept;
+      const CesiumGeometry::OctreeTileID& subtreeId,
+      const CesiumGeometry::OctreeTileID& tileId) const noexcept;
 
   /**
    * @brief Determines if a given tile in the subtree is available.
@@ -185,25 +185,25 @@ public:
   /**
    * @brief Sets the availability state of a given tile in the quadtree.
    *
-   * @param subtreeID The ID of the root tile of the subtree.
-   * @param tileID The ID of the tile for which to set availability.
+   * @param subtreeId The ID of the root tile of the subtree.
+   * @param tileId The ID of the tile for which to set availability.
    * @param isAvailable The new availability state for the tile.
    */
   void setTileAvailable(
-      const CesiumGeometry::QuadtreeTileID& subtreeID,
-      const CesiumGeometry::QuadtreeTileID& tileID,
+      const CesiumGeometry::QuadtreeTileID& subtreeId,
+      const CesiumGeometry::QuadtreeTileID& tileId,
       bool isAvailable) noexcept;
 
   /**
    * @brief Sets the availability state of a given tile in the octree.
    *
-   * @param subtreeID The ID of the root tile of the subtree.
-   * @param tileID The ID of the tile for which to set availability.
+   * @param subtreeId The ID of the root tile of the subtree.
+   * @param tileId The ID of the tile for which to set availability.
    * @param isAvailable The new availability state for the tile.
    */
   void setTileAvailable(
-      const CesiumGeometry::OctreeTileID& subtreeID,
-      const CesiumGeometry::OctreeTileID& tileID,
+      const CesiumGeometry::OctreeTileID& subtreeId,
+      const CesiumGeometry::OctreeTileID& tileId,
       bool isAvailable) noexcept;
 
   /**
@@ -224,27 +224,27 @@ public:
   /**
    * @brief Determines if content for a given tile in the quadtree is available.
    *
-   * @param subtreeID The ID of the root tile of the subtree.
-   * @param tileID The ID of the tile to query.
+   * @param subtreeId The ID of the root tile of the subtree.
+   * @param tileId The ID of the tile to query.
    * @param contentId The ID of the content to query.
    * @return True if the tile's content is available; otherwise, false.
    */
   bool isContentAvailable(
-      const CesiumGeometry::QuadtreeTileID& subtreeID,
-      const CesiumGeometry::QuadtreeTileID& tileID,
+      const CesiumGeometry::QuadtreeTileID& subtreeId,
+      const CesiumGeometry::QuadtreeTileID& tileId,
       uint64_t contentId) const noexcept;
 
   /**
    * @brief Determines if content for a given tile in the octree is available.
    *
-   * @param subtreeID The ID of the root tile of the subtree.
-   * @param tileID The ID of the tile to query.
+   * @param subtreeId The ID of the root tile of the subtree.
+   * @param tileId The ID of the tile to query.
    * @param contentId The ID of the content to query.
    * @return True if the tile's content is available; otherwise, false.
    */
   bool isContentAvailable(
-      const CesiumGeometry::OctreeTileID& subtreeID,
-      const CesiumGeometry::OctreeTileID& tileID,
+      const CesiumGeometry::OctreeTileID& subtreeId,
+      const CesiumGeometry::OctreeTileID& tileId,
       uint64_t contentId) const noexcept;
 
   /**
@@ -266,14 +266,14 @@ public:
    * @brief Sets the availability state of the content for a given tile in the
    * quadtree.
    *
-   * @param subtreeID The ID of the root tile of the subtree.
-   * @param tileID The ID of the tile for which to set content availability.
+   * @param subtreeId The ID of the root tile of the subtree.
+   * @param tileId The ID of the tile for which to set content availability.
    * @param contentId The ID of the content to query.
    * @param isAvailable The new availability state for the tile's content.
    */
   void setContentAvailable(
-      const CesiumGeometry::QuadtreeTileID& subtreeID,
-      const CesiumGeometry::QuadtreeTileID& tileID,
+      const CesiumGeometry::QuadtreeTileID& subtreeId,
+      const CesiumGeometry::QuadtreeTileID& tileId,
       uint64_t contentId,
       bool isAvailable) noexcept;
 
@@ -281,14 +281,14 @@ public:
    * @brief Sets the availability state of the content for a given tile in the
    * octree.
    *
-   * @param subtreeID The ID of the root tile of the subtree.
-   * @param tileID The ID of the tile for which to set content availability.
+   * @param subtreeId The ID of the root tile of the subtree.
+   * @param tileId The ID of the tile for which to set content availability.
    * @param contentId The ID of the content to query.
    * @param isAvailable The new availability state for the tile's content.
    */
   void setContentAvailable(
-      const CesiumGeometry::OctreeTileID& subtreeID,
-      const CesiumGeometry::OctreeTileID& tileID,
+      const CesiumGeometry::OctreeTileID& subtreeId,
+      const CesiumGeometry::OctreeTileID& tileId,
       uint64_t contentId,
       bool isAvailable) noexcept;
 

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Cesium3DTiles/Subtree.h>
 #include <CesiumAsync/Future.h>
 #include <CesiumAsync/IAssetAccessor.h>
 
@@ -9,6 +10,10 @@ namespace CesiumGeometry {
 struct QuadtreeTileID;
 struct OctreeTileID;
 } // namespace CesiumGeometry
+
+namespace Cesium3DTiles {
+struct ImplicitTiling;
+} // namespace Cesium3DTiles
 
 namespace Cesium3DTilesContent {
 struct SubtreeConstantAvailability {
@@ -24,12 +29,23 @@ using AvailabilityView =
 
 class SubtreeAvailability {
 public:
+  static std::optional<SubtreeAvailability>
+  fromSubtree(uint32_t powerOfTwo, Cesium3DTiles::Subtree&& subtree) noexcept;
+
+  static CesiumAsync::Future<std::optional<SubtreeAvailability>> loadSubtree(
+      uint32_t powerOf2,
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+      const std::shared_ptr<spdlog::logger>& pLogger,
+      const std::string& subtreeUrl,
+      const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders);
+
   SubtreeAvailability(
       uint32_t powerOf2,
       AvailabilityView tileAvailability,
       AvailabilityView subtreeAvailability,
       std::vector<AvailabilityView>&& contentAvailability,
-      std::vector<std::vector<std::byte>>&& buffers);
+      Cesium3DTiles::Subtree&& subtree);
 
   bool isTileAvailable(
       const CesiumGeometry::QuadtreeTileID& subtreeID,
@@ -60,14 +76,6 @@ public:
 
   bool isSubtreeAvailable(uint64_t relativeSubtreeMortonId) const noexcept;
 
-  static CesiumAsync::Future<std::optional<SubtreeAvailability>> loadSubtree(
-      uint32_t powerOf2,
-      const CesiumAsync::AsyncSystem& asyncSystem,
-      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
-      const std::shared_ptr<spdlog::logger>& pLogger,
-      const std::string& subtreeUrl,
-      const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders);
-
 private:
   bool isAvailable(
       uint32_t relativeTileLevel,
@@ -79,11 +87,11 @@ private:
       uint64_t relativeTileMortonId,
       const AvailabilityView& availabilityView) const noexcept;
 
+  Cesium3DTiles::Subtree _subtree;
   uint32_t _childCount;
   uint32_t _powerOf2;
   AvailabilityView _tileAvailability;
   AvailabilityView _subtreeAvailability;
   std::vector<AvailabilityView> _contentAvailability;
-  std::vector<std::vector<std::byte>> _buffers;
 };
 } // namespace Cesium3DTilesContent

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
@@ -16,21 +16,40 @@ struct ImplicitTiling;
 } // namespace Cesium3DTiles
 
 namespace Cesium3DTilesContent {
-struct SubtreeConstantAvailability {
-  bool constant;
+
+/**
+ * @brief Indicates how an implicit tile is subdivided.
+ */
+enum class ImplicitTileSubdivisionScheme {
+  /**
+   * @brief Implicit tiles are divided into four children, forming a quadree.
+   */
+  Quadtree,
+
+  /**
+   * @brief Implicit tiles are divided into eight children, forming an octree.
+   */
+  Octree
 };
 
-struct SubtreeBufferViewAvailability {
-  gsl::span<std::byte> view;
-};
-
-using AvailabilityView =
-    std::variant<SubtreeConstantAvailability, SubtreeBufferViewAvailability>;
-
+/**
+ * @brief Supports querying and modifying the various types of availablity
+ * information included in a {@link Cesium3DTiles::Subtree}.
+ */
 class SubtreeAvailability {
 public:
+  /**
+   * @brief Creates an instance from a `Subtree`.
+   *
+   * @param subdivisionScheme The subdivision scheme of the subtree (quadtree or
+   * octree).
+   * @param levelsInSubtree The number of levels in this subtree.
+   * @param subtree The subtree.
+   * @return The subtree availability, or std::nullopt if the subtree definition
+   * is invalid.
+   */
   static std::optional<SubtreeAvailability> fromSubtree(
-      uint32_t powerOfTwo,
+      ImplicitTileSubdivisionScheme subdivisionScheme,
       uint32_t levelsInSubtree,
       Cesium3DTiles::Subtree&& subtree) noexcept;
 
@@ -38,15 +57,36 @@ public:
    * @brief Creates an empty instance with all tiles initially available, while
    * all content and subtrees are initially unavailable.
    *
-   * @param powerOfTwo
-   * @param levelsInSubtree
-   * @return SubtreeAvailability
+   * @param subdivisionScheme The subdivision scheme of the subtree (quadtree or
+   * octree).
+   * @param levelsInSubtree The number of levels in this subtree.
+   * @return The subtree availability, or std::nullopt if the subtree definition
+   * is invalid.
    */
-  static std::optional<SubtreeAvailability>
-  createEmpty(uint32_t powerOfTwo, uint32_t levelsInSubtree) noexcept;
+  static std::optional<SubtreeAvailability> createEmpty(
+      ImplicitTileSubdivisionScheme subdivisionScheme,
+      uint32_t levelsInSubtree) noexcept;
 
+  /**
+   * @brief Asynchronously loads a subtree from a URL. The resource downloaded
+   * from the URL may be either a JSON or a binary subtree file.
+   *
+   * @param subdivisionScheme The subdivision scheme of the subtree (quadtree or
+   * octree).
+   * @param levelsInSubtree The number of levels in this subtree.
+   * @param asyncSystem The async system with which to do background work.
+   * @param pAssetAccessor The asset accessor to use to retrieve the subtree
+   * resource from the URL.
+   * @param pLogger The logger to which to load errors and warnings and occur
+   * during subtree load.
+   * @param subtreeUrl The URL from which to retrieve the subtree file.
+   * @param requestHeaders HTTP headers to include in the request for the
+   * subtree file.
+   * @return A future that resolves to a `SubtreeAvailability` instance for the
+   * subtree file, or std::nullopt if something goes wrong.
+   */
   static CesiumAsync::Future<std::optional<SubtreeAvailability>> loadSubtree(
-      uint32_t powerOf2,
+      ImplicitTileSubdivisionScheme subdivisionScheme,
       uint32_t levelsInSubtree,
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
@@ -54,99 +94,311 @@ public:
       const std::string& subtreeUrl,
       const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders);
 
+  /**
+   * @brief An AvailibilityView that indicates all tiles are either available or
+   * all tiles are unavailable.
+   */
+  struct SubtreeConstantAvailability {
+    /**
+     * @brief True if all tiles are availability, false if all tiles are
+     * unavailable.
+     */
+    bool constant;
+  };
+
+  /**
+   * @brief An AvailabilityView that access availability information from a
+   * bitstream.
+   */
+  struct SubtreeBufferViewAvailability {
+    /**
+     * @brief The buffer from which to read and write availability information.
+     */
+    gsl::span<std::byte> view;
+  };
+
+  /**
+   * @brief A mechanism for accessing availability information. It may be a
+   * constant value, or it may be read from a bitstream.
+   */
+  using AvailabilityView =
+      std::variant<SubtreeConstantAvailability, SubtreeBufferViewAvailability>;
+
+  /**
+   * @brief Constructs a new instance.
+   *
+   * @param subdivisionScheme The subdivision scheme of the subtree (quadtree or
+   * octree).
+   * @param levelsInSubtree The number of levels in this subtree.
+   * @param tileAvailability A view on the tile availability. If backed by a
+   * buffer, the buffer is expected to be in `subtree`.
+   * @param subtreeAvailability A view on the subtree availability. If backed by
+   * a buffer, the buffer is expected to be in `subtree`.
+   * @param contentAvailability A view on the content availability. If backed by
+   * a buffer, the buffer is expected to be in `subtree`.
+   * @param subtree The subtree with which this instance queries and modifies
+   * availability information.
+   */
   SubtreeAvailability(
-      uint32_t powerOf2,
+      ImplicitTileSubdivisionScheme subdivisionScheme,
       uint32_t levelsInSubtree,
       AvailabilityView tileAvailability,
       AvailabilityView subtreeAvailability,
       std::vector<AvailabilityView>&& contentAvailability,
       Cesium3DTiles::Subtree&& subtree);
 
+  /**
+   * @brief Determines if a given tile in the subtree is available.
+   *
+   * @param subtreeID The ID of the root tile of the subtree.
+   * @param tileID The ID of the tile to query.
+   * @return True if the tile is available; otherwise, false.
+   */
   bool isTileAvailable(
       const CesiumGeometry::QuadtreeTileID& subtreeID,
       const CesiumGeometry::QuadtreeTileID& tileID) const noexcept;
 
+  /**
+   * @brief Determines if a given tile in the subtree is available.
+   *
+   * @param subtreeID The ID of the root tile of the subtree.
+   * @param tileID The ID of the tile to query.
+   * @return True if the tile is available; otherwise, false.
+   */
   bool isTileAvailable(
       const CesiumGeometry::OctreeTileID& subtreeID,
       const CesiumGeometry::OctreeTileID& tileID) const noexcept;
 
+  /**
+   * @brief Determines if a given tile in the subtree is available.
+   *
+   * @param relativeTileLevel The level of the tile to query, relative to the
+   * root of the subtree.
+   * @param relativeTileMortonId The Morton ID of the tile to query. See
+   * {@link ImplicitTilingUtilities::computeRelativeMortonIndex}.
+   * @return True if the tile is available; otherwise, false.
+   */
   bool isTileAvailable(
       uint32_t relativeTileLevel,
       uint64_t relativeTileMortonId) const noexcept;
 
+  /**
+   * @brief Sets the availability state of a given tile in the subtree.
+   *
+   * @param subtreeID The ID of the root tile of the subtree.
+   * @param tileID The ID of the tile for which to set availability.
+   * @param isAvailable The new availability state for the tile.
+   */
   void setTileAvailable(
       const CesiumGeometry::QuadtreeTileID& subtreeID,
       const CesiumGeometry::QuadtreeTileID& tileID,
       bool isAvailable) noexcept;
 
+  /**
+   * @brief Sets the availability state of a given tile in the subtree.
+   *
+   * @param subtreeID The ID of the root tile of the subtree.
+   * @param tileID The ID of the tile for which to set availability.
+   * @param isAvailable The new availability state for the tile.
+   */
   void setTileAvailable(
       const CesiumGeometry::OctreeTileID& subtreeID,
       const CesiumGeometry::OctreeTileID& tileID,
       bool isAvailable) noexcept;
 
+  /**
+   * @brief Sets the availability state of a given tile in the subtree.
+   *
+   * @param relativeTileLevel The level of the tile for which to set
+   * availability, relative to the root of the subtree.
+   * @param relativeTileMortonId The Morton ID of the tile for which to set
+   * availability. See
+   * {@link ImplicitTilingUtilities::computeRelativeMortonIndex}.
+   * @param isAvailable The new availability state of the tile.
+   */
   void setTileAvailable(
       uint32_t relativeTileLevel,
       uint64_t relativeTileMortonId,
       bool isAvailable) noexcept;
 
+  /**
+   * @brief Determines if content for a given tile in the subtree is available.
+   *
+   * @param subtreeID The ID of the root tile of the subtree.
+   * @param tileID The ID of the tile to query.
+   * @return True if the tile's content is available; otherwise, false.
+   */
   bool isContentAvailable(
       const CesiumGeometry::QuadtreeTileID& subtreeID,
       const CesiumGeometry::QuadtreeTileID& tileID,
       uint64_t contentId) const noexcept;
 
+  /**
+   * @brief Determines if content for a given tile in the subtree is available.
+   *
+   * @param subtreeID The ID of the root tile of the subtree.
+   * @param tileID The ID of the tile to query.
+   * @return True if the tile's content is available; otherwise, false.
+   */
   bool isContentAvailable(
       const CesiumGeometry::OctreeTileID& subtreeID,
       const CesiumGeometry::OctreeTileID& tileID,
       uint64_t contentId) const noexcept;
 
+  /**
+   * @brief Determines if content for a given tile in the subtree is available.
+   *
+   * @param relativeTileLevel The level of the tile to query, relative to the
+   * root of the subtree.
+   * @param relativeTileMortonId The Morton ID of the tile to query. See
+   * {@link ImplicitTilingUtilities::computeRelativeMortonIndex}.
+   * @return True if the tile's content is available; otherwise, false.
+   */
   bool isContentAvailable(
       uint32_t relativeTileLevel,
       uint64_t relativeTileMortonId,
       uint64_t contentId) const noexcept;
 
+  /**
+   * @brief Sets the availability state of the content for a given tile in the
+   * subtree.
+   *
+   * @param subtreeID The ID of the root tile of the subtree.
+   * @param tileID The ID of the tile for which to set content availability.
+   * @param isAvailable The new availability state for the tile's content.
+   */
   void setContentAvailable(
       const CesiumGeometry::QuadtreeTileID& subtreeID,
       const CesiumGeometry::QuadtreeTileID& tileID,
       uint64_t contentId,
       bool isAvailable) noexcept;
 
+  /**
+   * @brief Sets the availability state of the content for a given tile in the
+   * subtree.
+   *
+   * @param subtreeID The ID of the root tile of the subtree.
+   * @param tileID The ID of the tile for which to set content availability.
+   * @param isAvailable The new availability state for the tile's content.
+   */
   void setContentAvailable(
       const CesiumGeometry::OctreeTileID& subtreeID,
       const CesiumGeometry::OctreeTileID& tileID,
       uint64_t contentId,
       bool isAvailable) noexcept;
 
+  /**
+   * @brief Sets the availability state of the content for a given tile in the
+   * subtree.
+   *
+   * @param relativeTileLevel The level of the tile for which to set
+   * content availability, relative to the root of the subtree.
+   * @param relativeTileMortonId The Morton ID of the tile for which to set
+   * content availability. See
+   * {@link ImplicitTilingUtilities::computeRelativeMortonIndex}.
+   * @param isAvailable The new availability state for the tile's content.
+   */
   void setContentAvailable(
       uint32_t relativeTileLevel,
       uint64_t relativeTileMortonId,
       uint64_t contentId,
       bool isAvailable) noexcept;
 
-  bool isSubtreeAvailable(uint64_t relativeSubtreeMortonId) const noexcept;
-
+  /**
+   * @brief Determines if the subtree rooted at the given tile is available.
+   *
+   * The provided `checkSubtreeID` must be a child of the leaves of this
+   * subtree.
+   *
+   * @param thisSubtreeID The ID of the root tile of this subtree.
+   * @param checkSubtreeID The ID of the tile to query to see if its subtree is
+   * available.
+   * @return True if the tile's content is available; otherwise, false.
+   */
   bool isSubtreeAvailable(
       const CesiumGeometry::QuadtreeTileID& thisSubtreeID,
       const CesiumGeometry::QuadtreeTileID& checkSubtreeID) const noexcept;
 
+  /**
+   * @brief Determines if the subtree rooted at the given tile is available.
+   *
+   * The provided `checkSubtreeID` must be a child of the leaves of this
+   * subtree.
+   *
+   * @param thisSubtreeID The ID of the root tile of this subtree.
+   * @param checkSubtreeID The ID of the tile to query to see if its subtree is
+   * available.
+   * @return True if the tile's content is available; otherwise, false.
+   */
   bool isSubtreeAvailable(
       const CesiumGeometry::OctreeTileID& thisSubtreeID,
       const CesiumGeometry::OctreeTileID& checkSubtreeID) const noexcept;
 
-  void setSubtreeAvailable(
-      uint64_t relativeSubtreeMortonId,
-      bool isAvailable) noexcept;
+  /**
+   * @brief Determines if the subtree rooted at the given tile is available.
+   *
+   * The provided `relativeSubtreeMortonId` must refer to a child of the leaves
+   * of this subtree.
+   *
+   * @param relativeTileMortonId The Morton ID of the tile for which to check
+   * subtree availability. See
+   * {@link ImplicitTilingUtilities::computeRelativeMortonIndex}.
+   * @return True if the tile's subtree is available; otherwise, false.
+   */
+  bool isSubtreeAvailable(uint64_t relativeSubtreeMortonId) const noexcept;
 
+  /**
+   * @brief Sets the availability state of the child subtree rooted at the given
+   * tile.
+   *
+   * The provided `setSubtreeID` must be a child of the leaves of this
+   * subtree.
+   *
+   * @param thisSubtreeID The ID of the root tile of this subtree.
+   * @param setSubtreeID The ID of the tile to query to see if its subtree is
+   * available.
+   * @return True if the tile's subtree is available; otherwise, false.
+   */
   void setSubtreeAvailable(
       const CesiumGeometry::QuadtreeTileID& thisSubtreeID,
       const CesiumGeometry::QuadtreeTileID& setSubtreeID,
       bool isAvailable) noexcept;
 
+  /**
+   * @brief Sets the availability state of the child subtree rooted at the given
+   * tile.
+   *
+   * The provided `setSubtreeID` must be a child of the leaves of this
+   * subtree.
+   *
+   * @param thisSubtreeID The ID of the root tile of this subtree.
+   * @param setSubtreeID The ID of the tile to query to see if its subtree is
+   * available.
+   * @return True if the tile's subtree is available; otherwise, false.
+   */
   void setSubtreeAvailable(
       const CesiumGeometry::OctreeTileID& thisSubtreeID,
       const CesiumGeometry::OctreeTileID& setSubtreeID,
       bool isAvailable) noexcept;
 
-  Cesium3DTiles::Subtree& getSubtree() noexcept { return this->_subtree; }
+  /**
+   * @brief Sets the availability state of the child subtree rooted at the given
+   * tile.
+   *
+   * The provided `relativeSubtreeMortonId` must refer to a child of the leaves
+   * of this subtree.
+   *
+   * @param relativeTileMortonId The Morton ID of the tile for which to set
+   * subtree availability. See
+   * {@link ImplicitTilingUtilities::computeRelativeMortonIndex}.
+   */
+  void setSubtreeAvailable(
+      uint64_t relativeSubtreeMortonId,
+      bool isAvailable) noexcept;
+
+  /**
+   * @brief Gets the subtree that this instance queries and modifies.
+   */
   const Cesium3DTiles::Subtree& getSubtree() const noexcept {
     return this->_subtree;
   }

--- a/Cesium3DTilesContent/src/SubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/src/SubtreeAvailability.cpp
@@ -30,7 +30,8 @@ std::optional<SubtreeAvailability::AvailabilityView> parseAvailabilityView(
     std::vector<Cesium3DTiles::BufferView>& bufferViews) {
   if (availability.constant) {
     return SubtreeAvailability::SubtreeConstantAvailability{
-        *availability.constant == 1};
+        *availability.constant ==
+        Cesium3DTiles::Availability::Constant::AVAILABLE};
   }
 
   int64_t bufferViewIndex = -1;
@@ -123,9 +124,12 @@ std::optional<SubtreeAvailability::AvailabilityView> parseAvailabilityView(
     ImplicitTileSubdivisionScheme subdivisionScheme,
     uint32_t levelsInSubtree) noexcept {
   Subtree subtree;
-  subtree.tileAvailability.constant = true;
-  subtree.contentAvailability.emplace_back().constant = false;
-  subtree.childSubtreeAvailability.constant = false;
+  subtree.tileAvailability.constant =
+      Cesium3DTiles::Availability::Constant::AVAILABLE;
+  subtree.contentAvailability.emplace_back().constant =
+      Cesium3DTiles::Availability::Constant::UNAVAILABLE;
+  subtree.childSubtreeAvailability.constant =
+      Cesium3DTiles::Availability::Constant::UNAVAILABLE;
 
   return SubtreeAvailability::fromSubtree(
       subdivisionScheme,

--- a/Cesium3DTilesContent/src/SubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/src/SubtreeAvailability.cpp
@@ -195,22 +195,22 @@ SubtreeAvailability::SubtreeAvailability(
 }
 
 bool SubtreeAvailability::isTileAvailable(
-    const CesiumGeometry::QuadtreeTileID& subtreeID,
-    const CesiumGeometry::QuadtreeTileID& tileID) const noexcept {
+    const CesiumGeometry::QuadtreeTileID& subtreeId,
+    const CesiumGeometry::QuadtreeTileID& tileId) const noexcept {
   uint64_t relativeTileMortonIdx =
-      ImplicitTilingUtilities::computeRelativeMortonIndex(subtreeID, tileID);
+      ImplicitTilingUtilities::computeRelativeMortonIndex(subtreeId, tileId);
   return this->isTileAvailable(
-      tileID.level - subtreeID.level,
+      tileId.level - subtreeId.level,
       relativeTileMortonIdx);
 }
 
 bool SubtreeAvailability::isTileAvailable(
-    const CesiumGeometry::OctreeTileID& subtreeID,
-    const CesiumGeometry::OctreeTileID& tileID) const noexcept {
+    const CesiumGeometry::OctreeTileID& subtreeId,
+    const CesiumGeometry::OctreeTileID& tileId) const noexcept {
   uint64_t relativeTileMortonIdx =
-      ImplicitTilingUtilities::computeRelativeMortonIndex(subtreeID, tileID);
+      ImplicitTilingUtilities::computeRelativeMortonIndex(subtreeId, tileId);
   return this->isTileAvailable(
-      tileID.level - subtreeID.level,
+      tileId.level - subtreeId.level,
       relativeTileMortonIdx);
 }
 
@@ -224,25 +224,25 @@ bool SubtreeAvailability::isTileAvailable(
 }
 
 void SubtreeAvailability::setTileAvailable(
-    const CesiumGeometry::QuadtreeTileID& subtreeID,
-    const CesiumGeometry::QuadtreeTileID& tileID,
+    const CesiumGeometry::QuadtreeTileID& subtreeId,
+    const CesiumGeometry::QuadtreeTileID& tileId,
     bool isAvailable) noexcept {
   uint64_t relativeTileMortonIdx =
-      ImplicitTilingUtilities::computeRelativeMortonIndex(subtreeID, tileID);
+      ImplicitTilingUtilities::computeRelativeMortonIndex(subtreeId, tileId);
   this->setTileAvailable(
-      tileID.level - subtreeID.level,
+      tileId.level - subtreeId.level,
       relativeTileMortonIdx,
       isAvailable);
 }
 
 void SubtreeAvailability::setTileAvailable(
-    const CesiumGeometry::OctreeTileID& subtreeID,
-    const CesiumGeometry::OctreeTileID& tileID,
+    const CesiumGeometry::OctreeTileID& subtreeId,
+    const CesiumGeometry::OctreeTileID& tileId,
     bool isAvailable) noexcept {
   uint64_t relativeTileMortonIdx =
-      ImplicitTilingUtilities::computeRelativeMortonIndex(subtreeID, tileID);
+      ImplicitTilingUtilities::computeRelativeMortonIndex(subtreeId, tileId);
   this->setTileAvailable(
-      tileID.level - subtreeID.level,
+      tileId.level - subtreeId.level,
       relativeTileMortonIdx,
       isAvailable);
 }
@@ -259,25 +259,25 @@ void SubtreeAvailability::setTileAvailable(
 }
 
 bool SubtreeAvailability::isContentAvailable(
-    const CesiumGeometry::QuadtreeTileID& subtreeID,
-    const CesiumGeometry::QuadtreeTileID& tileID,
+    const CesiumGeometry::QuadtreeTileID& subtreeId,
+    const CesiumGeometry::QuadtreeTileID& tileId,
     uint64_t contentId) const noexcept {
   uint64_t relativeTileMortonIdx =
-      ImplicitTilingUtilities::computeRelativeMortonIndex(subtreeID, tileID);
+      ImplicitTilingUtilities::computeRelativeMortonIndex(subtreeId, tileId);
   return this->isContentAvailable(
-      tileID.level - subtreeID.level,
+      tileId.level - subtreeId.level,
       relativeTileMortonIdx,
       contentId);
 }
 
 bool SubtreeAvailability::isContentAvailable(
-    const CesiumGeometry::OctreeTileID& subtreeID,
-    const CesiumGeometry::OctreeTileID& tileID,
+    const CesiumGeometry::OctreeTileID& subtreeId,
+    const CesiumGeometry::OctreeTileID& tileId,
     uint64_t contentId) const noexcept {
   uint64_t relativeTileMortonIdx =
-      ImplicitTilingUtilities::computeRelativeMortonIndex(subtreeID, tileID);
+      ImplicitTilingUtilities::computeRelativeMortonIndex(subtreeId, tileId);
   return this->isContentAvailable(
-      tileID.level - subtreeID.level,
+      tileId.level - subtreeId.level,
       relativeTileMortonIdx,
       contentId);
 }
@@ -293,28 +293,28 @@ bool SubtreeAvailability::isContentAvailable(
 }
 
 void SubtreeAvailability::setContentAvailable(
-    const CesiumGeometry::QuadtreeTileID& subtreeID,
-    const CesiumGeometry::QuadtreeTileID& tileID,
+    const CesiumGeometry::QuadtreeTileID& subtreeId,
+    const CesiumGeometry::QuadtreeTileID& tileId,
     uint64_t contentId,
     bool isAvailable) noexcept {
   uint64_t relativeTileMortonIdx =
-      ImplicitTilingUtilities::computeRelativeMortonIndex(subtreeID, tileID);
+      ImplicitTilingUtilities::computeRelativeMortonIndex(subtreeId, tileId);
   this->setContentAvailable(
-      tileID.level - subtreeID.level,
+      tileId.level - subtreeId.level,
       relativeTileMortonIdx,
       contentId,
       isAvailable);
 }
 
 void SubtreeAvailability::setContentAvailable(
-    const CesiumGeometry::OctreeTileID& subtreeID,
-    const CesiumGeometry::OctreeTileID& tileID,
+    const CesiumGeometry::OctreeTileID& subtreeId,
+    const CesiumGeometry::OctreeTileID& tileId,
     uint64_t contentId,
     bool isAvailable) noexcept {
   uint64_t relativeTileMortonIdx =
-      ImplicitTilingUtilities::computeRelativeMortonIndex(subtreeID, tileID);
+      ImplicitTilingUtilities::computeRelativeMortonIndex(subtreeId, tileId);
   this->setContentAvailable(
-      tileID.level - subtreeID.level,
+      tileId.level - subtreeId.level,
       relativeTileMortonIdx,
       contentId,
       isAvailable);

--- a/Cesium3DTilesContent/src/SubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/src/SubtreeAvailability.cpp
@@ -181,11 +181,11 @@ SubtreeAvailability::SubtreeAvailability(
     std::vector<AvailabilityView>&& contentAvailability,
     Cesium3DTiles::Subtree&& subtree)
     : _powerOf2{subdivisionScheme == ImplicitTileSubdivisionScheme::Quadtree ? 2U : 3U},
+      _levelsInSubtree{levelsInSubtree},
+      _subtree{std::move(subtree)},
       _childCount{
           subdivisionScheme == ImplicitTileSubdivisionScheme::Quadtree ? 4U
                                                                        : 8U},
-      _levelsInSubtree{levelsInSubtree},
-      _subtree{std::move(subtree)},
       _tileAvailability{tileAvailability},
       _subtreeAvailability{subtreeAvailability},
       _contentAvailability{std::move(contentAvailability)} {

--- a/Cesium3DTilesContent/src/SubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/src/SubtreeAvailability.cpp
@@ -1,8 +1,12 @@
+#include <Cesium3DTiles/ImplicitTiling.h>
+#include <Cesium3DTiles/Subtree.h>
 #include <Cesium3DTilesContent/ImplicitTilingUtilities.h>
 #include <Cesium3DTilesContent/SubtreeAvailability.h>
+#include <Cesium3DTilesReader/SubtreeFileReader.h>
 #include <CesiumAsync/IAssetResponse.h>
 #include <CesiumGeometry/OctreeTileID.h>
 #include <CesiumGeometry/QuadtreeTileID.h>
+#include <CesiumUtility/ErrorList.h>
 #include <CesiumUtility/Uri.h>
 
 #include <gsl/span>
@@ -11,93 +15,50 @@
 #include <optional>
 #include <string>
 
+using namespace Cesium3DTiles;
+using namespace Cesium3DTilesReader;
+using namespace CesiumJsonReader;
+
 namespace Cesium3DTilesContent {
+
 namespace {
-constexpr const char* const SUBTREE_MAGIC = "subt";
-
-struct SubtreeHeader {
-  unsigned char magic[4];
-  uint32_t version;
-  uint64_t jsonByteLength;
-  uint64_t binaryByteLength;
-};
-
-struct RequestedSubtreeBuffer {
-  size_t idx;
-  std::vector<std::byte> data;
-};
-
-struct SubtreeBufferView {
-  size_t bufferIdx;
-  size_t byteOffset;
-  size_t byteLength;
-};
-
-CesiumAsync::Future<RequestedSubtreeBuffer> requestBuffer(
-    const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
-    const CesiumAsync::AsyncSystem& asyncSystem,
-    size_t bufferIdx,
-    std::string&& subtreeUrl,
-    size_t bufferLength,
-    const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders) {
-  return pAssetAccessor->get(asyncSystem, subtreeUrl, requestHeaders)
-      .thenInWorkerThread(
-          [bufferIdx, bufferLength](
-              std::shared_ptr<CesiumAsync::IAssetRequest>&& pCompletedRequest) {
-            const CesiumAsync::IAssetResponse* pResponse =
-                pCompletedRequest->response();
-            if (!pResponse) {
-              return RequestedSubtreeBuffer{bufferIdx, {}};
-            }
-
-            uint16_t statusCode = pResponse->statusCode();
-            if (statusCode != 0 && (statusCode < 200 || statusCode >= 300)) {
-              return RequestedSubtreeBuffer{bufferIdx, {}};
-            }
-
-            auto data = pResponse->data();
-            if (data.size() < bufferLength) {
-              return RequestedSubtreeBuffer{bufferIdx, {}};
-            }
-
-            using vector_diff_type =
-                typename std::vector<std::byte>::difference_type;
-            std::vector<std::byte> buffer(
-                data.begin(),
-                data.begin() + static_cast<vector_diff_type>(bufferLength));
-            return RequestedSubtreeBuffer{bufferIdx, std::move(buffer)};
-          });
-}
 
 std::optional<AvailabilityView> parseAvailabilityView(
-    const rapidjson::Value& availabilityJson,
-    const std::vector<std::vector<std::byte>>& buffers,
-    const std::vector<SubtreeBufferView>& bufferViews) {
-  auto constantIt = availabilityJson.FindMember("constant");
-  if (constantIt != availabilityJson.MemberEnd() &&
-      constantIt->value.IsUint()) {
-    return SubtreeConstantAvailability{constantIt->value.GetUint() == 1U};
+    const Cesium3DTiles::Availability& availability,
+    const std::vector<Cesium3DTiles::Buffer>& buffers,
+    const std::vector<Cesium3DTiles::BufferView>& bufferViews) {
+  if (availability.constant) {
+    return SubtreeConstantAvailability{*availability.constant == 1};
   }
 
-  auto bitStreamIt = availabilityJson.FindMember("bitstream");
-  if (bitStreamIt == availabilityJson.MemberEnd()) {
+  int64_t bufferViewIndex = -1;
+
+  if (availability.bitstream) {
+    bufferViewIndex = *availability.bitstream;
+  } else {
     // old version uses bufferView property instead of bitstream. Same semantic
     // either way
-    bitStreamIt = availabilityJson.FindMember("bufferView");
+    auto bufferViewIt = availability.unknownProperties.find("bufferView");
+    if (bufferViewIt != availability.unknownProperties.end()) {
+      bufferViewIndex =
+          bufferViewIt->second.getSafeNumberOrDefault<int64_t>(-1);
+    }
   }
-  if (bitStreamIt != availabilityJson.MemberEnd() &&
-      bitStreamIt->value.IsUint()) {
-    uint32_t bufferViewIdx = bitStreamIt->value.GetUint();
-    if (bufferViewIdx < bufferViews.size()) {
-      const SubtreeBufferView& bufferView = bufferViews[bufferViewIdx];
 
-      if (bufferView.bufferIdx < buffers.size()) {
-        const std::vector<std::byte>& buffer = buffers[bufferView.bufferIdx];
-        if (bufferView.byteOffset + bufferView.byteLength <= buffer.size()) {
-          return SubtreeBufferViewAvailability{gsl::span<const std::byte>(
-              buffer.data() + bufferView.byteOffset,
-              bufferView.byteLength)};
-        }
+  if (bufferViewIndex >= 0 &&
+      bufferViewIndex < static_cast<int64_t>(bufferViews.size())) {
+    const Cesium3DTiles::BufferView& bufferView = bufferViews[bufferViewIndex];
+
+    if (bufferView.buffer >= 0 &&
+        bufferView.buffer < static_cast<int64_t>(buffers.size())) {
+      const Cesium3DTiles::Buffer& buffer = buffers[bufferView.buffer];
+      const std::vector<std::byte>& data = buffer.cesium.data;
+      int64_t bufferSize =
+          std::min(static_cast<int64_t>(data.size()), buffer.byteLength);
+      if (bufferView.byteOffset + bufferView.byteLength <= bufferSize) {
+        return SubtreeBufferViewAvailability{gsl::span<const std::byte>(
+            data.data() + bufferView.byteOffset,
+            bufferView.byteLength)};
       }
     }
   }
@@ -105,361 +66,100 @@ std::optional<AvailabilityView> parseAvailabilityView(
   return std::nullopt;
 }
 
-std::optional<SubtreeAvailability> createSubtreeAvailability(
-    uint32_t powerOf2,
-    const rapidjson::Document& subtreeJson,
-    std::vector<std::vector<std::byte>>&& buffers) {
-  // make sure all the required fields exist
-  auto tileAvailabilityIt = subtreeJson.FindMember("tileAvailability");
-  if (tileAvailabilityIt == subtreeJson.MemberEnd() ||
-      !tileAvailabilityIt->value.IsObject()) {
+} // namespace
+
+/*static*/ std::optional<SubtreeAvailability> SubtreeAvailability::fromSubtree(
+    uint32_t powerOfTwo,
+    Cesium3DTiles::Subtree&& subtree) noexcept {
+  std::optional<AvailabilityView> maybeTileAvailability = parseAvailabilityView(
+      subtree.tileAvailability,
+      subtree.buffers,
+      subtree.bufferViews);
+  if (!maybeTileAvailability)
     return std::nullopt;
-  }
 
-  auto contentAvailabilityIt = subtreeJson.FindMember("contentAvailability");
-  if (contentAvailabilityIt == subtreeJson.MemberEnd() ||
-      (!contentAvailabilityIt->value.IsArray() &&
-       !contentAvailabilityIt->value.IsObject())) {
+  std::optional<AvailabilityView> maybeChildSubtreeAvailability =
+      parseAvailabilityView(
+          subtree.childSubtreeAvailability,
+          subtree.buffers,
+          subtree.bufferViews);
+  if (!maybeChildSubtreeAvailability)
     return std::nullopt;
-  }
 
-  auto childSubtreeAvailabilityIt =
-      subtreeJson.FindMember("childSubtreeAvailability");
-  if (childSubtreeAvailabilityIt == subtreeJson.MemberEnd() ||
-      !childSubtreeAvailabilityIt->value.IsObject()) {
+  // At least one element is required in contentAvailability.
+  if (subtree.contentAvailability.empty())
     return std::nullopt;
-  }
-
-  std::vector<SubtreeBufferView> bufferViews;
-  auto bufferViewIt = subtreeJson.FindMember("bufferViews");
-  if (bufferViewIt != subtreeJson.MemberEnd() &&
-      bufferViewIt->value.IsArray()) {
-    bufferViews.resize(bufferViewIt->value.Size());
-    for (rapidjson::SizeType i = 0; i < bufferViewIt->value.Size(); ++i) {
-      const auto& bufferViewJson = bufferViewIt->value[i];
-      auto bufferIdxIt = bufferViewJson.FindMember("buffer");
-      auto byteOffsetIt = bufferViewJson.FindMember("byteOffset");
-      auto byteLengthIt = bufferViewJson.FindMember("byteLength");
-
-      if (bufferIdxIt == bufferViewJson.MemberEnd() ||
-          !bufferIdxIt->value.IsUint()) {
-        return std::nullopt;
-      }
-
-      if (byteOffsetIt == bufferViewJson.MemberEnd() ||
-          !byteOffsetIt->value.IsUint()) {
-        return std::nullopt;
-      }
-
-      if (byteLengthIt == bufferViewJson.MemberEnd() ||
-          !byteLengthIt->value.IsUint()) {
-        return std::nullopt;
-      }
-
-      bufferViews[i].bufferIdx = bufferIdxIt->value.GetUint();
-      bufferViews[i].byteOffset = byteOffsetIt->value.GetUint();
-      bufferViews[i].byteLength = byteLengthIt->value.GetUint();
-    }
-  }
-
-  auto tileAvailability =
-      parseAvailabilityView(tileAvailabilityIt->value, buffers, bufferViews);
-  if (!tileAvailability) {
-    return std::nullopt;
-  }
-
-  auto childSubtreeAvailability = parseAvailabilityView(
-      childSubtreeAvailabilityIt->value,
-      buffers,
-      bufferViews);
-  if (!childSubtreeAvailability) {
-    return std::nullopt;
-  }
 
   std::vector<AvailabilityView> contentAvailability;
-  if (contentAvailabilityIt->value.IsArray()) {
-    contentAvailability.reserve(contentAvailabilityIt->value.Size());
-    for (const auto& contentAvailabilityJson :
-         contentAvailabilityIt->value.GetArray()) {
-      auto availability =
-          parseAvailabilityView(contentAvailabilityJson, buffers, bufferViews);
-      if (!availability) {
-        return std::nullopt;
-      }
+  contentAvailability.reserve(subtree.contentAvailability.size());
 
-      contentAvailability.emplace_back(*availability);
+  for (const auto& availabilityDesc : subtree.contentAvailability) {
+    auto maybeAvailability = parseAvailabilityView(
+        availabilityDesc,
+        subtree.buffers,
+        subtree.bufferViews);
+    if (maybeAvailability) {
+      contentAvailability.emplace_back(std::move(*maybeAvailability));
     }
-  } else {
-    auto availability = parseAvailabilityView(
-        contentAvailabilityIt->value,
-        buffers,
-        bufferViews);
-    if (!availability) {
-      return std::nullopt;
-    }
-
-    contentAvailability.emplace_back(*availability);
   }
 
-  return SubtreeAvailability{
-      powerOf2,
-      *tileAvailability,
-      *childSubtreeAvailability,
+  return SubtreeAvailability(
+      powerOfTwo,
+      *maybeTileAvailability,
+      *maybeChildSubtreeAvailability,
       std::move(contentAvailability),
-      std::move(buffers)};
+      std::move(subtree));
 }
 
-CesiumAsync::Future<std::optional<SubtreeAvailability>> parseJsonSubtree(
+/*static*/ CesiumAsync::Future<std::optional<SubtreeAvailability>>
+SubtreeAvailability::loadSubtree(
     uint32_t powerOf2,
-    CesiumAsync::AsyncSystem&& asyncSystem,
-    std::shared_ptr<CesiumAsync::IAssetAccessor>&& pAssetAccessor,
-    std::shared_ptr<spdlog::logger>&& pLogger,
-    std::vector<CesiumAsync::IAssetAccessor::THeader>&& requestHeaders,
-    const std::string& baseUrl,
-    rapidjson::Document&& subtreeJson,
-    std::vector<std::byte>&& internalBuffer) {
-  // resolve all the buffers
-  std::vector<std::vector<std::byte>> resolvedBuffers;
-  auto bufferIt = subtreeJson.FindMember("buffers");
-  if (bufferIt != subtreeJson.MemberEnd() && bufferIt->value.IsArray()) {
-    const auto& arrayBufferJsons = bufferIt->value.GetArray();
-    resolvedBuffers.resize(arrayBufferJsons.Size());
-
-    std::vector<CesiumAsync::Future<RequestedSubtreeBuffer>> requestBuffers;
-    for (rapidjson::SizeType i = 0; i < arrayBufferJsons.Size(); ++i) {
-      const auto& bufferJson = arrayBufferJsons[i];
-      auto byteLengthIt = bufferJson.FindMember("byteLength");
-      if (byteLengthIt == bufferJson.MemberEnd() ||
-          !byteLengthIt->value.IsUint()) {
-        SPDLOG_LOGGER_ERROR(
-            pLogger,
-            "Subtree Buffer requires byteLength property.");
-        return asyncSystem
-            .createResolvedFuture<std::optional<SubtreeAvailability>>(
-                std::nullopt);
-      }
-
-      size_t byteLength = byteLengthIt->value.GetUint();
-
-      auto uriIt = bufferJson.FindMember("uri");
-      if (uriIt != bufferJson.MemberEnd()) {
-        if (!uriIt->value.IsString()) {
-          SPDLOG_LOGGER_ERROR(
-              pLogger,
-              "Subtree Buffer has uri field but it's not string.");
-          return asyncSystem
-              .createResolvedFuture<std::optional<SubtreeAvailability>>(
-                  std::nullopt);
-        }
-
-        std::string bufferUrl =
-            CesiumUtility::Uri::resolve(baseUrl, uriIt->value.GetString());
-        requestBuffers.emplace_back(requestBuffer(
-            pAssetAccessor,
-            asyncSystem,
-            i,
-            std::move(bufferUrl),
-            byteLength,
-            requestHeaders));
-      } else if (
-          !internalBuffer.empty() && internalBuffer.size() >= byteLength) {
-        resolvedBuffers[i] = std::move(internalBuffer);
-      }
-    }
-
-    // if we have buffers to request, resolve them now and then, create
-    // SubtreeAvailability later
-    if (!requestBuffers.empty()) {
-      return asyncSystem.all(std::move(requestBuffers))
-          .thenInWorkerThread([powerOf2,
-                               resolvedBuffers = std::move(resolvedBuffers),
-                               subtreeJson = std::move(subtreeJson)](
-                                  std::vector<RequestedSubtreeBuffer>&&
-                                      completedBuffers) mutable {
-            for (auto& requestedBuffer : completedBuffers) {
-              resolvedBuffers[requestedBuffer.idx] =
-                  std::move(requestedBuffer.data);
+    const CesiumAsync::AsyncSystem& asyncSystem,
+    const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+    const std::shared_ptr<spdlog::logger>& pLogger,
+    const std::string& subtreeUrl,
+    const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders) {
+  SubtreeFileReader reader;
+  return reader.load(asyncSystem, pAssetAccessor, subtreeUrl, requestHeaders)
+      .thenInMainThread(
+          [pLogger, subtreeUrl, powerOf2](ReadJsonResult<Subtree>&& subtree)
+              -> std::optional<SubtreeAvailability> {
+            if (!subtree.value) {
+              if (!subtree.errors.empty()) {
+                SPDLOG_LOGGER_ERROR(
+                    pLogger,
+                    "Errors while loading subtree from {}:\n- {}",
+                    subtreeUrl,
+                    CesiumUtility::joinToString(subtree.errors, "\n- "));
+              }
+              if (!subtree.warnings.empty()) {
+                SPDLOG_LOGGER_WARN(
+                    pLogger,
+                    "Warnings while loading subtree from {}:\n- {}",
+                    subtreeUrl,
+                    CesiumUtility::joinToString(subtree.warnings, "\n- "));
+              }
+              return std::nullopt;
             }
 
-            return createSubtreeAvailability(
+            return SubtreeAvailability::fromSubtree(
                 powerOf2,
-                subtreeJson,
-                std::move(resolvedBuffers));
+                std::move(*subtree.value));
           });
-    }
-  }
-
-  return asyncSystem.createResolvedFuture(createSubtreeAvailability(
-      powerOf2,
-      subtreeJson,
-      std::move(resolvedBuffers)));
 }
-
-CesiumAsync::Future<std::optional<SubtreeAvailability>> parseJsonSubtreeRequest(
-    uint32_t powerOf2,
-    CesiumAsync::AsyncSystem&& asyncSystem,
-    std::shared_ptr<CesiumAsync::IAssetAccessor>&& pAssetAccessor,
-    std::shared_ptr<spdlog::logger>&& pLogger,
-    std::shared_ptr<CesiumAsync::IAssetRequest>&& pCompletedRequest,
-    std::vector<CesiumAsync::IAssetAccessor::THeader>&& requestHeaders) {
-  const auto* pResponse = pCompletedRequest->response();
-  gsl::span<const std::byte> data = pResponse->data();
-
-  rapidjson::Document subtreeJson;
-  subtreeJson.Parse(reinterpret_cast<const char*>(data.data()), data.size());
-  if (subtreeJson.HasParseError()) {
-    SPDLOG_LOGGER_ERROR(
-        pLogger,
-        "Error when parsing feature table JSON, error code {} at byte offset "
-        "{}",
-        subtreeJson.GetParseError(),
-        subtreeJson.GetErrorOffset());
-    return asyncSystem.createResolvedFuture<std::optional<SubtreeAvailability>>(
-        std::nullopt);
-  }
-
-  return parseJsonSubtree(
-      powerOf2,
-      std::move(asyncSystem),
-      std::move(pAssetAccessor),
-      std::move(pLogger),
-      std::move(requestHeaders),
-      pCompletedRequest->url(),
-      std::move(subtreeJson),
-      {});
-}
-
-CesiumAsync::Future<std::optional<SubtreeAvailability>>
-parseBinarySubtreeRequest(
-    uint32_t powerOf2,
-    CesiumAsync::AsyncSystem&& asyncSystem,
-    std::shared_ptr<CesiumAsync::IAssetAccessor>&& pAssetAccessor,
-    std::shared_ptr<spdlog::logger>&& pLogger,
-    std::shared_ptr<CesiumAsync::IAssetRequest>&& pCompletedRequest,
-    std::vector<CesiumAsync::IAssetAccessor::THeader>&& requestHeaders) {
-  const auto* pResponse = pCompletedRequest->response();
-  gsl::span<const std::byte> data = pResponse->data();
-
-  size_t headerLength = sizeof(SubtreeHeader);
-  if (data.size() < headerLength) {
-    SPDLOG_LOGGER_ERROR(
-        pLogger,
-        "The Subtree file is invalid because it is too "
-        "small to include a Subtree header.");
-    return asyncSystem.createResolvedFuture<std::optional<SubtreeAvailability>>(
-        std::nullopt);
-  }
-
-  const SubtreeHeader* header =
-      reinterpret_cast<const SubtreeHeader*>(data.data());
-  if (header->jsonByteLength > data.size() - headerLength) {
-    SPDLOG_LOGGER_ERROR(
-        pLogger,
-        "The Subtree file is invalid because it is too "
-        "small to include the jsonByteLength specified in its header.");
-    return asyncSystem.createResolvedFuture<std::optional<SubtreeAvailability>>(
-        std::nullopt);
-  }
-
-  if (header->binaryByteLength >
-      data.size() - headerLength - header->jsonByteLength) {
-    SPDLOG_LOGGER_ERROR(
-        pLogger,
-        "The Subtree file is invalid because it is too "
-        "small to include the binaryByteLength specified in its header.");
-    return asyncSystem.createResolvedFuture<std::optional<SubtreeAvailability>>(
-        std::nullopt);
-  }
-
-  rapidjson::Document subtreeJson;
-  subtreeJson.Parse(
-      reinterpret_cast<const char*>(data.data() + headerLength),
-      header->jsonByteLength);
-  if (subtreeJson.HasParseError()) {
-    SPDLOG_LOGGER_ERROR(
-        pLogger,
-        "Error when parsing feature table JSON, error code {} at byte offset "
-        "{}",
-        subtreeJson.GetParseError(),
-        subtreeJson.GetErrorOffset());
-    return asyncSystem.createResolvedFuture<std::optional<SubtreeAvailability>>(
-        std::nullopt);
-  }
-
-  // get the internal buffer if there is any
-  std::vector<std::byte> internalBuffer;
-  if (header->binaryByteLength > 0) {
-    using vector_diff_type = typename std::vector<std::byte>::difference_type;
-    auto begin = data.begin() + static_cast<vector_diff_type>(headerLength) +
-                 static_cast<vector_diff_type>(header->jsonByteLength);
-    auto end = begin + static_cast<vector_diff_type>(header->binaryByteLength);
-    internalBuffer.insert(internalBuffer.end(), begin, end);
-  }
-
-  return parseJsonSubtree(
-      powerOf2,
-      std::move(asyncSystem),
-      std::move(pAssetAccessor),
-      std::move(pLogger),
-      std::move(requestHeaders),
-      pCompletedRequest->url(),
-      std::move(subtreeJson),
-      std::move(internalBuffer));
-}
-
-CesiumAsync::Future<std::optional<SubtreeAvailability>> parseSubtreeRequest(
-    uint32_t powerOf2,
-    CesiumAsync::AsyncSystem&& asyncSystem,
-    std::shared_ptr<CesiumAsync::IAssetAccessor>&& pAssetAccessor,
-    std::shared_ptr<spdlog::logger>&& pLogger,
-    std::shared_ptr<CesiumAsync::IAssetRequest>&& pCompletedRequest,
-    std::vector<CesiumAsync::IAssetAccessor::THeader>&& requestHeaders) {
-  const auto* pResponse = pCompletedRequest->response();
-  gsl::span<const std::byte> data = pResponse->data();
-
-  // check if this is binary subtree
-  bool isBinarySubtree = true;
-  if (data.size() >= 4) {
-    for (std::size_t i = 0; i < 4; ++i) {
-      if (data[i] != static_cast<std::byte>(SUBTREE_MAGIC[i])) {
-        isBinarySubtree = false;
-        break;
-      }
-    }
-  }
-
-  if (isBinarySubtree) {
-    return parseBinarySubtreeRequest(
-        powerOf2,
-        std::move(asyncSystem),
-        std::move(pAssetAccessor),
-        std::move(pLogger),
-        std::move(pCompletedRequest),
-        std::move(requestHeaders));
-  } else {
-    return parseJsonSubtreeRequest(
-        powerOf2,
-        std::move(asyncSystem),
-        std::move(pAssetAccessor),
-        std::move(pLogger),
-        std::move(pCompletedRequest),
-        std::move(requestHeaders));
-  }
-}
-} // namespace
 
 SubtreeAvailability::SubtreeAvailability(
     uint32_t powerOf2,
     AvailabilityView tileAvailability,
     AvailabilityView subtreeAvailability,
     std::vector<AvailabilityView>&& contentAvailability,
-    std::vector<std::vector<std::byte>>&& buffers)
-    : _childCount{1U << powerOf2},
+    Cesium3DTiles::Subtree&& subtree)
+    : _subtree(std::move(subtree)),
+      _childCount{1U << powerOf2},
       _powerOf2{powerOf2},
       _tileAvailability{tileAvailability},
       _subtreeAvailability{subtreeAvailability},
-      _contentAvailability{std::move(contentAvailability)},
-      _buffers{std::move(buffers)} {
+      _contentAvailability{std::move(contentAvailability)} {
   assert(
       (this->_childCount == 4 || this->_childCount == 8) &&
       "Only support quadtree and octree");
@@ -540,46 +240,6 @@ bool SubtreeAvailability::isSubtreeAvailable(
       0,
       relativeSubtreeMortonId,
       this->_subtreeAvailability);
-}
-
-CesiumAsync::Future<std::optional<SubtreeAvailability>>
-SubtreeAvailability::loadSubtree(
-    uint32_t powerOf2,
-    const CesiumAsync::AsyncSystem& asyncSystem,
-    const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
-    const std::shared_ptr<spdlog::logger>& pLogger,
-    const std::string& subtreeUrl,
-    const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders) {
-  return pAssetAccessor->get(asyncSystem, subtreeUrl, requestHeaders)
-      .thenInWorkerThread([powerOf2,
-                           asyncSystem = asyncSystem,
-                           pAssetAccessor = pAssetAccessor,
-                           pLogger = pLogger,
-                           requestHeaders = requestHeaders](
-                              std::shared_ptr<CesiumAsync::IAssetRequest>&&
-                                  pCompletedRequest) mutable {
-        const auto* pResponse = pCompletedRequest->response();
-        if (!pResponse) {
-          return asyncSystem
-              .createResolvedFuture<std::optional<SubtreeAvailability>>(
-                  std::nullopt);
-        }
-
-        uint16_t statusCode = pResponse->statusCode();
-        if (statusCode != 0 && (statusCode < 200 || statusCode >= 300)) {
-          return asyncSystem
-              .createResolvedFuture<std::optional<SubtreeAvailability>>(
-                  std::nullopt);
-        }
-
-        return parseSubtreeRequest(
-            powerOf2,
-            std::move(asyncSystem),
-            std::move(pAssetAccessor),
-            std::move(pLogger),
-            std::move(pCompletedRequest),
-            std::move(requestHeaders));
-      });
 }
 
 bool SubtreeAvailability::isAvailable(

--- a/Cesium3DTilesContent/src/SubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/src/SubtreeAvailability.cpp
@@ -290,6 +290,8 @@ bool SubtreeAvailability::isContentAvailable(
     uint32_t relativeTileLevel,
     uint64_t relativeTileMortonId,
     uint64_t contentId) const noexcept {
+  if (contentId >= this->_contentAvailability.size())
+    return false;
   return isAvailable(
       relativeTileLevel,
       relativeTileMortonId,
@@ -329,11 +331,13 @@ void SubtreeAvailability::setContentAvailable(
     uint64_t relativeTileMortonId,
     uint64_t contentId,
     bool isAvailable) noexcept {
-  this->setAvailable(
-      relativeTileLevel,
-      relativeTileMortonId,
-      this->_contentAvailability[contentId],
-      isAvailable);
+  if (contentId < this->_contentAvailability.size()) {
+    this->setAvailable(
+        relativeTileLevel,
+        relativeTileMortonId,
+        this->_contentAvailability[contentId],
+        isAvailable);
+  }
 }
 
 bool SubtreeAvailability::isSubtreeAvailable(

--- a/Cesium3DTilesContent/test/TestSubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/test/TestSubtreeAvailability.cpp
@@ -718,7 +718,7 @@ TEST_CASE("SubtreeAvailability modifications") {
 
   SubtreeAvailability& availability = *maybeAvailability;
 
-  SECTION("initially has all tiles available, and no content or subtress "
+  SECTION("initially has all tiles available, and no content or subtrees "
           "available") {
     CHECK(availability.isTileAvailable(
         QuadtreeTileID(0, 0, 0),

--- a/Cesium3DTilesContent/test/TestSubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/test/TestSubtreeAvailability.cpp
@@ -400,11 +400,11 @@ TEST_CASE("Test SubtreeAvailability methods") {
     subtreeAvailabilityBuffer.resize(subtreeBufferSize);
 
     subtree.buffers[0].byteLength = subtree.bufferViews[0].byteLength =
-        bufferSize;
+        int64_t(bufferSize);
     subtree.buffers[1].byteLength = subtree.bufferViews[1].byteLength =
-        bufferSize;
+        int64_t(bufferSize);
     subtree.buffers[2].byteLength = subtree.bufferViews[2].byteLength =
-        subtreeBufferSize;
+        int64_t(subtreeBufferSize);
 
     for (const auto& tileID : availableTileIDs) {
       markTileAvailableForQuadtree(tileID, tileAvailabilityBuffer);

--- a/Cesium3DTilesReader/CMakeLists.txt
+++ b/Cesium3DTilesReader/CMakeLists.txt
@@ -54,6 +54,7 @@ target_include_directories(
 target_link_libraries(Cesium3DTilesReader
     PUBLIC
         Cesium3DTiles
+        CesiumAsync
         CesiumJsonReader
         GSL
 )

--- a/Cesium3DTilesReader/include/Cesium3DTilesReader/SubtreeFileReader.h
+++ b/Cesium3DTilesReader/include/Cesium3DTilesReader/SubtreeFileReader.h
@@ -8,8 +8,6 @@
 
 namespace Cesium3DTilesReader {
 
-struct SubtreeReadOptions {};
-
 /**
  * @brief Reads 3D Tiles subtrees from a binary or JSON subtree file.
  *

--- a/Cesium3DTilesReader/include/Cesium3DTilesReader/SubtreeFileReader.h
+++ b/Cesium3DTilesReader/include/Cesium3DTilesReader/SubtreeFileReader.h
@@ -70,6 +70,7 @@ public:
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const std::string& url,
+      const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders,
       const gsl::span<const std::byte>& data) const noexcept;
 
 private:
@@ -78,18 +79,21 @@ private:
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const std::string& url,
+      const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders,
       const gsl::span<const std::byte>& data) const noexcept;
   CesiumAsync::Future<CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtree>>
   loadJson(
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const std::string& url,
+      const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders,
       const gsl::span<const std::byte>& data) const noexcept;
   CesiumAsync::Future<CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtree>>
   postprocess(
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const std::string& url,
+      const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders,
       CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtree>&& loaded)
       const noexcept;
 

--- a/Cesium3DTilesReader/include/Cesium3DTilesReader/SubtreeFileReader.h
+++ b/Cesium3DTilesReader/include/Cesium3DTilesReader/SubtreeFileReader.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <Cesium3DTilesReader/Library.h>
+#include <Cesium3DTilesReader/SubtreeReader.h>
+#include <CesiumAsync/AsyncSystem.h>
+#include <CesiumAsync/Future.h>
+#include <CesiumAsync/IAssetAccessor.h>
+
+namespace Cesium3DTilesReader {
+
+struct SubtreeReadOptions {};
+
+/**
+ * @brief Reads 3D Tiles subtrees from a binary or JSON subtree file.
+ *
+ * While {@link SubtreeReader} can parse a {@link Subtree} from a binary buffer
+ * as well, `SubtreeFileReader` additionally supports:
+ *
+ * 1. Loading binary subtree files.
+ * 2. Loading external buffers asynchronously.
+ * 3. Decoding buffers from data URIs.
+ *
+ * The subtree file need not be an actual file on disk.
+ */
+class CESIUM3DTILESREADER_API SubtreeFileReader {
+public:
+  /**
+   * @brief Constructs a new instance.
+   */
+  SubtreeFileReader();
+
+  /**
+   * @brief Gets the options controlling how the JSON is read.
+   */
+  CesiumJsonReader::JsonReaderOptions& getOptions();
+
+  /**
+   * @brief Gets the options controlling how the JSON is read.
+   */
+  const CesiumJsonReader::JsonReaderOptions& getOptions() const;
+
+  /**
+   * @brief Asynchronously loads a subtree from a URL.
+   *
+   * @param asyncSystem The AsyncSystem used to do asynchronous work.
+   * @param pAssetAccessor The accessor used to retrieve the URL and any other
+   * required resources.
+   * @param url The URL from which to get the subtree file.
+   * @param headers Headers to include in the request for the initial subtree
+   * file and any additional resources that are required.
+   * @return A future that resolves to the result of loading the subtree.
+   */
+  CesiumAsync::Future<CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtree>>
+  load(
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+      const std::string& url,
+      const std::vector<CesiumAsync::IAssetAccessor::THeader>& headers = {})
+      const noexcept;
+
+  CesiumAsync::Future<CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtree>>
+  load(
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+      const std::shared_ptr<CesiumAsync::IAssetRequest>& pRequest)
+      const noexcept;
+
+  CesiumAsync::Future<CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtree>>
+  load(
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+      const std::string& url,
+      const gsl::span<const std::byte>& data) const noexcept;
+
+private:
+  CesiumAsync::Future<CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtree>>
+  loadBinary(
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+      const std::string& url,
+      const gsl::span<const std::byte>& data) const noexcept;
+  CesiumAsync::Future<CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtree>>
+  loadJson(
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+      const std::string& url,
+      const gsl::span<const std::byte>& data) const noexcept;
+  CesiumAsync::Future<CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtree>>
+  postprocess(
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+      const std::string& url,
+      CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtree>&& loaded)
+      const noexcept;
+
+  SubtreeReader _reader;
+};
+
+} // namespace Cesium3DTilesReader

--- a/Cesium3DTilesReader/src/SubtreeFileReader.cpp
+++ b/Cesium3DTilesReader/src/SubtreeFileReader.cpp
@@ -1,0 +1,190 @@
+#include <Cesium3DTilesReader/SubtreeFileReader.h>
+#include <CesiumAsync/IAssetResponse.h>
+
+using namespace Cesium3DTiles;
+using namespace CesiumAsync;
+using namespace CesiumJsonReader;
+
+namespace Cesium3DTilesReader {
+
+SubtreeFileReader::SubtreeFileReader() : _reader() {}
+
+CesiumJsonReader::JsonReaderOptions& SubtreeFileReader::getOptions() {
+  return this->_reader.getOptions();
+}
+
+const CesiumJsonReader::JsonReaderOptions&
+SubtreeFileReader::getOptions() const {
+  return this->_reader.getOptions();
+}
+
+Future<ReadJsonResult<Cesium3DTiles::Subtree>> SubtreeFileReader::load(
+    const AsyncSystem& asyncSystem,
+    const std::shared_ptr<IAssetAccessor>& pAssetAccessor,
+    const std::string& url,
+    const std::vector<IAssetAccessor::THeader>& headers) const noexcept {
+  return pAssetAccessor->get(asyncSystem, url, headers)
+      .thenInWorkerThread([asyncSystem, pAssetAccessor, this](
+                              std::shared_ptr<IAssetRequest>&& pRequest) {
+        return this->load(asyncSystem, pAssetAccessor, pRequest);
+      });
+}
+
+Future<ReadJsonResult<Subtree>> SubtreeFileReader::load(
+    const AsyncSystem& asyncSystem,
+    const std::shared_ptr<IAssetAccessor>& pAssetAccessor,
+    const std::shared_ptr<IAssetRequest>& pRequest) const noexcept {
+  const IAssetResponse* pResponse = pRequest->response();
+  if (pResponse == nullptr) {
+    ReadJsonResult<Cesium3DTiles::Subtree> result;
+    result.errors.emplace_back("Request failed.");
+    return asyncSystem.createResolvedFuture(std::move(result));
+  }
+
+  uint16_t statusCode = pResponse->statusCode();
+  if (statusCode != 0 && (statusCode < 200 || statusCode >= 300)) {
+    CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtree> result;
+    result.errors.emplace_back(
+        fmt::format("Request failed with status code {}", statusCode));
+    return asyncSystem.createResolvedFuture(std::move(result));
+  }
+
+  return this
+      ->load(asyncSystem, pAssetAccessor, pRequest->url(), pResponse->data());
+}
+
+namespace {
+constexpr const char SUBTREE_MAGIC[] = "subt";
+}
+
+Future<ReadJsonResult<Subtree>> SubtreeFileReader::load(
+    const AsyncSystem& asyncSystem,
+    const std::shared_ptr<IAssetAccessor>& pAssetAccessor,
+    const std::string& url,
+    const gsl::span<const std::byte>& data) const noexcept {
+  if (data.size() < 4) {
+    CesiumJsonReader::ReadJsonResult<Subtree> result;
+    result.errors.emplace_back(fmt::format(
+        "Subtree file has only {} bytes, which is too few to be a valid "
+        "subtree.",
+        data.size()));
+    return asyncSystem.createResolvedFuture(std::move(result));
+  }
+
+  bool isBinarySubtree = true;
+  for (std::size_t i = 0; i < 4; ++i) {
+    if (data[i] != static_cast<std::byte>(SUBTREE_MAGIC[i])) {
+      isBinarySubtree = false;
+      break;
+    }
+  }
+
+  if (isBinarySubtree) {
+    return this->loadBinary(asyncSystem, pAssetAccessor, url, data);
+  } else {
+    return this->loadJson(asyncSystem, pAssetAccessor, url, data);
+  }
+}
+
+namespace {
+
+struct SubtreeHeader {
+  unsigned char magic[4];
+  uint32_t version;
+  uint64_t jsonByteLength;
+  uint64_t binaryByteLength;
+};
+
+} // namespace
+
+Future<ReadJsonResult<Subtree>> SubtreeFileReader::loadBinary(
+    const CesiumAsync::AsyncSystem& asyncSystem,
+    const std::shared_ptr<IAssetAccessor>& pAssetAccessor,
+    const std::string& url,
+    const gsl::span<const std::byte>& data) const noexcept {
+  if (data.size() < sizeof(SubtreeHeader)) {
+    CesiumJsonReader::ReadJsonResult<Subtree> result;
+    result.errors.emplace_back(fmt::format(
+        "The binary Subtree file is invalid because it is too small to include "
+        "a Subtree header.",
+        data.size()));
+    return asyncSystem.createResolvedFuture(std::move(result));
+  }
+
+  const SubtreeHeader* header =
+      reinterpret_cast<const SubtreeHeader*>(data.data());
+  if (header->jsonByteLength > data.size() - sizeof(SubtreeHeader)) {
+    CesiumJsonReader::ReadJsonResult<Subtree> result;
+    result.errors.emplace_back(fmt::format(
+        "The binary Subtree file is invalid because it is too small to include "
+        "the jsonByteLength specified in its header.",
+        data.size()));
+    return asyncSystem.createResolvedFuture(std::move(result));
+  }
+
+  if (header->binaryByteLength >
+      data.size() - sizeof(SubtreeHeader) - header->jsonByteLength) {
+    CesiumJsonReader::ReadJsonResult<Subtree> result;
+    result.errors.emplace_back(fmt::format(
+        "The binary Subtree file is invalid because it is too small to include "
+        "the binaryByteLength specified in its header.",
+        data.size()));
+    return asyncSystem.createResolvedFuture(std::move(result));
+  }
+
+  ReadJsonResult<Subtree> result = this->_reader.readFromJson(
+      data.subspan(sizeof(SubtreeHeader), header->jsonByteLength));
+
+  if (result.value) {
+    gsl::span<const std::byte> binaryChunk = data.subspan(
+        sizeof(SubtreeHeader) + header->jsonByteLength,
+        header->binaryByteLength);
+
+    if (result.value->buffers.empty()) {
+      result.errors.emplace_back("Subtree has a binary chunk but the JSON does "
+                                 "not define any buffers.");
+      return asyncSystem.createResolvedFuture(std::move(result));
+    }
+
+    Buffer& buffer = result.value->buffers[0];
+    if (buffer.uri) {
+      result.errors.emplace_back(
+          "Subtree has a binary chunk but the first buffer "
+          "in the JSON chunk also has a 'uri'.");
+      return asyncSystem.createResolvedFuture(std::move(result));
+    }
+
+    const int64_t binaryChunkSize = static_cast<int64_t>(binaryChunk.size());
+    if (buffer.byteLength > binaryChunkSize ||
+        buffer.byteLength + 3 < binaryChunkSize) {
+      result.errors.emplace_back("Subtree binary chunk size does not match the "
+                                 "size of the first buffer in the JSON chunk.");
+      return asyncSystem.createResolvedFuture(std::move(result));
+    }
+
+    buffer.cesium.data = std::vector<std::byte>(
+        binaryChunk.begin(),
+        binaryChunk.begin() + buffer.byteLength);
+  }
+
+  return postprocess(asyncSystem, pAssetAccessor, url, std::move(result));
+}
+
+CesiumAsync::Future<ReadJsonResult<Subtree>> SubtreeFileReader::loadJson(
+    const CesiumAsync::AsyncSystem& asyncSystem,
+    const std::shared_ptr<IAssetAccessor>& pAssetAccessor,
+    const std::string& url,
+    const gsl::span<const std::byte>& data) const noexcept {
+  ReadJsonResult<Subtree> result = this->_reader.readFromJson(data);
+  return postprocess(asyncSystem, pAssetAccessor, url, std::move(result));
+}
+
+Future<ReadJsonResult<Subtree>> SubtreeFileReader::postprocess(
+    const AsyncSystem& asyncSystem,
+    const std::shared_ptr<IAssetAccessor>& /* pAssetAccessor */,
+    const std::string& /* url */,
+    ReadJsonResult<Subtree>&& loaded) const noexcept {
+  return asyncSystem.createResolvedFuture(std::move(loaded));
+}
+
+} // namespace Cesium3DTilesReader

--- a/Cesium3DTilesReader/src/SubtreeFileReader.cpp
+++ b/Cesium3DTilesReader/src/SubtreeFileReader.cpp
@@ -280,7 +280,8 @@ Future<ReadJsonResult<Subtree>> SubtreeFileReader::postprocess(
                       "updated to match.",
                       buffer.byteLength,
                       completedBuffer.data.size()));
-                  buffer.byteLength = completedBuffer.data.size();
+                  buffer.byteLength =
+                      static_cast<int64_t>(completedBuffer.data.size());
                 }
                 buffer.cesium.data = std::move(completedBuffer.data);
               }

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
@@ -209,6 +209,7 @@ ImplicitOctreeLoader::loadTileContent(const TileLoadInput& loadInput) {
         subtreeID);
     return SubtreeAvailability::loadSubtree(
                3,
+               this->_subtreeLevels,
                asyncSystem,
                pAssetAccessor,
                pLogger,

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
@@ -208,7 +208,7 @@ ImplicitOctreeLoader::loadTileContent(const TileLoadInput& loadInput) {
         this->_subtreeUrlTemplate,
         subtreeID);
     return SubtreeAvailability::loadSubtree(
-               3,
+               ImplicitTileSubdivisionScheme::Octree,
                this->_subtreeLevels,
                asyncSystem,
                pAssetAccessor,

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -247,7 +247,7 @@ ImplicitQuadtreeLoader::loadTileContent(const TileLoadInput& loadInput) {
         this->_subtreeUrlTemplate,
         subtreeID);
     return SubtreeAvailability::loadSubtree(
-               2,
+               ImplicitTileSubdivisionScheme::Quadtree,
                this->_subtreeLevels,
                asyncSystem,
                pAssetAccessor,

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -248,6 +248,7 @@ ImplicitQuadtreeLoader::loadTileContent(const TileLoadInput& loadInput) {
         subtreeID);
     return SubtreeAvailability::loadSubtree(
                2,
+               this->_subtreeLevels,
                asyncSystem,
                pAssetAccessor,
                pLogger,

--- a/Cesium3DTilesSelection/test/TestImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/test/TestImplicitOctreeLoader.cpp
@@ -69,6 +69,7 @@ TEST_CASE("Test implicit octree loader") {
         OctreeTileID{0, 0, 0, 0},
         SubtreeAvailability{
             3,
+            5,
             SubtreeConstantAvailability{true},
             SubtreeConstantAvailability{false},
             {SubtreeConstantAvailability{false}},
@@ -104,6 +105,7 @@ TEST_CASE("Test implicit octree loader") {
         OctreeTileID{0, 0, 0, 0},
         SubtreeAvailability{
             2,
+            5,
             SubtreeConstantAvailability{true},
             SubtreeConstantAvailability{false},
             {SubtreeConstantAvailability{true}},
@@ -156,6 +158,7 @@ TEST_CASE("Test implicit octree loader") {
         OctreeTileID{0, 0, 0, 0},
         SubtreeAvailability{
             2,
+            5,
             SubtreeConstantAvailability{true},
             SubtreeConstantAvailability{false},
             {SubtreeConstantAvailability{true}},
@@ -245,6 +248,7 @@ TEST_CASE("Test tile subdivision for implicit octree loader") {
         OctreeTileID{0, 0, 0, 0},
         SubtreeAvailability{
             3,
+            5,
             SubtreeConstantAvailability{true},
             SubtreeConstantAvailability{false},
             {SubtreeConstantAvailability{true}},
@@ -445,6 +449,7 @@ TEST_CASE("Test tile subdivision for implicit octree loader") {
         OctreeTileID{0, 0, 0, 0},
         SubtreeAvailability{
             3,
+            5,
             SubtreeConstantAvailability{true},
             SubtreeConstantAvailability{false},
             {SubtreeConstantAvailability{true}},

--- a/Cesium3DTilesSelection/test/TestImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/test/TestImplicitOctreeLoader.cpp
@@ -68,11 +68,11 @@ TEST_CASE("Test implicit octree loader") {
     loader.addSubtreeAvailability(
         OctreeTileID{0, 0, 0, 0},
         SubtreeAvailability{
-            3,
+            ImplicitTileSubdivisionScheme::Octree,
             5,
-            SubtreeConstantAvailability{true},
-            SubtreeConstantAvailability{false},
-            {SubtreeConstantAvailability{false}},
+            SubtreeAvailability::SubtreeConstantAvailability{true},
+            SubtreeAvailability::SubtreeConstantAvailability{false},
+            {SubtreeAvailability::SubtreeConstantAvailability{false}},
             {}});
 
     // check that this tile will have empty content
@@ -104,11 +104,11 @@ TEST_CASE("Test implicit octree loader") {
     loader.addSubtreeAvailability(
         OctreeTileID{0, 0, 0, 0},
         SubtreeAvailability{
-            2,
+            ImplicitTileSubdivisionScheme::Quadtree,
             5,
-            SubtreeConstantAvailability{true},
-            SubtreeConstantAvailability{false},
-            {SubtreeConstantAvailability{true}},
+            SubtreeAvailability::SubtreeConstantAvailability{true},
+            SubtreeAvailability::SubtreeConstantAvailability{false},
+            {SubtreeAvailability::SubtreeConstantAvailability{true}},
             {}});
 
     // mock tile content b3dm
@@ -157,11 +157,11 @@ TEST_CASE("Test implicit octree loader") {
     loader.addSubtreeAvailability(
         OctreeTileID{0, 0, 0, 0},
         SubtreeAvailability{
-            2,
+            ImplicitTileSubdivisionScheme::Quadtree,
             5,
-            SubtreeConstantAvailability{true},
-            SubtreeConstantAvailability{false},
-            {SubtreeConstantAvailability{true}},
+            SubtreeAvailability::SubtreeConstantAvailability{true},
+            SubtreeAvailability::SubtreeConstantAvailability{false},
+            {SubtreeAvailability::SubtreeConstantAvailability{true}},
             {}});
 
     // mock random tile content
@@ -247,11 +247,11 @@ TEST_CASE("Test tile subdivision for implicit octree loader") {
     loader.addSubtreeAvailability(
         OctreeTileID{0, 0, 0, 0},
         SubtreeAvailability{
-            3,
+            ImplicitTileSubdivisionScheme::Octree,
             5,
-            SubtreeConstantAvailability{true},
-            SubtreeConstantAvailability{false},
-            {SubtreeConstantAvailability{true}},
+            SubtreeAvailability::SubtreeConstantAvailability{true},
+            SubtreeAvailability::SubtreeConstantAvailability{false},
+            {SubtreeAvailability::SubtreeConstantAvailability{true}},
             {}});
 
     // check subdivide root tile first
@@ -448,11 +448,11 @@ TEST_CASE("Test tile subdivision for implicit octree loader") {
     loader.addSubtreeAvailability(
         OctreeTileID{0, 0, 0, 0},
         SubtreeAvailability{
-            3,
+            ImplicitTileSubdivisionScheme::Octree,
             5,
-            SubtreeConstantAvailability{true},
-            SubtreeConstantAvailability{false},
-            {SubtreeConstantAvailability{true}},
+            SubtreeAvailability::SubtreeConstantAvailability{true},
+            SubtreeAvailability::SubtreeConstantAvailability{false},
+            {SubtreeAvailability::SubtreeConstantAvailability{true}},
             {}});
 
     // check subdivide root tile first

--- a/Cesium3DTilesSelection/test/TestImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/test/TestImplicitQuadtreeLoader.cpp
@@ -69,6 +69,7 @@ TEST_CASE("Test implicit quadtree loader") {
         QuadtreeTileID{0, 0, 0},
         SubtreeAvailability{
             2,
+            5,
             SubtreeConstantAvailability{true},
             SubtreeConstantAvailability{false},
             {SubtreeConstantAvailability{false}},
@@ -104,6 +105,7 @@ TEST_CASE("Test implicit quadtree loader") {
         QuadtreeTileID{0, 0, 0},
         SubtreeAvailability{
             2,
+            5,
             SubtreeConstantAvailability{true},
             SubtreeConstantAvailability{false},
             {SubtreeConstantAvailability{true}},
@@ -156,6 +158,7 @@ TEST_CASE("Test implicit quadtree loader") {
         QuadtreeTileID{0, 0, 0},
         SubtreeAvailability{
             2,
+            5,
             SubtreeConstantAvailability{true},
             SubtreeConstantAvailability{false},
             {SubtreeConstantAvailability{true}},
@@ -221,6 +224,7 @@ TEST_CASE("Test tile subdivision for implicit quadtree loader") {
         QuadtreeTileID{0, 0, 0},
         SubtreeAvailability{
             2,
+            5,
             SubtreeConstantAvailability{true},
             SubtreeConstantAvailability{false},
             {SubtreeConstantAvailability{true}},
@@ -362,6 +366,7 @@ TEST_CASE("Test tile subdivision for implicit quadtree loader") {
         QuadtreeTileID{0, 0, 0},
         SubtreeAvailability{
             2,
+            5,
             SubtreeConstantAvailability{true},
             SubtreeConstantAvailability{false},
             {SubtreeConstantAvailability{true}},
@@ -496,6 +501,7 @@ TEST_CASE("Test tile subdivision for implicit quadtree loader") {
         QuadtreeTileID{0, 0, 0},
         SubtreeAvailability{
             2,
+            5,
             SubtreeConstantAvailability{true},
             SubtreeConstantAvailability{false},
             {SubtreeConstantAvailability{true}},

--- a/Cesium3DTilesSelection/test/TestImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/test/TestImplicitQuadtreeLoader.cpp
@@ -68,11 +68,11 @@ TEST_CASE("Test implicit quadtree loader") {
     loader.addSubtreeAvailability(
         QuadtreeTileID{0, 0, 0},
         SubtreeAvailability{
-            2,
+            ImplicitTileSubdivisionScheme::Quadtree,
             5,
-            SubtreeConstantAvailability{true},
-            SubtreeConstantAvailability{false},
-            {SubtreeConstantAvailability{false}},
+            SubtreeAvailability::SubtreeConstantAvailability{true},
+            SubtreeAvailability::SubtreeConstantAvailability{false},
+            {SubtreeAvailability::SubtreeConstantAvailability{false}},
             {}});
 
     // check that this tile will have empty content
@@ -104,11 +104,11 @@ TEST_CASE("Test implicit quadtree loader") {
     loader.addSubtreeAvailability(
         QuadtreeTileID{0, 0, 0},
         SubtreeAvailability{
-            2,
+            ImplicitTileSubdivisionScheme::Quadtree,
             5,
-            SubtreeConstantAvailability{true},
-            SubtreeConstantAvailability{false},
-            {SubtreeConstantAvailability{true}},
+            SubtreeAvailability::SubtreeConstantAvailability{true},
+            SubtreeAvailability::SubtreeConstantAvailability{false},
+            {SubtreeAvailability::SubtreeConstantAvailability{true}},
             {}});
 
     // mock tile content b3dm
@@ -157,11 +157,11 @@ TEST_CASE("Test implicit quadtree loader") {
     loader.addSubtreeAvailability(
         QuadtreeTileID{0, 0, 0},
         SubtreeAvailability{
-            2,
+            ImplicitTileSubdivisionScheme::Quadtree,
             5,
-            SubtreeConstantAvailability{true},
-            SubtreeConstantAvailability{false},
-            {SubtreeConstantAvailability{true}},
+            SubtreeAvailability::SubtreeConstantAvailability{true},
+            SubtreeAvailability::SubtreeConstantAvailability{false},
+            {SubtreeAvailability::SubtreeConstantAvailability{true}},
             {}});
 
     // mock tile content b3dm
@@ -223,11 +223,11 @@ TEST_CASE("Test tile subdivision for implicit quadtree loader") {
     loader.addSubtreeAvailability(
         QuadtreeTileID{0, 0, 0},
         SubtreeAvailability{
-            2,
+            ImplicitTileSubdivisionScheme::Quadtree,
             5,
-            SubtreeConstantAvailability{true},
-            SubtreeConstantAvailability{false},
-            {SubtreeConstantAvailability{true}},
+            SubtreeAvailability::SubtreeConstantAvailability{true},
+            SubtreeAvailability::SubtreeConstantAvailability{false},
+            {SubtreeAvailability::SubtreeConstantAvailability{true}},
             {}});
 
     // check subdivide root tile first
@@ -365,11 +365,11 @@ TEST_CASE("Test tile subdivision for implicit quadtree loader") {
     loader.addSubtreeAvailability(
         QuadtreeTileID{0, 0, 0},
         SubtreeAvailability{
-            2,
+            ImplicitTileSubdivisionScheme::Quadtree,
             5,
-            SubtreeConstantAvailability{true},
-            SubtreeConstantAvailability{false},
-            {SubtreeConstantAvailability{true}},
+            SubtreeAvailability::SubtreeConstantAvailability{true},
+            SubtreeAvailability::SubtreeConstantAvailability{false},
+            {SubtreeAvailability::SubtreeConstantAvailability{true}},
             {}});
 
     // check subdivide root tile first
@@ -500,11 +500,11 @@ TEST_CASE("Test tile subdivision for implicit quadtree loader") {
     loader.addSubtreeAvailability(
         QuadtreeTileID{0, 0, 0},
         SubtreeAvailability{
-            2,
+            ImplicitTileSubdivisionScheme::Quadtree,
             5,
-            SubtreeConstantAvailability{true},
-            SubtreeConstantAvailability{false},
-            {SubtreeConstantAvailability{true}},
+            SubtreeAvailability::SubtreeConstantAvailability{true},
+            SubtreeAvailability::SubtreeConstantAvailability{false},
+            {SubtreeAvailability::SubtreeConstantAvailability{true}},
             {}});
 
     Tile tile(&loader);

--- a/Cesium3DTilesSelection/test/data/ImplicitTileset/subtrees/0.0.0.json
+++ b/Cesium3DTilesSelection/test/data/ImplicitTileset/subtrees/0.0.0.json
@@ -2,9 +2,9 @@
   "tileAvailability": {
     "constant": 1
   },
-  "contentAvailability": {
+  "contentAvailability": [{
     "constant": 1
-  },
+  }],
   "childSubtreeAvailability": {
     "constant": 0
   }

--- a/tools/generate-classes/3dTiles.json
+++ b/tools/generate-classes/3dTiles.json
@@ -18,6 +18,9 @@
     },
     "Metadata Entity": {
       "isBaseClass": true
+    },
+    "Buffer": {
+      "toBeInherited": true
     }
   },
   "extensions": [


### PR DESCRIPTION
This is a PR into #752 so merge that first.

This PR makes "querying" of implicit tile availability usable from outside the Cesium3DTilesSelection library and the selection-specific "loader" classes. It also adds the ability to modify availability information that is already loaded.