### PR TITLE
Add AsyncSystem::waitInMainThread

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Additions :tada:
+
+- Added `waitInMainThread` method to `AsyncSystem`.
+
 ### v0.33.0 - 2024-03-01
 
 ##### Breaking Changes :mega:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Additions :tada:
+
+- Added `waitInMainThread` method to `Future` and `SharedFuture`.
+
 ### v0.34.0 - 2024-04-01
 
 ##### Breaking Changes :mega:
@@ -13,10 +19,6 @@
 - Added overloads of `ImplicitTilingUtilities::computeBoundingVolume` that take a `Cesium3DTiles::BoundingVolume`.
 - Added overloads of `ImplicitTilingUtilities::computeBoundingVolume` that take an `S2CellBoundingVolume` and an `OctreeTileID`. Previously only `QuadtreeTileID` was supported.
 - Added `setOrientedBoundingBox`, `setBoundingRegion`, `setBoundingSphere`, and `setS2CellBoundingVolume` functions to `TileBoundingVolumes`.
-
-##### Additions :tada:
-
-- Added `waitInMainThread` method to `Future` and `SharedFuture`.
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@
 
 ##### Additions :tada:
 
-- Added `waitInMainThread` method to `AsyncSystem`.
+- Added `waitInMainThread` method to `Future` and `SharedFuture`.
 
 ##### Fixes :wrench:
 

--- a/CesiumAsync/include/CesiumAsync/AsyncSystem.h
+++ b/CesiumAsync/include/CesiumAsync/AsyncSystem.h
@@ -269,30 +269,6 @@ public:
   bool dispatchOneMainThreadTask();
 
   /**
-   * @brief Waits for the given future to resolve or reject in the main thread
-   * while also processing main-thread tasks.
-   *
-   * The function does not return until {@link Future::isReady} returns true.
-   * In the meantime, main-thread tasks are processed by calling
-   * {@link dispatchMainThreadTasks} repeatedly. Rather than occupying process
-   * time spin waiting, time slices are given up while waiting by sleeping the
-   * thread for 0ms.
-   *
-   * @return The value if the future resolves successfully.
-   * @throws An exception if the future rejected.
-   */
-  template <typename T> T waitInMainThread(Future<T>&& future) {
-    while (!future.isReady()) {
-      this->dispatchMainThreadTasks();
-      if (future.isReady())
-        break;
-      this->giveUpTimeSlice();
-    }
-
-    return future.wait();
-  }
-
-  /**
    * @brief Creates a new thread pool that can be used to run continuations.
    *
    * @param numberOfThreads The number of threads in the pool.
@@ -345,8 +321,6 @@ private:
                 });
     return Future<std::vector<T>>(this->_pSchedulers, std::move(task));
   }
-
-  void giveUpTimeSlice() const noexcept;
 
   std::shared_ptr<CesiumImpl::AsyncSystemSchedulers> _pSchedulers;
 

--- a/CesiumAsync/include/CesiumAsync/Future.h
+++ b/CesiumAsync/include/CesiumAsync/Future.h
@@ -233,13 +233,31 @@ public:
    * deadlock because the main thread tasks will never complete while this
    * method is blocking the main thread.
    *
-   * To wait in the main thread, use {@link AsyncSystem::waitInMainThread}
-   * instead.
+   * To wait in the main thread, use {@link waitInMainThread} instead.
    *
    * @return The value if the future resolves successfully.
    * @throws An exception if the future rejected.
    */
   T wait() { return this->_task.get(); }
+
+  /**
+   * @brief Waits for this future to resolve or reject in the main thread while
+   * also processing main-thread tasks.
+   *
+   * This method must be called from the main thread.
+   *
+   * The function does not return until {@link Future::isReady} returns true.
+   * In the meantime, main-thread tasks are processed as necessary. This method
+   * does not spin wait; it suspends the calling thread by waiting on a
+   * condition variable when there is no work to do.
+   *
+   * @return The value if the future resolves successfully.
+   * @throws An exception if the future rejected.
+   */
+  T waitInMainThread() {
+    return this->_pSchedulers->mainThread.dispatchUntilTaskCompletes(
+        std::move(this->_task));
+  }
 
   /**
    * @brief Determines if this future is already resolved or rejected.

--- a/CesiumAsync/include/CesiumAsync/Future.h
+++ b/CesiumAsync/include/CesiumAsync/Future.h
@@ -233,6 +233,9 @@ public:
    * deadlock because the main thread tasks will never complete while this
    * method is blocking the main thread.
    *
+   * To wait in the main thread, use {@link AsyncSystem::waitInMainThread}
+   * instead.
+   *
    * @return The value if the future resolves successfully.
    * @throws An exception if the future rejected.
    */

