### PR TITLE
Add support for new defaults service to CesiumIonClient.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### ? - ?
 
+##### Additions :tada:
+
+- Add `defaults` method to `CesiumIonClient::Connection`.
+
 ##### Fixes :wrench:
 
 - Fixed a bug where the `getApiUrl` method of `CesiumIonClient::Connection` would not return the default API URL if the attempt to access `config.json` failed in a more serious way, such as because of an invalid hostname.

--- a/CesiumIonClient/CMakeLists.txt
+++ b/CesiumIonClient/CMakeLists.txt
@@ -12,6 +12,7 @@ set_target_properties(CesiumIonClient
     PROPERTIES
         TEST_SOURCES "${CESIUM_ION_CLIENT_TEST_SOURCES}"
         TEST_HEADERS "${CESIUM_ION_CLIENT_TEST_HEADERS}"
+        TEST_DATA_DIR ${CMAKE_CURRENT_LIST_DIR}/test/data
 )
 
 set_target_properties(CesiumIonClient

--- a/CesiumIonClient/include/CesiumIonClient/Connection.h
+++ b/CesiumIonClient/include/CesiumIonClient/Connection.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Assets.h"
+#include "Defaults.h"
 #include "Profile.h"
 #include "Response.h"
 #include "Token.h"
@@ -163,6 +164,17 @@ public:
    * @return A future that resolves to the profile information.
    */
   CesiumAsync::Future<Response<Profile>> me() const;
+
+  /**
+   * @brief Retrieves default imagery, terrain and building assets along with
+   * quick add assets that can be useful to use within other applications.
+   *
+   * This route will always return data, but will return user specific
+   * information with any valid token.
+   *
+   * @return A future that resolves to the default information.
+   */
+  CesiumAsync::Future<Response<Defaults>> defaults() const;
 
   /**
    * @brief Gets the list of available assets.

--- a/CesiumIonClient/include/CesiumIonClient/Defaults.h
+++ b/CesiumIonClient/include/CesiumIonClient/Defaults.h
@@ -1,0 +1,95 @@
+#pragma once
+
+namespace CesiumIonClient {
+
+/**
+ * @brief The default assets.
+ */
+struct DefaultAssets {
+  /**
+   * @brief The asset id of the default imagery asset.
+   */
+  int64_t imagery = -1;
+
+  /**
+   * @brief The asset id of the default terrain asset.
+   */
+  int64_t terrain = -1;
+
+  /**
+   * @brief The asset id of the default buildings asset.
+   */
+  int64_t buildings = -1;
+};
+
+/**
+ * @brief A raster overlay available for use with a quick add asset.
+ */
+struct QuickAddRasterOverlay {
+  /**
+   * @brief The name of this asset.
+   */
+  std::string name{};
+
+  /**
+   * @brief The unique identifier for this asset.
+   */
+  int64_t assetId = -1;
+
+  /**
+   * @brief `true` if the user is subscribed to the asset, `false` otherwise.
+   */
+  bool subscribed = false;
+};
+
+/**
+ * @brief A quick add asset.
+ */
+struct QuickAddAsset {
+  /**
+   * @brief The name of this asset.
+   */
+  std::string name{};
+
+  /**
+   * @brief The name of the main asset. In most cases this will be the same as
+   * `name`, but in the cases of assets with raster overlays, this will be the
+   * non-imagery asset.
+   */
+  std::string objectName{};
+
+  /**
+   * @brief A Markdown compatible string describing this asset.
+   */
+  std::string description{};
+
+  /**
+   * @brief The unique identifier for this asset.
+   */
+  int64_t assetId = -1;
+
+  /**
+   * @brief This asset's type.
+   *
+   * Valid values are: `3DTILES`, `GLTF`, `IMAGERY`, `TERRAIN`, `KML`, `CZML`,
+   * `GEOJSON`.
+   */
+  std::string type{};
+
+  /**
+   * @brief `true` if the user is subscribed to the asset, `false` otherwise.
+   */
+  bool subscribed = false;
+
+  /**
+   * @brief The raster overlays available for this asset
+   */
+  std::vector<QuickAddRasterOverlay> rasterOverlays{};
+};
+
+struct Defaults {
+  DefaultAssets defaultAssets{};
+  std::vector<QuickAddAsset> quickAddAssets{};
+};
+
+} // namespace CesiumIonClient

