### PR TITLE
Allow implicit subtree buffers to be padded to 8 bytes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 - Added conversions from `std::string` to other metadata types in `MetadataConversions`. This enables the same conversions as `std::string_view`, while allowing runtime engines to use `std::string` for convenience.
 
+##### Fixes :wrench:
+
+- Fixed a bug that could cause binary implicit tiling subtrees with buffers padded to 8-bytes to fail to load.
+
 ### v0.31.0 - 2023-12-14
 
 ##### Additions :tada:

--- a/Cesium3DTilesContent/src/SubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/src/SubtreeAvailability.cpp
@@ -152,21 +152,22 @@ SubtreeAvailability::loadSubtree(
           [pLogger, subtreeUrl, subdivisionScheme, levelsInSubtree, pReader](
               ReadJsonResult<Subtree>&& subtree)
               -> std::optional<SubtreeAvailability> {
+            if (!subtree.errors.empty()) {
+              SPDLOG_LOGGER_ERROR(
+                  pLogger,
+                  "Errors while loading subtree from {}:\n- {}",
+                  subtreeUrl,
+                  CesiumUtility::joinToString(subtree.errors, "\n- "));
+            }
+            if (!subtree.warnings.empty()) {
+              SPDLOG_LOGGER_WARN(
+                  pLogger,
+                  "Warnings while loading subtree from {}:\n- {}",
+                  subtreeUrl,
+                  CesiumUtility::joinToString(subtree.warnings, "\n- "));
+            }
+
             if (!subtree.value) {
-              if (!subtree.errors.empty()) {
-                SPDLOG_LOGGER_ERROR(
-                    pLogger,
-                    "Errors while loading subtree from {}:\n- {}",
-                    subtreeUrl,
-                    CesiumUtility::joinToString(subtree.errors, "\n- "));
-              }
-              if (!subtree.warnings.empty()) {
-                SPDLOG_LOGGER_WARN(
-                    pLogger,
-                    "Warnings while loading subtree from {}:\n- {}",
-                    subtreeUrl,
-                    CesiumUtility::joinToString(subtree.warnings, "\n- "));
-              }
               return std::nullopt;
             }
 

--- a/Cesium3DTilesReader/src/SubtreeFileReader.cpp
+++ b/Cesium3DTilesReader/src/SubtreeFileReader.cpp
@@ -167,8 +167,16 @@ Future<ReadJsonResult<Subtree>> SubtreeFileReader::loadBinary(
     }
 
     const int64_t binaryChunkSize = static_cast<int64_t>(binaryChunk.size());
+
+    // We allow - but don't require - 8-byte padding.
+    int64_t maxPaddingBytes = 0;
+    int64_t paddingRemainder = buffer.byteLength % 8;
+    if (paddingRemainder > 0) {
+      maxPaddingBytes = 8 - paddingRemainder;
+    }
+
     if (buffer.byteLength > binaryChunkSize ||
-        buffer.byteLength + 3 < binaryChunkSize) {
+        buffer.byteLength + maxPaddingBytes < binaryChunkSize) {
       result.errors.emplace_back("Subtree binary chunk size does not match the "
                                  "size of the first buffer in the JSON chunk.");
       return asyncSystem.createResolvedFuture(std::move(result));

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
@@ -221,10 +221,13 @@ ImplicitOctreeLoader::loadTileContent(const TileLoadInput& loadInput) {
             this->addSubtreeAvailability(
                 subtreeID,
                 std::move(*subtreeAvailability));
-          }
 
-          // tell client to retry later
-          return TileLoadResult::createRetryLaterResult(nullptr);
+            // tell client to retry later
+            return TileLoadResult::createRetryLaterResult(nullptr);
+          } else {
+            // Subtree load failed, so this tile fails, too.
+            return TileLoadResult::createFailedResult(nullptr);
+          }
         });
   }
 

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -260,10 +260,13 @@ ImplicitQuadtreeLoader::loadTileContent(const TileLoadInput& loadInput) {
             this->addSubtreeAvailability(
                 subtreeID,
                 std::move(*subtreeAvailability));
-          }
 
-          // tell client to retry later
-          return TileLoadResult::createRetryLaterResult(nullptr);
+            // tell client to retry later
+            return TileLoadResult::createRetryLaterResult(nullptr);
+          } else {
+            // Subtree load failed, so this tile fails, too.
+            return TileLoadResult::createFailedResult(nullptr);
+          }
         });
   }
 


### PR DESCRIPTION
The latest version of the 3D Tiles spec says that [binary implicit tiling subtrees](https://github.com/CesiumGS/3d-tiles/blob/main/specification/ImplicitTiling/README.adoc#subtree-binary-format) should have a binary buffer that is padded to 8 bytes. But cesium-native was only expecting 4-byte alignment, and considering the subtree to be invalid if it was too large. To make matters worse, the "buffer is not the expected size" error was lost and not displayed to the user. This PR fixes both problems.

As reported here:
https://community.cesium.com/t/re-catching-up-cesium-scaled-foundations/29226
