### PR TITLE
Add some new bounding volume related helper functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### ? - ?
+
+##### Additions :tada:
+
+- Added overloads of `ImplicitTilingUtilities::computeBoundingVolume` taking a `Cesium3DTiles::BoundingVolume`.
+- Added overloads of `ImplicitTilingUtilities::computeBoundingVolume` taking an `S2CellBoundingVolume` and an `OctreeTileID`. Previously only `QuadtreeTileID` was supported.
+- Added `setOrientedBoundingBox`, `setBoundingRegion`, `setBoundingSphere`, and `setS2CellBoundingVolume` functions to `TileBoundingVolumes`.
+
 ### v0.33.0 - 2024-03-01
 
 ##### Breaking Changes :mega:

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/ImplicitTilingUtilities.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/ImplicitTilingUtilities.h
@@ -16,6 +16,10 @@ namespace CesiumGeometry {
 class OrientedBoundingBox;
 }
 
+namespace Cesium3DTiles {
+struct BoundingVolume;
+}
+
 namespace Cesium3DTilesContent {
 
 /**
@@ -289,6 +293,30 @@ public:
 
   /**
    * @brief Computes the bounding volume for an implicit quadtree tile with the
+   * given ID as a {@link Cesium3DTiles::BoundingVolume}.
+   *
+   * @param rootBoundingVolume The bounding volume of the root tile.
+   * @param tileID The tile ID for which to compute the bounding volume.
+   * @return The bounding volume for the given implicit tile.
+   */
+  static Cesium3DTiles::BoundingVolume computeBoundingVolume(
+      const Cesium3DTiles::BoundingVolume& rootBoundingVolume,
+      const CesiumGeometry::QuadtreeTileID& tileID) noexcept;
+
+  /**
+   * @brief Computes the bounding volume for an implicit octree tile with the
+   * given ID as a {@link Cesium3DTiles::BoundingVolume}.
+   *
+   * @param rootBoundingVolume The bounding volume of the root tile.
+   * @param tileID The tile ID for which to compute the bounding volume.
+   * @return The bounding volume for the given implicit tile.
+   */
+  static Cesium3DTiles::BoundingVolume computeBoundingVolume(
+      const Cesium3DTiles::BoundingVolume& rootBoundingVolume,
+      const CesiumGeometry::OctreeTileID& tileID) noexcept;
+
+  /**
+   * @brief Computes the bounding volume for an implicit quadtree tile with the
    * given ID as a bounding region.
    *
    * @param rootBoundingVolume The bounding region of the root tile.
@@ -346,6 +374,18 @@ public:
   static CesiumGeospatial::S2CellBoundingVolume computeBoundingVolume(
       const CesiumGeospatial::S2CellBoundingVolume& rootBoundingVolume,
       const CesiumGeometry::QuadtreeTileID& tileID) noexcept;
+
+  /**
+   * @brief Computes the bounding volume for an implicit octree tile
+   * with the given ID as an S2 cell bounding volume.
+   *
+   * @param rootBoundingVolume The S2 cell bounding volume of the root tile.
+   * @param tileID The tile ID for which to compute the S2 cell bounding volume.
+   * @return The S2 cell bounding volume for the given implicit tile.
+   */
+  static CesiumGeospatial::S2CellBoundingVolume computeBoundingVolume(
+      const CesiumGeospatial::S2CellBoundingVolume& rootBoundingVolume,
+      const CesiumGeometry::OctreeTileID& tileID) noexcept;
 };
 
 } // namespace Cesium3DTilesContent

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/TileBoundingVolumes.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/TileBoundingVolumes.h
@@ -31,6 +31,19 @@ public:
   getOrientedBoundingBox(const Cesium3DTiles::BoundingVolume& boundingVolume);
 
   /**
+   * @brief Sets the `box` property in a {@link Cesium3DTiles::BoundingVolume}
+   * based on an {@link CesiumGeometry::OrientedBoundingBox}.
+   *
+   * Other bounding volume types, if any, are not modified.
+   *
+   * @param boundingVolume The bounding volume to set.
+   * @param boundingBox The bounding box with which to set the property.
+   */
+  static void setOrientedBoundingBox(
+      Cesium3DTiles::BoundingVolume& boundingVolume,
+      const CesiumGeometry::OrientedBoundingBox& boundingBox);
+
+  /**
    * @brief Gets the bounding region defined in a
    * {@link Cesium3DTiles::BoundingVolume}, if any.
    *
@@ -42,6 +55,19 @@ public:
   getBoundingRegion(const Cesium3DTiles::BoundingVolume& boundingVolume);
 
   /**
+   * @brief Sets the `region` property in a {@link Cesium3DTiles::BoundingVolume}
+   * based on a {@link CesiumGeospatial::BoundingRegion}.
+   *
+   * Other bounding volume types, if any, are not modified.
+   *
+   * @param boundingVolume The bounding volume to set.
+   * @param boundingRegion The bounding region with which to set the property.
+   */
+  static void setBoundingRegion(
+      Cesium3DTiles::BoundingVolume& boundingVolume,
+      const CesiumGeospatial::BoundingRegion& boundingRegion);
+
+  /**
    * @brief Gets the bounding sphere defined in a
    * {@link Cesium3DTiles::BoundingVolume}, if any.
    *
@@ -51,6 +77,19 @@ public:
    */
   static std::optional<CesiumGeometry::BoundingSphere>
   getBoundingSphere(const Cesium3DTiles::BoundingVolume& boundingVolume);
