### PR TITLE
Fix crash from accessing deleted SubtreeFileReader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a crash in `SubtreeAvailability::loadSubtree`.
+
 ### v0.30.0 - 2023-12-01
 
 ##### Breaking Changes :mega:

--- a/Cesium3DTilesContent/src/SubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/src/SubtreeAvailability.cpp
@@ -146,10 +146,10 @@ SubtreeAvailability::loadSubtree(
     const std::shared_ptr<spdlog::logger>& pLogger,
     const std::string& subtreeUrl,
     const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders) {
-  auto reader = std::make_shared<SubtreeFileReader>();
-  return reader->load(asyncSystem, pAssetAccessor, subtreeUrl, requestHeaders)
+  auto pReader = std::make_shared<SubtreeFileReader>();
+  return pReader->load(asyncSystem, pAssetAccessor, subtreeUrl, requestHeaders)
       .thenInMainThread(
-          [pLogger, subtreeUrl, subdivisionScheme, levelsInSubtree, reader](
+          [pLogger, subtreeUrl, subdivisionScheme, levelsInSubtree, pReader](
               ReadJsonResult<Subtree>&& subtree)
               -> std::optional<SubtreeAvailability> {
             if (!subtree.value) {

--- a/Cesium3DTilesContent/src/SubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/src/SubtreeAvailability.cpp
@@ -146,10 +146,10 @@ SubtreeAvailability::loadSubtree(
     const std::shared_ptr<spdlog::logger>& pLogger,
     const std::string& subtreeUrl,
     const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders) {
-  SubtreeFileReader reader;
-  return reader.load(asyncSystem, pAssetAccessor, subtreeUrl, requestHeaders)
+  auto reader = std::make_shared<SubtreeFileReader>();
+  return reader->load(asyncSystem, pAssetAccessor, subtreeUrl, requestHeaders)
       .thenInMainThread(
-          [pLogger, subtreeUrl, subdivisionScheme, levelsInSubtree](
+          [pLogger, subtreeUrl, subdivisionScheme, levelsInSubtree, reader](
               ReadJsonResult<Subtree>&& subtree)
               -> std::optional<SubtreeAvailability> {
             if (!subtree.value) {

--- a/Cesium3DTilesContent/test/TestSubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/test/TestSubtreeAvailability.cpp
@@ -4,6 +4,8 @@
 #include <CesiumGeometry/QuadtreeTileID.h>
 #include <CesiumNativeTests/SimpleAssetAccessor.h>
 #include <CesiumNativeTests/SimpleTaskProcessor.h>
+#include <CesiumNativeTests/ThreadTaskProcessor.h>
+#include <CesiumNativeTests/waitForFuture.h>
 
 #include <catch2/catch.hpp>
 #include <libmorton/morton.h>
@@ -284,7 +286,7 @@ std::optional<SubtreeAvailability> mockLoadSubtreeJson(
       std::make_shared<SimpleAssetAccessor>(std::move(mapUrlToRequest));
 
   // mock async system
-  auto pMockTaskProcessor = std::make_shared<SimpleTaskProcessor>();
+  auto pMockTaskProcessor = std::make_shared<ThreadTaskProcessor>();
   CesiumAsync::AsyncSystem asyncSystem{pMockTaskProcessor};
 
   auto subtreeFuture = SubtreeAvailability::loadSubtree(
@@ -296,8 +298,7 @@ std::optional<SubtreeAvailability> mockLoadSubtreeJson(
       "test",
       {});
 
-  asyncSystem.dispatchMainThreadTasks();
-  return subtreeFuture.wait();
+  return waitForFuture(asyncSystem, std::move(subtreeFuture));
 }
 } // namespace
 

--- a/Cesium3DTilesReader/include/Cesium3DTilesReader/SubtreeFileReader.h
+++ b/Cesium3DTilesReader/include/Cesium3DTilesReader/SubtreeFileReader.h
@@ -40,6 +40,12 @@ public:
   /**
    * @brief Asynchronously loads a subtree from a URL.
    *
+   * Please note that the `SubtreeFileReader` instance must remain valid until
+   * the returned future resolves or rejects. Destroying it earlier will result
+   * in undefined behavior. One easy way to achieve this is to construct the
+   * reader with `std::make_shared` and capture the `std::shared_ptr` in the
+   * continuation lambda.
+   *
    * @param asyncSystem The AsyncSystem used to do asynchronous work.
    * @param pAssetAccessor The accessor used to retrieve the URL and any other
    * required resources.

--- a/CesiumNativeTests/include/CesiumNativeTests/ThreadTaskProcessor.h
+++ b/CesiumNativeTests/include/CesiumNativeTests/ThreadTaskProcessor.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <CesiumAsync/ITaskProcessor.h>
+
+#include <thread>
+
+namespace CesiumNativeTests {
+class ThreadTaskProcessor : public CesiumAsync::ITaskProcessor {
+public:
+  virtual void startTask(std::function<void()> f) override {
+    std::thread(f).detach();
+  }
+};
+} // namespace CesiumNativeTests


### PR DESCRIPTION
This change keeps SubtreeFileReader instance in the loaders future context. Should fix https://github.com/CesiumGS/cesium-native/issues/774