### PR TITLE
Fix `SimplePlanarEllipsoidCurve` when one of the points has a negative height

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+- Fixed a bug where coordinates returned from `SimplePlanarEllipsoidCurve` were inverted if one of the input points had a negative height.
+
 ### v0.33.0 - 2024-03-01
 
 ##### Breaking Changes :mega:

--- a/CesiumGeospatial/src/SimplePlanarEllipsoidCurve.cpp
+++ b/CesiumGeospatial/src/SimplePlanarEllipsoidCurve.cpp
@@ -102,8 +102,7 @@ SimplePlanarEllipsoidCurve::SimplePlanarEllipsoidCurve(
   this->_destinationHeight =
       glm::length(originalDestinationEcef) - glm::length(scaledDestinationEcef);
 
-  this->_sourceDirection =
-      glm::normalize(originalSourceEcef);
+  this->_sourceDirection = glm::normalize(originalSourceEcef);
 }
 
 } // namespace CesiumGeospatial

--- a/CesiumGeospatial/src/SimplePlanarEllipsoidCurve.cpp
+++ b/CesiumGeospatial/src/SimplePlanarEllipsoidCurve.cpp
@@ -95,12 +95,15 @@ SimplePlanarEllipsoidCurve::SimplePlanarEllipsoidCurve(
   this->_rotationAxis = glm::axis(flyQuat);
   this->_totalAngle = glm::angle(flyQuat);
 
-  this->_sourceHeight = glm::length(originalSourceEcef - scaledSourceEcef);
+  // Calculate difference between lengths instead of length between points -
+  // allows for negative source height
+  this->_sourceHeight =
+      glm::length(originalSourceEcef) - glm::length(scaledSourceEcef);
   this->_destinationHeight =
-      glm::length(originalDestinationEcef - scaledDestinationEcef);
+      glm::length(originalDestinationEcef) - glm::length(scaledDestinationEcef);
 
   this->_sourceDirection =
-      glm::normalize(originalSourceEcef - scaledSourceEcef);
+      glm::normalize(originalSourceEcef);
 }
 
 } // namespace CesiumGeospatial

--- a/CesiumGeospatial/test/TestSimplePlanarEllipsoidCurve.cpp
+++ b/CesiumGeospatial/test/TestSimplePlanarEllipsoidCurve.cpp
@@ -23,6 +23,17 @@ const Cartographic philadelphiaLlh(
 const Cartographic
     tokyoLlh(2.4390907007049445, 0.6222806863437318, 283.242432000711);
 
+// A point above New York City
+const glm::dvec3 newYorkCityEcef(
+    1329752.6826922249,
+    -4657851.870887691,
+    4140135.1399898543);
+
+// Times Square in NYC
+// This point is -10 meters below the surface of the ellipsoid (negative height)
+const glm::dvec3
+timesSquareEcef(1334771.9227395034, -4650343.070699833, 4142168.965635141);
+
 TEST_CASE("SimplePlanarEllipsoidCurve::getPosition") {
   SECTION("positions at start and end of curve are identical to input "
           "coordinates") {
@@ -166,6 +177,32 @@ TEST_CASE("SimplePlanarEllipsoidCurve::getPosition") {
         position75Percent.value().height,
         (endHeight - startHeight) * 0.75 + startHeight,
         Math::Epsilon6));
+  }
+
+  // Testing a bug in SimplePlanarEllipsoidCurve where a path from a point with negative height
+  // to one with positive height would give results on the other side of the earth
+  SECTION("should correctly handle points with negative height") {
+    std::optional<SimplePlanarEllipsoidCurve> curve =
+        SimplePlanarEllipsoidCurve::fromEarthCenteredEarthFixedCoordinates(
+            Ellipsoid::WGS84,
+            timesSquareEcef,
+            newYorkCityEcef);
+    std::optional<SimplePlanarEllipsoidCurve> backwardsCurve =
+        SimplePlanarEllipsoidCurve::fromEarthCenteredEarthFixedCoordinates(
+            Ellipsoid::WGS84,
+            newYorkCityEcef,
+            timesSquareEcef);
+
+    CHECK(curve.has_value());
+    const double expectedDistance = glm::distance(timesSquareEcef, newYorkCityEcef);
+    const glm::dvec3 midpoint = curve->getPosition(0.5);
+    const double totalActualDistance = glm::distance(timesSquareEcef, midpoint) +
+                                glm::distance(newYorkCityEcef, midpoint);
+
+    CHECK(Math::equalsEpsilon(
+        expectedDistance,
+        totalActualDistance,
+        Math::Epsilon4));
   }
 }
 