+
+  /**
+   * @brief Sets the `sphere` property in a {@link Cesium3DTiles::BoundingVolume}
+   * based on a {@link CesiumGeometry::BoundingSphere}.
+   *
+   * Other bounding volume types, if any, are not modified.
+   *
+   * @param boundingVolume The bounding volume to set.
+   * @param boundingSphere The bounding sphere with which to set the property.
+   */
+  static void setBoundingSphere(
+      Cesium3DTiles::BoundingVolume& boundingVolume,
+      const CesiumGeometry::BoundingSphere& boundingSphere);
 
   /**
    * @brief Gets the S2 cell bounding volume defined in the
@@ -65,6 +104,21 @@ public:
    */
   static std::optional<CesiumGeospatial::S2CellBoundingVolume>
   getS2CellBoundingVolume(const Cesium3DTiles::BoundingVolume& boundingVolume);
+
+  /**
+   * @brief Adds the `3DTILES_bounding_volume_S2` extension to a
+   * {@link Cesium3DTiles::BoundingVolume} based on a
+   * {@link CesiumGeospatial::S2CellBoundingVolume}.
+   *
+   * Other bounding volume types, if any, are not modified.
+   *
+   * @param boundingVolume The bounding volume to set.
+   * @param s2BoundingVolume The S2 bounding volume with which to set the
+   * property.
+   */
+  static void setS2CellBoundingVolume(
+      Cesium3DTiles::BoundingVolume& boundingVolume,
+      const CesiumGeospatial::S2CellBoundingVolume& s2BoundingVolume);
 };
 
 } // namespace Cesium3DTilesContent

--- a/Cesium3DTilesContent/src/TileBoundingVolumes.cpp
+++ b/Cesium3DTilesContent/src/TileBoundingVolumes.cpp
@@ -19,6 +19,26 @@ std::optional<OrientedBoundingBox> TileBoundingVolumes::getOrientedBoundingBox(
       glm::dmat3(a[3], a[4], a[5], a[6], a[7], a[8], a[9], a[10], a[11]));
 }
 
+void TileBoundingVolumes::setOrientedBoundingBox(
+    Cesium3DTiles::BoundingVolume& boundingVolume,
+    const CesiumGeometry::OrientedBoundingBox& boundingBox) {
+  const glm::dvec3& center = boundingBox.getCenter();
+  const glm::dmat3& halfAxes = boundingBox.getHalfAxes();
+  boundingVolume.box = {
+      center.x,
+      center.y,
+      center.z,
+      halfAxes[0].x,
+      halfAxes[0].y,
+      halfAxes[0].z,
+      halfAxes[1].x,
+      halfAxes[1].y,
+      halfAxes[1].z,
+      halfAxes[2].x,
+      halfAxes[2].y,
+      halfAxes[2].z};
+}
+
 std::optional<BoundingRegion>
 TileBoundingVolumes::getBoundingRegion(const BoundingVolume& boundingVolume) {
   if (boundingVolume.region.size() < 6)
@@ -31,6 +51,20 @@ TileBoundingVolumes::getBoundingRegion(const BoundingVolume& boundingVolume) {
       a[5]);
 }
 