--- a/CesiumAsync/include/CesiumAsync/Impl/QueuedScheduler.h
+++ b/CesiumAsync/include/CesiumAsync/Impl/QueuedScheduler.h
@@ -8,14 +8,55 @@ namespace CesiumImpl {
 
 class QueuedScheduler {
 public:
+  QueuedScheduler();
+  ~QueuedScheduler();
+
   void schedule(async::task_run_handle t);
   void dispatchQueuedContinuations();
   bool dispatchZeroOrOneContinuation();
 
+  template <typename T> T dispatchUntilTaskCompletes(async::task<T>&& task) {
+    // Set up a continuation to unblock the blocking dispatch when this task
+    // completes.
+    async::task<T> unblockTask =
+        task.then(async::inline_scheduler(), [this](auto&& value) {
+          this->unblock();
+          return std::move(value);
+        });
+
+    while (!unblockTask.ready()) {
+      this->dispatchInternal(true);
+    }
+
+    return std::move(unblockTask).get();
+  }
+
+  template <typename T>
+  T dispatchUntilTaskCompletes(const async::shared_task<T>& task) {
+    // Set up a continuation to unblock the blocking dispatch when this task
+    // completes. Unlike the non-shared future case above, we don't need to pass
+    // the future value through because shared_task supports multiple
+    // continuations.
+    async::task<void> unblockTask =
+        task.then(async::inline_scheduler(), [this](const auto&) {
+          this->unblock();
+        });
+
+    while (!task.ready()) {
+      this->dispatchInternal(true);
+    }
+
+    return task.get();
+  }
+
   ImmediateScheduler<QueuedScheduler> immediate{this};
 
 private:
-  async::fifo_scheduler _scheduler;
+  bool dispatchInternal(bool blockIfNoTasks);
+  void unblock();
+
+  struct Impl;
+  std::unique_ptr<Impl> _pImpl;
 };
 
 } // namespace CesiumImpl

--- a/CesiumAsync/include/CesiumAsync/SharedFuture.h
+++ b/CesiumAsync/include/CesiumAsync/SharedFuture.h
@@ -217,6 +217,8 @@ public:
    * deadlock because the main thread tasks will never complete while this
    * method is blocking the main thread.
    *
+   * To wait in the main thread, use {@link waitInMainThread} instead.
+   *
    * @return The value if the future resolves successfully.
    * @throws An exception if the future rejected.
    */