--- a/CesiumGeospatial/test/TestSimplePlanarEllipsoidCurve.cpp
+++ b/CesiumGeospatial/test/TestSimplePlanarEllipsoidCurve.cpp
@@ -186,11 +186,6 @@ TEST_CASE("SimplePlanarEllipsoidCurve::getPosition") {
             Ellipsoid::WGS84,
             timesSquareEcef,
             newYorkCityEcef);
-    std::optional<SimplePlanarEllipsoidCurve> backwardsCurve =
-        SimplePlanarEllipsoidCurve::fromEarthCenteredEarthFixedCoordinates(
-            Ellipsoid::WGS84,
-            newYorkCityEcef,
-            timesSquareEcef);
 
     CHECK(curve.has_value());
     const double expectedDistance =

--- a/CesiumGeospatial/test/TestSimplePlanarEllipsoidCurve.cpp
+++ b/CesiumGeospatial/test/TestSimplePlanarEllipsoidCurve.cpp
@@ -24,15 +24,13 @@ const Cartographic
     tokyoLlh(2.4390907007049445, 0.6222806863437318, 283.242432000711);
 
 // A point above New York City
-const glm::dvec3 newYorkCityEcef(
-    1329752.6826922249,
-    -4657851.870887691,
-    4140135.1399898543);
+const glm::dvec3
+    newYorkCityEcef(1329752.6826922249, -4657851.870887691, 4140135.1399898543);
 
 // Times Square in NYC
 // This point is -10 meters below the surface of the ellipsoid (negative height)
 const glm::dvec3
-timesSquareEcef(1334771.9227395034, -4650343.070699833, 4142168.965635141);
+    timesSquareEcef(1334771.9227395034, -4650343.070699833, 4142168.965635141);
 
 TEST_CASE("SimplePlanarEllipsoidCurve::getPosition") {
   SECTION("positions at start and end of curve are identical to input "
@@ -179,8 +177,9 @@ TEST_CASE("SimplePlanarEllipsoidCurve::getPosition") {
         Math::Epsilon6));
   }
 
-  // Testing a bug in SimplePlanarEllipsoidCurve where a path from a point with negative height
-  // to one with positive height would give results on the other side of the earth
+  // Testing a bug in SimplePlanarEllipsoidCurve where a path from a point with
+  // negative height to one with positive height would give results on the other
+  // side of the earth
   SECTION("should correctly handle points with negative height") {
     std::optional<SimplePlanarEllipsoidCurve> curve =
         SimplePlanarEllipsoidCurve::fromEarthCenteredEarthFixedCoordinates(
@@ -194,10 +193,12 @@ TEST_CASE("SimplePlanarEllipsoidCurve::getPosition") {
             timesSquareEcef);
 
     CHECK(curve.has_value());
-    const double expectedDistance = glm::distance(timesSquareEcef, newYorkCityEcef);
+    const double expectedDistance =
+        glm::distance(timesSquareEcef, newYorkCityEcef);
     const glm::dvec3 midpoint = curve->getPosition(0.5);
-    const double totalActualDistance = glm::distance(timesSquareEcef, midpoint) +
-                                glm::distance(newYorkCityEcef, midpoint);
+    const double totalActualDistance =
+        glm::distance(timesSquareEcef, midpoint) +
+        glm::distance(newYorkCityEcef, midpoint);
 
     CHECK(Math::equalsEpsilon(
         expectedDistance,


### PR DESCRIPTION
The `SimplePlanarEllipsoidCurve` used for flight paths currently doesn't work for paths where the source point is below the surface of the ellipsoid. It currently causes the calculated coordinates to be inverted, giving points on the other side of the earth. This is because the math in `SimplePlanarEllipsoidCurve` first scales the source and destination points to the surface of the ellipsoid, and then assumes that these surface points must be lower in elevation than the original points for the rest of the calculations. This meant that height wasn't calculated correctly, and crucially, `_sourceDirection` was calculated pointing the wrong direction, resulting in the inverted coordinates. I've fixed the math so that it should work the same when points are below the ellipsoid.