+void TileBoundingVolumes::setBoundingRegion(
+    Cesium3DTiles::BoundingVolume& boundingVolume,
+    const CesiumGeospatial::BoundingRegion& boundingRegion) {
+  const CesiumGeospatial::GlobeRectangle& rectangle =
+      boundingRegion.getRectangle();
+  boundingVolume.region = {
+      rectangle.getWest(),
+      rectangle.getSouth(),
+      rectangle.getEast(),
+      rectangle.getNorth(),
+      boundingRegion.getMinimumHeight(),
+      boundingRegion.getMaximumHeight()};
+}
+
 std::optional<BoundingSphere>
 TileBoundingVolumes::getBoundingSphere(const BoundingVolume& boundingVolume) {
   if (boundingVolume.sphere.size() < 4)
@@ -38,6 +72,14 @@ TileBoundingVolumes::getBoundingSphere(const BoundingVolume& boundingVolume) {
 
   const std::vector<double>& a = boundingVolume.sphere;
   return CesiumGeometry::BoundingSphere(glm::dvec3(a[0], a[1], a[2]), a[3]);
+}
+
+void TileBoundingVolumes::setBoundingSphere(
+    Cesium3DTiles::BoundingVolume& boundingVolume,
+    const CesiumGeometry::BoundingSphere& boundingSphere) {
+  const glm::dvec3& center = boundingSphere.getCenter();
+  boundingVolume
+      .sphere = {center.x, center.y, center.z, boundingSphere.getRadius()};
 }
 
 std::optional<S2CellBoundingVolume>
@@ -52,6 +94,16 @@ TileBoundingVolumes::getS2CellBoundingVolume(
       CesiumGeospatial::S2CellID::fromToken(pExtension->token),
       pExtension->minimumHeight,
       pExtension->maximumHeight);
+}
+
+void TileBoundingVolumes::setS2CellBoundingVolume(
+    Cesium3DTiles::BoundingVolume& boundingVolume,
+    const CesiumGeospatial::S2CellBoundingVolume& s2BoundingVolume) {
+  Extension3dTilesBoundingVolumeS2& extension =
+      boundingVolume.addExtension<Extension3dTilesBoundingVolumeS2>();
+  extension.token = s2BoundingVolume.getCellID().toToken();
+  extension.minimumHeight = s2BoundingVolume.getMinimumHeight();
+  extension.maximumHeight = s2BoundingVolume.getMaximumHeight();
 }
 
 } // namespace Cesium3DTilesContent

--- a/Cesium3DTilesContent/test/TestImplicitTilingUtilities.cpp
+++ b/Cesium3DTilesContent/test/TestImplicitTilingUtilities.cpp
@@ -1,4 +1,6 @@
+#include <Cesium3DTiles/BoundingVolume.h>
 #include <Cesium3DTilesContent/ImplicitTilingUtilities.h>
+#include <Cesium3DTilesContent/TileBoundingVolumes.h>
 #include <CesiumGeometry/OrientedBoundingBox.h>
 #include <CesiumGeospatial/BoundingRegion.h>
 #include <CesiumGeospatial/S2CellBoundingVolume.h>
@@ -8,9 +10,10 @@
 
 #include <algorithm>
 
+using namespace Cesium3DTiles;
+using namespace Cesium3DTilesContent;
 using namespace CesiumGeometry;
 using namespace CesiumGeospatial;
