### PR TITLE
Fix problems with QuantizedMeshLoader-generated glTFs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Change Log
 
+### ? - ?
+
 ### v0.33.0 - 2024-03-01
+
+##### Fixes :wrench:
+
+- `QuantizedMeshLoader` now creates spec-compliant glTFs from a quantized-mesh terrain tile. Previously, the generated glTF had small problems that could confuse some clients.
 
 ##### Breaking Changes :mega:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 ##### Additions :tada:
 
 - Added `TileTransform::setTransform`.
-- 
+
 ##### Fixes :wrench:
 
 - `QuantizedMeshLoader` now creates spec-compliant glTFs from a quantized-mesh terrain tile. Previously, the generated glTF had small problems that could confuse some clients.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,11 @@
 
 ### ? - ?
 
-### v0.33.0 - 2024-03-01
-
 ##### Fixes :wrench:
 
 - `QuantizedMeshLoader` now creates spec-compliant glTFs from a quantized-mesh terrain tile. Previously, the generated glTF had small problems that could confuse some clients.
+
+### v0.33.0 - 2024-03-01
 
 ##### Breaking Changes :mega:
 

--- a/Cesium3DTilesContent/src/QuantizedMeshLoader.cpp
+++ b/Cesium3DTilesContent/src/QuantizedMeshLoader.cpp
@@ -921,6 +921,8 @@ static std::vector<std::byte> generateNormals(
   // create gltf
   CesiumGltf::Model& model = result.model.emplace();
 
+  model.asset.version = "2.0";
+
   CesiumGltf::Material& material = model.materials.emplace_back();
   CesiumGltf::MaterialPBRMetallicRoughness& pbr =
       material.pbrMetallicRoughness.emplace();
@@ -940,6 +942,7 @@ static std::vector<std::byte> generateNormals(
   const size_t positionBufferId = model.buffers.size();
   model.buffers.emplace_back();
   CesiumGltf::Buffer& positionBuffer = model.buffers[positionBufferId];
+  positionBuffer.byteLength = int64_t(outputPositionsBuffer.size());
   positionBuffer.cesium.data = std::move(outputPositionsBuffer);
 
   const size_t positionBufferViewId = model.bufferViews.size();
@@ -970,6 +973,7 @@ static std::vector<std::byte> generateNormals(
     const size_t normalBufferId = model.buffers.size();
     model.buffers.emplace_back();
     CesiumGltf::Buffer& normalBuffer = model.buffers[normalBufferId];
+    normalBuffer.byteLength = int64_t(outputNormalsBuffer.size());
     normalBuffer.cesium.data = std::move(outputNormalsBuffer);
 
     const size_t normalBufferViewId = model.bufferViews.size();
@@ -998,6 +1002,7 @@ static std::vector<std::byte> generateNormals(
   const size_t indicesBufferId = model.buffers.size();
   model.buffers.emplace_back();
   CesiumGltf::Buffer& indicesBuffer = model.buffers[indicesBufferId];
+  indicesBuffer.byteLength = int64_t(outputIndicesBuffer.size());
   indicesBuffer.cesium.data = std::move(outputIndicesBuffer);
 
   const size_t indicesBufferViewId = model.bufferViews.size();
@@ -1007,8 +1012,8 @@ static std::vector<std::byte> generateNormals(
   indicesBufferView.buffer = int32_t(indicesBufferId);
   indicesBufferView.byteOffset = 0;
   indicesBufferView.byteLength = int64_t(indicesBuffer.cesium.data.size());
-  indicesBufferView.byteStride = indexSizeBytes;
-  indicesBufferView.target = CesiumGltf::BufferView::Target::ARRAY_BUFFER;
+  indicesBufferView.target =
+      CesiumGltf::BufferView::Target::ELEMENT_ARRAY_BUFFER;
 
   const size_t indicesAccessorId = model.accessors.size();
   model.accessors.emplace_back();
@@ -1107,6 +1112,11 @@ static std::vector<std::byte> generateNormals(
       center.z,
       -center.y,
       1.0};
+
+  CesiumGltf::Scene& scene = model.scenes.emplace_back();
+  scene.nodes.emplace_back(0);
+
+  model.scene = 0;
 
   result.updatedBoundingVolume =
       BoundingRegion(rectangle, minimumHeight, maximumHeight);

--- a/Cesium3DTilesContent/test/TestQuantizedMeshLoader.cpp
+++ b/Cesium3DTilesContent/test/TestQuantizedMeshLoader.cpp
@@ -678,6 +678,47 @@ static void checkGeneratedGridNormal(
   }
 }
 
+static void checkGltfSanity(const Model& model) {
+  CHECK(model.asset.version == "2.0");
+  REQUIRE(model.scene >= 0);
+  REQUIRE(size_t(model.scene) < model.scenes.size());
+  CHECK(!model.getSafe(model.scenes, model.scene).nodes.empty());
+
+  for (const Buffer& buffer : model.buffers) {
+    CHECK(buffer.byteLength > 0);
+  }
+
+  for (const BufferView& bufferView : model.bufferViews) {
+    CHECK(bufferView.byteLength > 0);
+  }
+
+  for (const Mesh& mesh : model.meshes) {
+    for (const MeshPrimitive& primitive : mesh.primitives) {
+      const Accessor* pIndicesAccessor =
+          model.getSafe(&model.accessors, primitive.indices);
+      REQUIRE(pIndicesAccessor);
+      const BufferView* pIndicesBufferView =
+          model.getSafe(&model.bufferViews, pIndicesAccessor->bufferView);
+      REQUIRE(pIndicesBufferView);
+
+      CHECK(
+          pIndicesBufferView->target ==
+          BufferView::Target::ELEMENT_ARRAY_BUFFER);
+
+      for (const auto& attribute : primitive.attributes) {
+        const Accessor* pAttributeAccessor =
+            model.getSafe(&model.accessors, attribute.second);
+        REQUIRE(pAttributeAccessor);
+        const BufferView* pAttributeBufferView =
+            model.getSafe(&model.bufferViews, pAttributeAccessor->bufferView);
+        REQUIRE(pAttributeBufferView);
+
+        CHECK(pAttributeBufferView->target == BufferView::Target::ARRAY_BUFFER);
+      }
+    }
+  }
+}
+
 TEST_CASE("Test converting quantized mesh to gltf with skirt") {
   registerAllTileContentTypes();
 
@@ -720,6 +761,8 @@ TEST_CASE("Test converting quantized mesh to gltf with skirt") {
         QuantizedMeshLoader::load(tileID, boundingVolume, "url", data, false);
     REQUIRE(!loadResult.errors.hasErrors());
     REQUIRE(loadResult.model != std::nullopt);
+
+    checkGltfSanity(*loadResult.model);
 
     // make sure the gltf is the grid
     const CesiumGltf::Model& model = *loadResult.model;
@@ -792,6 +835,8 @@ TEST_CASE("Test converting quantized mesh to gltf with skirt") {
     REQUIRE(!loadResult.errors.hasErrors());
     REQUIRE(loadResult.model != std::nullopt);
 
+    checkGltfSanity(*loadResult.model);
+
     // make sure the gltf is the grid
     const CesiumGltf::Model& model = *loadResult.model;
     const CesiumGltf::Mesh& mesh = model.meshes.front();
@@ -862,6 +907,8 @@ TEST_CASE("Test converting quantized mesh to gltf with skirt") {
         QuantizedMeshLoader::load(tileID, boundingVolume, "url", data, false);
     REQUIRE(!loadResult.errors.hasErrors());
     REQUIRE(loadResult.model != std::nullopt);
+
+    checkGltfSanity(*loadResult.model);
 
     // make sure the gltf is the grid
     const CesiumGltf::Model& model = *loadResult.model;
@@ -950,6 +997,8 @@ TEST_CASE("Test converting quantized mesh to gltf with skirt") {
         QuantizedMeshLoader::load(tileID, boundingVolume, "url", data, false);
     REQUIRE(!loadResult.errors.hasErrors());
     REQUIRE(loadResult.model != std::nullopt);
+
+    checkGltfSanity(*loadResult.model);
 
     // make sure the gltf has normals
     const CesiumGltf::Model& model = *loadResult.model;

--- a/Cesium3DTilesContent/test/TestQuantizedMeshLoader.cpp
+++ b/Cesium3DTilesContent/test/TestQuantizedMeshLoader.cpp
@@ -686,6 +686,7 @@ static void checkGltfSanity(const Model& model) {
 
   for (const Buffer& buffer : model.buffers) {
     CHECK(buffer.byteLength > 0);
+    CHECK(buffer.byteLength == static_cast<int64_t>(buffer.cesium.data.size()));
   }
 
   for (const BufferView& bufferView : model.bufferViews) {


### PR DESCRIPTION
Before this PR, the glTFs generated from quantized-mesh tiles were technically invalid. Our game engine clients weren't too fussed about these problems, which is why we didn't notice.

Fixed the following problems:

* The `asset.version` field was not set.
* The `byteLength` of the buffers was not set. Most clients just used `cesium.data.size()` anyway.
* The `target` type of the bufferView used to store indices was incorrectly set to `ARRAY_BUFFER` instead of `ELEMENT_ARRAY_BUFFER`.
* The bufferView used to store indices had its `byteStride` property set, which is not allowed.
* The glTF did not have any scenes.