### PR TITLE
Add `AccessorUtility.h`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 - Added `Cesium3DTilesContent` library and namespace. It has classes for loading, converting, and manipulating 3D Tiles tile content.
 - Added `MetadataConversions`, which enables metadata values to be converted to different types for better usability in runtime engines.
 - Added various `typedef`s to catch all possible types of `AccessorView`s for an attribute, including `FeatureIdAccessorType` for feature ID attribute accessors, `IndexAccessorType` for index accessors, and `TexCoordAccessorType` for texture coordinate attribute accessors.
-- Added `GetFeatureIdAccessorView`, `GetIndexAccessorView`, and `GetTexCoordAccessorView` to retrieve the `AccessorView` as a `FeatureIdAccessorType`, `IndexAccessorType`, or `TexCoordAccessorType` respectively.
+- Added `getFeatureIdAccessorView`, `getIndexAccessorView`, and `getTexCoordAccessorView` to retrieve the `AccessorView` as a `FeatureIdAccessorType`, `IndexAccessorType`, or `TexCoordAccessorType` respectively.
 - Added `StatusFromAccessor` and `CountFromAccessor` visitors to retrieve the accessor status and size respectively. This can be used with `FeatureIdAccessorType`, `IndexAccessorType`, or `TexCoordAccessorType`.
 - Added `FeatureIdFromAccessor` to retrieve feature IDs from a `FeatureIdAccessorType`.
 - Added `IndicesForFaceFromAccessor` to retrieve the indices of the vertices that make up a face, as supplied by `IndexAccessorType`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@
 - Added `MetadataConversions`, which enables metadata values to be converted to different types for better usability in runtime engines.
 - Added various `typedef`s to catch all possible types of `AccessorView`s for an attribute, including `FeatureIdAccessorType` for feature ID attribute accessors, `IndexAccessorType` for index accessors, and `TexCoordAccessorType` for texture coordinate attribute accessors.
 - Added `GetFeatureIdAccessorView`, `GetIndexAccessorView`, and `GetTexCoordAccessorView` to retrieve the `AccessorView` as a `FeatureIdAccessorType`, `IndexAccessorType`, or `TexCoordAccessorType` respectively.
-- Added `CountFromAccessor` to retrieve the accessor size from a `FeatureIdAccessorType`, `IndexAccessorType`, or `TexCoordAccessorType`.
+- Added `StatusFromAccessor` and `CountFromAccessor` visitors to retrieve the accessor status and size respectively. This can be used with `FeatureIdAccessorType`, `IndexAccessorType`, or `TexCoordAccessorType`.
 - Added `FeatureIdFromAccessor` to retrieve feature IDs from a `FeatureIdAccessorType`.
 - Added `IndicesForFaceFromAccessor` to retrieve the indices of the vertices that make up a face, as supplied by `IndexAccessorType`.
 - Added `TexCoordFromAccessor` to retrieve the texture coordinates from a `TexCoordAccessorType`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,12 @@
 
 - Added `Cesium3DTilesContent` library and namespace. It has classes for loading, converting, and manipulating 3D Tiles tile content.
 - Added `MetadataConversions`, which enables metadata values to be converted to different types for better usability in runtime engines.
+- Added various `typedef`s to catch all possible types of `AccessorView`s for an attribute, including `FeatureIdAccessorType` for feature ID attribute accessors, `IndexAccessorType` for index accessors, and `TexCoordAccessorType` for texture coordinate attribute accessors.
+- Added `GetFeatureIdAccessorView`, `GetIndexAccessorView`, and `GetTexCoordAccessorView` to retrieve the `AccessorView` as a `FeatureIdAccessorType`, `IndexAccessorType`, or `TexCoordAccessorType` respectively.
+- Added `CountFromAccessor` to retrieve the accessor size from a `FeatureIdAccessorType`, `IndexAccessorType`, or `TexCoordAccessorType`.
+- Added `FeatureIdFromAccessor` to retrieve feature IDs from a `FeatureIdAccessorType`.
+- Added `IndicesForFaceFromAccessor` to retrieve the indices of the vertices that make up a face, as supplied by `IndexAccessorType`.
+- Added `TexCoordFromAccessor` to retrieve the texture coordinates from a `TexCoordAccessorType`.
 
 ##### Fixes :wrench:
 

--- a/CesiumGltf/include/CesiumGltf/AccessorUtility.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorUtility.h
@@ -20,6 +20,21 @@ struct CountFromAccessor {
 };
 
 /**
+ * @brief Visitor that retrieves the status from the given accessor. Returns an
+ * invalid status for a std::monostate (interpreted as a nonexistent accessor).
+ */
+struct StatusFromAccessor {
+  AccessorViewStatus operator()(std::monostate) {
+    return AccessorViewStatus::InvalidAccessorIndex;
+  }
+
+  template <typename T>
+  AccessorViewStatus operator()(const AccessorView<T>& value) {
+    return value.status();
+  }
+};
+
+/**
  * Type definition for all kinds of feature ID attribute accessors.
  */
 typedef std::variant<