-using namespace Cesium3DTilesContent;
 
 TEST_CASE("ImplicitTilingUtilities child tile iteration") {
   SECTION("QuadtreeTileID") {
@@ -374,6 +377,163 @@ TEST_CASE("ImplicitTilingUtilities::computeBoundingVolume") {
           S2CellID::fromQuadtreeTileID(1, QuadtreeTileID(1, 0, 1)).getID());
       CHECK(l1x0y1.getMinimumHeight() == 10.0);
       CHECK(l1x0y1.getMaximumHeight() == 20.0);
+    }
+
+    SECTION("octree") {
+      S2CellBoundingVolume root(
+          S2CellID::fromQuadtreeTileID(1, QuadtreeTileID(0, 0, 0)),
+          10.0,
+          20.0);
+
+      S2CellBoundingVolume l1x0y0z0 =
+          ImplicitTilingUtilities::computeBoundingVolume(
+              root,
+              OctreeTileID(1, 0, 0, 0));
+      CHECK(l1x0y0z0.getCellID().getFace() == 1);
+      CHECK(
+          l1x0y0z0.getCellID().getID() ==
+          S2CellID::fromQuadtreeTileID(1, QuadtreeTileID(1, 0, 0)).getID());
+      CHECK(l1x0y0z0.getMinimumHeight() == 10.0);
+      CHECK(l1x0y0z0.getMaximumHeight() == 15.0);
+
+      S2CellBoundingVolume l1x1y0z0 =
+          ImplicitTilingUtilities::computeBoundingVolume(
+              root,
+              OctreeTileID(1, 1, 0, 0));
+      CHECK(l1x1y0z0.getCellID().getFace() == 1);
+      CHECK(
+          l1x1y0z0.getCellID().getID() ==
+          S2CellID::fromQuadtreeTileID(1, QuadtreeTileID(1, 1, 0)).getID());
+      CHECK(l1x1y0z0.getMinimumHeight() == 10.0);
+      CHECK(l1x1y0z0.getMaximumHeight() == 15.0);
+
+      S2CellBoundingVolume l1x0y1z0 =
+          ImplicitTilingUtilities::computeBoundingVolume(
+              root,
+              OctreeTileID(1, 0, 1, 0));
+      CHECK(l1x0y1z0.getCellID().getFace() == 1);
+      CHECK(
+          l1x0y1z0.getCellID().getID() ==
+          S2CellID::fromQuadtreeTileID(1, QuadtreeTileID(1, 0, 1)).getID());
+      CHECK(l1x0y1z0.getMinimumHeight() == 10.0);
+      CHECK(l1x0y1z0.getMaximumHeight() == 15.0);
+
+      S2CellBoundingVolume l1x0y0z1 =
+          ImplicitTilingUtilities::computeBoundingVolume(
+              root,
+              OctreeTileID(1, 0, 0, 1));
+      CHECK(l1x0y0z1.getCellID().getFace() == 1);
+      CHECK(
+          l1x0y0z1.getCellID().getID() ==
+          S2CellID::fromQuadtreeTileID(1, QuadtreeTileID(1, 0, 0)).getID());
+      CHECK(l1x0y0z1.getMinimumHeight() == 15.0);
+      CHECK(l1x0y0z1.getMaximumHeight() == 20.0);
+    }
+  }
+
+  SECTION("BoundingVolume") {
+    SECTION("quadtree") {
+      BoundingVolume root{};
+
+      TileBoundingVolumes::setOrientedBoundingBox(
+          root,
+          OrientedBoundingBox(glm::dvec3(1.0, 2.0, 3.0), glm::dmat3(10.0)));
+      TileBoundingVolumes::setBoundingRegion(
+          root,
+          BoundingRegion(GlobeRectangle(1.0, 2.0, 3.0, 4.0), 10.0, 20.0));
+      TileBoundingVolumes::setS2CellBoundingVolume(
+          root,
+          S2CellBoundingVolume(
+              S2CellID::fromQuadtreeTileID(1, QuadtreeTileID(0, 0, 0)),
+              10.0,
+              20.0));
+
+      BoundingVolume l1x0y0 = ImplicitTilingUtilities::computeBoundingVolume(
+          root,
+          QuadtreeTileID(1, 0, 0));
+      std::optional<OrientedBoundingBox> maybeBox =
+          TileBoundingVolumes::getOrientedBoundingBox(l1x0y0);
+      REQUIRE(maybeBox);
+      CHECK(maybeBox->getCenter() == glm::dvec3(-4.0, -3.0, 3.0));
+      CHECK(maybeBox->getLengths() == glm::dvec3(10.0, 10.0, 20.0));
+
+      BoundingVolume l1x1y0 = ImplicitTilingUtilities::computeBoundingVolume(
+          root,
+          QuadtreeTileID(1, 1, 0));
+      std::optional<BoundingRegion> maybeRegion =
+          TileBoundingVolumes::getBoundingRegion(l1x1y0);
+      REQUIRE(maybeRegion);
+      CHECK(maybeRegion->getRectangle().getWest() == 2.0);
+      CHECK(maybeRegion->getRectangle().getSouth() == 2.0);
+      CHECK(maybeRegion->getRectangle().getEast() == 3.0);
+      CHECK(maybeRegion->getRectangle().getNorth() == 3.0);
+      CHECK(maybeRegion->getMinimumHeight() == 10.0);
+      CHECK(maybeRegion->getMaximumHeight() == 20.0);
+
+      BoundingVolume l1x0y1 = ImplicitTilingUtilities::computeBoundingVolume(
+          root,
+          QuadtreeTileID(1, 0, 1));
+      std::optional<S2CellBoundingVolume> maybeS2 =
+          TileBoundingVolumes::getS2CellBoundingVolume(l1x0y1);
+      REQUIRE(maybeS2);
+      CHECK(maybeS2->getCellID().getFace() == 1);
+      CHECK(
+          maybeS2->getCellID().getID() ==
+          S2CellID::fromQuadtreeTileID(1, QuadtreeTileID(1, 0, 1)).getID());
+      CHECK(maybeS2->getMinimumHeight() == 10.0);
+      CHECK(maybeS2->getMaximumHeight() == 20.0);
+    }
+
+    SECTION("octree") {
+      BoundingVolume root{};
+
+      TileBoundingVolumes::setOrientedBoundingBox(
+          root,
+          OrientedBoundingBox(glm::dvec3(1.0, 2.0, 3.0), glm::dmat3(10.0)));
+      TileBoundingVolumes::setBoundingRegion(
+          root,
+          BoundingRegion(GlobeRectangle(1.0, 2.0, 3.0, 4.0), 10.0, 20.0));
+      TileBoundingVolumes::setS2CellBoundingVolume(
+          root,
+          S2CellBoundingVolume(
+              S2CellID::fromQuadtreeTileID(1, QuadtreeTileID(0, 0, 0)),
+              10.0,
+              20.0));
+
+      BoundingVolume l1x0y0 = ImplicitTilingUtilities::computeBoundingVolume(
+          root,
+          OctreeTileID(1, 0, 0, 0));
+      std::optional<OrientedBoundingBox> maybeBox =
+          TileBoundingVolumes::getOrientedBoundingBox(l1x0y0);
+      REQUIRE(maybeBox);
+      CHECK(maybeBox->getCenter() == glm::dvec3(-4.0, -3.0, -2.0));
+      CHECK(maybeBox->getLengths() == glm::dvec3(10.0, 10.0, 10.0));
+
+      BoundingVolume l1x1y0 = ImplicitTilingUtilities::computeBoundingVolume(
+          root,
+          OctreeTileID(1, 1, 0, 0));
+      std::optional<BoundingRegion> maybeRegion =
+          TileBoundingVolumes::getBoundingRegion(l1x1y0);
+      REQUIRE(maybeRegion);
+      CHECK(maybeRegion->getRectangle().getWest() == 2.0);
+      CHECK(maybeRegion->getRectangle().getSouth() == 2.0);
+      CHECK(maybeRegion->getRectangle().getEast() == 3.0);
+      CHECK(maybeRegion->getRectangle().getNorth() == 3.0);
+      CHECK(maybeRegion->getMinimumHeight() == 10.0);
+      CHECK(maybeRegion->getMaximumHeight() == 15.0);
+
+      BoundingVolume l1x0y1 = ImplicitTilingUtilities::computeBoundingVolume(
+          root,
+          OctreeTileID(1, 0, 1, 0));
+      std::optional<S2CellBoundingVolume> maybeS2 =
+          TileBoundingVolumes::getS2CellBoundingVolume(l1x0y1);
+      REQUIRE(maybeS2);
+      CHECK(maybeS2->getCellID().getFace() == 1);
+      CHECK(
+          maybeS2->getCellID().getID() ==
+          S2CellID::fromQuadtreeTileID(1, QuadtreeTileID(1, 0, 1)).getID());
+      CHECK(maybeS2->getMinimumHeight() == 10.0);
+      CHECK(maybeS2->getMaximumHeight() == 15.0);
     }
   }
 }

