### PR TITLE
Let feature + metadata textures make copies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,9 +9,11 @@
 
 ##### Additions :tada:
 
+- Added `TextureViewOptions`, which includes the following flags:
+  - `applyKhrTextureTransformExtension` . When true, the view will automatically transform texture coordinates before sampling the texture.
+  - `makeImageCopy`. When true, the view will make its own CPU copy of the image data.
+- Added `TextureView`, which views an arbitrary glTF texture and can be affected by `TextureViewOptions`. `FeatureIdTextureView` and `PropertyTexturePropertyView` now inherit this class.
 - Added `KhrTextureTransform`, a utility class that parses the `KHR_texture_transform` glTF extension and reports whether it is valid. UVs may be transformed on the CPU using `applyTransform`.
-- Added `applyKhrTextureTransformExtension` to the constructors of `FeatureIdTextureView` and `PropertyTexturePropertyView`. When true, the views will automatically transform texture coordinates before retrieving features and metadata. This is false by default to avoid breaking existing implementations.
-- Added `getTextureTransform` methods to `FeatureIdTextureView` and `PropertyTexturePropertyView`.
 - Added `contains` method to `BoundingSphere`.
 - Added `GlobeRectangle::MAXIMUM` static field.
 - Added `ReferenceCountedThreadSafe` type alias.

--- a/CesiumGltf/include/CesiumGltf/FeatureIdTextureView.h
+++ b/CesiumGltf/include/CesiumGltf/FeatureIdTextureView.h
@@ -4,8 +4,8 @@
 #include "CesiumGltf/Image.h"
 #include "CesiumGltf/ImageCesium.h"
 #include "CesiumGltf/KhrTextureTransform.h"
-#include "CesiumGltf/Model.h"
 #include "CesiumGltf/Texture.h"
+#include "CesiumGltf/TextureView.h"
 
 #include <algorithm>
 #include <cmath>
@@ -14,6 +14,9 @@
 #include <optional>
 
 namespace CesiumGltf {
+
+class Model;
+
 /**
  * @brief The status of a feature ID texture view.
  *
@@ -76,7 +79,7 @@ enum class FeatureIdTextureViewStatus {
  * It provides the ability to sample the feature IDs from the
  * {@link FeatureIdTexture} using texture coordinates.
  */
-class FeatureIdTextureView {
+class FeatureIdTextureView : public TextureView {
 public:
   /**
    * @brief Constructs an uninitialized and invalid view.
@@ -108,7 +111,7 @@ public:
   FeatureIdTextureView(
       const Model& model,
       const FeatureIdTexture& featureIdTexture,
-      bool applyKhrTextureTransformExtension = false) noexcept;
+      TextureViewOptions options = TextureViewOptions()) noexcept;
 
   /**
    * @brief Get the feature ID from the texture at the given texture
@@ -130,72 +133,13 @@ public:
   FeatureIdTextureViewStatus status() const noexcept { return this->_status; }
 
   /**
-   * @brief Get the actual feature ID texture.
-   *
-   * This will be nullptr if the feature ID texture view runs into problems
-   * during construction.
-   */
-  const ImageCesium* getImage() const noexcept { return this->_pImage; }
-
-  /**
-   * @brief Get the sampler describing how to sample the data from the
-   * feature ID texture.
-   *
-   * This will be nullptr if the feature ID texture view runs into
-   * problems during construction.
-   */
-  const Sampler* getSampler() const noexcept { return this->_pSampler; }
-
-  /**
    * @brief Get the channels of this feature ID texture. The channels represent
    * the bytes of the actual feature ID, in little-endian order.
    */
   std::vector<int64_t> getChannels() const noexcept { return this->_channels; }
 
-  /**
-   * @brief Get the texture coordinate set index for this feature ID
-   * texture.
-   *
-   * If applyKhrTextureTransformExtension is true, and if the feature ID texture
-   * contains the `KHR_texture_transform` extension, this will return the value
-   * from the extension, as it is meant to override the original index. However,
-   * if the extension does not specify a TEXCOORD set index, then the original
-   * index of the feature ID texture is returned.
-   */
-  int64_t getTexCoordSetIndex() const noexcept {
-    if (this->_applyTextureTransform && this->_textureTransform) {
-      return this->_textureTransform->getTexCoordSetIndex().value_or(
-          this->_texCoordSetIndex);
-    }
-    return this->_texCoordSetIndex;
-  }
-
-  /**
-   * @brief Get the KHR_texture_transform for this feature ID texture, if it
-   * exists.
-   *
-   * Even if this view was constructed with applyKhrTextureTransformExtension
-   * set to false, it will save the extension's values, and they may be
-   * retrieved through this function.
-   *
-   * If this view was constructed with applyKhrTextureTransformExtension set to
-   * true, any texture coordinates passed into `getFeatureID` will be
-   * automatically transformed, so there's no need to re-apply the transform
-   * here.
-   */
-  std::optional<KhrTextureTransform> getTextureTransform() const noexcept {
-    return this->_textureTransform;
-  }
-
 private:
   FeatureIdTextureViewStatus _status;
-  int64_t _texCoordSetIndex;
   std::vector<int64_t> _channels;
-
-  const ImageCesium* _pImage;
-  const Sampler* _pSampler;
-
-  bool _applyTextureTransform;
-  std::optional<KhrTextureTransform> _textureTransform;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/include/CesiumGltf/FeatureIdTextureView.h
+++ b/CesiumGltf/include/CesiumGltf/FeatureIdTextureView.h
@@ -15,7 +15,7 @@
 
 namespace CesiumGltf {
 
-class Model;
+struct Model;
 
 /**
  * @brief The status of a feature ID texture view.

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -7,7 +7,6 @@
 #include "CesiumGltf/PropertyTypeTraits.h"
 #include "CesiumGltf/PropertyView.h"
 #include "CesiumGltf/Sampler.h"
-#include "CesiumGltf/SamplerUtility.h"
 #include "CesiumGltf/TextureView.h"
 
 #include <array>

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -82,6 +82,44 @@ public:
   static const int ErrorChannelsAndTypeMismatch = 22;
 };
 
+/**
+ * @brief Describes options for constructing a {@link PropertyTexturePropertyView}.
+ */
+struct PropertyTexturePropertyViewOptions {
+  /**
+   * @brief Whether to automatically apply the `KHR_texture_transform` extension
+   * to the property texture property, if it exists.
+   *
+   * A property texture property may contain the `KHR_texture_transform`
+   * extension, which transforms the texture coordinates used to sample the
+   * texture. The extension may also override the TEXCOORD set index that was
+   * originally specified by the property texture property.
+   *
+   * If a view is constructed with applyKhrTextureTransformExtension set to
+   * true, the view will automatically apply the texture transform to any UV
+   * coordinates used to sample the texture. If the extension defines its own
+   * TEXCOORD set index, it will override the original value.
+   *
+   * Otherwise, if the flag is set to false, UVs will not be transformed and
+   * the original TEXCOORD set index will be preserved. The extension's values
+   * may still be retrieved using getTextureTransform, if desired.
+   */
+  bool applyKhrTextureTransformExtension;
+
+  /**
+   * @brief Whether to copy the input image.
+   *
+   * By default, a view is constructed on the input glTF image without copying
+   * its pixels. This can be problematic for clients that move or delete the
+   * original glTF model. When this flag is true, the view will manage its own
+   * copy of the pixel data to avoid such issues.
+   */
+  bool makeImageCopy;
+
+  PropertyTexturePropertyViewOptions()
+      : applyKhrTextureTransformExtension(false), makeImageCopy(false) {}
+};
+
 template <typename ElementType>
 ElementType assembleScalarValue(const gsl::span<uint8_t> bytes) noexcept {
   if constexpr (std::is_same_v<ElementType, float>) {
@@ -300,43 +338,29 @@ public:
   /**
    * @brief Construct a view of the data specified by a {@link PropertyTextureProperty}.
    *
-   * A property texture property may contain the `KHR_texture_transform`
-   * extension, which transforms the texture coordinates used to sample the
-   * texture. The extension may also override the TEXCOORD set index that was
-   * originally specified by the property texture property.
-   *
-   * If a view is constructed with applyKhrTextureTransformExtension set to
-   * true, the view will automatically apply the texture transform to any UV
-   * coordinates used to sample the texture. If the extension defines its own
-   * TEXCOORD set index, it will override the original value.
-   *
-   * Otherwise, if the flag is set to false, UVs will not be transformed and
-   * the original TEXCOORD set index will be preserved. The extension's values
-   * may still be retrieved using getTextureTransform, if desired.
-   *
    * @param property The {@link PropertyTextureProperty}
    * @param classProperty The {@link ClassProperty} this property conforms to.
    * @param sampler The {@link Sampler} used by the property.
    * @param image The {@link ImageCesium} used by the property.
    * @param channels The value of {@link PropertyTextureProperty::channels}.
-   * @param applyKhrTextureTransformExtension Whether to automatically apply the
-   * `KHR_texture_transform` extension to the property texture property, if it
-   * exists.
+   * @param options The options for constructing the view.
    */
   PropertyTexturePropertyView(
       const PropertyTextureProperty& property,
       const ClassProperty& classProperty,
       const Sampler& sampler,
       const ImageCesium& image,
-      bool applyKhrTextureTransformExtension = false) noexcept
+      PropertyTexturePropertyViewOptions options =
+          PropertyTexturePropertyViewOptions()) noexcept
       : PropertyView<ElementType, false>(classProperty, property),
         _pSampler(&sampler),
-        _pImage(&image),
+        _pImage(nullptr),
         _texCoordSetIndex(property.texCoord),
         _channels(property.channels),
         _swizzle(),
-        _applyTextureTransform(applyKhrTextureTransformExtension),
-        _textureTransform(std::nullopt) {
+        _applyTextureTransform(options.applyKhrTextureTransformExtension),
+        _textureTransform(std::nullopt),
+        _imageCopy(std::nullopt) {
     if (this->_status != PropertyTexturePropertyViewStatus::Valid) {
       return;
     }
@@ -367,6 +391,12 @@ public:
 
     if (pTextureTransform) {
       this->_textureTransform = KhrTextureTransform(*pTextureTransform);
+    }
+
+    if (options.makeImageCopy) {
+      this->_imageCopy = ImageCesium(image);
+    } else {
+      this->_pImage = &image;
     }
   }
 
@@ -438,8 +468,9 @@ public:
     u = applySamplerWrapS(u, this->_pSampler->wrapS);
     v = applySamplerWrapT(v, this->_pSampler->wrapT);
 
+    const ImageCesium& image = this->_imageCopy.value_or(*this->_pImage);
     std::array<uint8_t, 4> sample =
-        sampleNearestPixel(*this->_pImage, this->_channels, u, v);
+        sampleNearestPixel(image, this->_channels, u, v);
     return assembleValueFromChannels<ElementType>(
         gsl::span(sample.data(), this->_channels.size()));
   }
@@ -447,11 +478,12 @@ public:
   /**
    * @brief Get the texture coordinate set index for this property.
    *
-   * If applyKhrTextureTransformExtension is true, and if the property texture
-   * property contains the `KHR_texture_transform` extension, this will return
-   * the value from the extension, as it is meant to override the original
-   * index. However, if the extension does not specify a TEXCOORD set index,
-   * then the original index of the property texture property is returned.
+   * If this view was constructed with options.applyKhrTextureTransformExtension
+   * as true, and if the property texture property contains the
+   * `KHR_texture_transform` extension, this will return the value from the
+   * extension, as it is meant to override the original index. However, if the
+   * extension does not specify a TEXCOORD set index, then the original index of
+   * the property texture property is returned.
    */
   int64_t getTexCoordSetIndex() const noexcept {
     if (this->_applyTextureTransform && this->_textureTransform) {
@@ -476,7 +508,12 @@ public:
    * This will be nullptr if the property texture property view runs into
    * problems during construction.
    */
-  const ImageCesium* getImage() const noexcept { return this->_pImage; }
+  const ImageCesium* getImage() const noexcept {
+    if (this->_imageCopy) {
+      return &(this->_imageCopy.value());
+    }
+    return this->_pImage;
+  }
 
   /**
    * @brief Gets the channels of this property texture property.
@@ -491,15 +528,15 @@ public:
   const std::string& getSwizzle() const noexcept { return this->_swizzle; }
 
   /**
-   * @brief Get the KHR_texture_transform for this property texture property, if
-   * it exists.
+   * @brief Get the KHR_texture_transform for this property texture property,
+   * if it exists.
    *
-   * Even if this view was constructed with applyKhrTextureTransformExtension
-   * set to false, it will save the extension's values, and they may be
-   * retrieved through this function.
+   * Even if this view was constructed with
+   * options.applyKhrTextureTransformExtension set to false, it will save the
+   * extension's values, and they may be retrieved through this function.
    *
-   * If this view was constructed with applyKhrTextureTransformExtension set to
-   * true, any texture coordinates passed into `get` or `getRaw` will be
+   * If this view was constructed with applyKhrTextureTransformExtension set
+   * to true, any texture coordinates passed into `get` or `getRaw` will be
    * automatically transformed, so there's no need to re-apply the transform
    * here.
    */
@@ -513,8 +550,10 @@ private:
   int64_t _texCoordSetIndex;
   std::vector<int64_t> _channels;
   std::string _swizzle;
+
   bool _applyTextureTransform;
   std::optional<KhrTextureTransform> _textureTransform;
+  std::optional<ImageCesium> _imageCopy;
 };
 
 #pragma endregion
@@ -564,12 +603,14 @@ public:
         _textureTransform(std::nullopt) {
     assert(
         this->_status != PropertyTexturePropertyViewStatus::Valid &&
-        "An empty property view should not be constructed with a valid status");
+        "An empty property view should not be constructed with a valid "
+        "status");
   }
 
   /**
-   * @brief Constructs an instance of an empty property that specifies a default
-   * value. Although this property has no data, it can return the default value
+   * @brief Constructs an instance of an empty property that specifies a
+   * default value. Although this property has no data, it can return the
+   * default value
    * when {@link PropertyTexturePropertyView::get} is called. However,
    * {@link PropertyTexturePropertyView::getRaw} cannot be used.
    *
@@ -605,42 +646,27 @@ public:
   /**
    * @brief Construct a view of the data specified by a {@link PropertyTextureProperty}.
    *
-   * A property texture property may contain the `KHR_texture_transform`
-   * extension, which transforms the texture coordinates used to sample the
-   * texture. The extension may also override the TEXCOORD set index that was
-   * originally specified by the property texture property.
-   *
-   * If a view is constructed with applyKhrTextureTransformExtension set to
-   * true, the view will automatically apply the texture transform to any UV
-   * coordinates used to sample the texture. If the extension defines its own
-   * TEXCOORD set index, it will override the original value.
-   *
-   * Otherwise, if the flag is set to false, UVs will not be transformed and
-   * the original TEXCOORD set index will be preserved. The extension's values
-   * may still be retrieved using getTextureTransform, if desired.
-   *
    * @param property The {@link PropertyTextureProperty}
    * @param classProperty The {@link ClassProperty} this property conforms to.
    * @param sampler The {@link Sampler} used by the property.
    * @param image The {@link ImageCesium} used by the property.
    * @param channels The value of {@link PropertyTextureProperty::channels}.
-   * @param applyKhrTextureTransformExtension Whether to automatically apply the
-   * `KHR_texture_transform` extension to the property texture property, if it
-   * exists.
+   * @param options The options for constructing the view.
    */
   PropertyTexturePropertyView(
       const PropertyTextureProperty& property,
       const ClassProperty& classProperty,
       const Sampler& sampler,
       const ImageCesium& image,
-      bool applyKhrTextureTransformExtension = false) noexcept
+      PropertyTexturePropertyViewOptions options =
+          PropertyTexturePropertyViewOptions()) noexcept
       : PropertyView<ElementType, true>(classProperty, property),
         _pSampler(&sampler),
         _pImage(&image),
         _texCoordSetIndex(property.texCoord),
         _channels(property.channels),
         _swizzle(),
-        _applyTextureTransform(applyKhrTextureTransformExtension),
+        _applyTextureTransform(options.applyKhrTextureTransformExtension),
         _textureTransform(std::nullopt) {
     if (this->_status != PropertyTexturePropertyViewStatus::Valid) {
       return;
@@ -672,6 +698,12 @@ public:
     if (pTextureTransform) {
       this->_textureTransform = KhrTextureTransform(*pTextureTransform);
     }
+
+    if (options.makeImageCopy) {
+      this->_imageCopy = ImageCesium(image);
+    } else {
+      this->_pImage = &image;
+    }
   }
 
   /**
@@ -681,10 +713,10 @@ public:
    * returned. The sampler's wrapping mode will be used when sampling the
    * texture.
    *
-   * If this property has a specified "no data" value, and the retrieved element
-   * is equal to that value, then this will return the property's specified
-   * default value. If the property did not provide a default value, this
-   * returns std::nullopt.
+   * If this property has a specified "no data" value, and the retrieved
+   * element is equal to that value, then this will return the property's
+   * specified default value. If the property did not provide a default value,
+   * this returns std::nullopt.
    *
    * @param u The u-component of the texture coordinates.
    * @param v The v-component of the texture coordinates.
@@ -746,8 +778,8 @@ public:
    * coordinates. The sampler's wrapping mode will be used when sampling the
    * texture.
    *
-   * If this property has a specified "no data" value, the raw value will still
-   * be returned, even if it equals the "no data" value.
+   * If this property has a specified "no data" value, the raw value will
+   * still be returned, even if it equals the "no data" value.
    *
    * @param u The u-component of the texture coordinates.
    * @param v The v-component of the texture coordinates.
@@ -769,8 +801,9 @@ public:
     u = applySamplerWrapS(u, this->_pSampler->wrapS);
     v = applySamplerWrapT(v, this->_pSampler->wrapT);
 
+    const ImageCesium& image = this->_imageCopy.value_or(*this->_pImage);
     std::array<uint8_t, 4> sample =
-        sampleNearestPixel(*this->_pImage, this->_channels, u, v);
+        sampleNearestPixel(image, this->_channels, u, v);
 
     return assembleValueFromChannels<ElementType>(
         gsl::span(sample.data(), this->_channels.size()));
@@ -778,12 +811,12 @@ public:
 
   /**
    * @brief Get the texture coordinate set index for this property.
-   *
-   * If applyKhrTextureTransformExtension is true, and if the property texture
-   * property contains the `KHR_texture_transform` extension, this will return
-   * the value from the extension, as it is meant to override the original
-   * index. However, if the extension does not specify a TEXCOORD set index,
-   * then the original index of the property texture property is returned.
+   * If this view was constructed with options.applyKhrTextureTransformExtension
+   * as true, and if the property texture property contains the
+   * `KHR_texture_transform` extension, this will return the value from the
+   * extension, as it is meant to override the original index. However, if the
+   * extension does not specify a TEXCOORD set index, then the original index of
+   * the property texture property is returned.
    */
   int64_t getTexCoordSetIndex() const noexcept {
     if (this->_applyTextureTransform && this->_textureTransform) {
@@ -808,7 +841,12 @@ public:
    * This will be nullptr if the property texture property view runs into
    * problems during construction.
    */
-  const ImageCesium* getImage() const noexcept { return this->_pImage; }
+  const ImageCesium* getImage() const noexcept {
+    if (this->_imageCopy) {
+      return &(this->_imageCopy.value());
+    }
+    return this->_pImage;
+  }
 
   /**
    * @brief Gets the channels of this property texture property.
@@ -823,15 +861,15 @@ public:
   const std::string& getSwizzle() const noexcept { return this->_swizzle; }
 
   /**
-   * @brief Get the KHR_texture_transform for this property texture property, if
-   * it exists.
+   * @brief Get the KHR_texture_transform for this property texture property,
+   * if it exists.
    *
-   * Even if this view was constructed with applyKhrTextureTransformExtension
-   * set to false, it will save the extension's values, and they may be
-   * retrieved through this function.
+   * Even if this view was constructed with
+   * options.applyKhrTextureTransformExtension set to false, it will save the
+   * extension's values, and they may be retrieved through this function.
    *
-   * If this view was constructed with applyKhrTextureTransformExtension set to
-   * true, any texture coordinates passed into `get` or `getRaw` will be
+   * If this view was constructed with applyKhrTextureTransformExtension set
+   * to true, any texture coordinates passed into `get` or `getRaw` will be
    * automatically transformed, so there's no need to re-apply the transform
    * here.
    */
@@ -845,8 +883,11 @@ private:
   int64_t _texCoordSetIndex;
   std::vector<int64_t> _channels;
   std::string _swizzle;
+
   bool _applyTextureTransform;
   std::optional<KhrTextureTransform> _textureTransform;
+
+  std::optional<ImageCesium> _imageCopy;
 };
 #pragma endregion
 

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -229,14 +229,8 @@ public:
    */
   PropertyTexturePropertyView() noexcept
       : PropertyView<ElementType, false>(),
-        TextureView(),
-        _pSampler(nullptr),
-        _pImage(nullptr),
-        _texCoordSetIndex(0),
-        _channels(),
-        _swizzle(),
-        _applyTextureTransform(false),
-        _textureTransform(std::nullopt) {}
+        TextureView() _channels(),
+        _swizzle() {}
 
   /**
    * @brief Constructs an invalid instance for an erroneous property.

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -229,7 +229,8 @@ public:
    */
   PropertyTexturePropertyView() noexcept
       : PropertyView<ElementType, false>(),
-        TextureView() _channels(),
+        TextureView(),
+        _channels(),
         _swizzle() {}
 
   /**

--- a/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
@@ -5,7 +5,7 @@
 #include "CesiumGltf/ExtensionModelExtStructuralMetadata.h"
 #include "CesiumGltf/PropertyTexture.h"
 #include "CesiumGltf/PropertyTexturePropertyView.h"
-#include "CesiumGltf/Texture.h"
+#include "CesiumGltf/TextureView.h"
 #include "Model.h"
 
 namespace CesiumGltf {
@@ -62,8 +62,7 @@ public:
   PropertyTextureView(
       const Model& model,
       const PropertyTexture& propertyTexture,
-      PropertyTexturePropertyViewOptions propertyOptions =
-          PropertyTexturePropertyViewOptions()) noexcept;
+      TextureViewOptions propertyOptions = TextureViewOptions()) noexcept;
 
   /**
    * @brief Gets the status of this property texture view.
@@ -726,7 +725,7 @@ private:
   const PropertyTexture* _pPropertyTexture;
   const Class* _pClass;
 
-  PropertyTexturePropertyViewOptions _propertyOptions;
+  TextureViewOptions _propertyOptions;
   PropertyTextureViewStatus _status;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
@@ -55,10 +55,14 @@ public:
    * @param model The glTF that contains the property texture's data.
    * @param propertyTexture The {@link PropertyTexture}
    * from which the view will retrieve data.
+   * @param applyKhrTextureTransformExtension Whether to automatically apply the
+   * `KHR_texture_transform` extension to the properties in this property
+   * texture, if present.
    */
   PropertyTextureView(
       const Model& model,
-      const PropertyTexture& propertyTexture) noexcept;
+      const PropertyTexture& propertyTexture,
+      bool applyKhrTextureTransformExtension = false) noexcept;
 
   /**
    * @brief Gets the status of this property texture view.
@@ -699,7 +703,8 @@ private:
         propertyTextureProperty,
         classProperty,
         _pModel->samplers[samplerIndex],
-        image);
+        image,
+        this->_applyTextureTransform);
   }
 
   PropertyViewStatusType getTextureSafe(
@@ -719,6 +724,8 @@ private:
   const Model* _pModel;
   const PropertyTexture* _pPropertyTexture;
   const Class* _pClass;
+
+  bool _applyTextureTransform;
 
   PropertyTextureViewStatus _status;
 };

--- a/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
@@ -55,14 +55,10 @@ public:
    * @param model The glTF that contains the property texture's data.
    * @param propertyTexture The {@link PropertyTexture}
    * from which the view will retrieve data.
-   * @param applyKhrTextureTransformExtension Whether to automatically apply the
-   * `KHR_texture_transform` extension to the properties in this property
-   * texture, if present.
    */
   PropertyTextureView(
       const Model& model,
-      const PropertyTexture& propertyTexture,
-      TextureViewOptions propertyOptions = TextureViewOptions()) noexcept;
+      const PropertyTexture& propertyTexture) noexcept;
 
   /**
    * @brief Gets the status of this property texture view.
@@ -117,13 +113,15 @@ public:
    * @tparam T The C++ type corresponding to the type of the data retrieved.
    * @tparam Normalized Whether the property is normalized. Only applicable to
    * types with integer components.
-   * @param propertyId The id of the property to retrieve data from
+   * @param propertyId The ID of the property to retrieve data from
+   * @param propertyOptions The options to apply to the property.
    * @return A {@link PropertyTexturePropertyView} of the property. If no valid
    * property is found, the property view will be invalid.
    */
   template <typename T, bool Normalized = false>
-  PropertyTexturePropertyView<T, Normalized>
-  getPropertyView(const std::string& propertyId) const {
+  PropertyTexturePropertyView<T, Normalized> getPropertyView(
+      const std::string& propertyId,
+      TextureViewOptions propertyOptions = TextureViewOptions()) const {
     if (this->_status != PropertyTextureViewStatus::Valid) {
       return PropertyTexturePropertyView<T, Normalized>(
           PropertyTexturePropertyViewStatus::ErrorInvalidPropertyTexture);
@@ -135,7 +133,10 @@ public:
           PropertyTexturePropertyViewStatus::ErrorNonexistentProperty);
     }
 
-    return getPropertyViewImpl<T, Normalized>(propertyId, *pClassProperty);
+    return getPropertyViewImpl<T, Normalized>(
+        propertyId,
+        *pClassProperty,
+        propertyOptions);
   }
 
   /**
@@ -156,10 +157,13 @@ public:
    * @param propertyId The id of the property to retrieve data from
    * @tparam callback A callback function that accepts a property id and a
    * {@link PropertyTexturePropertyView<T>}
+   * @param propertyOptions The options to apply to the property.
    */
   template <typename Callback>
-  void
-  getPropertyView(const std::string& propertyId, Callback&& callback) const {
+  void getPropertyView(
+      const std::string& propertyId,
+      Callback&& callback,
+      TextureViewOptions propertyOptions = TextureViewOptions()) const {
     if (this->_status != PropertyTextureViewStatus::Valid) {
       callback(
           propertyId,
@@ -201,14 +205,16 @@ public:
             *pClassProperty,
             type,
             componentType,
-            std::forward<Callback>(callback));
+            std::forward<Callback>(callback),
+            propertyOptions);
       } else {
         getArrayPropertyViewImpl<Callback, false>(
             propertyId,
             *pClassProperty,
             type,
             componentType,
-            std::forward<Callback>(callback));
+            std::forward<Callback>(callback),
+            propertyOptions);
       }
       return;
     }
@@ -219,13 +225,15 @@ public:
             propertyId,
             *pClassProperty,
             componentType,
-            std::forward<Callback>(callback));
+            std::forward<Callback>(callback),
+            propertyOptions);
       } else {
         getScalarPropertyViewImpl<Callback, false>(
             propertyId,
             *pClassProperty,
             componentType,
-            std::forward<Callback>(callback));
+            std::forward<Callback>(callback),
+            propertyOptions);
       }
       return;
     }