--- a/CesiumGltf/include/CesiumGltf/AccessorUtility.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorUtility.h
@@ -8,11 +8,6 @@
 
 namespace CesiumGltf {
 /**
- * @brief Type definition for a position accessor.
- */
-typedef AccessorView<AccessorTypes::VEC3<float>> PositionAccessorType;
-
-/**
  * @brief Visitor that retrieves the count of elements in the given accessor
  * type as an int64_t.
  */
@@ -35,6 +30,16 @@ typedef std::variant<
     AccessorView<uint32_t>,
     AccessorView<float>>
     FeatureIdAccessorType;
+
+/**
+ * Retrieves an accessor view for the specified feature ID attribute from the
+ * given glTF primitive and model. This verifies that the accessor is of a valid
+ * type. If not, the returned accessor view will be invalid.
+ */
+FeatureIdAccessorType GetFeatureIdAccessorView(
+    const Model& model,
+    const MeshPrimitive& primitive,
+    int32_t featureIdAttributeIndex);
 
 /**
  * Visitor that retrieves the feature ID from the given accessor type as an
@@ -73,6 +78,14 @@ typedef std::variant<
     AccessorView<uint16_t>,
     AccessorView<uint32_t>>
     IndexAccessorType;
+
+/**
+ * Retrieves an accessor view for the indices of the given glTF primitive from
+ * the model. The primitive may not specify any indices; if so, std::monostate
+ * is returned.
+ */
+IndexAccessorType
+GetIndexAccessorView(const Model& model, const MeshPrimitive& primitive);
 
 /**
  * Visitor that retrieves the vertex indices from the given accessor type

--- a/CesiumGltf/include/CesiumGltf/AccessorUtility.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorUtility.h
@@ -1,0 +1,182 @@
+#pragma once
+
+#include "AccessorView.h"
+
+#include <glm/common.hpp>
+
+#include <variant>
+
+namespace CesiumGltf {
+/**
+ * @brief Type definition for a position accessor.
+ */
+typedef AccessorView<AccessorTypes::VEC3<float>> PositionAccessorType;
+
+/**
+ * @brief Visitor that retrieves the count of elements in the given accessor
+ * type as an int64_t.
+ */
+struct CountFromAccessor {
+  int64_t operator()(std::monostate) { return 0; }
+
+  template <typename T> int64_t operator()(const AccessorView<T>& value) {
+    return value.size();
+  }
+};
+
+/**
+ * Type definition for all kinds of feature ID attribute accessors.
+ */
+typedef std::variant<
+    AccessorView<int8_t>,
+    AccessorView<uint8_t>,
+    AccessorView<int16_t>,
+    AccessorView<uint16_t>,
+    AccessorView<uint32_t>,
+    AccessorView<float>>
+    FeatureIdAccessorType;
+
+/**
+ * Visitor that retrieves the feature ID from the given accessor type as an
+ * int64_t. This should be initialized with the index of the vertex whose
+ * feature ID is being queried.
+ *
+ * -1 is used to indicate errors retrieving the feature ID, e.g., if the given
+ * index was out-of-bounds.
+ */
+struct FeatureIdFromAccessor {
+  int64_t operator()(const AccessorView<float>& value) {
+    if (index < 0 || index >= value.size()) {
+      return -1;
+    }
+    return static_cast<int64_t>(glm::round(value[index]));
+  }
+
+  template <typename T> int64_t operator()(const AccessorView<T>& value) {
+    if (index < 0 || index >= value.size()) {
+      return -1;
+    }
+    return static_cast<int64_t>(value[index]);
+  }
+
+  int64_t index;
+};
+
+/**
+ * Type definition for all kinds of index accessors. std::monostate
+ * indicates a nonexistent accessor, which can happen (and is valid) if the
+ * primitive vertices are defined without an index buffer.
+ */
+typedef std::variant<
+    std::monostate,
+    AccessorView<uint8_t>,
+    AccessorView<uint16_t>,
+    AccessorView<uint32_t>>
+    IndexAccessorType;
+
+/**
+ * Visitor that retrieves the vertex indices from the given accessor type
+ * corresponding to a given face index. These indices are returned as an array
+ * of int64_ts. This should be initialized with the index of the face and the
+ * total number of vertices in the primitive.
+ *
+ * -1 is used to indicate errors retrieving the index, e.g., if the given
+ * index was out-of-bounds.
+ */
+struct IndicesForFaceFromAccessor {
+  std::array<int64_t, 3> operator()(std::monostate) {
+    if (faceIndex < 0 || faceIndex >= vertexCount / 3) {
+      return {-1, -1, -1};
+    }
+
+    const int64_t firstVertex = faceIndex * 3;
+    std::array<int64_t, 3> result;
+
+    for (int64_t i = 0; i < 3; i++) {
+      int64_t vertexIndex = firstVertex + i;
+      result[i] = vertexIndex < vertexCount ? vertexIndex : -1;
+    }
+
+    return result;
+  }
+
+  template <typename T>
+  std::array<int64_t, 3> operator()(const AccessorView<T>& value) {
+    if (faceIndex < 0 || faceIndex >= value.size() / 3) {
+      return {-1, -1, -1};
+    }
+
+    const int64_t firstVertex = faceIndex * 3;
+    std::array<int64_t, 3> result;
+
+    for (int64_t i = 0; i < 3; i++) {
+      int64_t vertexIndex = firstVertex + i;
+      result[i] = vertexIndex < value.size()
+                      ? static_cast<int64_t>(value[vertexIndex])
+                      : -1;
+    }
+
+    return result;
+  }
+
+  int64_t faceIndex;
+  int64_t vertexCount;
+};
+
+/**
+ * Type definition for all kinds of texture coordinate (TEXCOORD_n) accessors.
+ */
+typedef std::variant<
+    AccessorView<AccessorTypes::VEC2<uint8_t>>,
+    AccessorView<AccessorTypes::VEC2<uint16_t>>,
+    AccessorView<AccessorTypes::VEC2<float>>>
+    TexCoordAccessorType;
+
+/**
+ * Retrieves an accessor view for the specified texture coordinate set from the
+ * given glTF primitive and model. This verifies that the accessor is of a valid
+ * type. If not, the returned accessor view will be invalid.,
+ */
+TexCoordAccessorType GetTexCoordAccessorView(
+    const Model& model,
+    const MeshPrimitive& primitive,
+    int32_t textureCoordinateSetIndex);
+
+/**
+ * Visitor that retrieves the texture coordinates from the given accessor type
+ * as a glm::dvec2. This should be initialized with the target index.
+ *
+ * There are technically no invalid UV values because of clamp / wrap
+ * behavior, so we use std::nullopt to denote an erroneous value.
+ */
+struct TexCoordFromAccessor {
+  std::optional<glm::dvec2>
+  operator()(const AccessorView<AccessorTypes::VEC2<float>>& value) {
+    if (index < 0 || index >= value.size()) {
+      return std::nullopt;
+    }
+
+    return glm::dvec2(value[index].value[0], value[index].value[1]);
+  }
+
+  template <typename T>
+  std::optional<glm::dvec2>
+  operator()(const AccessorView<AccessorTypes::VEC2<T>>& value) {
+    if (index < 0 || index >= value.size()) {
+      return std::nullopt;
+    }
+
+    double u = static_cast<double>(value[index].value[0]);
+    double v = static_cast<double>(value[index].value[1]);
+
+    // TODO: do normalization logic in accessor view?
+    u /= std::numeric_limits<T>::max();
+    v /= std::numeric_limits<T>::max();
+
+    return glm::dvec2(u, v);
+  }
+
+  int64_t index;
+};
+
+} // namespace CesiumGltf

--- a/CesiumGltf/include/CesiumGltf/AccessorUtility.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorUtility.h
@@ -51,7 +51,7 @@ typedef std::variant<
  * given glTF primitive and model. This verifies that the accessor is of a valid
  * type. If not, the returned accessor view will be invalid.
  */
