### PR TITLE
Remove Pull Request triggers for CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: cesium-native
-on: [push, pull_request]
+on: [push]
 jobs:
   QuickChecks:
     name: "Quick Checks"


### PR DESCRIPTION
It's not obvious to me why this is needed.

It's also a little annoying (and wasteful) to have a PR created, push commits to it, and see two builds get triggered.