### PR TITLE
Add `PositionAccessorType` to `AccessorUtility.h`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - Added `IntersectionTests::pointInTriangle`, which tests if a point is inside the triangle specified with 3D coordinates. One overload includes a `barycentricCoordinates` parameter that outputs the barycentric coordinates at that point.
+- Added `PositionAccessorType`, which is a type definition for a position accessor. It can be constructed using `getPositionAccessorView`.
 
 ### v0.33.0 - 2024-03-01
 

--- a/CesiumGltf/include/CesiumGltf/AccessorUtility.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorUtility.h
@@ -37,6 +37,19 @@ struct StatusFromAccessor {
 };
 
 /**
+ * Type definition for position accessor.
+ */
+typedef AccessorView<AccessorTypes::VEC3<float>> PositionAccessorType;
+
+/**
+ * Retrieves an accessor view for the position attribute from the given glTF
+ * primitive and model. This verifies that the accessor is of a valid type. If
+ * not, the returned accessor view will be invalid.
+ */
+PositionAccessorType
+getPositionAccessorView(const Model& model, const MeshPrimitive& primitive);
+
+/**
  * Type definition for all kinds of feature ID attribute accessors.
  */
 typedef std::variant<

--- a/CesiumGltf/src/AccessorUtility.cpp
+++ b/CesiumGltf/src/AccessorUtility.cpp
@@ -3,6 +3,23 @@
 #include "CesiumGltf/Model.h"
 
 namespace CesiumGltf {
+PositionAccessorType
+getPositionAccessorView(const Model& model, const MeshPrimitive& primitive) {
+  auto positionAttribute = primitive.attributes.find("POSITION");
+  if (positionAttribute == primitive.attributes.end()) {
+    return PositionAccessorType();
+  }
+
+  const Accessor* pAccessor =
+      model.getSafe<Accessor>(&model.accessors, primitive.indices);
+  if (!pAccessor || pAccessor->type != Accessor::Type::VEC3 ||
+      pAccessor->componentType != Accessor::ComponentType::FLOAT) {
+    return PositionAccessorType();
+  }
+
+  return PositionAccessorType(model, *pAccessor);
+}
+
 FeatureIdAccessorType getFeatureIdAccessorView(
     const Model& model,
     const MeshPrimitive& primitive,

--- a/CesiumGltf/src/AccessorUtility.cpp
+++ b/CesiumGltf/src/AccessorUtility.cpp
@@ -11,7 +11,7 @@ getPositionAccessorView(const Model& model, const MeshPrimitive& primitive) {
   }
 
   const Accessor* pAccessor =
-      model.getSafe<Accessor>(&model.accessors, primitive.indices);
+      model.getSafe<Accessor>(&model.accessors, positionAttribute->second);
   if (!pAccessor || pAccessor->type != Accessor::Type::VEC3 ||
       pAccessor->componentType != Accessor::ComponentType::FLOAT) {
     return PositionAccessorType();

--- a/CesiumGltf/test/TestAccessorUtility.cpp
+++ b/CesiumGltf/test/TestAccessorUtility.cpp
@@ -81,7 +81,7 @@ TEST_CASE("Test getPositionAccessorView") {
     accessor.bufferView = 0;
     accessor.componentType = Accessor::ComponentType::FLOAT;
     accessor.type = Accessor::Type::VEC3;
-    accessor.count = positions.size();
+    accessor.count = static_cast<int64_t>(positions.size());
   }
 
   Mesh& mesh = model.meshes.emplace_back();
@@ -111,7 +111,6 @@ TEST_CASE("Test getPositionAccessorView") {
   }
 
   SECTION("Creates from valid accessor") {
-    IndexAccessorType indexAccessor = getIndexAccessorView(model, primitive);
     PositionAccessorType positionAccessor =
         getPositionAccessorView(model, primitive);
     REQUIRE(positionAccessor.status() == AccessorViewStatus::Valid);

--- a/CesiumGltf/test/TestAccessorUtility.cpp
+++ b/CesiumGltf/test/TestAccessorUtility.cpp
@@ -57,6 +57,68 @@ TEST_CASE("Test CountFromAccessor") {
   }
 }
 
+TEST_CASE("Test getPositionAccessorView") {
+  Model model;
+  std::vector<glm::vec3> positions{
+      glm::vec3(0, 1, 2),
+      glm::vec3(3, 4, 5),
+      glm::vec3(6, 7, 8)};
+
+  {
+    Buffer& buffer = model.buffers.emplace_back();
+    buffer.cesium.data.resize(positions.size() * sizeof(glm::vec3));
+    std::memcpy(
+        buffer.cesium.data.data(),
+        positions.data(),
+        buffer.cesium.data.size());
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
+
+    BufferView& bufferView = model.bufferViews.emplace_back();
+    bufferView.buffer = 0;
+    bufferView.byteLength = buffer.byteLength;
+
+    Accessor& accessor = model.accessors.emplace_back();
+    accessor.bufferView = 0;
+    accessor.componentType = Accessor::ComponentType::FLOAT;
+    accessor.type = Accessor::Type::VEC3;
+    accessor.count = positions.size();
+  }
+
+  Mesh& mesh = model.meshes.emplace_back();
+  MeshPrimitive primitive = mesh.primitives.emplace_back();
+  primitive.attributes.insert({"POSITION", 0});
+
+  SECTION("Handles invalid accessor type") {
+    model.accessors[0].type = Accessor::Type::SCALAR;
+
+    PositionAccessorType positionAccessor =
+        getPositionAccessorView(model, primitive);
+    REQUIRE(positionAccessor.status() != AccessorViewStatus::Valid);
+    REQUIRE(positionAccessor.size() == 0);
+
+    model.accessors[0].type = Accessor::Type::VEC3;
+  }
+
+  SECTION("Handles unsupported accessor component type") {
+    model.accessors[0].componentType = Accessor::ComponentType::BYTE;
+
+    PositionAccessorType positionAccessor =
+        getPositionAccessorView(model, primitive);
+    REQUIRE(positionAccessor.status() != AccessorViewStatus::Valid);
+    REQUIRE(positionAccessor.size() == 0);
+
+    model.accessors[0].componentType = Accessor::ComponentType::FLOAT;
+  }
+
+  SECTION("Creates from valid accessor") {
+    IndexAccessorType indexAccessor = getIndexAccessorView(model, primitive);
+    PositionAccessorType positionAccessor =
+        getPositionAccessorView(model, primitive);
+    REQUIRE(positionAccessor.status() == AccessorViewStatus::Valid);
+    REQUIRE(static_cast<size_t>(positionAccessor.size()) == positions.size());
+  }
+}
+
 TEST_CASE("Test getFeatureIdAccessorView") {
   Model model;
   std::vector<uint8_t> featureIds0{1, 2, 3, 4};


### PR DESCRIPTION
Depends on #826 so merge that first.

This adds the `PositionAccessorType` typedef to `AccessorUtility.h`, as well as the `getPositionAccessorView` method. Although there's only one possible type of position accessor, it's still helpful to put the construction logic here to avoid duplication in our runtimes.