--- a/CesiumIonClient/include/CesiumIonClient/Defaults.h
+++ b/CesiumIonClient/include/CesiumIonClient/Defaults.h
@@ -87,8 +87,20 @@ struct QuickAddAsset {
   std::vector<QuickAddRasterOverlay> rasterOverlays{};
 };
 
+/**
+ * @brief The data returned by Cesium ion's `v1/defaults` service. It includes
+ * information about default imagery, terrain and building assets along with
+ * quick add assets that can be useful to use within other applications.
+ */
 struct Defaults {
+  /**
+   * @brief The default assets
+   */
   DefaultAssets defaultAssets{};
+
+  /**
+   * @brief The quick add assets
+   */
   std::vector<QuickAddAsset> quickAddAssets{};
 };
 

--- a/CesiumIonClient/src/Connection.cpp
+++ b/CesiumIonClient/src/Connection.cpp
@@ -419,6 +419,111 @@ CesiumIonClient::Connection::getApiUrl(
           [ionUrl](std::exception&&) { return generateApiUrl(ionUrl); });
 }
 
+namespace {
+
+QuickAddRasterOverlay
+jsonToQuickAddRasterOverlay(const rapidjson::Value& json) {
+  QuickAddRasterOverlay result;
+
+  result.name = JsonHelpers::getStringOrDefault(json, "name", std::string());
+  result.assetId = JsonHelpers::getInt64OrDefault(json, "assetId", -1);
+  result.subscribed = JsonHelpers::getBoolOrDefault(json, "subscribed", false);
+
+  return result;
+}
+
+QuickAddAsset jsonToQuickAddAsset(const rapidjson::Value& json) {
+  QuickAddAsset result;
+
+  result.name = JsonHelpers::getStringOrDefault(json, "name", std::string());
+  result.objectName =
+      JsonHelpers::getStringOrDefault(json, "objectName", std::string());
+  result.description =
+      JsonHelpers::getStringOrDefault(json, "description", std::string());
+  result.assetId = JsonHelpers::getInt64OrDefault(json, "assetId", -1);
+  result.type = JsonHelpers::getStringOrDefault(json, "type", std::string());
+  result.subscribed = JsonHelpers::getBoolOrDefault(json, "subscribed", false);
+
+  auto overlaysIt = json.FindMember("rasterOverlays");
+  if (overlaysIt != json.MemberEnd() && overlaysIt->value.IsArray()) {
+    const rapidjson::Value& items = overlaysIt->value;
+    result.rasterOverlays.resize(items.Size());
+    std::transform(
+        items.Begin(),
+        items.End(),
+        result.rasterOverlays.begin(),
+        jsonToQuickAddRasterOverlay);
+  }
+
+  return result;
+}
+
+Defaults defaultsFromJson(const rapidjson::Document& json) {
+  Defaults defaults;
+
+  auto defaultAssetsIt = json.FindMember("defaultAssets");
+  if (defaultAssetsIt != json.MemberEnd() &&
+      defaultAssetsIt->value.IsObject()) {
+    defaults.defaultAssets.imagery =
+        JsonHelpers::getInt64OrDefault(defaultAssetsIt->value, "imagery", -1);
+    defaults.defaultAssets.terrain =
+        JsonHelpers::getInt64OrDefault(defaultAssetsIt->value, "terrain", -1);
+    defaults.defaultAssets.buildings =
+        JsonHelpers::getInt64OrDefault(defaultAssetsIt->value, "buildings", -1);
+  }
+
+  auto quickAddAssetsIt = json.FindMember("quickAddAssets");
+  if (quickAddAssetsIt != json.MemberEnd() &&
+      quickAddAssetsIt->value.IsArray()) {
+    const rapidjson::Value& items = quickAddAssetsIt->value;
+    defaults.quickAddAssets.resize(items.Size());
+    std::transform(
+        items.Begin(),
+        items.End(),
+        defaults.quickAddAssets.begin(),
+        jsonToQuickAddAsset);
+  }
+
+  return defaults;
+}
+
+} // namespace
+
+Future<Response<Defaults>> Connection::defaults() const {
+  return this->_pAssetAccessor
+      ->get(
+          this->_asyncSystem,
+          CesiumUtility::Uri::resolve(this->_apiUrl, "v1/defaults"),
+          {{"Accept", "application/json"},
+           {"Authorization", "Bearer " + this->_accessToken}})
+      .thenInMainThread(
+          [](std::shared_ptr<CesiumAsync::IAssetRequest>&& pRequest) {
+            const IAssetResponse* pResponse = pRequest->response();
+            if (!pResponse) {
+              return createEmptyResponse<Defaults>();
+            }
+
+            if (pResponse->statusCode() < 200 ||
+                pResponse->statusCode() >= 300) {
+              return createErrorResponse<Defaults>(pResponse);
+            }
+
+            rapidjson::Document d;
+            if (!parseJsonObject(pResponse, d)) {
+              return createJsonErrorResponse<Defaults>(pResponse, d);
+            }
+            if (!d.IsObject()) {
+              return createJsonTypeResponse<Defaults>(pResponse, "object");
+            }
+
+            return Response<Defaults>(
+                defaultsFromJson(d),
+                pResponse->statusCode(),
+                std::string(),
+                std::string());
+          });
+}
+
 CesiumAsync::Future<Response<Assets>> Connection::assets() const {
   return this->_pAssetAccessor
       ->get(
@@ -507,7 +612,7 @@ TokenList tokenListFromJson(const rapidjson::Value& json) {
   TokenList result;
 
   const auto itemsIt = json.FindMember("items");
-  if (itemsIt != json.MemberEnd() || !itemsIt->value.IsArray()) {
+  if (itemsIt != json.MemberEnd() && itemsIt->value.IsArray()) {
     const rapidjson::Value& items = itemsIt->value;
 
     for (auto it = items.Begin(); it != items.End(); ++it) {

--- a/CesiumIonClient/src/Response.cpp
+++ b/CesiumIonClient/src/Response.cpp
@@ -1,6 +1,7 @@
 #include "CesiumIonClient/Response.h"
 
 #include "CesiumIonClient/Assets.h"
+#include "CesiumIonClient/Defaults.h"
 #include "CesiumIonClient/Profile.h"
 #include "CesiumIonClient/TokenList.h"
 #include "parseLinkHeader.h"
@@ -73,6 +74,7 @@ Response<T>::Response(
 // Explicit instantiations
 template struct Response<Asset>;
 template struct Response<Assets>;
+template struct Response<Defaults>;
 template struct Response<NoValue>;
 template struct Response<Profile>;
 template struct Response<Token>;

--- a/CesiumIonClient/test/TestConnection.cpp
+++ b/CesiumIonClient/test/TestConnection.cpp
@@ -1,0 +1,74 @@
+#include <CesiumAsync/AsyncSystem.h>
+#include <CesiumIonClient/Connection.h>
+#include <CesiumNativeTests/SimpleAssetAccessor.h>
+#include <CesiumNativeTests/SimpleTaskProcessor.h>
+#include <CesiumNativeTests/readFile.h>
+#include <CesiumNativeTests/waitForFuture.h>
+
+#include <catch2/catch.hpp>
+
+using namespace CesiumAsync;
+using namespace CesiumIonClient;
+using namespace CesiumNativeTests;
+
+TEST_CASE("CesiumIonClient::Connection") {
+  std::shared_ptr<SimpleAssetAccessor> pAssetAccessor =
+      std::make_shared<SimpleAssetAccessor>(
+          std::map<std::string, std::shared_ptr<SimpleAssetRequest>>());
+
+  std::unique_ptr<SimpleAssetResponse> pResponse =
+      std::make_unique<SimpleAssetResponse>(
+          static_cast<uint16_t>(200),
+          "doesn't matter",
+          CesiumAsync::HttpHeaders{},
+          readFile(
+              std::filesystem::path(CesiumIonClient_TEST_DATA_DIR) /
+              "defaults.json"));
+
+  std::shared_ptr<SimpleAssetRequest> pRequest =
+      std::make_shared<SimpleAssetRequest>(
+          "GET",
+          "doesn't matter",
+          CesiumAsync::HttpHeaders{},
+          std::move(pResponse));
+
+  pAssetAccessor->mockCompletedRequests.insert(
+      {"https://example.com/v1/defaults", std::move(pRequest)});
+
+  AsyncSystem asyncSystem(std::make_shared<SimpleTaskProcessor>());
+  Connection connection(
+      asyncSystem,
+      pAssetAccessor,
+      "my access token",
+      "https://example.com/");
+
+  Future<Response<Defaults>> futureDefaults = connection.defaults();
+  Response<Defaults> defaults =
+      waitForFuture(asyncSystem, std::move(futureDefaults));
+
+  REQUIRE(defaults.value);
+
+  CHECK(defaults.value->defaultAssets.imagery == 2);
+  CHECK(defaults.value->defaultAssets.terrain == 1);
+  CHECK(defaults.value->defaultAssets.buildings == 624);
+
+  REQUIRE(defaults.value->quickAddAssets.size() == 9);
+  const QuickAddAsset& cwtAndBing = defaults.value->quickAddAssets[6];
+  CHECK(cwtAndBing.name == "Cesium World Terrain + Bing Maps Aerial");
+  CHECK(cwtAndBing.objectName == "Cesium World Terrain");
+  CHECK(
+      cwtAndBing.description ==
+      "High-resolution global terrain tileset curated from several data "
+      "sources.  See the official [Cesium World "
+      "Terrain](https://cesium.com/content/cesium-world-terrain/) page for "
+      "details. textured with Aerial imagery.");
+  CHECK(cwtAndBing.assetId == 1);
+  CHECK(cwtAndBing.type == "TERRAIN");
+  CHECK(cwtAndBing.subscribed == true);
+
+  REQUIRE(cwtAndBing.rasterOverlays.size() == 1);
+  const QuickAddRasterOverlay& bing = cwtAndBing.rasterOverlays[0];
+  CHECK(bing.name == "Bing Maps Aerial");
+  CHECK(bing.assetId == 2);
+  CHECK(bing.subscribed == true);
+}

--- a/CesiumIonClient/test/data/defaults.json
+++ b/CesiumIonClient/test/data/defaults.json
@@ -1,0 +1,90 @@
+{
+  "defaultAssets": { "imagery": 2, "terrain": 1, "buildings": 624 },
+  "quickAddAssets": [
+    {
+      "name": "Cesium World Terrain",
+      "objectName": "Cesium World Terrain",
+      "description": "High-resolution global terrain tileset curated from several data sources.  See the official [Cesium World Terrain](https://cesium.com/content/cesium-world-terrain/) page for details.",
+      "assetId": 1,
+      "type": "TERRAIN",
+      "subscribed": true
+    },
+    {
+      "name": "Bing Maps Aerial",
+      "objectName": "Bing Maps Aerial",
+      "description": "Aerial imagery.",
+      "assetId": 2,
+      "type": "IMAGERY",
+      "subscribed": true
+    },
+    {
+      "name": "Bing Maps Aerial with Labels",
+      "objectName": "Bing Maps Aerial with Labels",
+      "description": "Bing Maps Aerial with Labels",
+      "assetId": 23,
+      "type": "IMAGERY",
+      "subscribed": false
+    },
+    {
+      "name": "Sentinel-2",
+      "objectName": "Sentinel-2",
+      "description": "Sentinel-2 cloudless imagery of the entire world down to zoom level 13.",
+      "assetId": 623,
+      "type": "IMAGERY",
+      "subscribed": false
+    },
+    {
+      "name": "Cesium OSM Buildings",
+      "objectName": "Cesium OSM Buildings",
+      "description": "A 3D buildings layer derived from OpenStreetMap covering the entire world. It contains over 350 million buildings with per-feature data like name, address, whether a building is commercial or residential, and more.\n\nSee the [Cesium OSM Buildings page](https://cesium.com/content/cesium-osm-buildings/) to learn about the available properties and what you can do with this asset.\n\nThis tileset is updated monthly. For the latest news, visit our [community forum thread](https://community.cesium.com/t/weve-just-updated-cesium-osm-buildings/10764/last).",
+      "assetId": 624,
+      "type": "3DTILES",
+      "subscribed": true
+    },
+    {
+      "name": "Google Photorealistic 3D Tiles",
+      "objectName": "Google Photorealistic 3D Tiles",
+      "description": "Photorealistic 3D Tiles from Google Maps Platform. \n\nYour use of this asset is subject to the current versions of these documents:\n\n- Google Maps Platform Service Specific Terms at https://cloud.google.com/maps-platform/terms/maps-service-terms \n- The Google Maps/Google Earth Additional Terms of Service at https://maps.google.com/help/terms_maps.html \n- The Map Tiles API Policy at https://developers.google.com/maps/documentation/tile/policies \n- The Google Privacy Policy at https://www.google.com/policies/privacy/ ",
+      "assetId": 823,
+      "type": "3DTILES",
+      "subscribed": true
+    },
+    {
+      "name": "Cesium World Terrain + Bing Maps Aerial",
+      "objectName": "Cesium World Terrain",
+      "description": "High-resolution global terrain tileset curated from several data sources.  See the official [Cesium World Terrain](https://cesium.com/content/cesium-world-terrain/) page for details. textured with Aerial imagery.",
+      "assetId": 1,
+      "type": "TERRAIN",
+      "subscribed": true,
+      "rasterOverlays": [
+        { "name": "Bing Maps Aerial", "assetId": 2, "subscribed": true }
+      ]
+    },
+    {
+      "name": "Cesium World Terrain + Bing Maps Aerial with Labels",
+      "objectName": "Cesium World Terrain",
+      "description": "High-resolution global terrain tileset curated from several data sources.  See the official [Cesium World Terrain](https://cesium.com/content/cesium-world-terrain/) page for details. textured with Bing Maps Aerial with Labels",
+      "assetId": 1,
+      "type": "TERRAIN",
+      "subscribed": true,
+      "rasterOverlays": [
+        {
+          "name": "Bing Maps Aerial with Labels",
+          "assetId": 23,
+          "subscribed": false
+        }
+      ]
+    },
+    {
+      "name": "Cesium World Terrain + Sentinel-2",
+      "objectName": "Cesium World Terrain",
+      "description": "High-resolution global terrain tileset curated from several data sources.  See the official [Cesium World Terrain](https://cesium.com/content/cesium-world-terrain/) page for details. textured with Sentinel-2 cloudless imagery of the entire world down to zoom level 13.",
+      "assetId": 1,
+      "type": "TERRAIN",
+      "subscribed": true,
+      "rasterOverlays": [
+        { "name": "Sentinel-2", "assetId": 623, "subscribed": false }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is a PR into #772 so merge that first.

Adds support for Cesium ion's new `defaults` service which will be used to populate the Quick Add panels. The new service is not available in the public Cesium ion just yet, though.