### PR TITLE
Fix VS 2022 17.8 warnings/errors in v0.27.x by defining _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v0.27.4 - ?
+
+##### Fixes :wrench:
+
+- Fixed WD4996 warnings-as-errors when compiling with Visual Studio 2022 v17.8.
+
 ### v0.27.3 - 2023-10-01
 
 ##### Additions :tada:

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -68,6 +68,7 @@ add_subdirectory(asyncplusplus)
 
 set(SPDLOG_BUILD_TESTING OFF CACHE INTERNAL "Disable SPDLOG Testing")
 add_subdirectory(spdlog)
+target_compile_definitions(spdlog PUBLIC _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING)
 
 if (NOT TARGET sqlite3)
   add_subdirectory(sqlite3)


### PR DESCRIPTION
This is the same as #767 except it's a PR into the v0.27.x branch, which we're still using in Cesium for Unity until we can update to the new metadata system.