### PR TITLE
Fix VS 2022 17.8 warnings/errors by defining _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 
 - Fixed a bug in `OrientedBoundingBox::contains` where it didn't account for the bounding box's center.
 - Fixed compiler error when calling `PropertyAttributeView::forEachProperty`.
+- Fixed WD4996 warnings-as-errors when compiling with Visual Studio 2002 v17.8.
 
 ### v0.29.0 - 2023-11-01
 

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -68,6 +68,7 @@ add_subdirectory(asyncplusplus)
 
 set(SPDLOG_BUILD_TESTING OFF CACHE INTERNAL "Disable SPDLOG Testing")
 add_subdirectory(spdlog)
+target_compile_definitions(spdlog PUBLIC _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING)
 
 if (NOT TARGET sqlite3)
   add_subdirectory(sqlite3)


### PR DESCRIPTION
Longer term, we should upgrade fmt. Our copy is included in spdlog.
https://github.com/fmtlib/fmt/issues/3540
