### PR TITLE
Fix `PropertyAttributeView::forEachProperty`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,10 @@
 
 - Added `Cesium3DTilesContent` library and namespace. It has classes for loading, converting, and manipulating 3D Tiles tile content.
 
+##### Fixes :wrench:
+
+- Fixed compiler error when calling `PropertyAttributeView::forEachProperty`.
+
 ### v0.29.0 - 2023-11-01
 
 ##### Breaking Changes :mega:

--- a/CesiumGltf/include/CesiumGltf/PropertyAttributeView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyAttributeView.h
@@ -308,8 +308,8 @@ public:
   forEachProperty(const MeshPrimitive& primitive, Callback&& callback) const {
     for (const auto& property : this->_pClass->properties) {
       getPropertyView(
-          property.first,
           primitive,
+          property.first,
           std::forward<Callback>(callback));
     }
   }


### PR DESCRIPTION
Fixes `PropertyAttributeView::forEachProperty`. The parameter order just needed to be swapped.