@@ -234,6 +236,25 @@ public:
       std::enable_if_t<std::is_same_v<U, void>, int> = 0>
   void wait() const {
     this->_task.get();
+  }
+
+  /**
+   * @brief Waits for this future to resolve or reject in the main thread while
+   * also processing main-thread tasks.
+   *
+   * This method must be called from the main thread.
+   *
+   * The function does not return until {@link Future::isReady} returns true.
+   * In the meantime, main-thread tasks are processed as necessary. This method
+   * does not spin wait; it suspends the calling thread by waiting on a
+   * condition variable when there is no work to do.
+   *
+   * @return The value if the future resolves successfully.
+   * @throws An exception if the future rejected.
+   */
+  T waitInMainThread() {
+    return this->_pSchedulers->mainThread.dispatchUntilTaskCompletes(
+        std::move(this->_task));
   }
 
   /**

--- a/CesiumAsync/src/AsyncSystem.cpp
+++ b/CesiumAsync/src/AsyncSystem.cpp
@@ -2,8 +2,6 @@
 
 #include "CesiumAsync/ITaskProcessor.h"
 
-#include <thread>
-
 namespace CesiumAsync {
 AsyncSystem::AsyncSystem(
     const std::shared_ptr<ITaskProcessor>& pTaskProcessor) noexcept

--- a/CesiumAsync/src/AsyncSystem.cpp
+++ b/CesiumAsync/src/AsyncSystem.cpp
@@ -3,6 +3,7 @@
 #include "CesiumAsync/ITaskProcessor.h"
 
 #include <future>
+#include <thread>
 
 namespace CesiumAsync {
 AsyncSystem::AsyncSystem(
@@ -29,6 +30,10 @@ bool AsyncSystem::operator==(const AsyncSystem& rhs) const noexcept {
 
 bool AsyncSystem::operator!=(const AsyncSystem& rhs) const noexcept {
   return this->_pSchedulers != rhs._pSchedulers;
+}
+
+void AsyncSystem::giveUpTimeSlice() const noexcept {
+  std::this_thread::sleep_for(std::chrono::duration<double, std::milli>(0.0));
 }
 
 } // namespace CesiumAsync

--- a/CesiumAsync/src/AsyncSystem.cpp
+++ b/CesiumAsync/src/AsyncSystem.cpp
@@ -2,7 +2,6 @@
 
 #include "CesiumAsync/ITaskProcessor.h"
 
-#include <future>
 #include <thread>
 
 namespace CesiumAsync {
@@ -30,10 +29,6 @@ bool AsyncSystem::operator==(const AsyncSystem& rhs) const noexcept {
 
 bool AsyncSystem::operator!=(const AsyncSystem& rhs) const noexcept {
   return this->_pSchedulers != rhs._pSchedulers;
-}
-
-void AsyncSystem::giveUpTimeSlice() const noexcept {
-  std::this_thread::sleep_for(std::chrono::duration<double, std::milli>(0.0));
 }
 
 } // namespace CesiumAsync

--- a/CesiumAsync/src/QueuedScheduler.cpp
+++ b/CesiumAsync/src/QueuedScheduler.cpp
@@ -22,7 +22,7 @@ QueuedScheduler::QueuedScheduler() : _pImpl(std::make_unique<Impl>()) {}
 QueuedScheduler::~QueuedScheduler() = default;
 
 void QueuedScheduler::schedule(async::task_run_handle t) {
-  std::lock_guard<std::mutex> guard(this->_pImpl->mutex);
+  std::unique_lock<std::mutex> guard(this->_pImpl->mutex);
   this->_pImpl->queue.push(std::move(t));
 
   // Notify listeners that there is new work.
@@ -59,7 +59,7 @@ bool QueuedScheduler::dispatchInternal(bool blockIfNoTasks) {
 }
 
 void QueuedScheduler::unblock() {
-  std::lock_guard<std::mutex> guard(this->_pImpl->mutex);
+  std::unique_lock<std::mutex> guard(this->_pImpl->mutex);
   this->_pImpl->conditionVariable.notify_all();
 }
 

--- a/CesiumAsync/src/QueuedScheduler.cpp
+++ b/CesiumAsync/src/QueuedScheduler.cpp
@@ -1,17 +1,66 @@
 #include "CesiumAsync/Impl/QueuedScheduler.h"
 
-using namespace CesiumAsync::CesiumImpl;
+#include <condition_variable>
+#include <mutex>
+
+// Hackily use Async++'s internal fifo_queue. We could copy it instead - it's
+// not much code - but why create the duplication? However, we are assuming that
+// Async++'s source (not just headers) are available while building
+// cesium-native. If that's a problem in some context, we'll need to do that
+// duplication of fifo_queue after all.
+#include <async++/../../src/fifo_queue.h>
+
+namespace CesiumAsync::CesiumImpl {
+
+struct QueuedScheduler::Impl {
+  async::detail::fifo_queue queue;
+  std::mutex mutex;
+  std::condition_variable conditionVariable;
+};
+
+QueuedScheduler::QueuedScheduler() : _pImpl(std::make_unique<Impl>()) {}
+QueuedScheduler::~QueuedScheduler() = default;
 
 void QueuedScheduler::schedule(async::task_run_handle t) {
-  this->_scheduler.schedule(std::move(t));
+  std::lock_guard<std::mutex> guard(this->_pImpl->mutex);
+  this->_pImpl->queue.push(std::move(t));
+
+  // Notify listeners that there is new work.
+  this->_pImpl->conditionVariable.notify_all();
 }
 
 void QueuedScheduler::dispatchQueuedContinuations() {
-  auto scope = this->immediate.scope();
-  this->_scheduler.run_all_tasks();
+  while (this->dispatchZeroOrOneContinuation()) {
+  }
 }
 
 bool QueuedScheduler::dispatchZeroOrOneContinuation() {
-  auto scope = this->immediate.scope();
-  return this->_scheduler.try_run_one_task();
+  return this->dispatchInternal(false);
 }
+
+bool QueuedScheduler::dispatchInternal(bool blockIfNoTasks) {
+  async::task_run_handle t;
+
+  {
+    std::unique_lock<std::mutex> guard(this->_pImpl->mutex);
+    t = this->_pImpl->queue.pop();
+    if (blockIfNoTasks && !t) {
+      this->_pImpl->conditionVariable.wait(guard);
+    }
+  }
+
+  if (t) {
+    auto scope = this->immediate.scope();
+    t.run();
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void QueuedScheduler::unblock() {
+  std::lock_guard<std::mutex> guard(this->_pImpl->mutex);
+  this->_pImpl->conditionVariable.notify_all();
+}
+
+} // namespace CesiumAsync::CesiumImpl

--- a/CesiumAsync/test/TestAsyncSystem.cpp
+++ b/CesiumAsync/test/TestAsyncSystem.cpp
@@ -572,4 +572,16 @@ TEST_CASE("AsyncSystem") {
 
     CHECK(checksCompleted);
   }
+
+  SECTION("waitInMainThread") {
+    bool called = false;
+    auto future =
+        asyncSystem.createResolvedFuture().thenInMainThread([&called]() {
+          called = true;
+          return 4;
+        });
+    int value = asyncSystem.waitInMainThread(std::move(future));
+    CHECK(called);
+    CHECK(value == 4);
+  }
 }


### PR DESCRIPTION
Adds a new method, `waitInMainThread`, to `AsyncSystem`. 

Calling `asyncSystem.waitInMainThread(std::move(future))` is similar to calling `future.wait()`. Both wait for the future to resolve or reject, and then either return the value or throw an exception. `waitInMainThread` _also_ continues to dispatch main thread tasks while waiting, however. This means that it is safe to call from the main thread even if the future has `thenInMainThread` continuations. `future.wait()`, on the other hand, is very likely to deadlock in this situation.