--- a/Cesium3DTilesContent/test/TestTileBoundingVolumes.cpp
+++ b/Cesium3DTilesContent/test/TestTileBoundingVolumes.cpp
@@ -32,6 +32,10 @@ TEST_CASE("TileBoundingVolumes") {
     CHECK(glm::length(box->getHalfAxes()[0]) == Approx(100.0));
     CHECK(glm::length(box->getHalfAxes()[1]) == Approx(100.0));
     CHECK(glm::length(box->getHalfAxes()[2]) == Approx(10.0));
+
+    BoundingVolume next{};
+    TileBoundingVolumes::setOrientedBoundingBox(next, *box);
+    CHECK(next.box == bv.box);
   }
 
   SECTION("sphere") {
@@ -48,6 +52,10 @@ TEST_CASE("TileBoundingVolumes") {
     CHECK(sphere->getCenter().y == Approx(0.0));
     CHECK(sphere->getCenter().z == Approx(10.0));
     CHECK(sphere->getRadius() == Approx(141.4214));
+
+    BoundingVolume next{};
+    TileBoundingVolumes::setBoundingSphere(next, *sphere);
+    CHECK(next.sphere == bv.sphere);
   }
 
   SECTION("region") {
@@ -72,6 +80,10 @@ TEST_CASE("TileBoundingVolumes") {
     CHECK(region->getRectangle().getNorth() == Approx(0.6988897891));
     CHECK(region->getMinimumHeight() == Approx(0.0));
     CHECK(region->getMaximumHeight() == Approx(20.0));
+
+    BoundingVolume next{};
+    TileBoundingVolumes::setBoundingRegion(next, *region);
+    CHECK(next.region == bv.region);
   }
 
   SECTION("S2") {
@@ -91,6 +103,14 @@ TEST_CASE("TileBoundingVolumes") {
     CHECK(s2->getCellID().getID() == S2CellID::fromToken("89c6c7").getID());
     CHECK(s2->getMinimumHeight() == Approx(0.0));
     CHECK(s2->getMaximumHeight() == Approx(1000.0));
+
+    BoundingVolume next{};
+    TileBoundingVolumes::setS2CellBoundingVolume(next, *s2);
+    Extension3dTilesBoundingVolumeS2* pNextExtension =
+        bv.getExtension<Extension3dTilesBoundingVolumeS2>();
+    CHECK(pNextExtension->token == extension.token);
+    CHECK(pNextExtension->minimumHeight == extension.minimumHeight);
+    CHECK(pNextExtension->maximumHeight == extension.maximumHeight);
   }
 
   SECTION("invalid") {


### PR DESCRIPTION
From the changelog:

- Added overloads of `ImplicitTilingUtilities::computeBoundingVolume` taking a `Cesium3DTiles::BoundingVolume`.
- Added overloads of `ImplicitTilingUtilities::computeBoundingVolume` taking an `S2CellBoundingVolume` and an `OctreeTileID`. Previously only `QuadtreeTileID` was supported.
- Added `setOrientedBoundingBox`, `setBoundingRegion`, `setBoundingSphere`, and `setS2CellBoundingVolume` functions to `TileBoundingVolumes`.

These just round out some useful capabilities for working with implicit tiling and `Cesium3DTiles::BoundingVolume` instances.