@@ -237,14 +245,16 @@ public:
             *pClassProperty,
             type,
             componentType,
-            std::forward<Callback>(callback));
+            std::forward<Callback>(callback),
+            propertyOptions);
       } else {
         getVecNPropertyViewImpl<Callback, false>(
             propertyId,
             *pClassProperty,
             type,
             componentType,
-            std::forward<Callback>(callback));
+            std::forward<Callback>(callback),
+            propertyOptions);
       }
       return;
     }
@@ -271,13 +281,21 @@ public:
    * error status will be passed to the callback. Otherwise, a valid property
    * view will be passed to the callback.
    *
-   * @param propertyId The id of the property to retrieve data from
    * @tparam callback A callback function that accepts property id and
    * {@link PropertyTexturePropertyView<T>}
+   * @param propertyOptions The options to apply to each property in the
+   * property texture.
    */
-  template <typename Callback> void forEachProperty(Callback&& callback) const {
+
+  template <typename Callback>
+  void forEachProperty(
+      Callback&& callback,
+      TextureViewOptions propertyOptions = TextureViewOptions()) const {
     for (const auto& property : this->_pClass->properties) {
-      getPropertyView(property.first, std::forward<Callback>(callback));
+      getPropertyView(
+          property.first,
+          std::forward<Callback>(callback),
+          propertyOptions);
     }
   }
 
@@ -285,7 +303,8 @@ private:
   template <typename T, bool Normalized>
   PropertyTexturePropertyView<T, Normalized> getPropertyViewImpl(
       const std::string& propertyId,
-      const ClassProperty& classProperty) const {
+      const ClassProperty& classProperty,
+      const TextureViewOptions& propertyOptions) const {
     auto propertyTexturePropertyIter =
         _pPropertyTexture->properties.find(propertyId);
     if (propertyTexturePropertyIter == _pPropertyTexture->properties.end()) {
@@ -306,19 +325,21 @@ private:
     if constexpr (IsMetadataScalar<T>::value) {
       return createScalarPropertyView<T, Normalized>(
           classProperty,
-          propertyTextureProperty);
+          propertyTextureProperty,
+          propertyOptions);
     }
 
     if constexpr (IsMetadataVecN<T>::value) {
       return createVecNPropertyView<T, Normalized>(
           classProperty,
-          propertyTextureProperty);
+          propertyTextureProperty,
+          propertyOptions);
     }
 
     if constexpr (IsMetadataArray<T>::value) {
       return createArrayPropertyView<
           typename MetadataArrayType<T>::type,
-          Normalized>(classProperty, propertyTextureProperty);
+          Normalized>(classProperty, propertyTextureProperty, propertyOptions);
     }
   }
 
@@ -328,7 +349,8 @@ private:
       const ClassProperty& classProperty,
       PropertyType type,
       PropertyComponentType componentType,
-      Callback&& callback) const {
+      Callback&& callback,
+      const TextureViewOptions& propertyOptions) const {
     // Only scalar arrays are supported.
     if (type != PropertyType::Scalar) {
       callback(
@@ -353,28 +375,32 @@ private:
           propertyId,
           getPropertyViewImpl<PropertyArrayView<int8_t>, Normalized>(
               propertyId,
-              classProperty));
+              classProperty,
+              propertyOptions));
       break;
     case PropertyComponentType::Uint8:
       callback(
           propertyId,
           getPropertyViewImpl<PropertyArrayView<uint8_t>, Normalized>(
               propertyId,
-              classProperty));
+              classProperty,
+              propertyOptions));
       break;
     case PropertyComponentType::Int16:
       callback(
           propertyId,
           getPropertyViewImpl<PropertyArrayView<int16_t>, Normalized>(
               propertyId,
-              classProperty));
+              classProperty,
+              propertyOptions));
       break;
     case PropertyComponentType::Uint16:
       callback(
           propertyId,
           getPropertyViewImpl<PropertyArrayView<uint16_t>, Normalized>(
               propertyId,
-              classProperty));
+              classProperty,
+              propertyOptions));
       break;
     default:
       callback(
@@ -390,42 +416,64 @@ private:
       const std::string& propertyId,
       const ClassProperty& classProperty,
       PropertyComponentType componentType,
-      Callback&& callback) const {
+      Callback&& callback,
+      const TextureViewOptions& propertyOptions) const {
     switch (componentType) {
     case PropertyComponentType::Int8:
       callback(
           propertyId,
-          getPropertyViewImpl<int8_t, Normalized>(propertyId, classProperty));
+          getPropertyViewImpl<int8_t, Normalized>(
+              propertyId,
+              classProperty,
+              propertyOptions));
       return;
     case PropertyComponentType::Uint8:
       callback(
           propertyId,
-          getPropertyViewImpl<uint8_t, Normalized>(propertyId, classProperty));
+          getPropertyViewImpl<uint8_t, Normalized>(
+              propertyId,
+              classProperty,
+              propertyOptions));
       return;
     case PropertyComponentType::Int16:
       callback(
           propertyId,
-          getPropertyViewImpl<int16_t, Normalized>(propertyId, classProperty));
+          getPropertyViewImpl<int16_t, Normalized>(
+              propertyId,
+              classProperty,
+              propertyOptions));
       return;
     case PropertyComponentType::Uint16:
       callback(
           propertyId,
-          getPropertyViewImpl<uint16_t, Normalized>(propertyId, classProperty));
+          getPropertyViewImpl<uint16_t, Normalized>(
+              propertyId,
+              classProperty,
+              propertyOptions));
       break;
     case PropertyComponentType::Int32:
       callback(
           propertyId,
-          getPropertyViewImpl<int32_t, Normalized>(propertyId, classProperty));
+          getPropertyViewImpl<int32_t, Normalized>(
+              propertyId,
+              classProperty,
+              propertyOptions));
       break;
     case PropertyComponentType::Uint32:
       callback(
           propertyId,
-          getPropertyViewImpl<uint32_t, Normalized>(propertyId, classProperty));
+          getPropertyViewImpl<uint32_t, Normalized>(
+              propertyId,
+              classProperty,
+              propertyOptions));
       break;
     case PropertyComponentType::Float32:
       callback(
           propertyId,
-          getPropertyViewImpl<float, false>(propertyId, classProperty));
+          getPropertyViewImpl<float, false>(
+              propertyId,
+              classProperty,
+              propertyOptions));
       break;
     default:
       callback(
@@ -441,21 +489,24 @@ private:
       const std::string& propertyId,
       const ClassProperty& classProperty,
       PropertyComponentType componentType,
-      Callback&& callback) const {
+      Callback&& callback,
+      const TextureViewOptions& propertyOptions) const {
     switch (componentType) {
     case PropertyComponentType::Int8:
       callback(
           propertyId,
           getPropertyViewImpl<glm::vec<N, int8_t>, Normalized>(
               propertyId,
-              classProperty));
+              classProperty,
+              propertyOptions));
       break;
     case PropertyComponentType::Uint8:
       callback(
           propertyId,
           getPropertyViewImpl<glm::vec<N, uint8_t>, Normalized>(
               propertyId,
-              classProperty));
+              classProperty,
+              propertyOptions));
       break;
     case PropertyComponentType::Int16:
       if constexpr (N == 2) {
@@ -463,7 +514,8 @@ private:
             propertyId,
             getPropertyViewImpl<glm::vec<N, int16_t>, Normalized>(
                 propertyId,
-                classProperty));
+                classProperty,
+                propertyOptions));
         break;
       }
       [[fallthrough]];
@@ -473,7 +525,8 @@ private:
             propertyId,
             getPropertyViewImpl<glm::vec<N, uint16_t>, Normalized>(
                 propertyId,
-                classProperty));
+                classProperty,
+                propertyOptions));
         break;
       }
       [[fallthrough]];
@@ -492,7 +545,8 @@ private:
       const ClassProperty& classProperty,
       PropertyType type,
       PropertyComponentType componentType,
