### PR TITLE
Add thenPassThrough method to Future and SharedFuture

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 - Added `TileTransform` class to `Cesium3DTilesContent`, making it easier to create a `glm::dmat4` from the `transform` property of a `Cesium3DTiles::Tile`.
 - Added `ImplicitTilingUtilities` class to `Cesium3DTilesContent`.
 - Added overloads of `isTileAvailable` and `isContentAvailable` on the `SubtreeAvailability` class that take the subtree root tile ID and the tile ID of interest, instead of a relative level and Morton index.
+- Added `Future<T>::thenPassThrough`, used to easily pass additional values through to the next continuation.
 
 ##### Fixes :wrench:
 

--- a/CesiumAsync/include/CesiumAsync/Future.h
+++ b/CesiumAsync/include/CesiumAsync/Future.h
@@ -202,6 +202,30 @@ public:
   }
 
   /**
+   * @brief Passes through one or more additional values to the next
+   * continuation.
+   *
+   * The next continuation will receive a tuple with each of the provided
+   * values, followed by the result of the current Future.
+   *
+   * @tparam TPassThrough The types to pass through to the next continuation.
+   * @param value The values to pass through to the next continuation.
+   * @return A new Future that resolves to a tuple with the pass-through values,
+   * followed by the result of the last Future.
+   */
+  template <typename... TPassThrough>
+  Future<std::tuple<TPassThrough..., T>>
+  thenPassThrough(TPassThrough&&... values) && {
+    return std::move(*this).thenImmediately(
+        [values = std::tuple(std::forward<TPassThrough>(values)...)](
+            T&& result) mutable {
+          return std::tuple_cat(
+              std::move(values),
+              std::make_tuple(std::move(result)));
+        });
+  }
+
+  /**
    * @brief Waits for the future to resolve or reject and returns the result.
    *
    * This method must not be called from the main thread, the one that calls

--- a/CesiumAsync/include/CesiumAsync/SharedFuture.h
+++ b/CesiumAsync/include/CesiumAsync/SharedFuture.h
@@ -188,6 +188,28 @@ public:
   }
 
   /**
+   * @brief Passes through one or more additional values to the next
+   * continuation.
+   *
+   * The next continuation will receive a tuple with each of the provided
+   * values, followed by the result of the current Future.
+   *
+   * @tparam TPassThrough The types to pass through to the next continuation.
+   * @param value The values to pass through to the next continuation.
+   * @return A new Future that resolves to a tuple with the pass-through values,
+   * followed by the result of the last Future.
+   */
+  template <typename... TPassThrough>
+  Future<std::tuple<TPassThrough..., T>>
+  thenPassThrough(TPassThrough&&... values) {
+    return this->thenImmediately(
+        [values = std::tuple(std::forward<TPassThrough>(values)...)](
+            const T& result) mutable {
+          return std::tuple_cat(std::move(values), std::make_tuple(result));
+        });
+  }
+
+  /**
    * @brief Waits for the future to resolve or reject and returns the result.
    *
    * This method must not be called from the main thread, the one that calls

--- a/CesiumAsync/test/TestAsyncSystem.cpp
+++ b/CesiumAsync/test/TestAsyncSystem.cpp
@@ -539,4 +539,37 @@ TEST_CASE("AsyncSystem") {
     CHECK(future.isReady());
     future.wait();
   }
+
+  SECTION("thenPassThrough") {
+    bool checksCompleted = false;
+
+    asyncSystem.createResolvedFuture(3.1)
+        .thenPassThrough(std::string("foo"), 4)
+        .thenImmediately([&](std::tuple<std::string, int, double>&& tuple) {
+          auto& [s, i, d] = tuple;
+          CHECK(s == "foo");
+          CHECK(i == 4);
+          CHECK(d == 3.1);
+          checksCompleted = true;
+        });
+
+    CHECK(checksCompleted);
+  }
+
+  SECTION("thenPassThrough on a SharedFuture") {
+    bool checksCompleted = false;
+
+    asyncSystem.createResolvedFuture(3.1)
+        .share()
+        .thenPassThrough(std::string("foo"), 4)
+        .thenImmediately([&](std::tuple<std::string, int, double>&& tuple) {
+          auto& [s, i, d] = tuple;
+          CHECK(s == "foo");
+          CHECK(i == 4);
+          CHECK(d == 3.1);
+          checksCompleted = true;
+        });
+
+    CHECK(checksCompleted);
+  }
 }


### PR DESCRIPTION
When using cesium-native's AsyncSystem, it often happens that you have some values computed inside one continuation that you want to pass to the next continuation in the chain. You can do this by bundling them up in a struct and returning that struct from the current continuation. Or even use a `std::tuple`, if defining a struct seems like too much ceremony. 

Unfortunately, that breaks down when the continuation itself returns another future. For example:

```cpp
whatever.thenInMainThread([](Whatever&& whatever) {
  SomeType value = computeSomeValue(whatever);
  return startAnAsyncOperation(value);
}).thenInMainThread([](AsyncOperationResult&& result) {
  // ... do something with the result of the async operation
});
```

What if the "do something with the result of the async operation" also requires access to the `SomeType value`? It gets awkward fast! Here's how it can be done:

```cpp
whatever.thenInMainThread([](Whatever&& whatever) {
  SomeType value = computeSomeValue(whatever);
  return startAnAsyncOperation(value)
    .thenImmediately([value = std::move(value)](AsyncOperationResult&& result) mutable {
      return std::make_tuple(std::move(value), std::move(result));
    });
}).thenInMainThread([](std::tuple<SomeType, AsyncOperationResult>>&& tuple) {
  auto& [value, result] = tuple;
  // now we have access to both the SomeType value and the async op result
});
```

It works, but it's pretty ugly, and there are a lot of details to get right. Forgetting the mutable or any of the std::moves will make it a lot less efficient.

This PR adds a new method, `thenPassThrough`, on `Future` and `SharedFuture` that makes this a little easier to deal with:

```cpp
whatever.thenInMainThread([](Whatever&& whatever) {
  SomeType value = computeSomeValue(whatever);
  return startAnAsyncOperation(value)
    .thenPassThrough(std::move(value));
}).thenInMainThread([](std::tuple<SomeType, AsyncOperationResult>>&& tuple) {
  auto& [value, result] = tuple;
  // now we have access to both the SomeType value and the async op result
});
```

You can pass as many parameters as you like to `thenPassThrough`, and they all get wrapped up in the tuple. There are a lot less details to get right.