### PR TITLE
Support texture transform extension on occlusion and normal textures.

### DIFF
--- a/CesiumGltfReader/generated/src/registerExtensions.cpp
+++ b/CesiumGltfReader/generated/src/registerExtensions.cpp
@@ -27,6 +27,8 @@
 #include <CesiumGltf/Buffer.h>
 #include <CesiumGltf/BufferView.h>
 #include <CesiumGltf/Material.h>
+#include <CesiumGltf/MaterialNormalTextureInfo.h>
+#include <CesiumGltf/MaterialOcclusionTextureInfo.h>
 #include <CesiumGltf/MeshPrimitive.h>
 #include <CesiumGltf/Model.h>
 #include <CesiumGltf/Node.h>
@@ -95,6 +97,12 @@ void registerExtensions(CesiumJsonReader::JsonReaderOptions& options) {
       ExtensionTextureWebpJsonHandler>();
   options.registerExtension<
       CesiumGltf::TextureInfo,
+      ExtensionKhrTextureTransformJsonHandler>();
+  options.registerExtension<
+      CesiumGltf::MaterialOcclusionTextureInfo,
+      ExtensionKhrTextureTransformJsonHandler>();
+  options.registerExtension<
+      CesiumGltf::MaterialNormalTextureInfo,
       ExtensionKhrTextureTransformJsonHandler>();
 }
 } // namespace CesiumGltfReader

--- a/CesiumGltfWriter/generated/src/registerExtensions.cpp
+++ b/CesiumGltfWriter/generated/src/registerExtensions.cpp
@@ -28,6 +28,8 @@
 #include <CesiumGltf/ExtensionNodeMaxarMeshVariants.h>
 #include <CesiumGltf/ExtensionTextureWebp.h>
 #include <CesiumGltf/Material.h>
+#include <CesiumGltf/MaterialNormalTextureInfo.h>
+#include <CesiumGltf/MaterialOcclusionTextureInfo.h>
 #include <CesiumGltf/MeshPrimitive.h>
 #include <CesiumGltf/Model.h>
 #include <CesiumGltf/Node.h>
@@ -95,6 +97,12 @@ void registerExtensions(CesiumJsonWriter::ExtensionWriterContext& context) {
       .registerExtension<CesiumGltf::Texture, ExtensionTextureWebpJsonWriter>();
   context.registerExtension<
       CesiumGltf::TextureInfo,
+      ExtensionKhrTextureTransformJsonWriter>();
+  context.registerExtension<
+      CesiumGltf::MaterialOcclusionTextureInfo,
+      ExtensionKhrTextureTransformJsonWriter>();
+  context.registerExtension<
+      CesiumGltf::MaterialNormalTextureInfo,
       ExtensionKhrTextureTransformJsonWriter>();
 }
 } // namespace CesiumGltfWriter

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cesium-native",
-  "version": "0.26.0",
+  "version": "0.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cesium-native",
-      "version": "0.26.0",
+      "version": "0.31.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "clang-format": "^1.5.0"

--- a/tools/generate-classes/glTF.json
+++ b/tools/generate-classes/glTF.json
@@ -276,7 +276,9 @@
       "extensionName": "KHR_texture_transform",
       "schema": "Khronos/KHR_texture_transform/schema/KHR_texture_transform.textureInfo.schema.json",
       "attachTo": [
-        "textureInfo"
+        "textureInfo",
+        "material.occlusionTextureInfo",
+        "material.normalTextureInfo"
       ]
     },
     {


### PR DESCRIPTION
These two texture types have custom classes, `MaterialOcclusionTextureInfo` and `MaterialNormalTextureInfo`, but the `KHR_texture_transform` extension was configured to only apply to `TextureInfo` classes. The custom classes are derived from `TextureInfo`, but the code generator isn't that clever.

The end result was that instances of `KHR_texture_transform` attached to an occlusion or normal texture showed up as an unknown extension (expressed as a `JsonValue`) rather than as `ExtensionKhrTextureTransform`.