-      Callback&& callback) const {
+      Callback&& callback,
+      const TextureViewOptions& propertyOptions) const {
     const glm::length_t N = getDimensionsFromPropertyType(type);
     switch (N) {
     case 2:
@@ -500,21 +554,24 @@ private:
           propertyId,
           classProperty,
           componentType,
-          std::forward<Callback>(callback));
+          std::forward<Callback>(callback),
+          propertyOptions);
       break;
     case 3:
       getVecNPropertyViewImpl<Callback, 3, Normalized>(
           propertyId,
           classProperty,
           componentType,
-          std::forward<Callback>(callback));
+          std::forward<Callback>(callback),
+          propertyOptions);
       break;
     case 4:
       getVecNPropertyViewImpl<Callback, 4, Normalized>(
           propertyId,
           classProperty,
           componentType,
-          std::forward<Callback>(callback));
+          std::forward<Callback>(callback),
+          propertyOptions);
       break;
     default:
       callback(
@@ -528,8 +585,8 @@ private:
   template <typename T, bool Normalized>
   PropertyTexturePropertyView<T, Normalized> createScalarPropertyView(
       const ClassProperty& classProperty,
-      [[maybe_unused]] const PropertyTextureProperty& propertyTextureProperty)
-      const {
+      [[maybe_unused]] const PropertyTextureProperty& propertyTextureProperty,
+      TextureViewOptions propertyOptions) const {
     if (classProperty.array) {
       return PropertyTexturePropertyView<T, Normalized>(
           PropertyTexturePropertyViewStatus::ErrorArrayTypeMismatch);
@@ -559,7 +616,8 @@ private:
       return createPropertyViewImpl<T, Normalized>(
           classProperty,
           propertyTextureProperty,
-          sizeof(T));
+          sizeof(T),
+          propertyOptions);
     } else {
       return PropertyTexturePropertyView<T, Normalized>(
           PropertyTexturePropertyViewStatus::ErrorUnsupportedProperty);
@@ -569,8 +627,8 @@ private:
   template <typename T, bool Normalized>
   PropertyTexturePropertyView<T, Normalized> createVecNPropertyView(
       const ClassProperty& classProperty,
-      [[maybe_unused]] const PropertyTextureProperty& propertyTextureProperty)
-      const {
+      [[maybe_unused]] const PropertyTextureProperty& propertyTextureProperty,
+      [[maybe_unused]] const TextureViewOptions& propertyOptions) const {
     if (classProperty.array) {
       return PropertyTexturePropertyView<T, Normalized>(
           PropertyTexturePropertyViewStatus::ErrorArrayTypeMismatch);
@@ -600,7 +658,8 @@ private:
       return createPropertyViewImpl<T, Normalized>(
           classProperty,
           propertyTextureProperty,
-          sizeof(T));
+          sizeof(T),
+          propertyOptions);
     } else {
       return PropertyTexturePropertyView<T, Normalized>(
           PropertyTexturePropertyViewStatus::ErrorUnsupportedProperty);
@@ -611,8 +670,8 @@ private:
   PropertyTexturePropertyView<PropertyArrayView<T>, Normalized>
   createArrayPropertyView(
       const ClassProperty& classProperty,
-      [[maybe_unused]] const PropertyTextureProperty& propertyTextureProperty)
-      const {
+      [[maybe_unused]] const PropertyTextureProperty& propertyTextureProperty,
+      [[maybe_unused]] const TextureViewOptions& propertyOptions) const {
     if (!classProperty.array) {
       return PropertyTexturePropertyView<PropertyArrayView<T>, Normalized>(
           PropertyTexturePropertyViewStatus::ErrorArrayTypeMismatch);
@@ -655,7 +714,8 @@ private:
       return createPropertyViewImpl<PropertyArrayView<T>, Normalized>(
           classProperty,
           propertyTextureProperty,
-          count * sizeof(T));
+          count * sizeof(T),
+          propertyOptions);
     } else {
       return PropertyTexturePropertyView<PropertyArrayView<T>, Normalized>(
           PropertyTexturePropertyViewStatus::ErrorUnsupportedProperty);
@@ -666,7 +726,8 @@ private:
   PropertyTexturePropertyView<T, Normalized> createPropertyViewImpl(
       const ClassProperty& classProperty,
       const PropertyTextureProperty& propertyTextureProperty,
-      size_t elementSize) const {
+      size_t elementSize,
+      const TextureViewOptions& propertyOptions) const {
     int32_t samplerIndex;
     int32_t imageIndex;
 
@@ -704,7 +765,7 @@ private:
         classProperty,
         _pModel->samplers[samplerIndex],
         image,
-        this->_propertyOptions);
+        propertyOptions);
   }
 
   PropertyViewStatusType getTextureSafe(
@@ -725,7 +786,6 @@ private:
   const PropertyTexture* _pPropertyTexture;
   const Class* _pClass;
 
-  TextureViewOptions _propertyOptions;
   PropertyTextureViewStatus _status;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
@@ -62,7 +62,8 @@ public:
   PropertyTextureView(
       const Model& model,
       const PropertyTexture& propertyTexture,
-      bool applyKhrTextureTransformExtension = false) noexcept;
+      PropertyTexturePropertyViewOptions propertyOptions =
+          PropertyTexturePropertyViewOptions()) noexcept;
 
   /**
    * @brief Gets the status of this property texture view.
@@ -704,7 +705,7 @@ private:
         classProperty,
         _pModel->samplers[samplerIndex],
         image,
-        this->_applyTextureTransform);
+        this->_propertyOptions);
   }
 
   PropertyViewStatusType getTextureSafe(
@@ -725,8 +726,7 @@ private:
   const PropertyTexture* _pPropertyTexture;
   const Class* _pClass;
 
-  bool _applyTextureTransform;
-
+  PropertyTexturePropertyViewOptions _propertyOptions;
   PropertyTextureViewStatus _status;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/include/CesiumGltf/TextureView.h
+++ b/CesiumGltf/include/CesiumGltf/TextureView.h
@@ -1,0 +1,222 @@
+#pragma once
+
+#include "CesiumGltf/ImageCesium.h"
+#include "CesiumGltf/KhrTextureTransform.h"
+#include "CesiumGltf/Sampler.h"
+#include "CesiumGltf/TextureInfo.h"
+
+#include <vector>
+
+namespace CesiumGltf {
+
+class Model;
+
+/**
+ * @brief Describes options for constructing a view on a glTF texture.
+ */
+struct TextureViewOptions {
+  /**
+   * @brief Whether to automatically apply the `KHR_texture_transform` extension
+   * to the texture view, if it exists.
+   *
+   * A glTF texture may contain the `KHR_texture_transform` extension, which
+   * transforms the texture coordinates used to sample the texture. The
+   * extension may also override the TEXCOORD set index that was specified by
+   * the original texture info.
+   *
+   * If a view is constructed with applyKhrTextureTransformExtension set to
+   * true, it should automatically apply the texture transform to any UV
+   * coordinates used to sample the texture. If the extension defines its own
+   * TEXCOORD set index, it will override the original value.
+   *
+   * Otherwise, if the flag is set to false, UVs will not be transformed and
+   * the original TEXCOORD set index will be preserved. The extension's values
+   * may still be retrieved using getTextureTransform, if desired.
+   */
+  bool applyKhrTextureTransformExtension;
+
+  /**
+   * @brief Whether to copy the input image.
+   *
+   * By default, a view is constructed on the input glTF image without copying
+   * its pixels. This can be problematic for clients that move or delete the
+   * original glTF model. When this flag is true, the view will manage its own
+   * copy of the pixel data to avoid such issues.
+   */
+  bool makeImageCopy;
+
+  TextureViewOptions()
+      : applyKhrTextureTransformExtension(false), makeImageCopy(false) {}
+};
+
+/**
+ * @brief Indicates the status of a texture view.
+ *
+ * The {@link TextureView} constructor always completes
+ * successfully. However it may not always reflect the actual content of the
+ * corresponding texture. This enumeration provides the reason.
+ */
+enum class TextureViewStatus {
+  /**
+   * @brief This texture view is valid and ready to use.
+   */
+  Valid,
+
+  /**
+   * @brief This texture view has not yet been initialized.
+   */
+  ErrorUninitialized,
+
+  /**
+   * @brief This texture view does not have a valid texture index.
+   */
+  ErrorInvalidTexture,
+
+  /**
+   * @brief This texture view does not have a valid sampler index.
+   */
+  ErrorInvalidSampler,
+
+  /**
+   * @brief This texture view does not have a valid image index.
+   */
+  ErrorInvalidImage,
+
+  /**
+   * @brief This texture is viewing an empty image.
+   */
+  ErrorEmptyImage,
+
+  /**
+   * @brief The image for this texture has channels that take up more than a
+   * byte. Only single-byte channels are supported.
+   */
+  ErrorInvalidBytesPerChannel,
+};
+
+class TextureView {
+public:
+  /**
+   * @brief Constructs an empty, uninitialized texture view.
+   */
+  TextureView() noexcept;
+
+  /**
+   * @brief Constructs a view of the texture specified by the given {@link TextureInfo}.
+   *
+   * @param model The glTF model in which to look for the texture's data.
+   * @param textureInfo The texture info to create a view for.
+   * @param options The options for constructing the view.
+   */
+  TextureView(
+      const Model& model,
+      const TextureInfo& textureInfo,
+      TextureViewOptions options = TextureViewOptions()) noexcept;
+
+  /**
+   * @brief Constructs a view of the texture specified by the given {@link Sampler}
+   * and {@link ImageCesium}.
+   *
+   * @param sampler The {@link Sampler} used by the texture.
+   * @param image The {@link ImageCesium} used by the texture.
+   * @param textureCoordinateSetIndex The set index for the `TEXCOORD_n`
+   * attribute used to sample this texture.
+   * @param pKhrTextureTransformExtension A pointer to the KHR_texture_transform
+   * extension on the texture, if it exists.
+   * @param options The options for constructing the view.
+   */
+  TextureView(
+      const Sampler& sampler,
+      const ImageCesium& image,
+      int64_t textureCoordinateSetIndex,
+      const ExtensionKhrTextureTransform* pKhrTextureTransformExtension =
+          nullptr,
+      TextureViewOptions options = TextureViewOptions()) noexcept;
+
+  /**
+   * @brief Get the status of this texture view.
+   *
+   * If invalid, it will not be safe to sample from this view.
+   */
+  TextureViewStatus getTextureViewStatus() const noexcept {
+    return this->_textureViewStatus;
+  }
+
+  /**
+   * @brief Get the texture coordinate set index for this view.
+   * If this view was constructed with options.applyKhrTextureTransformExtension
+   * as true, and if the texture contains the `KHR_texture_transform` extension,
+   * then this will return the value from the extension since it is meant to
+   * override the original index. However, if the extension does not specify a
+   * TEXCOORD set index, then the original index of the texture is returned.
+   */
+  int64_t getTexCoordSetIndex() const noexcept {
+    if (this->_applyTextureTransform && this->_textureTransform) {
+      return this->_textureTransform->getTexCoordSetIndex().value_or(
+          this->_texCoordSetIndex);
+    }
+    return this->_texCoordSetIndex;
+  }
+
+  /**
+   * @brief Get the sampler describing how to sample the data from the
+   * property's texture.
+   *
+   * This will be nullptr if the property texture property view runs into
+   * problems during construction.
+   */
+  const Sampler* getSampler() const noexcept { return this->_pSampler; }
+
+  /**
+   * @brief Get the image containing this property's data.
+   *
+   * This will be nullptr if the texture view runs into
+   * problems during construction.
+   */
+  const ImageCesium* getImage() const noexcept {
+    if (this->_imageCopy) {
+      return &(this->_imageCopy.value());
+    }
+    return this->_pImage;
+  }
+
+  /**
+   * @brief Get the KHR_texture_transform for this texture if it exists.
+   *
+   * Even if this view was constructed with
+   * options.applyKhrTextureTransformExtension set to false, it will save the
+   * extension's values, and they may be retrieved through this function.
+   *
+   * If this view was constructed with applyKhrTextureTransformExtension set
+   * to true, any texture coordinates passed into `get` or `getRaw` will be
+   * automatically transformed, so there's no need to re-apply the transform
+   * here.
+   */
+  std::optional<KhrTextureTransform> getTextureTransform() const noexcept {
+    return this->_textureTransform;
+  }
+
+  /**
+   * @brief Samples the image at the specified texture coordinates using NEAREST
+   * pixel filtering, returning the bytes as uint8_t values. A channels vector
+   * must be supplied to specify how many image channels are needed, and in what
+   * order the bytes should be retrieved.
+   */
+  std::vector<uint8_t> sampleNearestPixel(
+      double u,
+      double v,
+      const std::vector<int64_t>& channels) const noexcept;
+
+private:
+  TextureViewStatus _textureViewStatus;
+
+  const Sampler* _pSampler;
+  const ImageCesium* _pImage;
+  int64_t _texCoordSetIndex;
+
+  bool _applyTextureTransform;
+  std::optional<KhrTextureTransform> _textureTransform;
+
+  std::optional<ImageCesium> _imageCopy;
+};
+} // namespace CesiumGltf

--- a/CesiumGltf/include/CesiumGltf/TextureView.h
+++ b/CesiumGltf/include/CesiumGltf/TextureView.h
@@ -9,7 +9,7 @@
 
 namespace CesiumGltf {
 
-class Model;
+struct Model;
 
 /**
  * @brief Describes options for constructing a view on a glTF texture.

--- a/CesiumGltf/include/CesiumGltf/TextureView.h
+++ b/CesiumGltf/include/CesiumGltf/TextureView.h
@@ -168,7 +168,9 @@ public:
   const Sampler* getSampler() const noexcept { return this->_pSampler; }
 
   /**
-   * @brief Get the image containing this property's data.
+   * @brief Get the image containing this property's data. If this view was
+   * constructed with options.makeImageCopy set to true, this will return a
+   * pointer to the copied image.
    *
    * This will be nullptr if the texture view runs into
    * problems during construction.

--- a/CesiumGltf/src/FeatureIdTextureView.cpp
+++ b/CesiumGltf/src/FeatureIdTextureView.cpp
@@ -1,69 +1,48 @@
 #include "CesiumGltf/FeatureIdTextureView.h"
 
 #include "CesiumGltf/ExtensionKhrTextureTransform.h"
+#include "CesiumGltf/Model.h"
 #include "CesiumGltf/SamplerUtility.h"
 
 namespace CesiumGltf {
 FeatureIdTextureView::FeatureIdTextureView() noexcept
-    : _status(FeatureIdTextureViewStatus::ErrorUninitialized),
-      _texCoordSetIndex(0),
-      _channels(),
-      _pImage(nullptr),
-      _pSampler(nullptr),
-      _applyTextureTransform(false),
-      _textureTransform(std::nullopt) {}
+    : TextureView(),
+      _status(FeatureIdTextureViewStatus::ErrorUninitialized),
+      _channels() {}
 
 FeatureIdTextureView::FeatureIdTextureView(
     const Model& model,
     const FeatureIdTexture& featureIdTexture,
-    bool applyKhrTextureTransform) noexcept
-    : _status(FeatureIdTextureViewStatus::ErrorUninitialized),
-      _texCoordSetIndex(featureIdTexture.texCoord),
-      _channels(),
-      _pImage(nullptr),
-      _pSampler(nullptr),
-      _applyTextureTransform(applyKhrTextureTransform),
-      _textureTransform(std::nullopt) {
-  int32_t textureIndex = featureIdTexture.index;
-  if (textureIndex < 0 ||
-      static_cast<size_t>(textureIndex) >= model.textures.size()) {
-    this->_status = FeatureIdTextureViewStatus::ErrorInvalidTexture;
-    return;
-  }
-
-  const Texture& texture = model.textures[static_cast<size_t>(textureIndex)];
-  if (texture.source < 0 ||
-      static_cast<size_t>(texture.source) >= model.images.size()) {
-    this->_status = FeatureIdTextureViewStatus::ErrorInvalidImage;
-    return;
-  }
-
-  this->_pImage = &model.images[static_cast<size_t>(texture.source)].cesium;
-  if (this->_pImage->width < 1 || this->_pImage->height < 1) {
-    this->_status = FeatureIdTextureViewStatus::ErrorEmptyImage;
-    return;
-  }
-
-  if (texture.sampler < 0 ||
-      static_cast<size_t>(texture.sampler) >= model.samplers.size()) {
+    TextureViewOptions options) noexcept
+    : TextureView(model, featureIdTexture, options),
+      _status(FeatureIdTextureViewStatus::ErrorUninitialized),
+      _channels() {
+  switch (this->getTextureViewStatus()) {
+  case TextureViewStatus::Valid:
+    break;
+  case TextureViewStatus::ErrorInvalidSampler:
     this->_status = FeatureIdTextureViewStatus::ErrorInvalidSampler;
     return;
-  }
-
-  this->_pSampler = &model.samplers[static_cast<size_t>(texture.sampler)];
-
-  // TODO: once compressed texture support is merged, check that the image is
-  // decompressed here.
-
-  if (this->_pImage->bytesPerChannel > 1) {
+  case TextureViewStatus::ErrorInvalidImage:
+    this->_status = FeatureIdTextureViewStatus::ErrorInvalidImage;
+    return;
+  case TextureViewStatus::ErrorEmptyImage:
+    this->_status = FeatureIdTextureViewStatus::ErrorEmptyImage;
+    return;
+  case TextureViewStatus::ErrorInvalidBytesPerChannel:
     this->_status =
         FeatureIdTextureViewStatus::ErrorInvalidImageBytesPerChannel;
+    return;
+  case TextureViewStatus::ErrorUninitialized:
+  case TextureViewStatus::ErrorInvalidTexture:
+  default:
+    this->_status = FeatureIdTextureViewStatus::ErrorInvalidTexture;
     return;
   }
 
   const std::vector<int64_t>& channels = featureIdTexture.channels;
   if (channels.size() == 0 || channels.size() > 4 ||
-      channels.size() > static_cast<size_t>(this->_pImage->channels)) {
+      channels.size() > static_cast<size_t>(this->getImage()->channels)) {
     this->_status = FeatureIdTextureViewStatus::ErrorInvalidChannels;
     return;
   }
@@ -75,15 +54,9 @@ FeatureIdTextureView::FeatureIdTextureView(
       return;
     }
   }
+
   this->_channels = channels;
-
   this->_status = FeatureIdTextureViewStatus::Valid;
-
-  const ExtensionKhrTextureTransform* pTextureTransform =
-      featureIdTexture.getExtension<ExtensionKhrTextureTransform>();
-  if (pTextureTransform) {
-    this->_textureTransform = KhrTextureTransform(*pTextureTransform);
-  }
 } // namespace CesiumGltf
 
 int64_t FeatureIdTextureView::getFeatureID(double u, double v) const noexcept {
@@ -91,38 +64,7 @@ int64_t FeatureIdTextureView::getFeatureID(double u, double v) const noexcept {
     return -1;
   }
 
-  if (this->_applyTextureTransform && this->_textureTransform) {
-    glm::dvec2 transformedUvs = this->_textureTransform->applyTransform(u, v);
-    u = transformedUvs.x;
-    v = transformedUvs.y;
-  }
-
-  u = applySamplerWrapS(u, this->_pSampler->wrapS);
-  v = applySamplerWrapT(v, this->_pSampler->wrapT);
-
-  // Always use nearest filtering, and use std::floor instead of std::round.
-  // This is because filtering is supposed to consider the pixel centers. But
-  // memory access here acts as sampling the beginning of the pixel. Example:
-  // 0.4 * 2 = 0.8. In a 2x1 pixel image, that should be closer to the left
-  // pixel's center. But it will round to 1.0 which corresponds to the right
-  // pixel. So the right pixel has a bigger range than the left one, which is
-  // incorrect.
-  double xCoord = std::floor(u * this->_pImage->width);
-  double yCoord = std::floor(v * this->_pImage->height);
-
-  // Clamp to ensure no out-of-bounds data access
-  int64_t x = glm::clamp(
-      static_cast<int64_t>(xCoord),
-      static_cast<int64_t>(0),
-      static_cast<int64_t>(this->_pImage->width - 1));
-  int64_t y = glm::clamp(
-      static_cast<int64_t>(yCoord),
-      static_cast<int64_t>(0),
-      static_cast<int64_t>(this->_pImage->height - 1));
-
-  int64_t pixelOffset = this->_pImage->bytesPerChannel *
-                        this->_pImage->channels *
-                        (y * this->_pImage->width + x);
+  std::vector<uint8_t> sample = this->sampleNearestPixel(u, v, this->_channels);
 
   int64_t value = 0;
   int64_t bitOffset = 0;
@@ -130,9 +72,7 @@ int64_t FeatureIdTextureView::getFeatureID(double u, double v) const noexcept {
   // unsigned 8 bit integers, and represent the bytes of the actual feature ID,
   // in little-endian order.
   for (size_t i = 0; i < this->_channels.size(); i++) {
-    int64_t channelValue = static_cast<int64_t>(
-        this->_pImage
-            ->pixelData[static_cast<size_t>(pixelOffset + this->_channels[i])]);
+    int64_t channelValue = static_cast<int64_t>(sample[i]);
     value |= channelValue << bitOffset;
     bitOffset += 8;
   }

--- a/CesiumGltf/src/PropertyTexturePropertyView.cpp
+++ b/CesiumGltf/src/PropertyTexturePropertyView.cpp
@@ -22,46 +22,4 @@ const PropertyViewStatusType
 const PropertyViewStatusType
     PropertyTexturePropertyViewStatus::ErrorChannelsAndTypeMismatch;
 
-std::array<uint8_t, 4> sampleNearestPixel(
-    const ImageCesium& image,
-    const std::vector<int64_t>& channels,
-    const double u,
-    const double v) {
-  // For nearest filtering, std::floor is used instead of std::round.
-  // This is because filtering is supposed to consider the pixel centers. But
-  // memory access here acts as sampling the beginning of the pixel. Example:
-  // 0.4 * 2 = 0.8. In a 2x1 pixel image, that should be closer to the left
-  // pixel's center. But it will round to 1.0 which corresponds to the right
-  // pixel. So the right pixel has a bigger range than the left one, which is
-  // incorrect.
-  double xCoord = std::floor(u * image.width);
-  double yCoord = std::floor(v * image.height);
-
-  // Clamp to ensure no out-of-bounds data access
-  int64_t x = glm::clamp(
-      static_cast<int64_t>(xCoord),
-      static_cast<int64_t>(0),
-      static_cast<int64_t>(image.width) - 1);
-  int64_t y = glm::clamp(
-      static_cast<int64_t>(yCoord),
-      static_cast<int64_t>(0),
-      static_cast<int64_t>(image.height) - 1);
-
-  int64_t pixelIndex =
-      image.bytesPerChannel * image.channels * (y * image.width + x);
-
-  // TODO: Currently stb only outputs uint8 pixel types. If that
-  // changes this should account for additional pixel byte sizes.
-  const uint8_t* pValue =
-      reinterpret_cast<const uint8_t*>(image.pixelData.data() + pixelIndex);
-
-  std::array<uint8_t, 4> channelValues{0, 0, 0, 0};
-  size_t len = glm::min(channels.size(), channelValues.size());
-  for (size_t i = 0; i < len; i++) {
-    channelValues[i] = *(pValue + channels[i]);
-  }
-
-  return channelValues;
-}
-
 } // namespace CesiumGltf

--- a/CesiumGltf/src/PropertyTextureView.cpp
+++ b/CesiumGltf/src/PropertyTextureView.cpp
@@ -3,10 +3,12 @@
 namespace CesiumGltf {
 PropertyTextureView::PropertyTextureView(
     const Model& model,
-    const PropertyTexture& propertyTexture) noexcept
+    const PropertyTexture& propertyTexture,
+    bool applyKhrTextureTransformExtension) noexcept
     : _pModel(&model),
       _pPropertyTexture(&propertyTexture),
       _pClass(nullptr),
+      _applyTextureTransform(applyKhrTextureTransformExtension),
       _status() {
   const ExtensionModelExtStructuralMetadata* pMetadata =
       model.getExtension<ExtensionModelExtStructuralMetadata>();

--- a/CesiumGltf/src/PropertyTextureView.cpp
+++ b/CesiumGltf/src/PropertyTextureView.cpp
@@ -4,11 +4,11 @@ namespace CesiumGltf {
 PropertyTextureView::PropertyTextureView(
     const Model& model,
     const PropertyTexture& propertyTexture,
-    bool applyKhrTextureTransformExtension) noexcept
+    PropertyTexturePropertyViewOptions options) noexcept
     : _pModel(&model),
       _pPropertyTexture(&propertyTexture),
       _pClass(nullptr),
-      _applyTextureTransform(applyKhrTextureTransformExtension),
+      _propertyOptions(options),
       _status() {
   const ExtensionModelExtStructuralMetadata* pMetadata =
       model.getExtension<ExtensionModelExtStructuralMetadata>();

--- a/CesiumGltf/src/PropertyTextureView.cpp
+++ b/CesiumGltf/src/PropertyTextureView.cpp
@@ -4,7 +4,7 @@ namespace CesiumGltf {
 PropertyTextureView::PropertyTextureView(
     const Model& model,
     const PropertyTexture& propertyTexture,
-    PropertyTexturePropertyViewOptions options) noexcept
+    TextureViewOptions options) noexcept
     : _pModel(&model),
       _pPropertyTexture(&propertyTexture),
       _pClass(nullptr),

--- a/CesiumGltf/src/PropertyTextureView.cpp
+++ b/CesiumGltf/src/PropertyTextureView.cpp
@@ -3,12 +3,10 @@
 namespace CesiumGltf {
 PropertyTextureView::PropertyTextureView(
     const Model& model,
-    const PropertyTexture& propertyTexture,
-    TextureViewOptions options) noexcept
+    const PropertyTexture& propertyTexture) noexcept
     : _pModel(&model),
       _pPropertyTexture(&propertyTexture),
       _pClass(nullptr),
-      _propertyOptions(options),
       _status() {
   const ExtensionModelExtStructuralMetadata* pMetadata =
       model.getExtension<ExtensionModelExtStructuralMetadata>();

--- a/CesiumGltf/src/TextureView.cpp
+++ b/CesiumGltf/src/TextureView.cpp
@@ -1,0 +1,168 @@
+#include "CesiumGltf/TextureView.h"
+
+#include "CesiumGltf/Model.h"
+#include "CesiumGltf/SamplerUtility.h"
+
+namespace CesiumGltf {
+
+TextureView::TextureView() noexcept
+    : _textureViewStatus(TextureViewStatus::ErrorUninitialized),
+      _pSampler(nullptr),
+      _pImage(nullptr),
+      _texCoordSetIndex(-1),
+      _applyTextureTransform(false),
+      _textureTransform(std::nullopt),
+      _imageCopy(std::nullopt) {}
+
+TextureView::TextureView(
+    const Model& model,
+    const TextureInfo& textureInfo,
+    TextureViewOptions options) noexcept
+    : _textureViewStatus(TextureViewStatus::ErrorUninitialized),
+      _pSampler(nullptr),
+      _pImage(nullptr),
+      _texCoordSetIndex(textureInfo.texCoord),
+      _applyTextureTransform(options.applyKhrTextureTransformExtension),
+      _textureTransform(std::nullopt),
+      _imageCopy(std::nullopt) {
+  int32_t textureIndex = textureInfo.index;
+  if (textureIndex < 0 ||
+      static_cast<size_t>(textureIndex) >= model.textures.size()) {
+    this->_textureViewStatus = TextureViewStatus::ErrorInvalidTexture;
+    return;
+  }
+
+  const Texture& texture = model.textures[static_cast<size_t>(textureIndex)];
+  if (texture.source < 0 ||
+      static_cast<size_t>(texture.source) >= model.images.size()) {
+    this->_textureViewStatus = TextureViewStatus::ErrorInvalidImage;
+    return;
+  }
+
+  this->_pImage = &model.images[static_cast<size_t>(texture.source)].cesium;
+  if (this->_pImage->width < 1 || this->_pImage->height < 1) {
+    this->_textureViewStatus = TextureViewStatus::ErrorEmptyImage;
+    return;
+  }
+
+  if (texture.sampler < 0 ||
+      static_cast<size_t>(texture.sampler) >= model.samplers.size()) {
+    this->_textureViewStatus = TextureViewStatus::ErrorInvalidSampler;
+    return;
+  }
+
+  this->_pSampler = &model.samplers[static_cast<size_t>(texture.sampler)];
+
+  // TODO: once compressed texture support is merged, check that the image is
+  // decompressed here.
+
+  if (this->_pImage->bytesPerChannel > 1) {
+    this->_textureViewStatus =
+        TextureViewStatus::ErrorInvalidBytesPerChannel;
+    return;
+  }
+
+  const ExtensionKhrTextureTransform* pTextureTransform =
+      textureInfo.getExtension<ExtensionKhrTextureTransform>();
+
+  if (pTextureTransform) {
+    this->_textureTransform = KhrTextureTransform(*pTextureTransform);
+  }
+
+  if (options.makeImageCopy) {
+    this->_imageCopy = ImageCesium(*this->_pImage);
+  }
+
+  this->_textureViewStatus = TextureViewStatus::Valid;
+}
+
+TextureView::TextureView(
+    const Sampler& sampler,
+    const ImageCesium& image,
+    int64_t textureCoordinateSetIndex,
+    const ExtensionKhrTextureTransform* pKhrTextureTransformExtension,
+    TextureViewOptions options) noexcept
+    : _textureViewStatus(TextureViewStatus::ErrorUninitialized),
+      _pSampler(&sampler),
+      _pImage(&image),
+      _texCoordSetIndex(textureCoordinateSetIndex),
+      _applyTextureTransform(options.applyKhrTextureTransformExtension),
+      _textureTransform(std::nullopt),
+      _imageCopy(std::nullopt) {
+  // TODO: once compressed texture support is merged, check that the image is
+  // decompressed here.
+
+  if (this->_pImage->bytesPerChannel > 1) {
+    this->_textureViewStatus =
+        TextureViewStatus::ErrorInvalidBytesPerChannel;
+    return;
+  }
+
+  if (pKhrTextureTransformExtension) {
+    this->_textureTransform =
+        KhrTextureTransform(*pKhrTextureTransformExtension);
+  }
+
+  if (options.makeImageCopy) {
+    this->_imageCopy = ImageCesium(*this->_pImage);
+  }
+
+  this->_textureViewStatus = TextureViewStatus::Valid;
+}
+
+std::vector<uint8_t> TextureView::sampleNearestPixel(
+    double u,
+    double v,
+    const std::vector<int64_t>& channels) const noexcept {
+  assert(this->_textureViewStatus == TextureViewStatus::Valid);
+  std::vector<uint8_t> result(channels.size());
+
+  if (channels.size() == 0) {
+    return result;
+  }
+
+  if (this->_applyTextureTransform && this->_textureTransform) {
+    glm::dvec2 transformedUvs = this->_textureTransform->applyTransform(u, v);
+    u = transformedUvs.x;
+    v = transformedUvs.y;
+  }
+
+  u = applySamplerWrapS(u, this->_pSampler->wrapS);
+  v = applySamplerWrapT(v, this->_pSampler->wrapT);
+
+  const ImageCesium& image = this->_imageCopy.value_or(*this->_pImage);
+
+  // For nearest filtering, std::floor is used instead of std::round.
+  // This is because filtering is supposed to consider the pixel centers. But
+  // memory access here acts as sampling the beginning of the pixel. Example:
+  // 0.4 * 2 = 0.8. In a 2x1 pixel image, that should be closer to the left
+  // pixel's center. But it will round to 1.0 which corresponds to the right
+  // pixel. So the right pixel has a bigger range than the left one, which is
+  // incorrect.
+  double xCoord = std::floor(u * image.width);
+  double yCoord = std::floor(v * image.height);
+
+  // Clamp to ensure no out-of-bounds data access
+  int64_t x = glm::clamp(
+      static_cast<int64_t>(xCoord),
+      static_cast<int64_t>(0),
+      static_cast<int64_t>(image.width) - 1);
+  int64_t y = glm::clamp(
+      static_cast<int64_t>(yCoord),
+      static_cast<int64_t>(0),
+      static_cast<int64_t>(image.height) - 1);
+
+  int64_t pixelIndex =
+      image.bytesPerChannel * image.channels * (y * image.width + x);
+
+  // TODO: Currently stb only outputs uint8 pixel types. If that
+  // changes this should account for additional pixel byte sizes.
+  const uint8_t* pValue =
+      reinterpret_cast<const uint8_t*>(image.pixelData.data() + pixelIndex);
+  for (size_t i = 0; i < result.size(); i++) {
+    result[i] = *(pValue + channels[i]);
+  }
+
+  return result;
+}
+} // namespace CesiumGltf

--- a/CesiumGltf/src/TextureView.cpp
+++ b/CesiumGltf/src/TextureView.cpp
@@ -57,8 +57,7 @@ TextureView::TextureView(
   // decompressed here.
 
   if (this->_pImage->bytesPerChannel > 1) {
-    this->_textureViewStatus =
-        TextureViewStatus::ErrorInvalidBytesPerChannel;
+    this->_textureViewStatus = TextureViewStatus::ErrorInvalidBytesPerChannel;
     return;
   }
 
@@ -93,8 +92,7 @@ TextureView::TextureView(
   // decompressed here.
 
   if (this->_pImage->bytesPerChannel > 1) {
-    this->_textureViewStatus =
-        TextureViewStatus::ErrorInvalidBytesPerChannel;
+    this->_textureViewStatus = TextureViewStatus::ErrorInvalidBytesPerChannel;
     return;
   }
 

--- a/CesiumGltf/test/TestPropertyTexturePropertyView.cpp
+++ b/CesiumGltf/test/TestPropertyTexturePropertyView.cpp
@@ -1805,8 +1805,11 @@ TEST_CASE("Test PropertyTextureProperty constructs with "
 
   property.channels = {0};
 
+  PropertyTexturePropertyViewOptions options;
+  options.applyKhrTextureTransformExtension = true;
+
   PropertyTexturePropertyView<uint8_t>
-      view(property, classProperty, sampler, image, true);
+      view(property, classProperty, sampler, image, options);
   REQUIRE(view.status() == PropertyTexturePropertyViewStatus::Valid);
 
   auto textureTransform = view.getTextureTransform();
@@ -1875,8 +1878,11 @@ TEST_CASE("Test normalized PropertyTextureProperty constructs with "
 
   property.channels = {0};
 
+  PropertyTexturePropertyViewOptions options;
+  options.applyKhrTextureTransformExtension = true;
+
   PropertyTexturePropertyView<uint8_t, true>
-      view(property, classProperty, sampler, image, true);
+      view(property, classProperty, sampler, image, options);
   REQUIRE(view.status() == PropertyTexturePropertyViewStatus::Valid);
 
   auto textureTransform = view.getTextureTransform();
@@ -1909,5 +1915,129 @@ TEST_CASE("Test normalized PropertyTextureProperty constructs with "
     REQUIRE(
         view.get(uv[0], uv[1]) ==
         static_cast<double>(expectedValues[i]) / 255.0);
+  }
+}
+
+TEST_CASE("Test PropertyTextureProperty constructs with makeImageCopy = true") {
+  std::vector<uint8_t> data{0, 64, 127, 255};
+
+  PropertyTextureProperty property;
+  property.texCoord = 0;
+
+  ExtensionKhrTextureTransform& textureTransformExtension =
+      property.addExtension<ExtensionKhrTextureTransform>();
+  textureTransformExtension.offset = {0.5, -0.5};
+  textureTransformExtension.rotation = CesiumUtility::Math::PiOverTwo;
+  textureTransformExtension.scale = {0.5, 0.5};
+  textureTransformExtension.texCoord = 10;
+
+  ClassProperty classProperty;
+  classProperty.type = ClassProperty::Type::SCALAR;
+  classProperty.componentType = ClassProperty::ComponentType::UINT8;
+  classProperty.normalized = true;
+
+  Sampler sampler;
+  sampler.wrapS = Sampler::WrapS::REPEAT;
+  sampler.wrapT = Sampler::WrapT::REPEAT;
+
+  ImageCesium image;
+  image.width = 2;
+  image.height = 2;
+  image.channels = 1;
+  image.bytesPerChannel = 1;
+
+  std::vector<std::byte>& imageData = image.pixelData;
+  imageData.resize(data.size());
+  std::memcpy(imageData.data(), data.data(), data.size());
+
+  property.channels = {0};
+
+  PropertyTexturePropertyViewOptions options;
+  options.makeImageCopy = true;
+
+  PropertyTexturePropertyView<uint8_t, true>
+      view(property, classProperty, sampler, image, options);
+  REQUIRE(view.status() == PropertyTexturePropertyViewStatus::Valid);
+
+  // Clear the original image data.
+  std::vector<std::byte> emptyData;
+  image.pixelData.swap(emptyData);
+
+  const ImageCesium* pImage = view.getImage();
+  REQUIRE(pImage);
+  REQUIRE(pImage->pixelData.size() == data.size());
+
+  std::vector<glm::dvec2> texCoords{
+      glm::dvec2(0, 0),
+      glm::dvec2(0.5, 0),
+      glm::dvec2(0, 0.5),
+      glm::dvec2(0.5, 0.5)};
+
+  for (size_t i = 0; i < texCoords.size(); i++) {
+    glm::dvec2 uv = texCoords[i];
+    REQUIRE(view.getRaw(uv[0], uv[1]) == data[i]);
+    REQUIRE(view.get(uv[0], uv[1]) == static_cast<double>(data[i]) / 255.0);
+  }
+}
+
+TEST_CASE("Test normalized PropertyTextureProperty constructs with "
+          "makeImageCopy = true") {
+  std::vector<uint8_t> data{1, 2, 3, 4};
+
+  PropertyTextureProperty property;
+  property.texCoord = 0;
+
+  ExtensionKhrTextureTransform& textureTransformExtension =
+      property.addExtension<ExtensionKhrTextureTransform>();
+  textureTransformExtension.offset = {0.5, -0.5};
+  textureTransformExtension.rotation = CesiumUtility::Math::PiOverTwo;
+  textureTransformExtension.scale = {0.5, 0.5};
+  textureTransformExtension.texCoord = 10;
+
+  ClassProperty classProperty;
+  classProperty.type = ClassProperty::Type::SCALAR;
+  classProperty.componentType = ClassProperty::ComponentType::UINT8;
+
+  Sampler sampler;
+  sampler.wrapS = Sampler::WrapS::REPEAT;
+  sampler.wrapT = Sampler::WrapT::REPEAT;
+
+  ImageCesium image;
+  image.width = 2;
+  image.height = 2;
+  image.channels = 1;
+  image.bytesPerChannel = 1;
+
+  std::vector<std::byte>& imageData = image.pixelData;
+  imageData.resize(data.size());
+  std::memcpy(imageData.data(), data.data(), data.size());
+
+  property.channels = {0};
+
+  PropertyTexturePropertyViewOptions options;
+  options.makeImageCopy = true;
+
+  PropertyTexturePropertyView<uint8_t>
+      view(property, classProperty, sampler, image, options);
+  REQUIRE(view.status() == PropertyTexturePropertyViewStatus::Valid);
+
+  // Clear the original image data.
+  std::vector<std::byte> emptyData;
+  image.pixelData.swap(emptyData);
+
+  const ImageCesium* pImage = view.getImage();
+  REQUIRE(pImage);
+  REQUIRE(pImage->pixelData.size() == data.size());
+
+  std::vector<glm::dvec2> texCoords{
+      glm::dvec2(0, 0),
+      glm::dvec2(0.5, 0),
+      glm::dvec2(0, 0.5),
+      glm::dvec2(0.5, 0.5)};
+
+  for (size_t i = 0; i < texCoords.size(); i++) {
+    glm::dvec2 uv = texCoords[i];
+    REQUIRE(view.getRaw(uv[0], uv[1]) == data[i]);
+    REQUIRE(view.get(uv[0], uv[1]) == data[i]);
   }
 }

--- a/CesiumGltf/test/TestPropertyTexturePropertyView.cpp
+++ b/CesiumGltf/test/TestPropertyTexturePropertyView.cpp
@@ -1918,69 +1918,7 @@ TEST_CASE("Test normalized PropertyTextureProperty constructs with "
   }
 }
 
-TEST_CASE("Test PropertyTextureProperty constructs with makeImageCopy = true") {
-  std::vector<uint8_t> data{0, 64, 127, 255};
-
-  PropertyTextureProperty property;
-  property.texCoord = 0;
-
-  ExtensionKhrTextureTransform& textureTransformExtension =
-      property.addExtension<ExtensionKhrTextureTransform>();
-  textureTransformExtension.offset = {0.5, -0.5};
-  textureTransformExtension.rotation = CesiumUtility::Math::PiOverTwo;
-  textureTransformExtension.scale = {0.5, 0.5};
-  textureTransformExtension.texCoord = 10;
-
-  ClassProperty classProperty;
-  classProperty.type = ClassProperty::Type::SCALAR;
-  classProperty.componentType = ClassProperty::ComponentType::UINT8;
-  classProperty.normalized = true;
-
-  Sampler sampler;
-  sampler.wrapS = Sampler::WrapS::REPEAT;
-  sampler.wrapT = Sampler::WrapT::REPEAT;
-
-  ImageCesium image;
-  image.width = 2;
-  image.height = 2;
-  image.channels = 1;
-  image.bytesPerChannel = 1;
-
-  std::vector<std::byte>& imageData = image.pixelData;
-  imageData.resize(data.size());
-  std::memcpy(imageData.data(), data.data(), data.size());
-
-  property.channels = {0};
-
-  TextureViewOptions options;
-  options.makeImageCopy = true;
-
-  PropertyTexturePropertyView<uint8_t, true>
-      view(property, classProperty, sampler, image, options);
-  REQUIRE(view.status() == PropertyTexturePropertyViewStatus::Valid);
-
-  // Clear the original image data.
-  std::vector<std::byte> emptyData;
-  image.pixelData.swap(emptyData);
-
-  const ImageCesium* pImage = view.getImage();
-  REQUIRE(pImage);
-  REQUIRE(pImage->pixelData.size() == data.size());
-
-  std::vector<glm::dvec2> texCoords{
-      glm::dvec2(0, 0),
-      glm::dvec2(0.5, 0),
-      glm::dvec2(0, 0.5),
-      glm::dvec2(0.5, 0.5)};
-
-  for (size_t i = 0; i < texCoords.size(); i++) {
-    glm::dvec2 uv = texCoords[i];
-    REQUIRE(view.getRaw(uv[0], uv[1]) == data[i]);
-    REQUIRE(view.get(uv[0], uv[1]) == static_cast<double>(data[i]) / 255.0);
-  }
-}
-
-TEST_CASE("Test normalized PropertyTextureProperty constructs with "
+TEST_CASE("Test PropertyTextureProperty constructs with "
           "makeImageCopy = true") {
   std::vector<uint8_t> data{1, 2, 3, 4};
 
@@ -2027,6 +1965,10 @@ TEST_CASE("Test normalized PropertyTextureProperty constructs with "
 
   const ImageCesium* pImage = view.getImage();
   REQUIRE(pImage);
+  REQUIRE(pImage->width == image.width);
+  REQUIRE(pImage->height == image.height);
+  REQUIRE(pImage->channels == image.channels);
+  REQUIRE(pImage->bytesPerChannel == image.bytesPerChannel);
   REQUIRE(pImage->pixelData.size() == data.size());
 
   std::vector<glm::dvec2> texCoords{
@@ -2039,5 +1981,72 @@ TEST_CASE("Test normalized PropertyTextureProperty constructs with "
     glm::dvec2 uv = texCoords[i];
     REQUIRE(view.getRaw(uv[0], uv[1]) == data[i]);
     REQUIRE(view.get(uv[0], uv[1]) == data[i]);
+  }
+}
+
+TEST_CASE("Test normalized PropertyTextureProperty constructs with "
+          "makeImageCopy = true") {
+  std::vector<uint8_t> data{0, 64, 127, 255};
+
+  PropertyTextureProperty property;
+  property.texCoord = 0;
+
+  ExtensionKhrTextureTransform& textureTransformExtension =
+      property.addExtension<ExtensionKhrTextureTransform>();
+  textureTransformExtension.offset = {0.5, -0.5};
+  textureTransformExtension.rotation = CesiumUtility::Math::PiOverTwo;
+  textureTransformExtension.scale = {0.5, 0.5};
+  textureTransformExtension.texCoord = 10;
+
+  ClassProperty classProperty;
+  classProperty.type = ClassProperty::Type::SCALAR;
+  classProperty.componentType = ClassProperty::ComponentType::UINT8;
+  classProperty.normalized = true;
+
+  Sampler sampler;
+  sampler.wrapS = Sampler::WrapS::REPEAT;
+  sampler.wrapT = Sampler::WrapT::REPEAT;
+
+  ImageCesium image;
+  image.width = 2;
+  image.height = 2;
+  image.channels = 1;
+  image.bytesPerChannel = 1;
+
+  std::vector<std::byte>& imageData = image.pixelData;
+  imageData.resize(data.size());
+  std::memcpy(imageData.data(), data.data(), data.size());
+
+  property.channels = {0};
+
+  TextureViewOptions options;
+  options.makeImageCopy = true;
+
+  PropertyTexturePropertyView<uint8_t, true>
+      view(property, classProperty, sampler, image, options);
+  REQUIRE(view.status() == PropertyTexturePropertyViewStatus::Valid);
+
+  // Clear the original image data.
+  std::vector<std::byte> emptyData;
+  image.pixelData.swap(emptyData);
+
+  const ImageCesium* pImage = view.getImage();
+  REQUIRE(pImage);
+  REQUIRE(pImage->width == image.width);
+  REQUIRE(pImage->height == image.height);
+  REQUIRE(pImage->channels == image.channels);
+  REQUIRE(pImage->bytesPerChannel == image.bytesPerChannel);
+  REQUIRE(pImage->pixelData.size() == data.size());
+
+  std::vector<glm::dvec2> texCoords{
+      glm::dvec2(0, 0),
+      glm::dvec2(0.5, 0),
+      glm::dvec2(0, 0.5),
+      glm::dvec2(0.5, 0.5)};
+
+  for (size_t i = 0; i < texCoords.size(); i++) {
+    glm::dvec2 uv = texCoords[i];
+    REQUIRE(view.getRaw(uv[0], uv[1]) == data[i]);
+    REQUIRE(view.get(uv[0], uv[1]) == static_cast<double>(data[i]) / 255.0);
   }
 }

--- a/CesiumGltf/test/TestPropertyTexturePropertyView.cpp
+++ b/CesiumGltf/test/TestPropertyTexturePropertyView.cpp
@@ -1805,7 +1805,7 @@ TEST_CASE("Test PropertyTextureProperty constructs with "
 
   property.channels = {0};
 
-  PropertyTexturePropertyViewOptions options;
+  TextureViewOptions options;
   options.applyKhrTextureTransformExtension = true;
 
   PropertyTexturePropertyView<uint8_t>
@@ -1878,7 +1878,7 @@ TEST_CASE("Test normalized PropertyTextureProperty constructs with "
 
   property.channels = {0};
 
-  PropertyTexturePropertyViewOptions options;
+  TextureViewOptions options;
   options.applyKhrTextureTransformExtension = true;
 
   PropertyTexturePropertyView<uint8_t, true>
@@ -1952,7 +1952,7 @@ TEST_CASE("Test PropertyTextureProperty constructs with makeImageCopy = true") {
 
   property.channels = {0};
 
-  PropertyTexturePropertyViewOptions options;
+  TextureViewOptions options;
   options.makeImageCopy = true;
 
   PropertyTexturePropertyView<uint8_t, true>
@@ -2014,7 +2014,7 @@ TEST_CASE("Test normalized PropertyTextureProperty constructs with "
 
   property.channels = {0};
 
-  PropertyTexturePropertyViewOptions options;
+  TextureViewOptions options;
   options.makeImageCopy = true;
 
   PropertyTexturePropertyView<uint8_t>

--- a/CesiumGltf/test/TestPropertyTextureView.cpp
+++ b/CesiumGltf/test/TestPropertyTextureView.cpp
@@ -1,4 +1,5 @@
 #include "CesiumGltf/PropertyTextureView.h"
+#include "CesiumUtility/Math.h"
 
 #include <catch2/catch.hpp>
 #include <gsl/span>
@@ -34,6 +35,29 @@ void addTextureToModel(
   Texture& texture = model.textures.emplace_back();
   texture.sampler = static_cast<int32_t>(model.samplers.size() - 1);
   texture.source = static_cast<int32_t>(model.images.size() - 1);
+}
+
+template <typename T, bool Normalized>
+void verifyTextureTransformConstruction(
+    const PropertyTexturePropertyView<T, Normalized>& propertyView,
+    const ExtensionKhrTextureTransform& extension) {
+  auto textureTransform = propertyView.getTextureTransform();
+  REQUIRE(textureTransform != std::nullopt);
+  REQUIRE(
+      textureTransform->offset() ==
+      glm::dvec2{extension.offset[0], extension.offset[1]});
+  REQUIRE(textureTransform->rotation() == extension.rotation);
+  REQUIRE(
+      textureTransform->scale() ==
+      glm::dvec2{extension.scale[0], extension.scale[1]});
+
+  // Texcoord is overridden by value in KHR_texture_transform.
+  if (extension.texCoord) {
+    REQUIRE(
+        propertyView.getTexCoordSetIndex() ==
+        textureTransform->getTexCoordSetIndex());
+    REQUIRE(textureTransform->getTexCoordSetIndex() == *extension.texCoord);
+  }
 }
 } // namespace
 
@@ -119,8 +143,8 @@ TEST_CASE("Test scalar PropertyTextureProperty") {
 
   addTextureToModel(
       model,
-      Sampler::WrapS::CLAMP_TO_EDGE,
-      Sampler::WrapS::CLAMP_TO_EDGE,
+      Sampler::WrapS::REPEAT,
+      Sampler::WrapT::REPEAT,
       2,
       2,
       1,
@@ -162,6 +186,69 @@ TEST_CASE("Test scalar PropertyTextureProperty") {
     PropertyTexturePropertyView<uint8_t> uint8Property =
         view.getPropertyView<uint8_t>("TestClassProperty");
     REQUIRE(uint8Property.status() == PropertyTexturePropertyViewStatus::Valid);
+
+    std::vector<glm::dvec2> texCoords{
+        glm::dvec2(0, 0),
+        glm::dvec2(0.5, 0),
+        glm::dvec2(0, 0.5),
+        glm::dvec2(0.5, 0.5)};
+
+    for (size_t i = 0; i < texCoords.size(); ++i) {
+      glm::dvec2 uv = texCoords[i];
+      REQUIRE(uint8Property.getRaw(uv[0], uv[1]) == data[i]);
+      REQUIRE(uint8Property.get(uv[0], uv[1]) == data[i]);
+    }
+  }
+
+  SECTION("Access with KHR_texture_transform") {
+    TextureViewOptions options;
+    options.applyKhrTextureTransformExtension = true;
+
+    ExtensionKhrTextureTransform& extension =
+        propertyTextureProperty.addExtension<ExtensionKhrTextureTransform>();
+    extension.offset = {0.5, -0.5};
+    extension.rotation = CesiumUtility::Math::PiOverTwo;
+    extension.scale = {0.5, 0.5};
+    extension.texCoord = 10;
+
+    PropertyTexturePropertyView<uint8_t> uint8Property =
+        view.getPropertyView<uint8_t>("TestClassProperty", options);
+    REQUIRE(uint8Property.status() == PropertyTexturePropertyViewStatus::Valid);
+
+    verifyTextureTransformConstruction(uint8Property, extension);
+
+    // This transforms to the following UV values:
+    // (0, 0) -> (0.5, -0.5) -> wraps to (0.5, 0.5)
+    // (1, 0) -> (0.5, -1) -> wraps to (0.5, 0)
+    // (0, 1) -> (1, -0.5) -> wraps to (0, 0.5)
+    // (1, 1) -> (1, -1) -> wraps to (0.0, 0.0)
+    std::vector<glm::dvec2> texCoords{
+        glm::dvec2(0, 0),
+        glm::dvec2(1, 0),
+        glm::dvec2(0, 1),
+        glm::dvec2(1, 1)};
+
+    std::vector<uint8_t> expected{data[3], data[1], data[2], data[0]};
+    for (size_t i = 0; i < texCoords.size(); ++i) {
+      glm::dvec2 uv = texCoords[i];
+      REQUIRE(uint8Property.getRaw(uv[0], uv[1]) == expected[i]);
+      REQUIRE(uint8Property.get(uv[0], uv[1]) == expected[i]);
+    }
+
+    propertyTextureProperty.extensions.clear();
+  }
+
+  SECTION("Access with image copy") {
+    TextureViewOptions options;
+    options.makeImageCopy = true;
+
+    PropertyTexturePropertyView<uint8_t> uint8Property =
+        view.getPropertyView<uint8_t>("TestClassProperty", options);
+    REQUIRE(uint8Property.status() == PropertyTexturePropertyViewStatus::Valid);
+
+    // Clear the original image data.
+    std::vector<std::byte> emptyData;
+    model.images[model.images.size() - 1].cesium.pixelData.swap(emptyData);
 
     std::vector<glm::dvec2> texCoords{
         glm::dvec2(0, 0),
@@ -300,8 +387,8 @@ TEST_CASE("Test scalar PropertyTextureProperty (normalized)") {
 
   addTextureToModel(
       model,
-      Sampler::WrapS::CLAMP_TO_EDGE,
-      Sampler::WrapS::CLAMP_TO_EDGE,
+      Sampler::WrapS::REPEAT,
+      Sampler::WrapT::REPEAT,
       2,
       2,
       1,
@@ -344,6 +431,69 @@ TEST_CASE("Test scalar PropertyTextureProperty (normalized)") {
     PropertyTexturePropertyView<uint8_t, true> uint8Property =
         view.getPropertyView<uint8_t, true>("TestClassProperty");
     REQUIRE(uint8Property.status() == PropertyTexturePropertyViewStatus::Valid);
+
+    std::vector<glm::dvec2> texCoords{
+        glm::dvec2(0, 0),
+        glm::dvec2(0.5, 0),
+        glm::dvec2(0, 0.5),
+        glm::dvec2(0.5, 0.5)};
+
+    for (size_t i = 0; i < texCoords.size(); ++i) {
+      glm::dvec2 uv = texCoords[i];
+      REQUIRE(uint8Property.getRaw(uv[0], uv[1]) == data[i]);
+      REQUIRE(uint8Property.get(uv[0], uv[1]) == normalize(data[i]));
+    }
+  }
+
+  SECTION("Access with KHR_texture_transform") {
+    TextureViewOptions options;
+    options.applyKhrTextureTransformExtension = true;
+
+    ExtensionKhrTextureTransform& extension =
+        propertyTextureProperty.addExtension<ExtensionKhrTextureTransform>();
+    extension.offset = {0.5, -0.5};
+    extension.rotation = CesiumUtility::Math::PiOverTwo;
+    extension.scale = {0.5, 0.5};
+    extension.texCoord = 10;
+
+    PropertyTexturePropertyView<uint8_t, true> uint8Property =
+        view.getPropertyView<uint8_t, true>("TestClassProperty", options);
+    REQUIRE(uint8Property.status() == PropertyTexturePropertyViewStatus::Valid);
+
+    verifyTextureTransformConstruction(uint8Property, extension);
+
+    // This transforms to the following UV values:
+    // (0, 0) -> (0.5, -0.5) -> wraps to (0.5, 0.5)
+    // (1, 0) -> (0.5, -1) -> wraps to (0.5, 0)
+    // (0, 1) -> (1, -0.5) -> wraps to (0, 0.5)
+    // (1, 1) -> (1, -1) -> wraps to (0.0, 0.0)
+    std::vector<glm::dvec2> texCoords{
+        glm::dvec2(0, 0),
+        glm::dvec2(1, 0),
+        glm::dvec2(0, 1),
+        glm::dvec2(1, 1)};
+
+    std::vector<uint8_t> expected{data[3], data[1], data[2], data[0]};
+    for (size_t i = 0; i < texCoords.size(); ++i) {
+      glm::dvec2 uv = texCoords[i];
+      REQUIRE(uint8Property.getRaw(uv[0], uv[1]) == expected[i]);
+      REQUIRE(uint8Property.get(uv[0], uv[1]) == normalize(expected[i]));
+    }
+
+    propertyTextureProperty.extensions.clear();
+  }
+
+  SECTION("Access with image copy") {
+    TextureViewOptions options;
+    options.makeImageCopy = true;
+
+    PropertyTexturePropertyView<uint8_t, true> uint8Property =
+        view.getPropertyView<uint8_t, true>("TestClassProperty", options);
+    REQUIRE(uint8Property.status() == PropertyTexturePropertyViewStatus::Valid);
+
+    // Clear the original image data.
+    std::vector<std::byte> emptyData;
+    model.images[model.images.size() - 1].cesium.pixelData.swap(emptyData);
 
     std::vector<glm::dvec2> texCoords{
         glm::dvec2(0, 0),
@@ -419,11 +569,16 @@ TEST_CASE("Test scalar PropertyTextureProperty (normalized)") {
 TEST_CASE("Test vecN PropertyTextureProperty") {
   Model model;
   std::vector<uint8_t> data = {12, 34, 10, 3, 40, 0, 30, 11};
+  std::vector<glm::u8vec2> expected{
+      glm::u8vec2(data[0], data[1]),
+      glm::u8vec2(data[2], data[3]),
+      glm::u8vec2(data[4], data[5]),
+      glm::u8vec2(data[6], data[7])};
 
   addTextureToModel(
       model,
-      Sampler::WrapS::CLAMP_TO_EDGE,
-      Sampler::WrapS::CLAMP_TO_EDGE,
+      Sampler::WrapS::REPEAT,
+      Sampler::WrapT::REPEAT,
       2,
       2,
       2,
@@ -473,11 +628,75 @@ TEST_CASE("Test vecN PropertyTextureProperty") {
         glm::dvec2(0, 0.5),
         glm::dvec2(0.5, 0.5)};
 
-    std::vector<glm::u8vec2> expected{
-        glm::u8vec2(12, 34),
-        glm::u8vec2(10, 3),
-        glm::u8vec2(40, 0),
-        glm::u8vec2(30, 11)};
+    for (size_t i = 0; i < texCoords.size(); ++i) {
+      glm::dvec2 uv = texCoords[i];
+      REQUIRE(u8vec2Property.getRaw(uv[0], uv[1]) == expected[i]);
+      REQUIRE(u8vec2Property.get(uv[0], uv[1]) == expected[i]);
+    }
+  }
+
+  SECTION("Access with KHR_texture_transform") {
+    TextureViewOptions options;
+    options.applyKhrTextureTransformExtension = true;
+
+    ExtensionKhrTextureTransform& extension =
+        propertyTextureProperty.addExtension<ExtensionKhrTextureTransform>();
+    extension.offset = {0.5, -0.5};
+    extension.rotation = CesiumUtility::Math::PiOverTwo;
+    extension.scale = {0.5, 0.5};
+    extension.texCoord = 10;
+
+    PropertyTexturePropertyView<glm::u8vec2> u8vec2Property =
+        view.getPropertyView<glm::u8vec2>("TestClassProperty", options);
+    REQUIRE(
+        u8vec2Property.status() == PropertyTexturePropertyViewStatus::Valid);
+
+    verifyTextureTransformConstruction(u8vec2Property, extension);
+
+    // This transforms to the following UV values:
+    // (0, 0) -> (0.5, -0.5) -> wraps to (0.5, 0.5)
+    // (1, 0) -> (0.5, -1) -> wraps to (0.5, 0)
+    // (0, 1) -> (1, -0.5) -> wraps to (0, 0.5)
+    // (1, 1) -> (1, -1) -> wraps to (0.0, 0.0)
+    std::vector<glm::dvec2> texCoords{
+        glm::dvec2(0, 0),
+        glm::dvec2(1, 0),
+        glm::dvec2(0, 1),
+        glm::dvec2(1, 1)};
+
+    std::vector<glm::u8vec2> expectedTransformed{
+        expected[3],
+        expected[1],
+        expected[2],
+        expected[0]};
+    for (size_t i = 0; i < texCoords.size(); ++i) {
+      glm::dvec2 uv = texCoords[i];
+      REQUIRE(u8vec2Property.getRaw(uv[0], uv[1]) == expectedTransformed[i]);
+      REQUIRE(u8vec2Property.get(uv[0], uv[1]) == expectedTransformed[i]);
+    }
+
+    propertyTextureProperty.extensions.clear();
+  }
+
+  SECTION("Access with image copy") {
+    TextureViewOptions options;
+    options.makeImageCopy = true;
+
+    PropertyTexturePropertyView<glm::u8vec2> u8vec2Property =
+        view.getPropertyView<glm::u8vec2>("TestClassProperty", options);
+    REQUIRE(
+        u8vec2Property.status() == PropertyTexturePropertyViewStatus::Valid);
+
+    // Clear the original image data.
+    std::vector<std::byte> emptyData;
+    model.images[model.images.size() - 1].cesium.pixelData.swap(emptyData);
+
+    std::vector<glm::dvec2> texCoords{
+        glm::dvec2(0, 0),
+        glm::dvec2(0.5, 0),
+        glm::dvec2(0, 0.5),
+        glm::dvec2(0.5, 0.5)};
+
     for (size_t i = 0; i < texCoords.size(); ++i) {
       glm::dvec2 uv = texCoords[i];
       REQUIRE(u8vec2Property.getRaw(uv[0], uv[1]) == expected[i]);
@@ -562,11 +781,16 @@ TEST_CASE("Test vecN PropertyTextureProperty") {
 TEST_CASE("Test vecN PropertyTextureProperty (normalized)") {
   Model model;
   std::vector<uint8_t> data = {12, 34, 10, 3, 40, 0, 30, 11};
+  std::vector<glm::u8vec2> expected{
+      glm::u8vec2(data[0], data[1]),
+      glm::u8vec2(data[2], data[3]),
+      glm::u8vec2(data[4], data[5]),
+      glm::u8vec2(data[6], data[7])};
 
   addTextureToModel(
       model,
-      Sampler::WrapS::CLAMP_TO_EDGE,
-      Sampler::WrapS::CLAMP_TO_EDGE,
+      Sampler::WrapS::REPEAT,
+      Sampler::WrapT::REPEAT,
       2,
       2,
       2,
@@ -616,12 +840,77 @@ TEST_CASE("Test vecN PropertyTextureProperty (normalized)") {
         glm::dvec2(0.5, 0),
         glm::dvec2(0, 0.5),
         glm::dvec2(0.5, 0.5)};
+    for (size_t i = 0; i < texCoords.size(); ++i) {
+      glm::dvec2 uv = texCoords[i];
+      REQUIRE(u8vec2Property.getRaw(uv[0], uv[1]) == expected[i]);
+      REQUIRE(u8vec2Property.get(uv[0], uv[1]) == normalize(expected[i]));
+    }
+  }
 
-    std::vector<glm::u8vec2> expected{
-        glm::u8vec2(12, 34),
-        glm::u8vec2(10, 3),
-        glm::u8vec2(40, 0),
-        glm::u8vec2(30, 11)};
+  SECTION("Access with KHR_texture_transform") {
+    TextureViewOptions options;
+    options.applyKhrTextureTransformExtension = true;
+
+    ExtensionKhrTextureTransform& extension =
+        propertyTextureProperty.addExtension<ExtensionKhrTextureTransform>();
+    extension.offset = {0.5, -0.5};
+    extension.rotation = CesiumUtility::Math::PiOverTwo;
+    extension.scale = {0.5, 0.5};
+    extension.texCoord = 10;
+
+    PropertyTexturePropertyView<glm::u8vec2, true> u8vec2Property =
+        view.getPropertyView<glm::u8vec2, true>("TestClassProperty", options);
+    REQUIRE(
+        u8vec2Property.status() == PropertyTexturePropertyViewStatus::Valid);
+
+    verifyTextureTransformConstruction(u8vec2Property, extension);
+
+    // This transforms to the following UV values:
+    // (0, 0) -> (0.5, -0.5) -> wraps to (0.5, 0.5)
+    // (1, 0) -> (0.5, -1) -> wraps to (0.5, 0)
+    // (0, 1) -> (1, -0.5) -> wraps to (0, 0.5)
+    // (1, 1) -> (1, -1) -> wraps to (0.0, 0.0)
+    std::vector<glm::dvec2> texCoords{
+        glm::dvec2(0, 0),
+        glm::dvec2(1, 0),
+        glm::dvec2(0, 1),
+        glm::dvec2(1, 1)};
+
+    std::vector<glm::u8vec2> expectedTransformed{
+        expected[3],
+        expected[1],
+        expected[2],
+        expected[0]};
+    for (size_t i = 0; i < texCoords.size(); ++i) {
+      glm::dvec2 uv = texCoords[i];
+      REQUIRE(u8vec2Property.getRaw(uv[0], uv[1]) == expectedTransformed[i]);
+      REQUIRE(
+          u8vec2Property.get(uv[0], uv[1]) ==
+          normalize(expectedTransformed[i]));
+    }
+
+    propertyTextureProperty.extensions.clear();
+  }
+
+  SECTION("Access with image copy") {
+    TextureViewOptions options;
+    options.makeImageCopy = true;
+
+    PropertyTexturePropertyView<glm::u8vec2, true> u8vec2Property =
+        view.getPropertyView<glm::u8vec2, true>("TestClassProperty", options);
+    REQUIRE(
+        u8vec2Property.status() == PropertyTexturePropertyViewStatus::Valid);
+
+    // Clear the original image data.
+    std::vector<std::byte> emptyData;
+    model.images[model.images.size() - 1].cesium.pixelData.swap(emptyData);
+
+    std::vector<glm::dvec2> texCoords{
+        glm::dvec2(0, 0),
+        glm::dvec2(0.5, 0),
+        glm::dvec2(0, 0.5),
+        glm::dvec2(0.5, 0.5)};
+
     for (size_t i = 0; i < texCoords.size(); ++i) {
       glm::dvec2 uv = texCoords[i];
       REQUIRE(u8vec2Property.getRaw(uv[0], uv[1]) == expected[i]);
@@ -704,11 +993,17 @@ TEST_CASE("Test array PropertyTextureProperty") {
     6, 3, 4,
   };
   // clang-format on
+  std::vector<std::array<uint8_t, 3>> expected = {
+      {data[0], data[1], data[2]},
+      {data[3], data[4], data[5]},
+      {data[6], data[7], data[8]},
+      {data[9], data[10], data[11]},
+  };
 
   addTextureToModel(
       model,
-      Sampler::WrapS::CLAMP_TO_EDGE,
-      Sampler::WrapS::CLAMP_TO_EDGE,
+      Sampler::WrapS::REPEAT,
+      Sampler::WrapT::REPEAT,
       2,
       2,
       3,
@@ -761,18 +1056,118 @@ TEST_CASE("Test array PropertyTextureProperty") {
         glm::dvec2(0, 0.5),
         glm::dvec2(0.5, 0.5)};
 
-    int64_t size = static_cast<int64_t>(texCoords.size());
-    for (int64_t i = 0; i < size; ++i) {
-      glm::dvec2 uv = texCoords[static_cast<size_t>(i)];
-
-      auto dataStart = data.begin() + i * 3;
-      std::vector<uint8_t> expected(dataStart, dataStart + 3);
+    for (size_t i = 0; i < texCoords.size(); ++i) {
+      glm::dvec2 uv = texCoords[i];
+      const std::array<uint8_t, 3>& expectedArray = expected[i];
 
       const PropertyArrayView<uint8_t>& value =
           uint8ArrayProperty.getRaw(uv[0], uv[1]);
-      REQUIRE(static_cast<size_t>(value.size()) == expected.size());
+      REQUIRE(static_cast<size_t>(value.size()) == expectedArray.size());
+
       for (int64_t j = 0; j < value.size(); j++) {
-        REQUIRE(value[j] == expected[static_cast<size_t>(j)]);
+        REQUIRE(value[j] == expectedArray[static_cast<size_t>(j)]);
+      }
+
+      auto maybeValue = uint8ArrayProperty.get(uv[0], uv[1]);
+      REQUIRE(maybeValue);
+      for (int64_t j = 0; j < maybeValue->size(); j++) {
+        REQUIRE((*maybeValue)[j] == value[j]);
+      }
+    }
+  }
+
+  SECTION("Access with KHR_texture_transform") {
+    TextureViewOptions options;
+    options.applyKhrTextureTransformExtension = true;
+
+    ExtensionKhrTextureTransform& extension =
+        propertyTextureProperty.addExtension<ExtensionKhrTextureTransform>();
+    extension.offset = {0.5, -0.5};
+    extension.rotation = CesiumUtility::Math::PiOverTwo;
+    extension.scale = {0.5, 0.5};
+    extension.texCoord = 10;
+
+    PropertyTexturePropertyView<PropertyArrayView<uint8_t>> uint8ArrayProperty =
+        view.getPropertyView<PropertyArrayView<uint8_t>>(
+            "TestClassProperty",
+            options);
+    REQUIRE(
+        uint8ArrayProperty.status() ==
+        PropertyTexturePropertyViewStatus::Valid);
+
+    verifyTextureTransformConstruction(uint8ArrayProperty, extension);
+
+    // This transforms to the following UV values:
+    // (0, 0) -> (0.5, -0.5) -> wraps to (0.5, 0.5)
+    // (1, 0) -> (0.5, -1) -> wraps to (0.5, 0)
+    // (0, 1) -> (1, -0.5) -> wraps to (0, 0.5)
+    // (1, 1) -> (1, -1) -> wraps to (0.0, 0.0)
+    std::vector<glm::dvec2> texCoords{
+        glm::dvec2(0, 0),
+        glm::dvec2(1, 0),
+        glm::dvec2(0, 1),
+        glm::dvec2(1, 1)};
+
+    std::vector<std::array<uint8_t, 3>> expectedTransformed{
+        expected[3],
+        expected[1],
+        expected[2],
+        expected[0]};
+
+    for (size_t i = 0; i < texCoords.size(); ++i) {
+      glm::dvec2 uv = texCoords[i];
+      const std::array<uint8_t, 3>& expectedArray = expectedTransformed[i];
+
+      const PropertyArrayView<uint8_t>& value =
+          uint8ArrayProperty.getRaw(uv[0], uv[1]);
+      REQUIRE(static_cast<size_t>(value.size()) == expectedArray.size());
+
+      for (int64_t j = 0; j < value.size(); j++) {
+        REQUIRE(value[j] == expectedArray[static_cast<size_t>(j)]);
+      }
+
+      auto maybeValue = uint8ArrayProperty.get(uv[0], uv[1]);
+      REQUIRE(maybeValue);
+      for (int64_t j = 0; j < maybeValue->size(); j++) {
+        REQUIRE((*maybeValue)[j] == value[j]);
+      }
+    }
+
+    propertyTextureProperty.extensions.clear();
+  }
+
+  SECTION("Access with image copy") {
+    TextureViewOptions options;
+    options.makeImageCopy = true;
+
+    PropertyTexturePropertyView<PropertyArrayView<uint8_t>> uint8ArrayProperty =
+        view.getPropertyView<PropertyArrayView<uint8_t>>(
+            "TestClassProperty",
+            options);
+    REQUIRE(
+        uint8ArrayProperty.status() ==
+        PropertyTexturePropertyViewStatus::Valid);
+
+    // Clear the original image data.
+    std::vector<std::byte> emptyData;
+    model.images[model.images.size() - 1].cesium.pixelData.swap(emptyData);
+
+    std::vector<glm::dvec2> texCoords{
+        glm::dvec2(0, 0),
+        glm::dvec2(0.5, 0),
+        glm::dvec2(0, 0.5),
+        glm::dvec2(0.5, 0.5)};
+
+    for (size_t i = 0; i < texCoords.size(); ++i) {
+      glm::dvec2 uv = texCoords[i];
+      const std::array<uint8_t, 3>& expectedArray = expected[i];
+
+      const PropertyArrayView<uint8_t>& value =
+          uint8ArrayProperty.getRaw(uv[0], uv[1]);
+      REQUIRE(static_cast<size_t>(value.size()) == expectedArray.size());
+
+      for (int64_t j = 0; j < value.size(); j++) {
+        REQUIRE(value[j] == expectedArray[static_cast<size_t>(j)]);
       }
 
       auto maybeValue = uint8ArrayProperty.get(uv[0], uv[1]);
@@ -862,10 +1257,17 @@ TEST_CASE("Test array PropertyTextureProperty (normalized)") {
   };
   // clang-format on
 
+  std::vector<std::array<uint8_t, 3>> expected = {
+      {data[0], data[1], data[2]},
+      {data[3], data[4], data[5]},
+      {data[6], data[7], data[8]},
+      {data[9], data[10], data[11]},
+  };
+
   addTextureToModel(
       model,
-      Sampler::WrapS::CLAMP_TO_EDGE,
-      Sampler::WrapS::CLAMP_TO_EDGE,
+      Sampler::WrapS::REPEAT,
+      Sampler::WrapT::REPEAT,
       2,
       2,
       3,
@@ -924,15 +1326,117 @@ TEST_CASE("Test array PropertyTextureProperty (normalized)") {
     int64_t size = static_cast<int64_t>(texCoords.size());
     for (int64_t i = 0; i < size; ++i) {
       glm::dvec2 uv = texCoords[static_cast<size_t>(i)];
-
-      auto dataStart = data.begin() + i * 3;
-      std::vector<uint8_t> expected(dataStart, dataStart + 3);
+      const std::array<uint8_t, 3>& expectedArray = expected[i];
 
       const PropertyArrayView<uint8_t>& value =
           uint8ArrayProperty.getRaw(uv[0], uv[1]);
-      REQUIRE(static_cast<size_t>(value.size()) == expected.size());
+      REQUIRE(static_cast<size_t>(value.size()) == expectedArray.size());
       for (int64_t j = 0; j < value.size(); j++) {
-        REQUIRE(value[j] == expected[static_cast<size_t>(j)]);
+        REQUIRE(value[j] == expectedArray[static_cast<size_t>(j)]);
+      }
+
+      auto maybeValue = uint8ArrayProperty.get(uv[0], uv[1]);
+      REQUIRE(maybeValue);
+      for (int64_t j = 0; j < maybeValue->size(); j++) {
+        REQUIRE((*maybeValue)[j] == normalize(value[j]));
+      }
+    }
+  }
+
+  SECTION("Access with KHR_texture_transform") {
+    TextureViewOptions options;
+    options.applyKhrTextureTransformExtension = true;
+
+    ExtensionKhrTextureTransform& extension =
+        propertyTextureProperty.addExtension<ExtensionKhrTextureTransform>();
+    extension.offset = {0.5, -0.5};
+    extension.rotation = CesiumUtility::Math::PiOverTwo;
+    extension.scale = {0.5, 0.5};
+    extension.texCoord = 10;
+
+    PropertyTexturePropertyView<PropertyArrayView<uint8_t>, true>
+        uint8ArrayProperty =
+            view.getPropertyView<PropertyArrayView<uint8_t>, true>(
+                "TestClassProperty",
+                options);
+    REQUIRE(
+        uint8ArrayProperty.status() ==
+        PropertyTexturePropertyViewStatus::Valid);
+
+    verifyTextureTransformConstruction(uint8ArrayProperty, extension);
+
+    // This transforms to the following UV values:
+    // (0, 0) -> (0.5, -0.5) -> wraps to (0.5, 0.5)
+    // (1, 0) -> (0.5, -1) -> wraps to (0.5, 0)
+    // (0, 1) -> (1, -0.5) -> wraps to (0, 0.5)
+    // (1, 1) -> (1, -1) -> wraps to (0.0, 0.0)
+    std::vector<glm::dvec2> texCoords{
+        glm::dvec2(0, 0),
+        glm::dvec2(1, 0),
+        glm::dvec2(0, 1),
+        glm::dvec2(1, 1)};
+
+    std::vector<std::array<uint8_t, 3>> expectedTransformed{
+        expected[3],
+        expected[1],
+        expected[2],
+        expected[0]};
+
+    for (size_t i = 0; i < texCoords.size(); ++i) {
+      glm::dvec2 uv = texCoords[i];
+      const std::array<uint8_t, 3>& expectedArray = expectedTransformed[i];
+
+      const PropertyArrayView<uint8_t>& value =
+          uint8ArrayProperty.getRaw(uv[0], uv[1]);
+      REQUIRE(static_cast<size_t>(value.size()) == expectedArray.size());
+
+      for (int64_t j = 0; j < value.size(); j++) {
+        REQUIRE(value[j] == expectedArray[static_cast<size_t>(j)]);
+      }
+
+      auto maybeValue = uint8ArrayProperty.get(uv[0], uv[1]);
+      REQUIRE(maybeValue);
+      for (int64_t j = 0; j < maybeValue->size(); j++) {
+        REQUIRE((*maybeValue)[j] == normalize(value[j]));
+      }
+    }
+
+    propertyTextureProperty.extensions.clear();
+  }
+
+  SECTION("Access with image copy") {
+    TextureViewOptions options;
+    options.makeImageCopy = true;
+
+    PropertyTexturePropertyView<PropertyArrayView<uint8_t>, true>
+        uint8ArrayProperty =
+            view.getPropertyView<PropertyArrayView<uint8_t>, true>(
+                "TestClassProperty",
+                options);
+    REQUIRE(
+        uint8ArrayProperty.status() ==
+        PropertyTexturePropertyViewStatus::Valid);
+
+    // Clear the original image data.
+    std::vector<std::byte> emptyData;
+    model.images[model.images.size() - 1].cesium.pixelData.swap(emptyData);
+
+    std::vector<glm::dvec2> texCoords{
+        glm::dvec2(0, 0),
+        glm::dvec2(0.5, 0),
+        glm::dvec2(0, 0.5),
+        glm::dvec2(0.5, 0.5)};
+
+    for (size_t i = 0; i < texCoords.size(); ++i) {
+      glm::dvec2 uv = texCoords[i];
+      const std::array<uint8_t, 3>& expectedArray = expected[i];
+
+      const PropertyArrayView<uint8_t>& value =
+          uint8ArrayProperty.getRaw(uv[0], uv[1]);
+      REQUIRE(static_cast<size_t>(value.size()) == expectedArray.size());
+
+      for (int64_t j = 0; j < value.size(); j++) {
+        REQUIRE(value[j] == expectedArray[static_cast<size_t>(j)]);
       }
 
       auto maybeValue = uint8ArrayProperty.get(uv[0], uv[1]);
@@ -1686,32 +2190,73 @@ TEST_CASE("Test callback for scalar PropertyTextureProperty") {
       glm::dvec2(0.5, 0.5)};
 
   std::vector<int16_t> expected{-1, 268, 542, -256};
-  uint32_t invokedCallbackCount = 0;
-  view.getPropertyView(
-      "TestClassProperty",
-      [&expected, &texCoords, &invokedCallbackCount](
-          const std::string& /*propertyId*/,
-          auto propertyValue) mutable {
-        invokedCallbackCount++;
-        if constexpr (std::is_same_v<
-                          PropertyTexturePropertyView<int16_t>,
-                          decltype(propertyValue)>) {
-          REQUIRE(
-              propertyValue.status() ==
-              PropertyTexturePropertyViewStatus::Valid);
 
-          for (size_t i = 0; i < expected.size(); ++i) {
-            glm::dvec2& uv = texCoords[i];
-            REQUIRE(propertyValue.getRaw(uv[0], uv[1]) == expected[i]);
-            REQUIRE(propertyValue.get(uv[0], uv[1]) == expected[i]);
+  SECTION("Works") {
+    uint32_t invokedCallbackCount = 0;
+    view.getPropertyView(
+        "TestClassProperty",
+        [&expected, &texCoords, &invokedCallbackCount](
+            const std::string& /*propertyId*/,
+            auto propertyValue) mutable {
+          invokedCallbackCount++;
+          if constexpr (std::is_same_v<
+                            PropertyTexturePropertyView<int16_t>,
+                            decltype(propertyValue)>) {
+            REQUIRE(
+                propertyValue.status() ==
+                PropertyTexturePropertyViewStatus::Valid);
+
+            for (size_t i = 0; i < expected.size(); ++i) {
+              glm::dvec2& uv = texCoords[i];
+              REQUIRE(propertyValue.getRaw(uv[0], uv[1]) == expected[i]);
+              REQUIRE(propertyValue.get(uv[0], uv[1]) == expected[i]);
+            }
+          } else {
+            FAIL("getPropertyView returned PropertyTexturePropertyView of "
+                 "incorrect type for TestClassProperty.");
           }
-        } else {
-          FAIL("getPropertyView returned PropertyTexturePropertyView of "
-               "incorrect type for TestClassProperty.");
-        }
-      });
+        });
 
-  REQUIRE(invokedCallbackCount == 1);
+    REQUIRE(invokedCallbackCount == 1);
+  }
+
+  SECTION("Works with options") {
+    TextureViewOptions options;
+    options.makeImageCopy = true;
+
+    uint32_t invokedCallbackCount = 0;
+    view.getPropertyView(
+        "TestClassProperty",
+        [&expected, &texCoords, &invokedCallbackCount, &model](
+            const std::string& /*propertyId*/,
+            auto propertyValue) mutable {
+          invokedCallbackCount++;
+          if constexpr (std::is_same_v<
+                            PropertyTexturePropertyView<int16_t>,
+                            decltype(propertyValue)>) {
+            REQUIRE(
+                propertyValue.status() ==
+                PropertyTexturePropertyViewStatus::Valid);
+
+            // Clear the original image data.
+            std::vector<std::byte> emptyData;
+            model.images[model.images.size() - 1].cesium.pixelData.swap(
+                emptyData);
+
+            for (size_t i = 0; i < expected.size(); ++i) {
+              glm::dvec2& uv = texCoords[i];
+              REQUIRE(propertyValue.getRaw(uv[0], uv[1]) == expected[i]);
+              REQUIRE(propertyValue.get(uv[0], uv[1]) == expected[i]);
+            }
+          } else {
+            FAIL("getPropertyView returned PropertyTexturePropertyView of "
+                 "incorrect type for TestClassProperty.");
+          }
+        },
+        options);
+
+    REQUIRE(invokedCallbackCount == 1);
+  }
 }
 
 TEST_CASE("Test callback for scalar PropertyTextureProperty (normalized)") {
@@ -1766,32 +2311,75 @@ TEST_CASE("Test callback for scalar PropertyTextureProperty (normalized)") {
       glm::dvec2(0.5, 0.5)};
 
   std::vector<int16_t> expected{-1, 268, 542, -256};
-  uint32_t invokedCallbackCount = 0;
-  view.getPropertyView(
-      "TestClassProperty",
-      [&expected, &texCoords, &invokedCallbackCount](
-          const std::string& /*propertyId*/,
-          auto propertyValue) mutable {
-        invokedCallbackCount++;
-        if constexpr (std::is_same_v<
-                          PropertyTexturePropertyView<int16_t, true>,
-                          decltype(propertyValue)>) {
-          REQUIRE(
-              propertyValue.status() ==
-              PropertyTexturePropertyViewStatus::Valid);
 
-          for (size_t i = 0; i < expected.size(); ++i) {
-            glm::dvec2& uv = texCoords[i];
-            REQUIRE(propertyValue.getRaw(uv[0], uv[1]) == expected[i]);
-            REQUIRE(propertyValue.get(uv[0], uv[1]) == normalize(expected[i]));
+  SECTION("Works") {
+    uint32_t invokedCallbackCount = 0;
+    view.getPropertyView(
+        "TestClassProperty",
+        [&expected, &texCoords, &invokedCallbackCount, &model](
+            const std::string& /*propertyId*/,
+            auto propertyValue) mutable {
+          invokedCallbackCount++;
+          if constexpr (std::is_same_v<
+                            PropertyTexturePropertyView<int16_t, true>,
+                            decltype(propertyValue)>) {
+            REQUIRE(
+                propertyValue.status() ==
+                PropertyTexturePropertyViewStatus::Valid);
+
+            for (size_t i = 0; i < expected.size(); ++i) {
+              glm::dvec2& uv = texCoords[i];
+              REQUIRE(propertyValue.getRaw(uv[0], uv[1]) == expected[i]);
+              REQUIRE(
+                  propertyValue.get(uv[0], uv[1]) == normalize(expected[i]));
+            }
+          } else {
+            FAIL("getPropertyView returned PropertyTexturePropertyView of "
+                 "incorrect type for TestClassProperty.");
           }
-        } else {
-          FAIL("getPropertyView returned PropertyTexturePropertyView of "
-               "incorrect type for TestClassProperty.");
-        }
-      });
+        });
 
-  REQUIRE(invokedCallbackCount == 1);
+    REQUIRE(invokedCallbackCount == 1);
+  }
+
+  SECTION("Works with options") {
+    TextureViewOptions options;
+    options.makeImageCopy = true;
+
+    uint32_t invokedCallbackCount = 0;
+    view.getPropertyView(
+        "TestClassProperty",
+        [&expected, &texCoords, &invokedCallbackCount, &model](
+            const std::string& /*propertyId*/,
+            auto propertyValue) mutable {
+          invokedCallbackCount++;
+          if constexpr (std::is_same_v<
+                            PropertyTexturePropertyView<int16_t, true>,
+                            decltype(propertyValue)>) {
+            REQUIRE(
+                propertyValue.status() ==
+                PropertyTexturePropertyViewStatus::Valid);
+
+            // Clear the original image data.
+            std::vector<std::byte> emptyData;
+            model.images[model.images.size() - 1].cesium.pixelData.swap(
+                emptyData);
+
+            for (size_t i = 0; i < expected.size(); ++i) {
+              glm::dvec2& uv = texCoords[i];
+              REQUIRE(propertyValue.getRaw(uv[0], uv[1]) == expected[i]);
+              REQUIRE(
+                  propertyValue.get(uv[0], uv[1]) == normalize(expected[i]));
+            }
+          } else {
+            FAIL("getPropertyView returned PropertyTexturePropertyView of "
+                 "incorrect type for TestClassProperty.");
+          }
+        },
+        options);
+
+    REQUIRE(invokedCallbackCount == 1);
+  }
 }
 
 TEST_CASE("Test callback for vecN PropertyTextureProperty") {
@@ -1856,32 +2444,72 @@ TEST_CASE("Test callback for vecN PropertyTextureProperty") {
       glm::dvec2(0, 0.5),
       glm::dvec2(0.5, 0.5)};
 
-  uint32_t invokedCallbackCount = 0;
-  view.getPropertyView(
-      "TestClassProperty",
-      [&expected, &texCoords, &invokedCallbackCount](
-          const std::string& /*propertyId*/,
-          auto propertyValue) mutable {
-        invokedCallbackCount++;
-        if constexpr (std::is_same_v<
-                          PropertyTexturePropertyView<glm::i8vec2>,
-                          decltype(propertyValue)>) {
-          REQUIRE(
-              propertyValue.status() ==
-              PropertyTexturePropertyViewStatus::Valid);
+  SECTION("Works") {
+    uint32_t invokedCallbackCount = 0;
+    view.getPropertyView(
+        "TestClassProperty",
+        [&expected, &texCoords, &invokedCallbackCount](
+            const std::string& /*propertyId*/,
+            auto propertyValue) mutable {
+          invokedCallbackCount++;
+          if constexpr (std::is_same_v<
+                            PropertyTexturePropertyView<glm::i8vec2>,
+                            decltype(propertyValue)>) {
+            REQUIRE(
+                propertyValue.status() ==
+                PropertyTexturePropertyViewStatus::Valid);
 
-          for (size_t i = 0; i < expected.size(); ++i) {
-            glm::dvec2& uv = texCoords[i];
-            REQUIRE(propertyValue.getRaw(uv[0], uv[1]) == expected[i]);
-            REQUIRE(propertyValue.get(uv[0], uv[1]) == expected[i]);
+            for (size_t i = 0; i < expected.size(); ++i) {
+              glm::dvec2& uv = texCoords[i];
+              REQUIRE(propertyValue.getRaw(uv[0], uv[1]) == expected[i]);
+              REQUIRE(propertyValue.get(uv[0], uv[1]) == expected[i]);
+            }
+          } else {
+            FAIL("getPropertyView returned PropertyTexturePropertyView of "
+                 "incorrect type for TestClassProperty.");
           }
-        } else {
-          FAIL("getPropertyView returned PropertyTexturePropertyView of "
-               "incorrect type for TestClassProperty.");
-        }
-      });
+        });
 
-  REQUIRE(invokedCallbackCount == 1);
+    REQUIRE(invokedCallbackCount == 1);
+  }
+
+  SECTION("Works with options") {
+    TextureViewOptions options;
+    options.makeImageCopy = true;
+
+    uint32_t invokedCallbackCount = 0;
+    view.getPropertyView(
+        "TestClassProperty",
+        [&expected, &texCoords, &invokedCallbackCount, &model](
+            const std::string& /*propertyId*/,
+            auto propertyValue) mutable {
+          invokedCallbackCount++;
+          if constexpr (std::is_same_v<
+                            PropertyTexturePropertyView<glm::i8vec2>,
+                            decltype(propertyValue)>) {
+            REQUIRE(
+                propertyValue.status() ==
+                PropertyTexturePropertyViewStatus::Valid);
+
+            // Clear the original image data.
+            std::vector<std::byte> emptyData;
+            model.images[model.images.size() - 1].cesium.pixelData.swap(
+                emptyData);
+
+            for (size_t i = 0; i < expected.size(); ++i) {
+              glm::dvec2& uv = texCoords[i];
+              REQUIRE(propertyValue.getRaw(uv[0], uv[1]) == expected[i]);
+              REQUIRE(propertyValue.get(uv[0], uv[1]) == expected[i]);
+            }
+          } else {
+            FAIL("getPropertyView returned PropertyTexturePropertyView of "
+                 "incorrect type for TestClassProperty.");
+          }
+        },
+        options);
+
+    REQUIRE(invokedCallbackCount == 1);
+  }
 }
 
 TEST_CASE("Test callback for vecN PropertyTextureProperty (normalized)") {
@@ -1947,32 +2575,74 @@ TEST_CASE("Test callback for vecN PropertyTextureProperty (normalized)") {
       glm::dvec2(0, 0.5),
       glm::dvec2(0.5, 0.5)};
 
-  uint32_t invokedCallbackCount = 0;
-  view.getPropertyView(
-      "TestClassProperty",
-      [&expected, &texCoords, &invokedCallbackCount](
-          const std::string& /*propertyId*/,
-          auto propertyValue) mutable {
-        invokedCallbackCount++;
-        if constexpr (std::is_same_v<
-                          PropertyTexturePropertyView<glm::i8vec2, true>,
-                          decltype(propertyValue)>) {
-          REQUIRE(
-              propertyValue.status() ==
-              PropertyTexturePropertyViewStatus::Valid);
+  SECTION("Works") {
+    uint32_t invokedCallbackCount = 0;
+    view.getPropertyView(
+        "TestClassProperty",
+        [&expected, &texCoords, &invokedCallbackCount](
+            const std::string& /*propertyId*/,
+            auto propertyValue) mutable {
+          invokedCallbackCount++;
+          if constexpr (std::is_same_v<
+                            PropertyTexturePropertyView<glm::i8vec2, true>,
+                            decltype(propertyValue)>) {
+            REQUIRE(
+                propertyValue.status() ==
+                PropertyTexturePropertyViewStatus::Valid);
 
-          for (size_t i = 0; i < expected.size(); ++i) {
-            glm::dvec2& uv = texCoords[i];
-            REQUIRE(propertyValue.getRaw(uv[0], uv[1]) == expected[i]);
-            REQUIRE(propertyValue.get(uv[0], uv[1]) == normalize(expected[i]));
+            for (size_t i = 0; i < expected.size(); ++i) {
+              glm::dvec2& uv = texCoords[i];
+              REQUIRE(propertyValue.getRaw(uv[0], uv[1]) == expected[i]);
+              REQUIRE(
+                  propertyValue.get(uv[0], uv[1]) == normalize(expected[i]));
+            }
+          } else {
+            FAIL("getPropertyView returned PropertyTexturePropertyView of "
+                 "incorrect type for TestClassProperty.");
           }
-        } else {
-          FAIL("getPropertyView returned PropertyTexturePropertyView of "
-               "incorrect type for TestClassProperty.");
-        }
-      });
+        });
 
-  REQUIRE(invokedCallbackCount == 1);
+    REQUIRE(invokedCallbackCount == 1);
+  }
+
+  SECTION("Works with options") {
+    TextureViewOptions options;
+    options.makeImageCopy = true;
+
+    uint32_t invokedCallbackCount = 0;
+    view.getPropertyView(
+        "TestClassProperty",
+        [&expected, &texCoords, &invokedCallbackCount, &model](
+            const std::string& /*propertyId*/,
+            auto propertyValue) mutable {
+          invokedCallbackCount++;
+          if constexpr (std::is_same_v<
+                            PropertyTexturePropertyView<glm::i8vec2, true>,
+                            decltype(propertyValue)>) {
+            REQUIRE(
+                propertyValue.status() ==
+                PropertyTexturePropertyViewStatus::Valid);
+
+            // Clear the original image data.
+            std::vector<std::byte> emptyData;
+            model.images[model.images.size() - 1].cesium.pixelData.swap(
+                emptyData);
+
+            for (size_t i = 0; i < expected.size(); ++i) {
+              glm::dvec2& uv = texCoords[i];
+              REQUIRE(propertyValue.getRaw(uv[0], uv[1]) == expected[i]);
+              REQUIRE(
+                  propertyValue.get(uv[0], uv[1]) == normalize(expected[i]));
+            }
+          } else {
+            FAIL("getPropertyView returned PropertyTexturePropertyView of "
+                 "incorrect type for TestClassProperty.");
+          }
+        },
+        options);
+
+    REQUIRE(invokedCallbackCount == 1);
+  }
 }
 
 TEST_CASE("Test callback for array PropertyTextureProperty") {
@@ -2039,49 +2709,108 @@ TEST_CASE("Test callback for array PropertyTextureProperty") {
       glm::dvec2(0, 0.5),
       glm::dvec2(0.5, 0.5)};
 
-  uint32_t invokedCallbackCount = 0;
-  view.getPropertyView(
-      "TestClassProperty",
-      [&expected, &texCoords, &invokedCallbackCount](
-          const std::string& /*propertyId*/,
-          auto propertyValue) mutable {
-        invokedCallbackCount++;
-        if constexpr (std::is_same_v<
-                          PropertyTexturePropertyView<
-                              PropertyArrayView<uint16_t>>,
-                          decltype(propertyValue)>) {
-          REQUIRE(
-              propertyValue.status() ==
-              PropertyTexturePropertyViewStatus::Valid);
-
-          for (size_t i = 0; i < expected.size(); ++i) {
-            std::vector<uint16_t>& expectedArray = expected[i];
-            glm::dvec2& uv = texCoords[i];
-            PropertyArrayView<uint16_t> array =
-                propertyValue.getRaw(uv[0], uv[1]);
-
-            REQUIRE(static_cast<size_t>(array.size()) == expectedArray.size());
-            for (int64_t j = 0; j < array.size(); j++) {
-              REQUIRE(array[j] == expectedArray[static_cast<size_t>(j)]);
-            }
-
-            auto maybeArray = propertyValue.get(uv[0], uv[1]);
-            REQUIRE(maybeArray);
+  SECTION("Works") {
+    uint32_t invokedCallbackCount = 0;
+    view.getPropertyView(
+        "TestClassProperty",
+        [&expected, &texCoords, &invokedCallbackCount](
+            const std::string& /*propertyId*/,
+            auto propertyValue) mutable {
+          invokedCallbackCount++;
+          if constexpr (std::is_same_v<
+                            PropertyTexturePropertyView<
+                                PropertyArrayView<uint16_t>>,
+                            decltype(propertyValue)>) {
             REQUIRE(
-                static_cast<size_t>(maybeArray->size()) ==
-                expectedArray.size());
-            for (int64_t j = 0; j < array.size(); j++) {
-              REQUIRE(
-                  (*maybeArray)[j] == expectedArray[static_cast<size_t>(j)]);
-            }
-          }
-        } else {
-          FAIL("getPropertyView returned PropertyTexturePropertyView of "
-               "incorrect type for TestClassProperty.");
-        }
-      });
+                propertyValue.status() ==
+                PropertyTexturePropertyViewStatus::Valid);
 
-  REQUIRE(invokedCallbackCount == 1);
+            for (size_t i = 0; i < expected.size(); ++i) {
+              std::vector<uint16_t>& expectedArray = expected[i];
+              glm::dvec2& uv = texCoords[i];
+              PropertyArrayView<uint16_t> array =
+                  propertyValue.getRaw(uv[0], uv[1]);
+
+              REQUIRE(
+                  static_cast<size_t>(array.size()) == expectedArray.size());
+              for (int64_t j = 0; j < array.size(); j++) {
+                REQUIRE(array[j] == expectedArray[static_cast<size_t>(j)]);
+              }
+
+              auto maybeArray = propertyValue.get(uv[0], uv[1]);
+              REQUIRE(maybeArray);
+              REQUIRE(
+                  static_cast<size_t>(maybeArray->size()) ==
+                  expectedArray.size());
+              for (int64_t j = 0; j < array.size(); j++) {
+                REQUIRE(
+                    (*maybeArray)[j] == expectedArray[static_cast<size_t>(j)]);
+              }
+            }
+          } else {
+            FAIL("getPropertyView returned PropertyTexturePropertyView of "
+                 "incorrect type for TestClassProperty.");
+          }
+        });
+
+    REQUIRE(invokedCallbackCount == 1);
+  }
+
+  SECTION("Works with options") {
+    TextureViewOptions options;
+    options.makeImageCopy = true;
+
+    uint32_t invokedCallbackCount = 0;
+    view.getPropertyView(
+        "TestClassProperty",
+        [&expected, &texCoords, &invokedCallbackCount, &model](
+            const std::string& /*propertyId*/,
+            auto propertyValue) mutable {
+          invokedCallbackCount++;
+          if constexpr (std::is_same_v<
+                            PropertyTexturePropertyView<
+                                PropertyArrayView<uint16_t>>,
+                            decltype(propertyValue)>) {
+            REQUIRE(
+                propertyValue.status() ==
+                PropertyTexturePropertyViewStatus::Valid);
+
+            // Clear the original image data.
+            std::vector<std::byte> emptyData;
+            model.images[model.images.size() - 1].cesium.pixelData.swap(
+                emptyData);
+
+            for (size_t i = 0; i < expected.size(); ++i) {
+              std::vector<uint16_t>& expectedArray = expected[i];
+              glm::dvec2& uv = texCoords[i];
+              PropertyArrayView<uint16_t> array =
+                  propertyValue.getRaw(uv[0], uv[1]);
+
+              REQUIRE(
+                  static_cast<size_t>(array.size()) == expectedArray.size());
+              for (int64_t j = 0; j < array.size(); j++) {
+                REQUIRE(array[j] == expectedArray[static_cast<size_t>(j)]);
+              }
+
+              auto maybeArray = propertyValue.get(uv[0], uv[1]);
+              REQUIRE(maybeArray);
+              REQUIRE(
+                  static_cast<size_t>(maybeArray->size()) ==
+                  expectedArray.size());
+              for (int64_t j = 0; j < array.size(); j++) {
+                REQUIRE(
+                    (*maybeArray)[j] == expectedArray[static_cast<size_t>(j)]);
+              }
+            }
+          } else {
+            FAIL("getPropertyView returned PropertyTexturePropertyView of "
+                 "incorrect type for TestClassProperty.");
+          }
+        },
+        options);
+
+    REQUIRE(invokedCallbackCount == 1);
+  }
 }
 
 TEST_CASE("Test callback for array PropertyTextureProperty (normalized)") {
@@ -2149,49 +2878,110 @@ TEST_CASE("Test callback for array PropertyTextureProperty (normalized)") {
       glm::dvec2(0, 0.5),
       glm::dvec2(0.5, 0.5)};
 
-  uint32_t invokedCallbackCount = 0;
-  view.getPropertyView(
-      "TestClassProperty",
-      [&expected, &texCoords, &invokedCallbackCount](
-          const std::string& /*propertyId*/,
-          auto propertyValue) mutable {
-        invokedCallbackCount++;
-        if constexpr (
-            std::is_same_v<
-                PropertyTexturePropertyView<PropertyArrayView<uint16_t>, true>,
-                decltype(propertyValue)>) {
-          REQUIRE(
-              propertyValue.status() ==
-              PropertyTexturePropertyViewStatus::Valid);
-
-          for (size_t i = 0; i < expected.size(); ++i) {
-            std::vector<uint16_t>& expectedArray = expected[i];
-            glm::dvec2& uv = texCoords[i];
-            PropertyArrayView<uint16_t> array =
-                propertyValue.getRaw(uv[0], uv[1]);
-
-            REQUIRE(static_cast<size_t>(array.size()) == expectedArray.size());
-            for (int64_t j = 0; j < array.size(); j++) {
-              REQUIRE(array[j] == expectedArray[static_cast<size_t>(j)]);
-            }
-
-            auto maybeArray = propertyValue.get(uv[0], uv[1]);
-            REQUIRE(maybeArray);
+  SECTION("Works") {
+    uint32_t invokedCallbackCount = 0;
+    view.getPropertyView(
+        "TestClassProperty",
+        [&expected, &texCoords, &invokedCallbackCount](
+            const std::string& /*propertyId*/,
+            auto propertyValue) mutable {
+          invokedCallbackCount++;
+          if constexpr (std::is_same_v<
+                            PropertyTexturePropertyView<
+                                PropertyArrayView<uint16_t>,
+                                true>,
+                            decltype(propertyValue)>) {
             REQUIRE(
-                static_cast<size_t>(maybeArray->size()) ==
-                expectedArray.size());
-            for (int64_t j = 0; j < array.size(); j++) {
-              auto rawValue = expectedArray[static_cast<size_t>(j)];
-              REQUIRE((*maybeArray)[j] == normalize(rawValue));
-            }
-          }
-        } else {
-          FAIL("getPropertyView returned PropertyTexturePropertyView of "
-               "incorrect type for TestClassProperty.");
-        }
-      });
+                propertyValue.status() ==
+                PropertyTexturePropertyViewStatus::Valid);
 
-  REQUIRE(invokedCallbackCount == 1);
+            for (size_t i = 0; i < expected.size(); ++i) {
+              std::vector<uint16_t>& expectedArray = expected[i];
+              glm::dvec2& uv = texCoords[i];
+              PropertyArrayView<uint16_t> array =
+                  propertyValue.getRaw(uv[0], uv[1]);
+
+              REQUIRE(
+                  static_cast<size_t>(array.size()) == expectedArray.size());
+              for (int64_t j = 0; j < array.size(); j++) {
+                REQUIRE(array[j] == expectedArray[static_cast<size_t>(j)]);
+              }
+
+              auto maybeArray = propertyValue.get(uv[0], uv[1]);
+              REQUIRE(maybeArray);
+              REQUIRE(
+                  static_cast<size_t>(maybeArray->size()) ==
+                  expectedArray.size());
+              for (int64_t j = 0; j < array.size(); j++) {
+                auto rawValue = expectedArray[static_cast<size_t>(j)];
+                REQUIRE((*maybeArray)[j] == normalize(rawValue));
+              }
+            }
+          } else {
+            FAIL("getPropertyView returned PropertyTexturePropertyView of "
+                 "incorrect type for TestClassProperty.");
+          }
+        });
+
+    REQUIRE(invokedCallbackCount == 1);
+  }
+
+  SECTION("Works with options") {
+    TextureViewOptions options;
+    options.makeImageCopy = true;
+
+    uint32_t invokedCallbackCount = 0;
+    view.getPropertyView(
+        "TestClassProperty",
+        [&expected, &texCoords, &invokedCallbackCount, &model](
+            const std::string& /*propertyId*/,
+            auto propertyValue) mutable {
+          invokedCallbackCount++;
+          if constexpr (std::is_same_v<
+                            PropertyTexturePropertyView<
+                                PropertyArrayView<uint16_t>,
+                                true>,
+                            decltype(propertyValue)>) {
+            REQUIRE(
+                propertyValue.status() ==
+                PropertyTexturePropertyViewStatus::Valid);
+
+            // Clear the original image data.
+            std::vector<std::byte> emptyData;
+            model.images[model.images.size() - 1].cesium.pixelData.swap(
+                emptyData);
+
+            for (size_t i = 0; i < expected.size(); ++i) {
+              std::vector<uint16_t>& expectedArray = expected[i];
+              glm::dvec2& uv = texCoords[i];
+              PropertyArrayView<uint16_t> array =
+                  propertyValue.getRaw(uv[0], uv[1]);
+
+              REQUIRE(
+                  static_cast<size_t>(array.size()) == expectedArray.size());
+              for (int64_t j = 0; j < array.size(); j++) {
+                REQUIRE(array[j] == expectedArray[static_cast<size_t>(j)]);
+              }
+
+              auto maybeArray = propertyValue.get(uv[0], uv[1]);
+              REQUIRE(maybeArray);
+              REQUIRE(
+                  static_cast<size_t>(maybeArray->size()) ==
+                  expectedArray.size());
+              for (int64_t j = 0; j < array.size(); j++) {
+                auto rawValue = expectedArray[static_cast<size_t>(j)];
+                REQUIRE((*maybeArray)[j] == normalize(rawValue));
+              }
+            }
+          } else {
+            FAIL("getPropertyView returned PropertyTexturePropertyView of "
+                 "incorrect type for TestClassProperty.");
+          }
+        },
+        options);
+
+    REQUIRE(invokedCallbackCount == 1);
+  }
 }
 
 TEST_CASE("Test callback on unsupported PropertyTextureProperty") {


### PR DESCRIPTION
This change looks a lot more intense than I intended to be, but here's a summary:

- Created `TextureView` base class that `FeatureIdTextureView` and `PropertyTexturePropertyView` now inherit from. This is copy pasting the common code from both implementations.
- Added `TextureViewOptions`, which includes the `applyKhrTextureTransform` flag from a previous PR. But now it includes `makeImageCopy`, which makes a CPU copy of the input image if true.
- Added unit tests for the new options.