### PR TITLE
Update generator config to work with updated glTF repo

### DIFF
--- a/CesiumGltf/generated/include/CesiumGltf/ExtensionKhrDracoMeshCompression.h
+++ b/CesiumGltf/generated/include/CesiumGltf/ExtensionKhrDracoMeshCompression.h
@@ -11,7 +11,7 @@
 
 namespace CesiumGltf {
 /**
- * @brief KHR_draco_mesh_compression extension
+ * @brief KHR_draco_mesh_compression glTF Mesh Primitive Extension
  */
 struct CESIUMGLTF_API ExtensionKhrDracoMeshCompression final
     : public CesiumUtility::ExtensibleObject {

--- a/CesiumGltf/generated/include/CesiumGltf/ExtensionMeshPrimitiveKhrMaterialsVariants.h
+++ b/CesiumGltf/generated/include/CesiumGltf/ExtensionMeshPrimitiveKhrMaterialsVariants.h
@@ -11,7 +11,7 @@
 
 namespace CesiumGltf {
 /**
- * @brief KHR_materials_variants mesh primitive extension
+ * @brief KHR_materials_variants glTF Mesh Primitive Extension
  */
 struct CESIUMGLTF_API ExtensionMeshPrimitiveKhrMaterialsVariants final
     : public CesiumUtility::ExtensibleObject {

--- a/tools/generate-classes/glTF.json
+++ b/tools/generate-classes/glTF.json
@@ -27,7 +27,7 @@
     "CESIUM_RTC": {
       "overrideName": "ExtensionCesiumRTC"
     },
-    "KHR_texture_basisu glTF extension": {
+    "KHR_texture_basisu glTF Texture Extension": {
       "overrideName": "ExtensionKhrTextureBasisu"
     },
     "EXT_texture_webp glTF extension": {
@@ -108,16 +108,16 @@
     "No Data Value": {
       "overrideName": "CesiumUtility::JsonValue"
     },
-    "KHR_draco_mesh_compression extension": {
+    "KHR_draco_mesh_compression glTF Mesh Primitive Extension": {
       "overrideName": "ExtensionKhrDracoMeshCompression"
     },
-    "KHR_materials_variants glTF extension": {
+    "KHR_materials_variants glTF Document Extension": {
       "overrideName": "ExtensionModelKhrMaterialsVariants"
     },
-    "KHR_materials_variants mesh primitive extension": {
+    "KHR_materials_variants glTF Mesh Primitive Extension": {
       "overrideName": "ExtensionMeshPrimitiveKhrMaterialsVariants"
     },
-    "KHR_materials_unlit glTF extension": {
+    "KHR_materials_unlit glTF Material Extension": {
       "overrideName": "ExtensionKhrMaterialsUnlit"
     },
     "MAXAR_mesh_variants glTF extension": {
@@ -126,7 +126,7 @@
     "MAXAR_mesh_variants node extension": {
       "overrideName": "ExtensionNodeMaxarMeshVariants"
     },
-    "KHR_texture_transform textureInfo extension": {
+    "KHR_texture_transform glTF TextureInfo Extension": {
       "overrideName": "ExtensionKhrTextureTransform"
     }
   },
@@ -179,7 +179,7 @@
     },
     {
       "extensionName": "KHR_materials_unlit",
-      "schema": "Khronos/KHR_materials_unlit/schema/glTF.KHR_materials_unlit.schema.json",
+      "schema": "Khronos/KHR_materials_unlit/schema/material.KHR_materials_unlit.schema.json",
       "attachTo": [
         "material"
       ]
@@ -215,7 +215,7 @@
     },
     {
       "extensionName": "KHR_texture_transform",
-      "schema": "Khronos/KHR_texture_transform/schema/KHR_texture_transform.textureInfo.schema.json",
+      "schema": "Khronos/KHR_texture_transform/schema/textureInfo.KHR_texture_transform.schema.json",
       "attachTo": [
         "textureInfo",
         "material.occlusionTextureInfo",


### PR DESCRIPTION
After https://github.com/CesiumGS/glTF/pull/65 was merged, the code generator was failing because some of the schema files no longer match the generator configuration. This PR fixes it.

I'm going to merge this immediately because the generator currently doesn't work in main, and these changes are trivial.