### PR TITLE
Rename `OPAQUE` to `OPAQUE_ENUM` to deconflict with define in `wingdi.h`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Breaking Changes :mega:
 
 - `IndicesForFaceFromAccessor` now propertly supports `TRIANGLE_STRIP` and `TRIANGLE_FAN` modes. This requires the struct to be initialized with the correct primitive mode.
+- `CesiumGltf::Material::AlphaMode::OPAQUE` has been renamed to `OPAQUE_ENUM` to deconflict with the `OPAQUE` define in `wingdi.h`.
 
 ##### Additions :tada:
 

--- a/Cesium3DTilesContent/test/TestPntsToGltfConverter.cpp
+++ b/Cesium3DTilesContent/test/TestPntsToGltfConverter.cpp
@@ -308,7 +308,7 @@ TEST_CASE("Converts point cloud with RGB to glTF") {
 
   REQUIRE(gltf.materials.size() == 1);
   Material& material = gltf.materials[0];
-  CHECK(material.alphaMode == Material::AlphaMode::OPAQUE);
+  CHECK(material.alphaMode == Material::AlphaMode::OPAQUE_ENUM);
   CHECK(material.hasExtension<ExtensionKhrMaterialsUnlit>());
 
   REQUIRE(gltf.accessors.size() == expectedAttributeCount);
@@ -368,7 +368,7 @@ TEST_CASE("Converts point cloud with RGB565 to glTF") {
 
   REQUIRE(gltf.materials.size() == 1);
   Material& material = gltf.materials[0];
-  CHECK(material.alphaMode == Material::AlphaMode::OPAQUE);
+  CHECK(material.alphaMode == Material::AlphaMode::OPAQUE_ENUM);
   CHECK(material.hasExtension<ExtensionKhrMaterialsUnlit>());
 
   REQUIRE(gltf.accessors.size() == expectedAttributeCount);

--- a/CesiumGltf/generated/include/CesiumGltf/Material.h
+++ b/CesiumGltf/generated/include/CesiumGltf/Material.h
@@ -24,7 +24,7 @@ struct CESIUMGLTF_API Material final : public CesiumGltf::NamedObject {
    * @brief Known values for The alpha rendering mode of the material.
    */
   struct AlphaMode {
-    inline static const std::string OPAQUE = "OPAQUE";
+    inline static const std::string OPAQUE_ENUM = "OPAQUE";
 
     inline static const std::string MASK = "MASK";
 
@@ -90,7 +90,7 @@ struct CESIUMGLTF_API Material final : public CesiumGltf::NamedObject {
    * The material's alpha rendering mode enumeration specifying the
    * interpretation of the alpha value of the base color.
    */
-  std::string alphaMode = AlphaMode::OPAQUE;
+  std::string alphaMode = AlphaMode::OPAQUE_ENUM;
 
   /**
    * @brief The alpha cutoff value of the material.

--- a/CesiumGltfWriter/generated/src/ModelJsonWriter.cpp
+++ b/CesiumGltfWriter/generated/src/ModelJsonWriter.cpp
@@ -2441,7 +2441,7 @@ void writeJson(
     writeJson(obj.emissiveFactor, jsonWriter, context);
   }
 
-  if (obj.alphaMode != CesiumGltf::Material::AlphaMode::OPAQUE) {
+  if (obj.alphaMode != CesiumGltf::Material::AlphaMode::OPAQUE_ENUM) {
     jsonWriter.Key("alphaMode");
     writeJson(obj.alphaMode, jsonWriter, context);
   }

--- a/tools/generate-classes/cppReservedWords.js
+++ b/tools/generate-classes/cppReservedWords.js
@@ -98,6 +98,7 @@ const cppReservedWords = [
   "while",
   "xor",
   "xor_eq",
+  "OPAQUE" // defined in wingdi.h
 ];
 
 module.exports = cppReservedWords;

--- a/tools/generate-classes/resolveProperty.js
+++ b/tools/generate-classes/resolveProperty.js
@@ -734,7 +734,9 @@ function makeNameIntoValidIdentifier(name) {
 }
 
 function makeNameIntoValidEnumIdentifier(name) {
-  // May use this in the future to deconflict glTF enums from system header defines
+  if (cppReservedWords.indexOf(name) >= 0) {
+    name += "_ENUM";
+  }
   return name;
 }
 


### PR DESCRIPTION
Renamed `CesiumGltf::Material::AlphaMode::OPAQUE` to `OPAQUE_ENUM` to deconflict with the define in `wingdi.h`

The fix was to add `OPAQUE` to the reserved words list and add a suffix to enums using reserved words.

Now projects using `CesiumGltf` don't need to add code like this everywhere:

```
#pragma push_macro("OPAQUE")
#undef OPAQUE
```

Unfortunately, this is a breaking change and it looks a little odd to see `OPAQUE_ENUM`, `MASK`, `BLEND`. So I'm open to alternatives here.