### PR TITLE
Fix property related docs

### DIFF
--- a/CesiumGltf/include/CesiumGltf/PropertyAttributePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyAttributePropertyView.h
@@ -16,7 +16,7 @@ namespace CesiumGltf {
  *
  * The {@link PropertyAttributePropertyView} constructor always completes
  * successfully. However it may not always reflect the actual content of the
- * corresponding property texture property. This enumeration provides the
+ * corresponding property attribute property. This enumeration provides the
  * reason.
  */
 class PropertyAttributePropertyViewStatus : public PropertyViewStatus {
@@ -190,7 +190,7 @@ public:
                 : 0} {}
 
   /**
-   * @brief Gets the value of the property for the given texture coordinates
+   * @brief Gets the value of the property for the given vertex index
    * with all value transforms applied. That is, if the property specifies an
    * offset and scale, they will be applied to the value before the value is
    * returned.
@@ -346,7 +346,7 @@ public:
                 : 0} {}
 
   /**
-   * @brief Gets the value of the property for the given texture coordinates
+   * @brief Gets the value of the property for the given vertex index
    * with all value transforms applied. That is, if the property specifies an
    * offset and scale, they will be applied to the value before the value is
    * returned.

--- a/CesiumGltf/include/CesiumGltf/PropertyAttributeView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyAttributeView.h
@@ -90,13 +90,13 @@ public:
 
   /**
    * @brief Finds the {@link ClassProperty} that
-   * describes the type information of the property with the specified name.
-   * @param propertyName The name of the property to retrieve the class for.
+   * describes the type information of the property with the specified id.
+   * @param propertyId The id of the property to retrieve the class for.
    * @return A pointer to the {@link ClassProperty}.
    * Return nullptr if the PropertyAttributeView is invalid or if no class
    * property was found.
    */
-  const ClassProperty* getClassProperty(const std::string& propertyName) const;
+  const ClassProperty* getClassProperty(const std::string& propertyId) const;
 
   /**
    * @brief Gets a {@link PropertyAttributePropertyView} that views the data of a
@@ -118,19 +118,19 @@ public:
    * @tparam Normalized Whether the property is normalized. Only applicable to
    * types with integer components.
    * @param primitive The target primitive
-   * @param propertyName The name of the property to retrieve data from
+   * @param propertyId The id of the property to retrieve data from
    * @return A {@link PropertyAttributePropertyView} of the property. If no valid
    * property is found, the property view will be invalid.
    */
   template <typename T, bool Normalized = false>
   PropertyAttributePropertyView<T, Normalized> getPropertyView(
       const MeshPrimitive& primitive,
-      const std::string& propertyName) const {
+      const std::string& propertyId) const {
     if (this->_status != PropertyAttributeViewStatus::Valid) {
       return PropertyAttributePropertyView<T, Normalized>(
           PropertyAttributePropertyViewStatus::ErrorInvalidPropertyAttribute);
     }
-    const ClassProperty* pClassProperty = getClassProperty(propertyName);
+    const ClassProperty* pClassProperty = getClassProperty(propertyId);
     if (!pClassProperty) {
       return PropertyAttributePropertyView<T, Normalized>(
           PropertyAttributePropertyViewStatus::ErrorNonexistentProperty);
@@ -145,14 +145,14 @@ public:
 
     return getPropertyViewImpl<T, Normalized>(
         primitive,
-        propertyName,
+        propertyId,
         *pClassProperty);
   }
 
   /**
    * @brief Gets a {@link PropertyAttributePropertyView} through a callback that accepts a
-   * property name and a {@link PropertyAttributePropertyView<T>} that views the data
-   * of the property with the specified name.
+   * property id and a {@link PropertyAttributePropertyView<T>} that views the data
+   * of the property with the specified id.
    *
    * This method will validate the EXT_structural_metadata format to ensure
    * {@link PropertyAttributePropertyView} retrieves the correct data. T must
@@ -165,28 +165,28 @@ public:
    * property view will be passed to the callback.
    *
    * @param primitive The target primitive
-   * @param propertyName The name of the property to retrieve data from
-   * @tparam callback A callback function that accepts a property name and a
+   * @param propertyId The id of the property to retrieve data from
+   * @tparam callback A callback function that accepts a property id and a
    * {@link PropertyAttributePropertyView<T>}
    */
   template <typename Callback>
   void getPropertyView(
       const MeshPrimitive& primitive,
-      const std::string& propertyName,
+      const std::string& propertyId,
       Callback&& callback) const {
     if (this->_status != PropertyAttributeViewStatus::Valid) {
       callback(
-          propertyName,
+          propertyId,
           PropertyAttributePropertyView<uint8_t>(
               PropertyAttributePropertyViewStatus::
                   ErrorInvalidPropertyAttribute));
       return;
     }
 
-    const ClassProperty* pClassProperty = getClassProperty(propertyName);
+    const ClassProperty* pClassProperty = getClassProperty(propertyId);
     if (!pClassProperty) {
       callback(
-          propertyName,
+          propertyId,
           PropertyAttributePropertyView<uint8_t>(
               PropertyAttributePropertyViewStatus::ErrorNonexistentProperty));
       return;
@@ -194,7 +194,7 @@ public:
 
     if (pClassProperty->array) {
       callback(
-          propertyName,
+          propertyId,
           PropertyAttributePropertyView<uint8_t>(
               PropertyAttributePropertyViewStatus::ErrorUnsupportedProperty));
       return;
@@ -210,7 +210,7 @@ public:
     bool normalized = pClassProperty->normalized;
     if (normalized && !isPropertyComponentTypeInteger(componentType)) {
       callback(
-          propertyName,
+          propertyId,
           PropertyAttributePropertyView<uint8_t>(
               PropertyAttributePropertyViewStatus::ErrorInvalidNormalization));
       return;
@@ -220,14 +220,14 @@ public:
       if (normalized) {
         getScalarPropertyViewImpl<Callback, true>(
             primitive,
-            propertyName,
+            propertyId,
             *pClassProperty,
             componentType,
             std::forward<Callback>(callback));
       } else {
         getScalarPropertyViewImpl<Callback, false>(
             primitive,
-            propertyName,
+            propertyId,
             *pClassProperty,
             componentType,
             std::forward<Callback>(callback));
@@ -239,7 +239,7 @@ public:
       if (normalized) {
         getVecNPropertyViewImpl<Callback, true>(
             primitive,
-            propertyName,
+            propertyId,
             *pClassProperty,
             type,
             componentType,
@@ -247,7 +247,7 @@ public:
       } else {
         getVecNPropertyViewImpl<Callback, false>(
             primitive,
-            propertyName,
+            propertyId,
             *pClassProperty,
             type,
             componentType,
@@ -260,7 +260,7 @@ public:
       if (normalized) {
         getMatNPropertyViewImpl<Callback, true>(
             primitive,
-            propertyName,
+            propertyId,
             *pClassProperty,
             type,
             componentType,
@@ -268,7 +268,7 @@ public:
       } else {
         getMatNPropertyViewImpl<Callback, false>(
             primitive,
-            propertyName,
+            propertyId,
             *pClassProperty,
             type,
             componentType,
@@ -278,7 +278,7 @@ public:
     }
 
     callback(
-        propertyName,
+        propertyId,
         PropertyAttributePropertyView<uint8_t>(
             PropertyAttributePropertyViewStatus::ErrorUnsupportedProperty));
     return;
@@ -286,21 +286,21 @@ public:
 
   /**
    * @brief Iterates over each property in the {@link PropertyAttribute} with a callback
-   * that accepts a property name and a {@link PropertyAttributePropertyView<T>} to view
+   * that accepts a property id and a {@link PropertyAttributePropertyView<T>} to view
    * the data stored in the {@link PropertyAttributeProperty}.
    *
    * This method will validate the EXT_structural_metadata format to ensure
    * {@link PropertyAttributePropertyView} retrieves the correct data. T must be
-   * a scalar with a supported component type (uint8_t, uint16_t, uint32_t,
-   * float), a glm vecN composed of one of the scalar types, or a
-   * PropertyArrayView containing one of the scalar types.
+   * a scalar with a supported component type (int8_t, uint8_t, int16_t,
+   * uint16_t, uint32_t, float), a glm vecN composed of one of the scalar types,
+   * or a PropertyArrayView containing one of the scalar types.
    *
    * If the property is invalid, an empty {@link PropertyAttributePropertyView} with an
    * error status will be passed to the callback. Otherwise, a valid property
    * view will be passed to the callback.
    *
-   * @param propertyName The name of the property to retrieve data from
-   * @tparam callback A callback function that accepts property name and
+   * @param propertyId The id of the property to retrieve data from
+   * @tparam callback A callback function that accepts property id and
    * {@link PropertyAttributePropertyView<T>}
    */
   template <typename Callback>
@@ -343,10 +343,10 @@ private:
   template <typename T, bool Normalized>
   PropertyAttributePropertyView<T, Normalized> getPropertyViewImpl(
       const MeshPrimitive& primitive,
-      const std::string& propertyName,
+      const std::string& propertyId,
       const ClassProperty& classProperty) const {
     auto propertyAttributePropertyIter =
-        _pPropertyAttribute->properties.find(propertyName);
+        _pPropertyAttribute->properties.find(propertyId);
     if (propertyAttributePropertyIter ==
         _pPropertyAttribute->properties.end()) {
       if (!classProperty.required && classProperty.defaultProperty) {
@@ -375,62 +375,62 @@ private:
   template <typename Callback, bool Normalized>
   void getScalarPropertyViewImpl(
       const MeshPrimitive& primitive,
-      const std::string& propertyName,
+      const std::string& propertyId,
       const ClassProperty& classProperty,
       PropertyComponentType componentType,
       Callback&& callback) const {
     switch (componentType) {
     case PropertyComponentType::Int8:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<int8_t, Normalized>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       return;
     case PropertyComponentType::Uint8:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<uint8_t, Normalized>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       return;
     case PropertyComponentType::Int16:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<int16_t, Normalized>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       return;
     case PropertyComponentType::Uint16:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<uint16_t, Normalized>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       break;
     case PropertyComponentType::Uint32:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<uint32_t, Normalized>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       break;
     case PropertyComponentType::Float32:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<float, false>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       break;
     default:
       callback(
-          propertyName,
+          propertyId,
           PropertyAttributePropertyView<uint8_t>(
               PropertyAttributePropertyViewStatus::ErrorUnsupportedProperty));
       break;
@@ -440,62 +440,62 @@ private:
   template <typename Callback, glm::length_t N, bool Normalized>
   void getVecNPropertyViewImpl(
       const MeshPrimitive& primitive,
-      const std::string& propertyName,
+      const std::string& propertyId,
       const ClassProperty& classProperty,
       PropertyComponentType componentType,
       Callback&& callback) const {
     switch (componentType) {
     case PropertyComponentType::Int8:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<glm::vec<N, int8_t>, Normalized>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       break;
     case PropertyComponentType::Uint8:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<glm::vec<N, uint8_t>, Normalized>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       break;
     case PropertyComponentType::Int16:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<glm::vec<N, int16_t>, Normalized>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       break;
     case PropertyComponentType::Uint16:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<glm::vec<N, uint16_t>, Normalized>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       break;
     case PropertyComponentType::Uint32:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<glm::vec<N, uint32_t>, Normalized>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       break;
     case PropertyComponentType::Float32:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<glm::vec<N, float>, false>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       break;
     default:
       callback(
-          propertyName,
+          propertyId,
           PropertyAttributePropertyView<uint8_t>(
               PropertyAttributePropertyViewStatus::ErrorUnsupportedProperty));
       break;
@@ -505,7 +505,7 @@ private:
   template <typename Callback, bool Normalized>
   void getVecNPropertyViewImpl(
       const MeshPrimitive& primitive,
-      const std::string& propertyName,
+      const std::string& propertyId,
       const ClassProperty& classProperty,
       PropertyType type,
       PropertyComponentType componentType,
@@ -515,7 +515,7 @@ private:
     case 2:
       getVecNPropertyViewImpl<Callback, 2, Normalized>(
           primitive,
-          propertyName,
+          propertyId,
           classProperty,
           componentType,
           std::forward<Callback>(callback));
@@ -523,7 +523,7 @@ private:
     case 3:
       getVecNPropertyViewImpl<Callback, 3, Normalized>(
           primitive,
-          propertyName,
+          propertyId,
           classProperty,
           componentType,
           std::forward<Callback>(callback));
@@ -531,14 +531,14 @@ private:
     case 4:
       getVecNPropertyViewImpl<Callback, 4, Normalized>(
           primitive,
-          propertyName,
+          propertyId,
           classProperty,
           componentType,
           std::forward<Callback>(callback));
       break;
     default:
       callback(
-          propertyName,
+          propertyId,
           PropertyAttributePropertyView<uint8_t>(
               PropertyAttributePropertyViewStatus::ErrorTypeMismatch));
       break;
@@ -548,62 +548,62 @@ private:
   template <typename Callback, glm::length_t N, bool Normalized>
   void getMatNPropertyViewImpl(
       const MeshPrimitive& primitive,
-      const std::string& propertyName,
+      const std::string& propertyId,
       const ClassProperty& classProperty,
       PropertyComponentType componentType,
       Callback&& callback) const {
     switch (componentType) {
     case PropertyComponentType::Int8:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<glm::mat<N, N, int8_t>, Normalized>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       break;
     case PropertyComponentType::Uint8:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<glm::mat<N, N, uint8_t>, Normalized>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       break;
     case PropertyComponentType::Int16:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<glm::mat<N, N, int16_t>, Normalized>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       break;
     case PropertyComponentType::Uint16:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<glm::mat<N, N, uint16_t>, Normalized>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       break;
     case PropertyComponentType::Uint32:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<glm::mat<N, N, uint32_t>, Normalized>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       break;
     case PropertyComponentType::Float32:
       callback(
-          propertyName,
+          propertyId,
           getPropertyViewImpl<glm::mat<N, N, float>, false>(
               primitive,
-              propertyName,
+              propertyId,
               classProperty));
       break;
     default:
       callback(
-          propertyName,
+          propertyId,
           PropertyAttributePropertyView<uint8_t>(
               PropertyAttributePropertyViewStatus::ErrorUnsupportedProperty));
       break;
@@ -613,7 +613,7 @@ private:
   template <typename Callback, bool Normalized>
   void getMatNPropertyViewImpl(
       const MeshPrimitive& primitive,
-      const std::string& propertyName,
+      const std::string& propertyId,
       const ClassProperty& classProperty,
       PropertyType type,
       PropertyComponentType componentType,
@@ -623,7 +623,7 @@ private:
     case 2:
       getMatNPropertyViewImpl<Callback, 2, Normalized>(
           primitive,
-          propertyName,
+          propertyId,
           classProperty,
           componentType,
           std::forward<Callback>(callback));
@@ -631,7 +631,7 @@ private:
     case 3:
       getMatNPropertyViewImpl<Callback, 3, Normalized>(
           primitive,
-          propertyName,
+          propertyId,
           classProperty,
           componentType,
           std::forward<Callback>(callback));
@@ -639,14 +639,14 @@ private:
     case 4:
       getMatNPropertyViewImpl<Callback, 4, Normalized>(
           primitive,
-          propertyName,
+          propertyId,
           classProperty,
           componentType,
           std::forward<Callback>(callback));
       break;
     default:
       callback(
-          propertyName,
+          propertyId,
           PropertyAttributePropertyView<uint8_t>(
               PropertyAttributePropertyViewStatus::ErrorTypeMismatch));
       break;

--- a/CesiumGltf/include/CesiumGltf/PropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyView.h
@@ -415,7 +415,7 @@ public:
 
   /**
    * @brief Gets the name of the property being viewed. Returns std::nullopt if
-   * no description was provided.
+   * no name was specified.
    */
   const std::optional<std::string>& name() const noexcept { return _name; }
 
@@ -431,7 +431,7 @@ public:
 
   /**
    * @brief Gets the description of the property being viewed. Returns
-   * std::nullopt if no name was specified.
+   * std::nullopt if no description was specified.
    */
   const std::optional<std::string>& description() const noexcept {
     return _description;
@@ -1596,7 +1596,7 @@ private:
           }
 
           if (property.scale) {
-            // Only floating point types can specify an offset.
+            // Only floating point types can specify a scale.
             switch (TypeToPropertyType<ElementType>::component) {
             case PropertyComponentType::Float32:
             case PropertyComponentType::Float64:

--- a/CesiumGltf/src/PropertyAttributeView.cpp
+++ b/CesiumGltf/src/PropertyAttributeView.cpp
@@ -78,12 +78,12 @@ PropertyAttributeView::PropertyAttributeView(
 }
 
 const ClassProperty*
-PropertyAttributeView::getClassProperty(const std::string& propertyName) const {
+PropertyAttributeView::getClassProperty(const std::string& propertyId) const {
   if (_status != PropertyAttributeViewStatus::Valid) {
     return nullptr;
   }
 
-  auto propertyIter = _pClass->properties.find(propertyName);
+  auto propertyIter = _pClass->properties.find(propertyId);
   if (propertyIter == _pClass->properties.end()) {
     return nullptr;
   }

--- a/CesiumGltf/src/PropertyTableView.cpp
+++ b/CesiumGltf/src/PropertyTableView.cpp
@@ -134,12 +134,12 @@ PropertyTableView::PropertyTableView(
 }
 
 const ClassProperty*
-PropertyTableView::getClassProperty(const std::string& propertyName) const {
+PropertyTableView::getClassProperty(const std::string& propertyId) const {
   if (_status != PropertyTableViewStatus::Valid) {
     return nullptr;
   }
 
-  auto propertyIter = _pClass->properties.find(propertyName);
+  auto propertyIter = _pClass->properties.find(propertyId);
   if (propertyIter == _pClass->properties.end()) {
     return nullptr;
   }

--- a/CesiumGltf/src/PropertyTextureView.cpp
+++ b/CesiumGltf/src/PropertyTextureView.cpp
@@ -32,12 +32,12 @@ PropertyTextureView::PropertyTextureView(
 }
 
 const ClassProperty*
-PropertyTextureView::getClassProperty(const std::string& propertyName) const {
+PropertyTextureView::getClassProperty(const std::string& propertyId) const {
   if (_status != PropertyTextureViewStatus::Valid) {
     return nullptr;
   }
 
-  auto propertyIter = _pClass->properties.find(propertyName);
+  auto propertyIter = _pClass->properties.find(propertyId);
   if (propertyIter == _pClass->properties.end()) {
     return nullptr;
   }

--- a/CesiumGltf/test/TestPropertyAttributeView.cpp
+++ b/CesiumGltf/test/TestPropertyAttributeView.cpp
@@ -1534,7 +1534,7 @@ TEST_CASE("Test callback on invalid property Attribute view") {
       primitive,
       "TestClassProperty",
       [&invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         REQUIRE(
@@ -1578,7 +1578,7 @@ TEST_CASE("Test callback on invalid PropertyAttributeProperty") {
 
   uint32_t invokedCallbackCount = 0;
   auto testCallback = [&invokedCallbackCount](
-                          const std::string& /*propertyName*/,
+                          const std::string& /*propertyId*/,
                           auto propertyValue) mutable {
     invokedCallbackCount++;
     REQUIRE(
@@ -1623,7 +1623,7 @@ TEST_CASE("Test callback on invalid normalized PropertyAttributeProperty") {
 
   uint32_t invokedCallbackCount = 0;
   auto testCallback = [&invokedCallbackCount](
-                          const std::string& /*propertyName*/,
+                          const std::string& /*propertyId*/,
                           auto propertyValue) mutable {
     invokedCallbackCount++;
     REQUIRE(
@@ -1680,7 +1680,7 @@ TEST_CASE("Test callback for scalar PropertyAttributeProperty") {
       primitive,
       "TestClassProperty",
       [&data, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         if constexpr (std::is_same_v<
@@ -1748,7 +1748,7 @@ TEST_CASE("Test callback for scalar PropertyAttributeProperty (normalized)") {
       primitive,
       "TestClassProperty",
       [&data, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         if constexpr (std::is_same_v<
@@ -1821,7 +1821,7 @@ TEST_CASE("Test callback for vecN PropertyAttributeProperty") {
       primitive,
       "TestClassProperty",
       [&data, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         if constexpr (std::is_same_v<
@@ -1893,7 +1893,7 @@ TEST_CASE("Test callback for vecN PropertyAttributeProperty (normalized)") {
       primitive,
       "TestClassProperty",
       [&data, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         if constexpr (std::is_same_v<
@@ -1976,7 +1976,7 @@ TEST_CASE("Test callback for matN PropertyAttributeProperty") {
       primitive,
       "TestClassProperty",
       [&data, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         if constexpr (std::is_same_v<
@@ -2062,7 +2062,7 @@ TEST_CASE("Test callback for matN PropertyAttributeProperty (normalized)") {
       primitive,
       "TestClassProperty",
       [&data, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         if constexpr (std::is_same_v<
@@ -2144,7 +2144,7 @@ TEST_CASE("Test callback on unsupported PropertyAttributeProperty") {
       primitive,
       "DoubleClassProperty",
       [&invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         REQUIRE(
@@ -2157,7 +2157,7 @@ TEST_CASE("Test callback on unsupported PropertyAttributeProperty") {
       primitive,
       "ArrayClassProperty",
       [&invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         REQUIRE(
@@ -2216,7 +2216,7 @@ TEST_CASE(
       primitive,
       "TestClassProperty",
       [defaultValue, &data, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         if constexpr (std::is_same_v<

--- a/CesiumGltf/test/TestPropertyTableView.cpp
+++ b/CesiumGltf/test/TestPropertyTableView.cpp
@@ -3953,7 +3953,7 @@ TEST_CASE("Test callback on invalid property table view") {
 
   uint32_t invokedCallbackCount = 0;
   auto callback = [&invokedCallbackCount](
-                      const std::string& /*propertyName*/,
+                      const std::string& /*propertyId*/,
                       auto property) mutable {
     invokedCallbackCount++;
     REQUIRE(
@@ -3998,7 +3998,7 @@ TEST_CASE("Test callback for invalid PropertyTableProperty") {
 
   uint32_t invokedCallbackCount = 0;
   auto testCallback = [&invokedCallbackCount](
-                          const std::string& /*propertyName*/,
+                          const std::string& /*propertyId*/,
                           auto propertyValue) mutable {
     invokedCallbackCount++;
     REQUIRE(propertyValue.status() != PropertyTablePropertyViewStatus::Valid);
@@ -4049,7 +4049,7 @@ TEST_CASE("Test callback for invalid normalized PropertyTableProperty") {
   view.getPropertyView(
       "TestClassProperty",
       [&invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         REQUIRE(
@@ -4102,7 +4102,7 @@ TEST_CASE("Test callback for scalar PropertyTableProperty") {
   view.getPropertyView(
       "TestClassProperty",
       [&values, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         if constexpr (std::is_same_v<
@@ -4170,7 +4170,7 @@ TEST_CASE("Test callback for scalar PropertyTableProperty (normalized)") {
   view.getPropertyView(
       "TestClassProperty",
       [&values, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         if constexpr (std::is_same_v<
@@ -4241,7 +4241,7 @@ TEST_CASE("Test callback for vecN PropertyTableProperty") {
   view.getPropertyView(
       "TestClassProperty",
       [&values, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         REQUIRE(
@@ -4313,7 +4313,7 @@ TEST_CASE("Test callback for vecN PropertyTableProperty (normalized)") {
   view.getPropertyView(
       "TestClassProperty",
       [&values, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         REQUIRE(
@@ -4392,7 +4392,7 @@ TEST_CASE("Test callback for matN PropertyTableProperty") {
   view.getPropertyView(
       "TestClassProperty",
       [&values, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         REQUIRE(
             propertyValue.status() == PropertyTablePropertyViewStatus::Valid);
@@ -4472,7 +4472,7 @@ TEST_CASE("Test callback for matN PropertyTableProperty (normalized)") {
   view.getPropertyView(
       "TestClassProperty",
       [&values, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         REQUIRE(
             propertyValue.status() == PropertyTablePropertyViewStatus::Valid);
@@ -4554,7 +4554,7 @@ TEST_CASE("Test callback for boolean PropertyTableProperty") {
   view.getPropertyView(
       "TestClassProperty",
       [&expected, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
 
@@ -4645,7 +4645,7 @@ TEST_CASE("Test callback for string PropertyTableProperty") {
   view.getPropertyView(
       "TestClassProperty",
       [&expected, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         REQUIRE(
@@ -4716,7 +4716,7 @@ TEST_CASE("Test callback for scalar array PropertyTableProperty") {
   view.getPropertyView(
       "TestClassProperty",
       [&values, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) {
         invokedCallbackCount++;
         REQUIRE(
@@ -4792,7 +4792,7 @@ TEST_CASE("Test callback for scalar array PropertyTableProperty (normalized)") {
   view.getPropertyView(
       "TestClassProperty",
       [&values, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) {
         invokedCallbackCount++;
         REQUIRE(
@@ -4873,7 +4873,7 @@ TEST_CASE("Test callback for vecN array PropertyTableProperty") {
   view.getPropertyView(
       "TestClassProperty",
       [&values, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) {
         invokedCallbackCount++;
         REQUIRE(
@@ -4955,7 +4955,7 @@ TEST_CASE("Test callback for vecN array PropertyTableProperty (normalized)") {
   view.getPropertyView(
       "TestClassProperty",
       [&values, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) {
         invokedCallbackCount++;
         REQUIRE(
@@ -5049,7 +5049,7 @@ TEST_CASE("Test callback for matN array PropertyTableProperty") {
   view.getPropertyView(
       "TestClassProperty",
       [&values, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) {
         invokedCallbackCount++;
         REQUIRE(
@@ -5140,7 +5140,7 @@ TEST_CASE("Test callback for boolean array PropertyTableProperty") {
   view.getPropertyView(
       "TestClassProperty",
       [&expected, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) {
         invokedCallbackCount++;
         REQUIRE(
@@ -5242,7 +5242,7 @@ TEST_CASE("Test callback for string array PropertyTableProperty") {
   view.getPropertyView(
       "TestClassProperty",
       [&invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) {
         invokedCallbackCount++;
         REQUIRE(
@@ -5326,7 +5326,7 @@ TEST_CASE("Test callback for empty PropertyTableProperty with default value") {
   view.getPropertyView(
       "TestClassProperty",
       [defaultValue, count = propertyTable.count, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         if constexpr (std::is_same_v<

--- a/CesiumGltf/test/TestPropertyTextureView.cpp
+++ b/CesiumGltf/test/TestPropertyTextureView.cpp
@@ -1540,7 +1540,7 @@ TEST_CASE("Test callback on invalid property texture view") {
   view.getPropertyView(
       "TestClassProperty",
       [&invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         REQUIRE(
@@ -1580,7 +1580,7 @@ TEST_CASE("Test callback on invalid PropertyTextureProperty") {
 
   uint32_t invokedCallbackCount = 0;
   auto testCallback = [&invokedCallbackCount](
-                          const std::string& /*propertyName*/,
+                          const std::string& /*propertyId*/,
                           auto propertyValue) mutable {
     invokedCallbackCount++;
     REQUIRE(propertyValue.status() != PropertyTexturePropertyViewStatus::Valid);
@@ -1622,7 +1622,7 @@ TEST_CASE("Test callback on invalid normalized PropertyTextureProperty") {
 
   uint32_t invokedCallbackCount = 0;
   auto testCallback = [&invokedCallbackCount](
-                          const std::string& /*propertyName*/,
+                          const std::string& /*propertyId*/,
                           auto propertyValue) mutable {
     invokedCallbackCount++;
     REQUIRE(
@@ -1690,7 +1690,7 @@ TEST_CASE("Test callback for scalar PropertyTextureProperty") {
   view.getPropertyView(
       "TestClassProperty",
       [&expected, &texCoords, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         if constexpr (std::is_same_v<
@@ -1770,7 +1770,7 @@ TEST_CASE("Test callback for scalar PropertyTextureProperty (normalized)") {
   view.getPropertyView(
       "TestClassProperty",
       [&expected, &texCoords, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         if constexpr (std::is_same_v<
@@ -1860,7 +1860,7 @@ TEST_CASE("Test callback for vecN PropertyTextureProperty") {
   view.getPropertyView(
       "TestClassProperty",
       [&expected, &texCoords, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         if constexpr (std::is_same_v<
@@ -1951,7 +1951,7 @@ TEST_CASE("Test callback for vecN PropertyTextureProperty (normalized)") {
   view.getPropertyView(
       "TestClassProperty",
       [&expected, &texCoords, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         if constexpr (std::is_same_v<
@@ -2043,7 +2043,7 @@ TEST_CASE("Test callback for array PropertyTextureProperty") {
   view.getPropertyView(
       "TestClassProperty",
       [&expected, &texCoords, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         if constexpr (std::is_same_v<
@@ -2153,7 +2153,7 @@ TEST_CASE("Test callback for array PropertyTextureProperty (normalized)") {
   view.getPropertyView(
       "TestClassProperty",
       [&expected, &texCoords, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         if constexpr (
@@ -2269,7 +2269,7 @@ TEST_CASE("Test callback on unsupported PropertyTextureProperty") {
   view.getPropertyView(
       "DoubleClassProperty",
       [&invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         REQUIRE(
@@ -2281,7 +2281,7 @@ TEST_CASE("Test callback on unsupported PropertyTextureProperty") {
   view.getPropertyView(
       "ArrayClassProperty",
       [&invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         REQUIRE(
@@ -2332,7 +2332,7 @@ TEST_CASE(
   view.getPropertyView(
       "TestClassProperty",
       [defaultValue, &texCoords, &invokedCallbackCount](
-          const std::string& /*propertyName*/,
+          const std::string& /*propertyId*/,
           auto propertyValue) mutable {
         invokedCallbackCount++;
         if constexpr (std::is_same_v<


### PR DESCRIPTION
The main thing here is renaming `propertyName` to `propertyId` for `getClassProperty`, `getPropertyView`, and related functions. This is to disambiguate the property id (the dictionary key) from the property name (its `name` field). When calling these functions you want to pass in the property id.

I also fixed some other doc issues that I noticed along the way.