### PR TITLE
Fix how batch tables choose sentinel values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@
 
 - Added conversions from `std::string` to other metadata types in `MetadataConversions`. This enables the same conversions as `std::string_view`, while allowing runtime engines to use `std::string` for convenience.
 
+##### Fixes :wrench:
+
+- Fixed a bug where upgraded batch table properties were not always assigned sentinel values, even when such values were available and required.
+
 ### v0.31.0 - 2023-12-14
 
 ##### Additions :tada:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,6 @@
 
 ### ? - ?
 
-
 ##### Breaking Changes :mega:
 
 - `IndicesForFaceFromAccessor` now propertly supports `TRIANGLE_STRIP` and `TRIANGLE_FAN` modes. This requires the struct to be initialized with the correct primitive mode.

--- a/Cesium3DTilesContent/src/BatchTableToGltfStructuralMetadata.cpp
+++ b/Cesium3DTilesContent/src/BatchTableToGltfStructuralMetadata.cpp
@@ -387,21 +387,19 @@ public:
    */
   void removeSentinelValues(CesiumUtility::JsonValue value) noexcept {
     if (value.isNumber()) {
-      _canUseNullStringSentinel = false;
-
       // Don't try to use string as sentinels for numbers.
-      if (value.isUint64()) {
-        _canUseZeroSentinel &= (value.getUint64() != 0);
-      }
+      _canUseNullStringSentinel = false;
 
       if (value.isInt64()) {
         auto intValue = value.getInt64();
         _canUseZeroSentinel &= (intValue != 0);
         _canUseNegativeOneSentinel &= (intValue != -1);
+      } else if (value.isUint64()) {
+        _canUseZeroSentinel &= (value.getUint64() != 0);
+        // Since the value is truly a uint64, -1 cannot be used.
+        _canUseNegativeOneSentinel = false;
       }
-    }
-
-    if (value.isString()) {
+    } else if (value.isString()) {
       // Don't try to use numbers as sentinels for strings.
       _canUseZeroSentinel = false;
       _canUseNegativeOneSentinel = false;
@@ -649,6 +647,13 @@ CompatibleTypes findCompatibleTypes(const TValueGetter& propertyValue) {
     if (it->IsString()) {
       compatibleTypes.removeSentinelValues(it->GetString());
     }
+  }
+
+  // If no sentinel value is available, then it's not possible to accurately
+  // represent the null value of this property. Make it a string property
+  // instead.
+  if (compatibleTypes.hasNullValue() && !compatibleTypes.getSentinelValue()) {
+    compatibleTypes.makeIncompatible();
   }
 
   return compatibleTypes;
@@ -1410,12 +1415,25 @@ void updateExtensionWithJsonProperty(
     return;
   }
 
-  // Set the "noData" value before copying the property (to avoid copying nulls)
-  if (compatibleTypes.hasNullValue()) {
-    classProperty.noData = compatibleTypes.getSentinelValue();
+  MaskedType type = compatibleTypes.toMaskedType();
+  auto maybeSentinel = compatibleTypes.getSentinelValue();
+
+  // Try to set the "noData" value before copying the property (to avoid copying
+  // nulls).
+  if (compatibleTypes.hasNullValue() && maybeSentinel) {
+    JsonValue sentinelValue = *maybeSentinel;
+    // If -1 is the only available sentinel, modify the masked type to only use
+    // signed integer types (if possible).
+    if (sentinelValue.getInt64OrDefault(0) == -1) {
+      type.isUint8 = false;
+      type.isUint16 = false;
+      type.isUint32 = false;
+      type.isUint64 = false;
+    }
+
+    classProperty.noData = sentinelValue;
   }
 
-  MaskedType type = compatibleTypes.toMaskedType();
   if (type.isBool) {
     updateExtensionWithJsonBooleanProperty(
         gltf,

--- a/Cesium3DTilesContent/src/BatchTableToGltfStructuralMetadata.cpp
+++ b/Cesium3DTilesContent/src/BatchTableToGltfStructuralMetadata.cpp
@@ -355,12 +355,6 @@ public:
    */
   const std::optional<CesiumUtility::JsonValue>
   getSentinelValue() const noexcept {
-    if (isCompatibleWithUnsignedInteger()) {
-      return _canUseZeroSentinel
-                 ? std::make_optional<CesiumUtility::JsonValue>(0)
-                 : std::nullopt;
-    }
-
     if (isCompatibleWithSignedInteger()) {
       if (_canUseZeroSentinel) {
         return 0;
@@ -369,6 +363,12 @@ public:
       if (_canUseNegativeOneSentinel) {
         return -1;
       }
+    }
+
+    if (isCompatibleWithUnsignedInteger()) {
+      return _canUseZeroSentinel
+                 ? std::make_optional<CesiumUtility::JsonValue>(0)
+                 : std::nullopt;
     }
 
     if (isIncompatible()) {

--- a/Cesium3DTilesContent/test/TestUpgradeBatchTableToExtStructuralMetadata.cpp
+++ b/Cesium3DTilesContent/test/TestUpgradeBatchTableToExtStructuralMetadata.cpp
@@ -1854,13 +1854,18 @@ TEST_CASE("Uses sentinel values for JSON null values") {
 }
 
 TEST_CASE("Defaults to string if no sentinel values are available") {
-  SECTION("Uint32") {
+  SECTION("Uint64") {
     Model model;
-    // Even though the values are typed uint32, they are small enough to be
-    // stored as uint8s. Signed types are preferred over unsigned, but this
-    // exceeds the range for int8.
-    std::vector<std::optional<uint32_t>>
-        expected{32, 45, 0, 255, std::nullopt, 0, 65, 78};
+    std::vector<std::optional<uint64_t>> expected{
+        32,
+        45,
+        0,
+        255,
+        std::nullopt,
+        0,
+        65,
+        78,
+        std::numeric_limits<uint64_t>::max()};
 
     rapidjson::Document featureTableJson;
     featureTableJson.SetObject();
@@ -1945,9 +1950,7 @@ TEST_CASE("Defaults to string if no sentinel values are available") {
 
   SECTION("Int32") {
     Model model;
-    // Even though the values are typed int32, they are small enough to be
-    // stored as int8s.
-    std::vector<std::optional<uint32_t>>
+    std::vector<std::optional<int32_t>>
         expected{32, 45, 0, -1, std::nullopt, 0, 65, 78};
 
     rapidjson::Document featureTableJson;

--- a/CesiumGltf/test/TestAccessorUtility.cpp
+++ b/CesiumGltf/test/TestAccessorUtility.cpp
@@ -418,7 +418,8 @@ TEST_CASE("Test IndicesForFaceFromAccessor") {
     REQUIRE(model.accessors.size() > 0);
     IndexAccessorType indexAccessor =
         AccessorView<uint32_t>(model, model.accessors[0]);
-    const size_t numFaces = std::visit(CountFromAccessor{}, indexAccessor) / 3;
+    const size_t numFaces =
+        static_cast<size_t>(std::visit(CountFromAccessor{}, indexAccessor) / 3);
 
     for (size_t i = 0; i < numFaces; i++) {
       auto indicesForFace = std::visit(
@@ -439,7 +440,8 @@ TEST_CASE("Test IndicesForFaceFromAccessor") {
     REQUIRE(model.accessors.size() > 1);
     IndexAccessorType indexAccessor =
         AccessorView<uint32_t>(model, model.accessors[1]);
-    const size_t numFaces = std::visit(CountFromAccessor{}, indexAccessor) - 2;
+    const size_t numFaces =
+        static_cast<size_t>(std::visit(CountFromAccessor{}, indexAccessor) - 2);
     for (size_t i = 0; i < numFaces; i++) {
       auto indicesForFace = std::visit(
           IndicesForFaceFromAccessor{
@@ -459,7 +461,8 @@ TEST_CASE("Test IndicesForFaceFromAccessor") {
     REQUIRE(model.accessors.size() > 1);
     IndexAccessorType indexAccessor =
         AccessorView<uint32_t>(model, model.accessors[1]);
-    const size_t numFaces = std::visit(CountFromAccessor{}, indexAccessor) - 2;
+    const size_t numFaces =
+        static_cast<size_t>(std::visit(CountFromAccessor{}, indexAccessor) - 2);
     for (size_t i = 0; i < numFaces; i++) {
       auto indicesForFace = std::visit(
           IndicesForFaceFromAccessor{


### PR DESCRIPTION
This PR fixes how batch tables choose `noData` values when upgrading to `EXT_structural_metadata`. Specifically,

- For signed `int`s, the order of checks in `getSentinelValue` prevented -1 from being chosen as a sentinel value if 0 was taken. The order has been changed to account for this.
- Unsigned `int`s will be upgraded to the next biggest signed `int` (if possible) if 0 cannot act as a sentinel value. This allows -1 to be used as its sentinel value instead.
- If no sentinel value is available for a property that has `null`, explicitly force it to a string property.

Without these checks, there is some unpredictable behavior because some of the code assumes a valid sentinel value exists, leading to dereferenced `nullopt`s 😬 