### PR TITLE
Track image data size independently of the `pixelData` array size

### DIFF
--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -173,7 +173,9 @@ int64_t Tile::computeByteSize() const noexcept {
         bytes -= bufferViews[size_t(bufferView)].byteLength;
       }
 
-      bytes += int64_t(image.cesium.pixelData.size());
+      // sizeBytes is set in TilesetContentManager::ContentKindSetter, if not
+      // sooner (e.g., by the renderer implementation).
+      bytes += image.cesium.sizeBytes;
     }
   }
 

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -173,9 +173,10 @@ int64_t Tile::computeByteSize() const noexcept {
         bytes -= bufferViews[size_t(bufferView)].byteLength;
       }
 
-      // sizeBytes is set in TilesetContentManager::ContentKindSetter, if not
-      // sooner (e.g., by the renderer implementation).
-      bytes += image.cesium.sizeBytes;
+      // lastKnownSizeInBytes is set in
+      // TilesetContentManager::ContentKindSetter, if not sooner (e.g., by the
+      // renderer implementation).
+      bytes += image.cesium.lastKnownSizeInBytes;
     }
   }
 

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -48,6 +48,16 @@ struct ContentKindSetter {
   }
 
   void operator()(CesiumGltf::Model&& model) {
+    for (CesiumGltf::Image& image : model.images) {
+      // If the image size hasn't been overridden, store the pixelData
+      // size now. We'll be adding this number to our total memory usage soon,
+      // and remove it when the tile is later unloaded, and we must use
+      // the same size in each case.
+      if (image.cesium.sizeBytes < 0) {
+        image.cesium.sizeBytes = int64_t(image.cesium.pixelData.size());
+      }
+    }
+
     auto pRenderContent = std::make_unique<TileRenderContent>(std::move(model));
     pRenderContent->setRenderResources(pRenderResources);
     if (rasterOverlayDetails) {

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -53,8 +53,9 @@ struct ContentKindSetter {
       // size now. We'll be adding this number to our total memory usage soon,
       // and remove it when the tile is later unloaded, and we must use
       // the same size in each case.
-      if (image.cesium.sizeBytes < 0) {
-        image.cesium.sizeBytes = int64_t(image.cesium.pixelData.size());
+      if (image.cesium.lastKnownSizeInBytes < 0) {
+        image.cesium.lastKnownSizeInBytes =
+            int64_t(image.cesium.pixelData.size());
       }
     }
 

--- a/CesiumGltf/include/CesiumGltf/ImageCesium.h
+++ b/CesiumGltf/include/CesiumGltf/ImageCesium.h
@@ -74,7 +74,7 @@ struct CESIUMGLTF_API ImageCesium final {
    * Otherwise, this buffer will store the compressed pixel data in the
    * specified format.
    *
-   * If mipOffsets is not empty, this buffer will contains multiple mips
+   * If mipPositions is not empty, this buffer will contains multiple mips
    * back-to-back.
    *
    * When this is an uncompressed texture:
@@ -95,5 +95,20 @@ struct CESIUMGLTF_API ImageCesium final {
    * | 4                  | red, green, blue, alpha   |
    */
   std::vector<std::byte> pixelData;
+
+  /**
+   * @brief The effective size of this image, in bytes, for estimating resource
+   * usage for caching purposes.
+   *
+   * When this value is less than zero (the default), the size of this image
+   * should be assumed to equal the size of the {@link pixelData} array. When
+   * it is greater than or equal to zero, the specified size should be used
+   * instead. For example, the overridden size may account for:
+   *   * The `pixelData` being cleared during the load process in order to save
+   * memory.
+   *   * The cost of any renderer resources (e.g., GPU textures) created for
+   * this image.
+   */
+  int64_t sizeBytes = -1;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/include/CesiumGltf/ImageCesium.h
+++ b/CesiumGltf/include/CesiumGltf/ImageCesium.h
@@ -109,6 +109,6 @@ struct CESIUMGLTF_API ImageCesium final {
    *   * The cost of any renderer resources (e.g., GPU textures) created for
    * this image.
    */
-  int64_t sizeBytes = -1;
+  int64_t lastKnownSizeInBytes = -1;
 };
 } // namespace CesiumGltf

--- a/CesiumRasterOverlays/src/RasterOverlayTileProvider.cpp
+++ b/CesiumRasterOverlays/src/RasterOverlayTileProvider.cpp
@@ -91,7 +91,7 @@ RasterOverlayTileProvider::getTile(
 void RasterOverlayTileProvider::removeTile(RasterOverlayTile* pTile) noexcept {
   assert(pTile->getReferenceCount() == 0);
 
-  this->_tileDataBytes -= pTile->getImage().sizeBytes;
+  this->_tileDataBytes -= pTile->getImage().lastKnownSizeInBytes;
 }
 
 CesiumAsync::Future<TileProviderAndTile>
@@ -349,11 +349,12 @@ CesiumAsync::Future<TileProviderAndTile> RasterOverlayTileProvider::doLoad(
             // size now. We'll add this number to our total memory usage now,
             // and remove it when the tile is later unloaded, and we must use
             // the same size in each case.
-            if (imageCesium.sizeBytes < 0) {
-              imageCesium.sizeBytes = int64_t(imageCesium.pixelData.size());
+            if (imageCesium.lastKnownSizeInBytes < 0) {
+              imageCesium.lastKnownSizeInBytes =
+                  int64_t(imageCesium.pixelData.size());
             }
 
-            thiz->_tileDataBytes += imageCesium.sizeBytes;
+            thiz->_tileDataBytes += imageCesium.lastKnownSizeInBytes;
 
             thiz->finalizeTileLoad(isThrottledLoad);
 


### PR DESCRIPTION
Added a `sizeBytes` property to `ImageCesium`, so that its size can be tracked even after `pixelData` has been cleared (such as in CesiumGS/cesium-unreal#1330.

This is a little hacky. Arguably this information should be stored somewhere else, such as is in the `Tile` and/or `RasterOverlayTile`. But putting it here keeps things simpler, particularly around thread safety. In CesiumGS/cesium-unreal#1330, the pixel data is cleared in the worker thread. But worker threads, by design, don't have access to `Tile` or `RasterOveralyTile`. So it all gets very elaborate, and hard to justify.