### PR TITLE
Create AccessorWriter from AccessorView

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ##### Additions :tada:
 
+- Added `AccessorWriter` constructor that takes an `AccessorView`.
 - Added `PositionAccessorType`, which is a type definition for a position accessor. It can be constructed using `getPositionAccessorView`.
 - Added overloads of `IntersectionTests::pointInTriangle` that handle 3D points. One overload includes a `barycentricCoordinates` parameter that outputs the barycentric coordinates at that point.
 - Added overloads of `ImplicitTilingUtilities::computeBoundingVolume` that take a `Cesium3DTiles::BoundingVolume`.

--- a/CesiumGltf/include/CesiumGltf/AccessorWriter.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorWriter.h
@@ -14,6 +14,12 @@ private:
 public:
   AccessorWriter() : _accessor() {}
 
+  /**
+   * @brief Constructs a new instance from an {@link AccessorView}.
+   */
+  AccessorWriter(const AccessorView<T>& accessorView)
+      : _accessor(accessorView) {}
+
   /** @copydoc AccessorView::AccessorView(const
    * uint8_t*,int64_t,int64_t,int64_t) */
   AccessorWriter(uint8_t* pData, int64_t stride, int64_t offset, int64_t size)


### PR DESCRIPTION
Adds an `AccessorWriter` constructor that takes an `AccessorView`.

This is helpful when you have an `AccessorView` but don't have the underlying `Accessor` or index, like if you're using some of the helper functions in `AccessorUtility`.