### PR TITLE
Fix Tileset::ComputeLoadProgress incorrectly reporting done, when main thread loading exists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
 
 - Fixed a bug in `BoundingVolume::estimateGlobeRectangle` where it returned an incorrect rectangle for boxes and spheres that encompass the entire globe.
 - Fixed an incorrect computation of wrapped texture coordinates in `applySamplerWrapS` and `applySamplerWrapT`.
+- Fixed another corner case where `Tileset::ComputeLoadProgress` can incorrectly report done (100%) before all tiles have finished their main thread loading
 
 ### v0.32.0 - 2024-02-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug where coordinates returned from `SimplePlanarEllipsoidCurve` were inverted if one of the input points had a negative height.
+- Fixed a bug where `Tileset::ComputeLoadProgress` could incorrectly report 100% before all tiles finished their main thread loading.
 
 ### v0.33.0 - 2024-03-01
 
@@ -45,7 +46,6 @@
 
 - Fixed a bug in `BoundingVolume::estimateGlobeRectangle` where it returned an incorrect rectangle for boxes and spheres that encompass the entire globe.
 - Fixed an incorrect computation of wrapped texture coordinates in `applySamplerWrapS` and `applySamplerWrapT`.
-- Fixed another corner case where `Tileset::ComputeLoadProgress` can incorrectly report done (100%) before all tiles have finished their main thread loading
 
 ### v0.32.0 - 2024-02-01
 

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -434,7 +434,8 @@ int32_t Tileset::getNumberOfTilesLoaded() const {
 
 float Tileset::computeLoadProgress() noexcept {
   int32_t queueSizeSum = static_cast<int32_t>(
-      this->_workerThreadLoadQueue.size() + this->_mainThreadLoadQueue.size());
+      this->_updateResult.workerThreadTileLoadQueueLength +
+      this->_updateResult.mainThreadTileLoadQueueLength);
   int32_t numOfTilesLoading =
       this->_pTilesetContentManager->getNumberOfTilesLoading();
   int32_t numOfTilesLoaded =


### PR DESCRIPTION
Fixes performance tests reporting completion times that are a little too early (1 second in some warm cache tests).

Could also fix any bugs in user applications where they use `::computeLoadProgress` to determine loading completion. 
Ex. waiting for loading before taking a screenshot, some parts of the screenshot might not have loaded to final detail

This fixes a bug in the mentioned function, where `this->_workerThreadLoadQueue.size()` is being used to calculate tile completion, but it's always 0, because it is cleared at the end of every `::update_view`. The fix is to use the saved value in `_updateResult`.

Discovered while working on PR #779.

Also relates to PR #733, which has a similar fix. I wouldn't be surprised if this was the original cause, but that PR just happened to fix it too. Regardless, the older PR is still valuable. Counting "tiles kicked" as current progress sounds reasonable.