-FeatureIdAccessorType GetFeatureIdAccessorView(
+FeatureIdAccessorType getFeatureIdAccessorView(
     const Model& model,
     const MeshPrimitive& primitive,
     int32_t featureIdAttributeIndex);
@@ -100,7 +100,7 @@ typedef std::variant<
  * is returned.
  */
 IndexAccessorType
-GetIndexAccessorView(const Model& model, const MeshPrimitive& primitive);
+getIndexAccessorView(const Model& model, const MeshPrimitive& primitive);
 
 /**
  * Visitor that retrieves the vertex indices from the given accessor type
@@ -165,7 +165,7 @@ typedef std::variant<
  * given glTF primitive and model. This verifies that the accessor is of a valid
  * type. If not, the returned accessor view will be invalid.,
  */
-TexCoordAccessorType GetTexCoordAccessorView(
+TexCoordAccessorType getTexCoordAccessorView(
     const Model& model,
     const MeshPrimitive& primitive,
     int32_t textureCoordinateSetIndex);

--- a/CesiumGltf/src/AccessorUtility.cpp
+++ b/CesiumGltf/src/AccessorUtility.cpp
@@ -3,6 +3,65 @@
 #include "CesiumGltf/Model.h"
 
 namespace CesiumGltf {
+FeatureIdAccessorType GetFeatureIdAccessorView(
+    const Model& model,
+    const MeshPrimitive& primitive,
+    int32_t featureIdAttributeIndex) {
+  const std::string attributeName =
+      "_FEATURE_ID_" + std::to_string(featureIdAttributeIndex);
+  auto featureId = primitive.attributes.find(attributeName);
+  if (featureId == primitive.attributes.end()) {
+    return FeatureIdAccessorType();
+  }
+
+  const Accessor* pAccessor =
+      model.getSafe<Accessor>(&model.accessors, featureId->second);
+  if (!pAccessor || pAccessor->type != Accessor::Type::SCALAR ||
+      pAccessor->normalized) {
+    return FeatureIdAccessorType();
+  }
+
+  switch (pAccessor->componentType) {
+  case Accessor::ComponentType::BYTE:
+    return AccessorView<int8_t>(model, *pAccessor);
+  case Accessor::ComponentType::UNSIGNED_BYTE:
+    return AccessorView<uint8_t>(model, *pAccessor);
+  case Accessor::ComponentType::SHORT:
+    return AccessorView<int16_t>(model, *pAccessor);
+  case Accessor::ComponentType::UNSIGNED_SHORT:
+    return AccessorView<uint16_t>(model, *pAccessor);
+  case Accessor::ComponentType::FLOAT:
+    return AccessorView<float>(model, *pAccessor);
+  default:
+    return FeatureIdAccessorType();
+  }
+}
+
+IndexAccessorType
+GetIndexAccessorView(const Model& model, const MeshPrimitive& primitive) {
+  if (primitive.indices < 0) {
+    return IndexAccessorType();
+  }
+
+  const Accessor* pAccessor =
+      model.getSafe<Accessor>(&model.accessors, primitive.indices);
+  if (!pAccessor || pAccessor->type != Accessor::Type::SCALAR ||
+      pAccessor->normalized) {
+    return AccessorView<uint8_t>();
+  }
+
+  switch (pAccessor->componentType) {
+  case Accessor::ComponentType::UNSIGNED_BYTE:
+    return AccessorView<uint8_t>(model, *pAccessor);
+  case Accessor::ComponentType::UNSIGNED_SHORT:
+    return AccessorView<uint16_t>(model, *pAccessor);
+  case Accessor::ComponentType::UNSIGNED_INT:
+    return AccessorView<uint32_t>(model, *pAccessor);
+  default:
+    return AccessorView<uint8_t>();
+  }
+}
+
 TexCoordAccessorType GetTexCoordAccessorView(
     const Model& model,
     const MeshPrimitive& primitive,
@@ -14,9 +73,8 @@ TexCoordAccessorType GetTexCoordAccessorView(
     return TexCoordAccessorType();
   }
 
-  const Accessor* pAccessor = model.getSafe<Accessor>(
-      &model.accessors,
-      primitive.attributes.at(texCoordName));
+  const Accessor* pAccessor =
+      model.getSafe<Accessor>(&model.accessors, texCoord->second);
   if (!pAccessor || pAccessor->type != Accessor::Type::VEC2) {
     return TexCoordAccessorType();
   }

--- a/CesiumGltf/src/AccessorUtility.cpp
+++ b/CesiumGltf/src/AccessorUtility.cpp
@@ -1,0 +1,44 @@
+#include "CesiumGltf/AccessorUtility.h"
+
+#include "CesiumGltf/Model.h"
+
+namespace CesiumGltf {
+TexCoordAccessorType GetTexCoordAccessorView(
+    const Model& model,
+    const MeshPrimitive& primitive,
+    int32_t textureCoordinateSetIndex) {
+  const std::string texCoordName =
+      "TEXCOORD_" + std::to_string(textureCoordinateSetIndex);
+  auto texCoord = primitive.attributes.find(texCoordName);
+  if (texCoord == primitive.attributes.end()) {
+    return TexCoordAccessorType();
+  }
+
+  const Accessor* pAccessor = model.getSafe<Accessor>(
+      &model.accessors,
+      primitive.attributes.at(texCoordName));
+  if (!pAccessor || pAccessor->type != Accessor::Type::VEC2) {
+    return TexCoordAccessorType();
+  }
+
+  switch (pAccessor->componentType) {
+  case Accessor::ComponentType::UNSIGNED_BYTE:
+    if (pAccessor->normalized) {
+      // Unsigned byte texcoords must be normalized.
+      return AccessorView<AccessorTypes::VEC2<uint8_t>>(model, *pAccessor);
+    }
+    [[fallthrough]];
+  case Accessor::ComponentType::UNSIGNED_SHORT:
+    if (pAccessor->normalized) {
+      // Unsigned short texcoords must be normalized.
+      return AccessorView<AccessorTypes::VEC2<uint16_t>>(model, *pAccessor);
+    }
+    [[fallthrough]];
+  case Accessor::ComponentType::FLOAT:
+    return AccessorView<AccessorTypes::VEC2<float>>(model, *pAccessor);
+  default:
+    return TexCoordAccessorType();
+  }
+}
+
+} // namespace CesiumGltf

--- a/CesiumGltf/src/AccessorUtility.cpp
+++ b/CesiumGltf/src/AccessorUtility.cpp
@@ -3,7 +3,7 @@
 #include "CesiumGltf/Model.h"
 
 namespace CesiumGltf {
-FeatureIdAccessorType GetFeatureIdAccessorView(
+FeatureIdAccessorType getFeatureIdAccessorView(
     const Model& model,
     const MeshPrimitive& primitive,
     int32_t featureIdAttributeIndex) {
@@ -38,7 +38,7 @@ FeatureIdAccessorType GetFeatureIdAccessorView(
 }
 
 IndexAccessorType
-GetIndexAccessorView(const Model& model, const MeshPrimitive& primitive) {
+getIndexAccessorView(const Model& model, const MeshPrimitive& primitive) {
   if (primitive.indices < 0) {
     return IndexAccessorType();
   }
@@ -62,7 +62,7 @@ GetIndexAccessorView(const Model& model, const MeshPrimitive& primitive) {
   }
 }
 
-TexCoordAccessorType GetTexCoordAccessorView(
+TexCoordAccessorType getTexCoordAccessorView(
     const Model& model,
     const MeshPrimitive& primitive,
     int32_t textureCoordinateSetIndex) {

--- a/CesiumGltf/test/TestAccessorUtility.cpp
+++ b/CesiumGltf/test/TestAccessorUtility.cpp
@@ -57,7 +57,7 @@ TEST_CASE("Test CountFromAccessor") {
   }
 }
 
-TEST_CASE("Test GetFeatureIdAccessorView") {
+TEST_CASE("Test getFeatureIdAccessorView") {
   Model model;
   std::vector<uint8_t> featureIds0{1, 2, 3, 4};
 
@@ -114,7 +114,7 @@ TEST_CASE("Test GetFeatureIdAccessorView") {
 
   SECTION("Handles invalid feature ID set index") {
     FeatureIdAccessorType featureIDAccessor =
-        GetFeatureIdAccessorView(model, primitive, 2);
+        getFeatureIdAccessorView(model, primitive, 2);
     REQUIRE(
         std::visit(StatusFromAccessor{}, featureIDAccessor) !=
         AccessorViewStatus::Valid);
@@ -125,7 +125,7 @@ TEST_CASE("Test GetFeatureIdAccessorView") {
     model.accessors[0].type = Accessor::Type::VEC2;
 
     FeatureIdAccessorType featureIDAccessor =
-        GetFeatureIdAccessorView(model, primitive, 0);
+        getFeatureIdAccessorView(model, primitive, 0);
     REQUIRE(
         std::visit(StatusFromAccessor{}, featureIDAccessor) !=
         AccessorViewStatus::Valid);
@@ -138,7 +138,7 @@ TEST_CASE("Test GetFeatureIdAccessorView") {
     model.accessors[1].normalized = true;
 
     FeatureIdAccessorType featureIDAccessor =
-        GetFeatureIdAccessorView(model, primitive, 1);
+        getFeatureIdAccessorView(model, primitive, 1);
     REQUIRE(
         std::visit(StatusFromAccessor{}, featureIDAccessor) !=
         AccessorViewStatus::Valid);
@@ -149,7 +149,7 @@ TEST_CASE("Test GetFeatureIdAccessorView") {
 
   SECTION("Creates from valid feature ID sets") {
     FeatureIdAccessorType featureIDAccessor =
-        GetFeatureIdAccessorView(model, primitive, 0);
+        getFeatureIdAccessorView(model, primitive, 0);
     REQUIRE(
         std::visit(StatusFromAccessor{}, featureIDAccessor) ==
         AccessorViewStatus::Valid);
@@ -157,7 +157,7 @@ TEST_CASE("Test GetFeatureIdAccessorView") {
         std::visit(CountFromAccessor{}, featureIDAccessor) ==
         static_cast<int64_t>(featureIds0.size()));
 
-    featureIDAccessor = GetFeatureIdAccessorView(model, primitive, 1);
+    featureIDAccessor = getFeatureIdAccessorView(model, primitive, 1);
     REQUIRE(
         std::visit(StatusFromAccessor{}, featureIDAccessor) ==
         AccessorViewStatus::Valid);
@@ -208,7 +208,7 @@ TEST_CASE("FeatureIdFromAccessor") {
   }
 }
 
-TEST_CASE("Test GetIndexAccessorView") {
+TEST_CASE("Test getIndexAccessorView") {
   Model model;
   std::vector<uint8_t> indices{0, 1, 2, 0, 2, 3};
 
@@ -239,7 +239,7 @@ TEST_CASE("Test GetIndexAccessorView") {
   SECTION("Handles invalid accessor type") {
     model.accessors[0].type = Accessor::Type::VEC2;
 
-    IndexAccessorType indexAccessor = GetIndexAccessorView(model, primitive);
+    IndexAccessorType indexAccessor = getIndexAccessorView(model, primitive);
     REQUIRE(
         std::visit(StatusFromAccessor{}, indexAccessor) !=
         AccessorViewStatus::Valid);
@@ -251,7 +251,7 @@ TEST_CASE("Test GetIndexAccessorView") {
   SECTION("Handles unsupported accessor component type") {
     model.accessors[0].componentType = Accessor::ComponentType::BYTE;
 
-    IndexAccessorType indexAccessor = GetIndexAccessorView(model, primitive);
+    IndexAccessorType indexAccessor = getIndexAccessorView(model, primitive);
     REQUIRE(
         std::visit(StatusFromAccessor{}, indexAccessor) !=
         AccessorViewStatus::Valid);
@@ -263,7 +263,7 @@ TEST_CASE("Test GetIndexAccessorView") {
   SECTION("Handles invalid normalized accessor") {
     model.accessors[0].normalized = true;
 
-    IndexAccessorType indexAccessor = GetIndexAccessorView(model, primitive);
+    IndexAccessorType indexAccessor = getIndexAccessorView(model, primitive);
     REQUIRE(
         std::visit(StatusFromAccessor{}, indexAccessor) !=
         AccessorViewStatus::Valid);
@@ -273,7 +273,7 @@ TEST_CASE("Test GetIndexAccessorView") {
   }
 
   SECTION("Creates from valid accessor") {
-    IndexAccessorType indexAccessor = GetIndexAccessorView(model, primitive);
+    IndexAccessorType indexAccessor = getIndexAccessorView(model, primitive);
     REQUIRE(
         std::visit(StatusFromAccessor{}, indexAccessor) ==
         AccessorViewStatus::Valid);
@@ -285,7 +285,7 @@ TEST_CASE("Test GetIndexAccessorView") {
   SECTION("Creates from nonexistent accessor") {
     primitive.indices = -1;
 
-    IndexAccessorType indexAccessor = GetIndexAccessorView(model, primitive);
+    IndexAccessorType indexAccessor = getIndexAccessorView(model, primitive);
     REQUIRE(std::get_if<std::monostate>(&indexAccessor));
   }
 }
@@ -385,7 +385,7 @@ TEST_CASE("Test FaceVertexIndicesFromAccessor") {
   }
 }
 
-TEST_CASE("Test GetTexCoordAccessorView") {
+TEST_CASE("Test getTexCoordAccessorView") {
   Model model;
   std::vector<glm::vec2> texCoords0{
       glm::vec2(0, 0),
@@ -452,7 +452,7 @@ TEST_CASE("Test GetTexCoordAccessorView") {
 
   SECTION("Handles invalid texture coordinate set index") {
     TexCoordAccessorType texCoordAccessor =
-        GetTexCoordAccessorView(model, primitive, 2);
+        getTexCoordAccessorView(model, primitive, 2);
     REQUIRE(
         std::visit(StatusFromAccessor{}, texCoordAccessor) !=
         AccessorViewStatus::Valid);
@@ -463,7 +463,7 @@ TEST_CASE("Test GetTexCoordAccessorView") {
     model.accessors[0].type = Accessor::Type::SCALAR;
 
     TexCoordAccessorType texCoordAccessor =
-        GetTexCoordAccessorView(model, primitive, 0);
+        getTexCoordAccessorView(model, primitive, 0);
     REQUIRE(
         std::visit(StatusFromAccessor{}, texCoordAccessor) !=
         AccessorViewStatus::Valid);
@@ -476,7 +476,7 @@ TEST_CASE("Test GetTexCoordAccessorView") {
     model.accessors[0].componentType = Accessor::ComponentType::BYTE;
 
     TexCoordAccessorType texCoordAccessor =
-        GetTexCoordAccessorView(model, primitive, 0);
+        getTexCoordAccessorView(model, primitive, 0);
     REQUIRE(
         std::visit(StatusFromAccessor{}, texCoordAccessor) !=
         AccessorViewStatus::Valid);
@@ -489,7 +489,7 @@ TEST_CASE("Test GetTexCoordAccessorView") {
     model.accessors[1].normalized = false;
 
     TexCoordAccessorType texCoordAccessor =
-        GetTexCoordAccessorView(model, primitive, 2);
+        getTexCoordAccessorView(model, primitive, 2);
     REQUIRE(
         std::visit(StatusFromAccessor{}, texCoordAccessor) !=
         AccessorViewStatus::Valid);
@@ -500,7 +500,7 @@ TEST_CASE("Test GetTexCoordAccessorView") {
 
   SECTION("Creates from valid texture coordinate sets") {
     TexCoordAccessorType texCoordAccessor =
-        GetTexCoordAccessorView(model, primitive, 0);
+        getTexCoordAccessorView(model, primitive, 0);
     REQUIRE(
         std::visit(StatusFromAccessor{}, texCoordAccessor) ==
         AccessorViewStatus::Valid);
@@ -508,7 +508,7 @@ TEST_CASE("Test GetTexCoordAccessorView") {
         std::visit(CountFromAccessor{}, texCoordAccessor) ==
         static_cast<int64_t>(texCoords0.size()));
 
-    texCoordAccessor = GetTexCoordAccessorView(model, primitive, 1);
+    texCoordAccessor = getTexCoordAccessorView(model, primitive, 1);
     REQUIRE(
         std::visit(StatusFromAccessor{}, texCoordAccessor) ==
         AccessorViewStatus::Valid);
@@ -585,20 +585,20 @@ TEST_CASE("Test TexCoordFromAccessor") {
 
   SECTION("Handles invalid accessor") {
     TexCoordAccessorType texCoordAccessor =
-        GetTexCoordAccessorView(model, primitive, 2);
+        getTexCoordAccessorView(model, primitive, 2);
     REQUIRE(!std::visit(TexCoordFromAccessor{0}, texCoordAccessor));
   }
 
   SECTION("Handles invalid index") {
     TexCoordAccessorType texCoordAccessor =
-        GetTexCoordAccessorView(model, primitive, 0);
+        getTexCoordAccessorView(model, primitive, 0);
     REQUIRE(!std::visit(TexCoordFromAccessor{-1}, texCoordAccessor));
     REQUIRE(!std::visit(TexCoordFromAccessor{10}, texCoordAccessor));
   }
 
   SECTION("Retrieves from valid accessor and index") {
     TexCoordAccessorType texCoordAccessor =
-        GetTexCoordAccessorView(model, primitive, 0);
+        getTexCoordAccessorView(model, primitive, 0);
     for (size_t i = 0; i < texCoords0.size(); i++) {
       auto maybeTexCoord = std::visit(
           TexCoordFromAccessor{static_cast<int64_t>(i)},
@@ -611,7 +611,7 @@ TEST_CASE("Test TexCoordFromAccessor") {
   }
   SECTION("Retrieves from valid normalized accessor and index") {
     TexCoordAccessorType texCoordAccessor =
-        GetTexCoordAccessorView(model, primitive, 1);
+        getTexCoordAccessorView(model, primitive, 1);
     for (size_t i = 0; i < texCoords1.size(); i++) {
       auto maybeTexCoord = std::visit(
           TexCoordFromAccessor{static_cast<int64_t>(i)},

--- a/CesiumGltf/test/TestAccessorUtility.cpp
+++ b/CesiumGltf/test/TestAccessorUtility.cpp
@@ -2,6 +2,8 @@
 
 #include <catch2/catch.hpp>
 
+#include <cstring>
+
 using namespace CesiumGltf;
 
 TEST_CASE("Test CountFromAccessor") {
@@ -14,7 +16,7 @@ TEST_CASE("Test CountFromAccessor") {
       buffer.cesium.data.data(),
       featureIds.data(),
       buffer.cesium.data.size());
-  buffer.byteLength = buffer.cesium.data.size();
+  buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
 
   BufferView& bufferView = model.bufferViews.emplace_back();
   bufferView.buffer = 0;
@@ -24,7 +26,7 @@ TEST_CASE("Test CountFromAccessor") {
   accessor.bufferView = 0;
   accessor.componentType = Accessor::ComponentType::UNSIGNED_BYTE;
   accessor.type = Accessor::Type::SCALAR;
-  accessor.count = bufferView.byteLength / sizeof(uint8_t);
+  accessor.count = bufferView.byteLength;
 
   SECTION("Handles invalid accessor") {
     // Wrong type
@@ -67,7 +69,7 @@ TEST_CASE("Test GetFeatureIdAccessorView") {
         buffer.cesium.data.data(),
         featureIds0.data(),
         buffer.cesium.data.size());
-    buffer.byteLength = buffer.cesium.data.size();
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
 
     BufferView& bufferView = model.bufferViews.emplace_back();
     bufferView.buffer = 0;
@@ -77,7 +79,7 @@ TEST_CASE("Test GetFeatureIdAccessorView") {
     accessor.bufferView = 0;
     accessor.componentType = Accessor::ComponentType::UNSIGNED_BYTE;
     accessor.type = Accessor::Type::SCALAR;
-    accessor.count = bufferView.byteLength / sizeof(uint8_t);
+    accessor.count = bufferView.byteLength;
   }
 
   std::vector<uint16_t> featureIds1{5, 6, 7, 8};
@@ -90,7 +92,7 @@ TEST_CASE("Test GetFeatureIdAccessorView") {
         buffer.cesium.data.data(),
         featureIds1.data(),
         buffer.cesium.data.size());
-    buffer.byteLength = buffer.cesium.data.size();
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
 
     BufferView& bufferView = model.bufferViews.emplace_back();
     bufferView.buffer = 1;
@@ -100,7 +102,8 @@ TEST_CASE("Test GetFeatureIdAccessorView") {
     accessor.bufferView = 1;
     accessor.componentType = Accessor::ComponentType::UNSIGNED_SHORT;
     accessor.type = Accessor::Type::SCALAR;
-    accessor.count = bufferView.byteLength / sizeof(uint16_t);
+    accessor.count =
+        bufferView.byteLength / static_cast<int64_t>(sizeof(uint16_t));
   }
 
   Mesh& mesh = model.meshes.emplace_back();
@@ -174,7 +177,7 @@ TEST_CASE("FeatureIdFromAccessor") {
       buffer.cesium.data.data(),
       featureIds.data(),
       buffer.cesium.data.size());
-  buffer.byteLength = buffer.cesium.data.size();
+  buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
 
   BufferView& bufferView = model.bufferViews.emplace_back();
   bufferView.buffer = 0;
@@ -184,7 +187,7 @@ TEST_CASE("FeatureIdFromAccessor") {
   accessor.bufferView = 0;
   accessor.componentType = Accessor::ComponentType::BYTE;
   accessor.type = Accessor::Type::SCALAR;
-  accessor.count = bufferView.byteLength / sizeof(int8_t);
+  accessor.count = bufferView.byteLength;
 
   SECTION("Handles invalid accessor") {
     // Wrong component type
@@ -216,7 +219,7 @@ TEST_CASE("Test GetIndexAccessorView") {
         buffer.cesium.data.data(),
         indices.data(),
         buffer.cesium.data.size());
-    buffer.byteLength = buffer.cesium.data.size();
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
 
     BufferView& bufferView = model.bufferViews.emplace_back();
     bufferView.buffer = 0;
@@ -226,7 +229,7 @@ TEST_CASE("Test GetIndexAccessorView") {
     accessor.bufferView = 0;
     accessor.componentType = Accessor::ComponentType::UNSIGNED_BYTE;
     accessor.type = Accessor::Type::SCALAR;
-    accessor.count = bufferView.byteLength / sizeof(uint8_t);
+    accessor.count = bufferView.byteLength;
   }
 
   Mesh& mesh = model.meshes.emplace_back();
@@ -298,7 +301,7 @@ TEST_CASE("Test FaceVertexIndicesFromAccessor") {
       buffer.cesium.data.data(),
       indices.data(),
       buffer.cesium.data.size());
-  buffer.byteLength = buffer.cesium.data.size();
+  buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
 
   BufferView& bufferView = model.bufferViews.emplace_back();
   bufferView.buffer = 0;
@@ -308,7 +311,8 @@ TEST_CASE("Test FaceVertexIndicesFromAccessor") {
   accessor.bufferView = 0;
   accessor.componentType = Accessor::ComponentType::UNSIGNED_INT;
   accessor.type = Accessor::Type::SCALAR;
-  accessor.count = bufferView.byteLength / sizeof(uint32_t);
+  accessor.count =
+      bufferView.byteLength / static_cast<int64_t>(sizeof(uint32_t));
 
   SECTION("Handles invalid accessor") {
     // Wrong component type
@@ -397,7 +401,7 @@ TEST_CASE("Test GetTexCoordAccessorView") {
         buffer.cesium.data.data(),
         texCoords0.data(),
         buffer.cesium.data.size());
-    buffer.byteLength = buffer.cesium.data.size();
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
 
     BufferView& bufferView = model.bufferViews.emplace_back();
     bufferView.buffer = 0;
@@ -407,7 +411,8 @@ TEST_CASE("Test GetTexCoordAccessorView") {
     accessor.bufferView = 0;
     accessor.componentType = Accessor::ComponentType::FLOAT;
     accessor.type = Accessor::Type::VEC2;
-    accessor.count = bufferView.byteLength / sizeof(glm::vec2);
+    accessor.count =
+        bufferView.byteLength / static_cast<int64_t>(sizeof(glm::vec2));
   }
 
   std::vector<glm::u8vec2> texCoords1{
@@ -424,7 +429,7 @@ TEST_CASE("Test GetTexCoordAccessorView") {
         buffer.cesium.data.data(),
         texCoords1.data(),
         buffer.cesium.data.size());
-    buffer.byteLength = buffer.cesium.data.size();
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
 
     BufferView& bufferView = model.bufferViews.emplace_back();
     bufferView.buffer = 1;
@@ -435,7 +440,8 @@ TEST_CASE("Test GetTexCoordAccessorView") {
     accessor.componentType = Accessor::ComponentType::UNSIGNED_BYTE;
     accessor.type = Accessor::Type::VEC2;
     accessor.normalized = true;
-    accessor.count = bufferView.byteLength / sizeof(glm::u8vec2);
+    accessor.count =
+        bufferView.byteLength / static_cast<int64_t>(sizeof(glm::u8vec2));
   }
 
   Mesh& mesh = model.meshes.emplace_back();
@@ -528,7 +534,7 @@ TEST_CASE("Test TexCoordFromAccessor") {
         buffer.cesium.data.data(),
         texCoords0.data(),
         buffer.cesium.data.size());
-    buffer.byteLength = buffer.cesium.data.size();
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
 
     BufferView& bufferView = model.bufferViews.emplace_back();
     bufferView.buffer = 0;
@@ -538,7 +544,8 @@ TEST_CASE("Test TexCoordFromAccessor") {
     accessor.bufferView = 0;
     accessor.componentType = Accessor::ComponentType::FLOAT;
     accessor.type = Accessor::Type::VEC2;
-    accessor.count = bufferView.byteLength / sizeof(glm::vec2);
+    accessor.count =
+        bufferView.byteLength / static_cast<int64_t>(sizeof(glm::vec2));
   }
 
   std::vector<glm::u8vec2> texCoords1{
@@ -555,7 +562,7 @@ TEST_CASE("Test TexCoordFromAccessor") {
         buffer.cesium.data.data(),
         texCoords1.data(),
         buffer.cesium.data.size());
-    buffer.byteLength = buffer.cesium.data.size();
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
 
     BufferView& bufferView = model.bufferViews.emplace_back();
     bufferView.buffer = 1;
@@ -566,7 +573,8 @@ TEST_CASE("Test TexCoordFromAccessor") {
     accessor.componentType = Accessor::ComponentType::UNSIGNED_BYTE;
     accessor.type = Accessor::Type::VEC2;
     accessor.normalized = true;
-    accessor.count = bufferView.byteLength / sizeof(glm::u8vec2);
+    accessor.count =
+        bufferView.byteLength / static_cast<int64_t>(sizeof(glm::u8vec2));
   }
 
   Mesh& mesh = model.meshes.emplace_back();

--- a/CesiumGltf/test/TestAccessorUtility.cpp
+++ b/CesiumGltf/test/TestAccessorUtility.cpp
@@ -30,17 +30,26 @@ TEST_CASE("Test CountFromAccessor") {
     // Wrong type
     TexCoordAccessorType texcoordAccessor =
         AccessorView<AccessorTypes::VEC2<uint8_t>>(model, accessor);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, texcoordAccessor) !=
+        AccessorViewStatus::Valid);
     REQUIRE(std::visit(CountFromAccessor{}, texcoordAccessor) == 0);
 
     // Wrong component type
     FeatureIdAccessorType featureIdAccessor =
         AccessorView<int16_t>(model, accessor);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, featureIdAccessor) !=
+        AccessorViewStatus::Valid);
     REQUIRE(std::visit(CountFromAccessor{}, featureIdAccessor) == 0);
   }
 
   SECTION("Retrieves from valid accessor") {
     FeatureIdAccessorType featureIdAccessor =
         AccessorView<uint8_t>(model, accessor);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, featureIdAccessor) ==
+        AccessorViewStatus::Valid);
     int64_t count = std::visit(CountFromAccessor{}, featureIdAccessor);
     REQUIRE(count == static_cast<int64_t>(featureIds.size()));
   }
@@ -103,6 +112,9 @@ TEST_CASE("Test GetFeatureIdAccessorView") {
   SECTION("Handles invalid feature ID set index") {
     FeatureIdAccessorType featureIDAccessor =
         GetFeatureIdAccessorView(model, primitive, 2);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, featureIDAccessor) !=
+        AccessorViewStatus::Valid);
     REQUIRE(std::visit(CountFromAccessor{}, featureIDAccessor) == 0);
   }
 
@@ -111,6 +123,9 @@ TEST_CASE("Test GetFeatureIdAccessorView") {
 
     FeatureIdAccessorType featureIDAccessor =
         GetFeatureIdAccessorView(model, primitive, 0);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, featureIDAccessor) !=
+        AccessorViewStatus::Valid);
     REQUIRE(std::visit(CountFromAccessor{}, featureIDAccessor) == 0);
 
     model.accessors[0].type = Accessor::Type::SCALAR;
@@ -121,6 +136,9 @@ TEST_CASE("Test GetFeatureIdAccessorView") {
 
     FeatureIdAccessorType featureIDAccessor =
         GetFeatureIdAccessorView(model, primitive, 1);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, featureIDAccessor) !=
+        AccessorViewStatus::Valid);
     REQUIRE(std::visit(CountFromAccessor{}, featureIDAccessor) == 0);
 
     model.accessors[1].normalized = false;
@@ -130,10 +148,16 @@ TEST_CASE("Test GetFeatureIdAccessorView") {
     FeatureIdAccessorType featureIDAccessor =
         GetFeatureIdAccessorView(model, primitive, 0);
     REQUIRE(
+        std::visit(StatusFromAccessor{}, featureIDAccessor) ==
+        AccessorViewStatus::Valid);
+    REQUIRE(
         std::visit(CountFromAccessor{}, featureIDAccessor) ==
         static_cast<int64_t>(featureIds0.size()));
 
     featureIDAccessor = GetFeatureIdAccessorView(model, primitive, 1);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, featureIDAccessor) ==
+        AccessorViewStatus::Valid);
     REQUIRE(
         std::visit(CountFromAccessor{}, featureIDAccessor) ==
         static_cast<int64_t>(featureIds1.size()));
@@ -213,6 +237,9 @@ TEST_CASE("Test GetIndexAccessorView") {
     model.accessors[0].type = Accessor::Type::VEC2;
 
     IndexAccessorType indexAccessor = GetIndexAccessorView(model, primitive);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, indexAccessor) !=
+        AccessorViewStatus::Valid);
     REQUIRE(std::visit(CountFromAccessor{}, indexAccessor) == 0);
 
     model.accessors[0].type = Accessor::Type::SCALAR;
@@ -222,6 +249,9 @@ TEST_CASE("Test GetIndexAccessorView") {
     model.accessors[0].componentType = Accessor::ComponentType::BYTE;
 
     IndexAccessorType indexAccessor = GetIndexAccessorView(model, primitive);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, indexAccessor) !=
+        AccessorViewStatus::Valid);
     REQUIRE(std::visit(CountFromAccessor{}, indexAccessor) == 0);
 
     model.accessors[0].componentType = Accessor::ComponentType::UNSIGNED_BYTE;
@@ -231,6 +261,9 @@ TEST_CASE("Test GetIndexAccessorView") {
     model.accessors[0].normalized = true;
 
     IndexAccessorType indexAccessor = GetIndexAccessorView(model, primitive);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, indexAccessor) !=
+        AccessorViewStatus::Valid);
     REQUIRE(std::visit(CountFromAccessor{}, indexAccessor) == 0);
 
     model.accessors[0].normalized = false;
@@ -238,6 +271,9 @@ TEST_CASE("Test GetIndexAccessorView") {
 
   SECTION("Creates from valid accessor") {
     IndexAccessorType indexAccessor = GetIndexAccessorView(model, primitive);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, indexAccessor) ==
+        AccessorViewStatus::Valid);
     REQUIRE(
         std::visit(CountFromAccessor{}, indexAccessor) ==
         static_cast<int64_t>(indices.size()));
@@ -411,6 +447,9 @@ TEST_CASE("Test GetTexCoordAccessorView") {
   SECTION("Handles invalid texture coordinate set index") {
     TexCoordAccessorType texCoordAccessor =
         GetTexCoordAccessorView(model, primitive, 2);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, texCoordAccessor) !=
+        AccessorViewStatus::Valid);
     REQUIRE(std::visit(CountFromAccessor{}, texCoordAccessor) == 0);
   }
 
@@ -419,6 +458,9 @@ TEST_CASE("Test GetTexCoordAccessorView") {
 
     TexCoordAccessorType texCoordAccessor =
         GetTexCoordAccessorView(model, primitive, 0);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, texCoordAccessor) !=
+        AccessorViewStatus::Valid);
     REQUIRE(std::visit(CountFromAccessor{}, texCoordAccessor) == 0);
 
     model.accessors[0].type = Accessor::Type::VEC2;
@@ -429,6 +471,9 @@ TEST_CASE("Test GetTexCoordAccessorView") {
 
     TexCoordAccessorType texCoordAccessor =
         GetTexCoordAccessorView(model, primitive, 0);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, texCoordAccessor) !=
+        AccessorViewStatus::Valid);
     REQUIRE(std::visit(CountFromAccessor{}, texCoordAccessor) == 0);
 
     model.accessors[0].componentType = Accessor::ComponentType::FLOAT;
@@ -439,6 +484,9 @@ TEST_CASE("Test GetTexCoordAccessorView") {
 
     TexCoordAccessorType texCoordAccessor =
         GetTexCoordAccessorView(model, primitive, 2);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, texCoordAccessor) !=
+        AccessorViewStatus::Valid);
     REQUIRE(std::visit(CountFromAccessor{}, texCoordAccessor) == 0);
 
     model.accessors[1].normalized = true;
@@ -448,10 +496,16 @@ TEST_CASE("Test GetTexCoordAccessorView") {
     TexCoordAccessorType texCoordAccessor =
         GetTexCoordAccessorView(model, primitive, 0);
     REQUIRE(
+        std::visit(StatusFromAccessor{}, texCoordAccessor) ==
+        AccessorViewStatus::Valid);
+    REQUIRE(
         std::visit(CountFromAccessor{}, texCoordAccessor) ==
         static_cast<int64_t>(texCoords0.size()));
 
     texCoordAccessor = GetTexCoordAccessorView(model, primitive, 1);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, texCoordAccessor) ==
+        AccessorViewStatus::Valid);
     REQUIRE(
         std::visit(CountFromAccessor{}, texCoordAccessor) ==
         static_cast<int64_t>(texCoords1.size()));

--- a/CesiumGltf/test/TestAccessorUtility.cpp
+++ b/CesiumGltf/test/TestAccessorUtility.cpp
@@ -1,0 +1,400 @@
+#include "CesiumGltf/AccessorUtility.h"
+
+#include <catch2/catch.hpp>
+
+using namespace CesiumGltf;
+
+TEST_CASE("Test CountFromAccessor") {
+  Model model;
+  std::vector<uint8_t> featureIds{1, 2, 3, 4};
+
+  Buffer& buffer = model.buffers.emplace_back();
+  buffer.cesium.data.resize(featureIds.size() * sizeof(uint8_t));
+  std::memcpy(
+      buffer.cesium.data.data(),
+      featureIds.data(),
+      buffer.cesium.data.size());
+  buffer.byteLength = buffer.cesium.data.size();
+
+  BufferView& bufferView = model.bufferViews.emplace_back();
+  bufferView.buffer = 0;
+  bufferView.byteLength = buffer.byteLength;
+
+  Accessor& accessor = model.accessors.emplace_back();
+  accessor.bufferView = 0;
+  accessor.componentType = Accessor::ComponentType::UNSIGNED_BYTE;
+  accessor.type = Accessor::Type::SCALAR;
+  accessor.count = bufferView.byteLength / sizeof(uint8_t);
+
+  SECTION("Handles invalid accessor") {
+    // Wrong type
+    TexCoordAccessorType texcoordAccessor =
+        AccessorView<AccessorTypes::VEC2<uint8_t>>(model, accessor);
+    REQUIRE(std::visit(CountFromAccessor{}, texcoordAccessor) == 0);
+
+    // Wrong component type
+    FeatureIdAccessorType featureIdAccessor =
+        AccessorView<int16_t>(model, accessor);
+    REQUIRE(std::visit(CountFromAccessor{}, featureIdAccessor) == 0);
+  }
+
+  SECTION("Retrieves from valid accessor") {
+    FeatureIdAccessorType featureIdAccessor =
+        AccessorView<uint8_t>(model, accessor);
+    int64_t count = std::visit(CountFromAccessor{}, featureIdAccessor);
+    REQUIRE(count == static_cast<int64_t>(featureIds.size()));
+  }
+}
+
+TEST_CASE("FeatureIdFromAccessor") {
+  Model model;
+  std::vector<int8_t> featureIds{1, 2, 3, 4};
+
+  Buffer& buffer = model.buffers.emplace_back();
+  buffer.cesium.data.resize(featureIds.size() * sizeof(int8_t));
+  std::memcpy(
+      buffer.cesium.data.data(),
+      featureIds.data(),
+      buffer.cesium.data.size());
+  buffer.byteLength = buffer.cesium.data.size();
+
+  BufferView& bufferView = model.bufferViews.emplace_back();
+  bufferView.buffer = 0;
+  bufferView.byteLength = buffer.byteLength;
+
+  Accessor& accessor = model.accessors.emplace_back();
+  accessor.bufferView = 0;
+  accessor.componentType = Accessor::ComponentType::BYTE;
+  accessor.type = Accessor::Type::SCALAR;
+  accessor.count = bufferView.byteLength / sizeof(int8_t);
+
+  SECTION("Handles invalid accessor") {
+    // Wrong component type
+    FeatureIdAccessorType featureIdAccessor =
+        AccessorView<int16_t>(model, accessor);
+    REQUIRE(std::visit(FeatureIdFromAccessor{0}, featureIdAccessor) == -1);
+  }
+
+  SECTION("Retrieves from valid accessor") {
+    FeatureIdAccessorType featureIdAccessor =
+        AccessorView<int8_t>(model, accessor);
+    for (size_t i = 0; i < featureIds.size(); i++) {
+      int64_t featureID = std::visit(
+          FeatureIdFromAccessor{static_cast<int64_t>(i)},
+          featureIdAccessor);
+      REQUIRE(featureID == featureIds[i]);
+    }
+  }
+}
+
+TEST_CASE("Test FaceVertexIndicesFromAccessor") {
+  Model model;
+  std::vector<uint32_t> indices{0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7, 6, 7, 8};
+  int64_t vertexCount = 9;
+
+  Buffer& buffer = model.buffers.emplace_back();
+  buffer.cesium.data.resize(indices.size() * sizeof(uint32_t));
+  std::memcpy(
+      buffer.cesium.data.data(),
+      indices.data(),
+      buffer.cesium.data.size());
+  buffer.byteLength = buffer.cesium.data.size();
+
+  BufferView& bufferView = model.bufferViews.emplace_back();
+  bufferView.buffer = 0;
+  bufferView.byteLength = buffer.byteLength;
+
+  Accessor& accessor = model.accessors.emplace_back();
+  accessor.bufferView = 0;
+  accessor.componentType = Accessor::ComponentType::UNSIGNED_INT;
+  accessor.type = Accessor::Type::SCALAR;
+  accessor.count = bufferView.byteLength / sizeof(uint32_t);
+
+  SECTION("Handles invalid accessor") {
+    // Wrong component type
+    IndexAccessorType indexAccessor = AccessorView<uint8_t>(model, accessor);
+    auto indicesForFace =
+        std::visit(IndicesForFaceFromAccessor{0, vertexCount}, indexAccessor);
+    for (int64_t index : indicesForFace) {
+      REQUIRE(index == -1);
+    }
+  }
+
+  SECTION("Handles invalid face index") {
+    IndexAccessorType indexAccessor = AccessorView<uint32_t>(model, accessor);
+    auto indicesForFace =
+        std::visit(IndicesForFaceFromAccessor{-1, vertexCount}, indexAccessor);
+    for (int64_t index : indicesForFace) {
+      REQUIRE(index == -1);
+    }
+
+    indicesForFace =
+        std::visit(IndicesForFaceFromAccessor{10, vertexCount}, indexAccessor);
+    for (int64_t index : indicesForFace) {
+      REQUIRE(index == -1);
+    }
+  }
+
+  SECTION("Retrieves from valid accessor and face index") {
+    IndexAccessorType indexAccessor = AccessorView<uint32_t>(model, accessor);
+    const size_t numFaces = indices.size() / 3;
+    for (size_t i = 0; i < numFaces; i++) {
+      auto indicesForFace = std::visit(
+          IndicesForFaceFromAccessor{static_cast<int64_t>(i), vertexCount},
+          indexAccessor);
+
+      for (size_t j = 0; j < indicesForFace.size(); j++) {
+        int64_t expected = static_cast<int64_t>(indices[i * 3 + j]);
+        REQUIRE(indicesForFace[j] == expected);
+      }
+    }
+  }
+
+  SECTION("Handles invalid face index for nonexistent accessor") {
+    IndexAccessorType indexAccessor;
+    auto indicesForFace =
+        std::visit(IndicesForFaceFromAccessor{-1, vertexCount}, indexAccessor);
+    for (int64_t index : indicesForFace) {
+      REQUIRE(index == -1);
+    }
+
+    indicesForFace =
+        std::visit(IndicesForFaceFromAccessor{10, vertexCount}, indexAccessor);
+    for (int64_t index : indicesForFace) {
+      REQUIRE(index == -1);
+    }
+  }
+
+  SECTION("Retrieves from valid face index for nonexistent accessor") {
+    IndexAccessorType indexAccessor;
+    const int64_t numFaces = vertexCount / 3;
+
+    for (int64_t i = 0; i < numFaces; i++) {
+      auto indicesForFace =
+          std::visit(IndicesForFaceFromAccessor{i, vertexCount}, indexAccessor);
+
+      for (size_t j = 0; j < indicesForFace.size(); j++) {
+        int64_t expected = i * 3 + static_cast<int64_t>(j);
+        REQUIRE(indicesForFace[j] == expected);
+      }
+    }
+  }
+}
+
+TEST_CASE("Test GetTexCoordAccessorView") {
+  Model model;
+  std::vector<glm::vec2> texCoords0{
+      glm::vec2(0, 0),
+      glm::vec2(1, 0),
+      glm::vec2(0, 1),
+      glm::vec2(1, 1)};
+
+  // First TEXCOORD set
+  {
+    Buffer& buffer = model.buffers.emplace_back();
+    buffer.cesium.data.resize(texCoords0.size() * sizeof(glm::vec2));
+    std::memcpy(
+        buffer.cesium.data.data(),
+        texCoords0.data(),
+        buffer.cesium.data.size());
+    buffer.byteLength = buffer.cesium.data.size();
+
+    BufferView& bufferView = model.bufferViews.emplace_back();
+    bufferView.buffer = 0;
+    bufferView.byteLength = buffer.byteLength;
+
+    Accessor& accessor = model.accessors.emplace_back();
+    accessor.bufferView = 0;
+    accessor.componentType = Accessor::ComponentType::FLOAT;
+    accessor.type = Accessor::Type::VEC2;
+    accessor.count = bufferView.byteLength / sizeof(glm::vec2);
+  }
+
+  std::vector<glm::u8vec2> texCoords1{
+      glm::u8vec2(0, 0),
+      glm::u8vec2(0, 255),
+      glm::u8vec2(255, 255),
+      glm::u8vec2(255, 0)};
+
+  // Second TEXCOORD set
+  {
+    Buffer& buffer = model.buffers.emplace_back();
+    buffer.cesium.data.resize(texCoords1.size() * sizeof(glm::u8vec2));
+    std::memcpy(
+        buffer.cesium.data.data(),
+        texCoords1.data(),
+        buffer.cesium.data.size());
+    buffer.byteLength = buffer.cesium.data.size();
+
+    BufferView& bufferView = model.bufferViews.emplace_back();
+    bufferView.buffer = 1;
+    bufferView.byteLength = buffer.byteLength;
+
+    Accessor& accessor = model.accessors.emplace_back();
+    accessor.bufferView = 1;
+    accessor.componentType = Accessor::ComponentType::UNSIGNED_BYTE;
+    accessor.type = Accessor::Type::VEC2;
+    accessor.normalized = true;
+    accessor.count = bufferView.byteLength / sizeof(glm::u8vec2);
+  }
+
+  Mesh& mesh = model.meshes.emplace_back();
+  MeshPrimitive primitive = mesh.primitives.emplace_back();
+
+  primitive.attributes.insert({"TEXCOORD_0", 0});
+  primitive.attributes.insert({"TEXCOORD_1", 1});
+
+  SECTION("Handles invalid texture coordinate set index") {
+    TexCoordAccessorType texCoordAccessor =
+        GetTexCoordAccessorView(model, primitive, 2);
+    REQUIRE(std::visit(CountFromAccessor{}, texCoordAccessor) == 0);
+  }
+
+  SECTION("Handles invalid accessor type") {
+    model.accessors[0].type = Accessor::Type::SCALAR;
+
+    TexCoordAccessorType texCoordAccessor =
+        GetTexCoordAccessorView(model, primitive, 0);
+    REQUIRE(std::visit(CountFromAccessor{}, texCoordAccessor) == 0);
+
+    model.accessors[0].type = Accessor::Type::VEC2;
+  }
+
+  SECTION("Handles unsupported accessor component type") {
+    model.accessors[0].componentType = Accessor::ComponentType::BYTE;
+
+    TexCoordAccessorType texCoordAccessor =
+        GetTexCoordAccessorView(model, primitive, 0);
+    REQUIRE(std::visit(CountFromAccessor{}, texCoordAccessor) == 0);
+
+    model.accessors[0].componentType = Accessor::ComponentType::FLOAT;
+  }
+
+  SECTION("Handles invalid un-normalized texcoord") {
+    model.accessors[1].normalized = false;
+
+    TexCoordAccessorType texCoordAccessor =
+        GetTexCoordAccessorView(model, primitive, 2);
+    REQUIRE(std::visit(CountFromAccessor{}, texCoordAccessor) == 0);
+
+    model.accessors[1].normalized = true;
+  }
+
+  SECTION("Creates from valid texture coordinate sets") {
+    TexCoordAccessorType texCoordAccessor =
+        GetTexCoordAccessorView(model, primitive, 0);
+    REQUIRE(
+        std::visit(CountFromAccessor{}, texCoordAccessor) ==
+        static_cast<int64_t>(texCoords0.size()));
+
+    texCoordAccessor = GetTexCoordAccessorView(model, primitive, 1);
+    REQUIRE(
+        std::visit(CountFromAccessor{}, texCoordAccessor) ==
+        static_cast<int64_t>(texCoords1.size()));
+  }
+}
+
+TEST_CASE("Test TexCoordFromAccessor") {
+  Model model;
+  std::vector<glm::vec2> texCoords0{
+      glm::vec2(0, 0),
+      glm::vec2(1, 0),
+      glm::vec2(0, 1),
+      glm::vec2(1, 1)};
+
+  // First TEXCOORD set
+  {
+    Buffer& buffer = model.buffers.emplace_back();
+    buffer.cesium.data.resize(texCoords0.size() * sizeof(glm::vec2));
+    std::memcpy(
+        buffer.cesium.data.data(),
+        texCoords0.data(),
+        buffer.cesium.data.size());
+    buffer.byteLength = buffer.cesium.data.size();
+
+    BufferView& bufferView = model.bufferViews.emplace_back();
+    bufferView.buffer = 0;
+    bufferView.byteLength = buffer.byteLength;
+
+    Accessor& accessor = model.accessors.emplace_back();
+    accessor.bufferView = 0;
+    accessor.componentType = Accessor::ComponentType::FLOAT;
+    accessor.type = Accessor::Type::VEC2;
+    accessor.count = bufferView.byteLength / sizeof(glm::vec2);
+  }
+
+  std::vector<glm::u8vec2> texCoords1{
+      glm::u8vec2(0, 0),
+      glm::u8vec2(0, 255),
+      glm::u8vec2(255, 255),
+      glm::u8vec2(255, 0)};
+
+  // Second TEXCOORD set
+  {
+    Buffer& buffer = model.buffers.emplace_back();
+    buffer.cesium.data.resize(texCoords1.size() * sizeof(glm::u8vec2));
+    std::memcpy(
+        buffer.cesium.data.data(),
+        texCoords1.data(),
+        buffer.cesium.data.size());
+    buffer.byteLength = buffer.cesium.data.size();
+
+    BufferView& bufferView = model.bufferViews.emplace_back();
+    bufferView.buffer = 1;
+    bufferView.byteLength = buffer.byteLength;
+
+    Accessor& accessor = model.accessors.emplace_back();
+    accessor.bufferView = 1;
+    accessor.componentType = Accessor::ComponentType::UNSIGNED_BYTE;
+    accessor.type = Accessor::Type::VEC2;
+    accessor.normalized = true;
+    accessor.count = bufferView.byteLength / sizeof(glm::u8vec2);
+  }
+
+  Mesh& mesh = model.meshes.emplace_back();
+  MeshPrimitive primitive = mesh.primitives.emplace_back();
+
+  primitive.attributes.insert({"TEXCOORD_0", 0});
+  primitive.attributes.insert({"TEXCOORD_1", 1});
+
+  SECTION("Handles invalid accessor") {
+    TexCoordAccessorType texCoordAccessor =
+        GetTexCoordAccessorView(model, primitive, 2);
+    REQUIRE(!std::visit(TexCoordFromAccessor{0}, texCoordAccessor));
+  }
+
+  SECTION("Handles invalid index") {
+    TexCoordAccessorType texCoordAccessor =
+        GetTexCoordAccessorView(model, primitive, 0);
+    REQUIRE(!std::visit(TexCoordFromAccessor{-1}, texCoordAccessor));
+    REQUIRE(!std::visit(TexCoordFromAccessor{10}, texCoordAccessor));
+  }
+
+  SECTION("Retrieves from valid accessor and index") {
+    TexCoordAccessorType texCoordAccessor =
+        GetTexCoordAccessorView(model, primitive, 0);
+    for (size_t i = 0; i < texCoords0.size(); i++) {
+      auto maybeTexCoord = std::visit(
+          TexCoordFromAccessor{static_cast<int64_t>(i)},
+          texCoordAccessor);
+      REQUIRE(maybeTexCoord);
+
+      auto expected = glm::dvec2(texCoords0[i][0], texCoords0[i][1]);
+      REQUIRE(*maybeTexCoord == expected);
+    }
+  }
+  SECTION("Retrieves from valid normalized accessor and index") {
+    TexCoordAccessorType texCoordAccessor =
+        GetTexCoordAccessorView(model, primitive, 1);
+    for (size_t i = 0; i < texCoords1.size(); i++) {
+      auto maybeTexCoord = std::visit(
+          TexCoordFromAccessor{static_cast<int64_t>(i)},
+          texCoordAccessor);
+      REQUIRE(maybeTexCoord);
+      auto expected = glm::dvec2(texCoords1[i][0], texCoords1[i][1]);
+      expected /= 255;
+
+      REQUIRE(*maybeTexCoord == expected);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds `AccessorUtility.h`, which is just the `GltfAccessors.h` file from Cesium for Unreal. It provides `typedef`s for the possible types of feature ID, index, and texcoord accessors, as well as visitors to retrieve their data. This is useful for retrieving feature IDs and texture coordinates without requiring them to be baked into mesh data, enabling picking.

This is a PR into #756 , so merge that first.