### PR TITLE
Addressed Include Errors for Linux/GCC Build

### DIFF
--- a/CesiumAsync/include/CesiumAsync/CacheItem.h
+++ b/CesiumAsync/include/CesiumAsync/CacheItem.h
@@ -5,6 +5,7 @@
 
 #include <gsl/span>
 
+#include <cstdint>
 #include <cstddef>
 #include <cstdint>
 #include <ctime>

--- a/CesiumAsync/include/CesiumAsync/IAssetResponse.h
+++ b/CesiumAsync/include/CesiumAsync/IAssetResponse.h
@@ -5,6 +5,7 @@
 
 #include <gsl/span>
 
+#include <cstdint>
 #include <cstddef>
 #include <cstdint>
 #include <map>


### PR DESCRIPTION
Adds the `#include <cstdint>` header to a handful of headers to build successfully on linux. This does not address a similar issue in with the Draco library which is mentioned in the linked issue. I will open a separate PR for that. 

Built with Ubuntu 18.04 w/ gcc 14.0, cmake 3.29

This issue is discussed in https://github.com/CesiumGS/cesium-native/issues/765

Additional note: I need to remove the `-werror` to get this to build successfully. It seems like there are additional issue with some of the sign conversions that throw warnings, however that is not addressed in this PR. 