### PR TITLE
Add a few helpful functions to `Model` and `GltfUtilities`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,10 @@
 - Added `TileTransform::setTransform`.
 - Added a new `CesiumQuantizedMeshTerrain` library and namespace, containing classes for working with terrain in the `quantized-mesh-1.0` format and its `layer.json` file.
 - Added `waitInMainThread` method to `Future` and `SharedFuture`.
-- Added `addExtensionUsed`, `addExtensionRequired`, `isExtensionUsed`, and `isExtensionRequired` methods to `CesiumGltf::Model`.
+- Added `forEachRootNodeInScene`, `addExtensionUsed`, `addExtensionRequired`, `isExtensionUsed`, and `isExtensionRequired` methods to `CesiumGltf::Model`.
+- Added `getNodeTransform`, `setNodeTransform`, `removeUnusedTextures`, `removeUnusedSamplers`, `removeUnusedImages`, `removeUnusedAccessors`, `removeUnusedBufferViews`, and `compactBuffers` methods to `GltfUtilities`.
+- Added `postprocessGltf` method to `GltfReader`.
+
 
 ##### Fixes :wrench:
 

--- a/CesiumGltf/include/CesiumGltf/Model.h
+++ b/CesiumGltf/include/CesiumGltf/Model.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "CesiumGltf/Library.h"
-#include "CesiumGltf/ModelSpec.h"
+#include <CesiumGltf/Library.h>
+#include <CesiumGltf/ModelSpec.h>
+#include <CesiumUtility/ErrorList.h>
 
 #include <glm/mat4x4.hpp>
 
@@ -22,7 +23,47 @@ struct CESIUMGLTF_API Model : public ModelSpec {
    *
    * @param rhs The model to merge into this one.
    */
-  void merge(Model&& rhs);
+  CesiumUtility::ErrorList merge(Model&& rhs);
+
+  /**
+   * @brief A callback function for {@link forEachPrimitiveInScene}.
+   */
+  typedef void ForEachRootNodeInSceneCallback(Model& gltf, Node& node);
+
+  /**
+   * @brief A callback function for {@link forEachPrimitiveInScene}.
+   */
+  typedef void
+  ForEachRootNodeInSceneConstCallback(const Model& gltf, const Node& node);
+
+  /**
+   * @brief Apply the given callback to the root nodes of the scene.
+   *
+   * If the given `sceneID` is non-negative and exists in the given glTF,
+   * then the given callback will be applied to all nodes of this scene.
+   *
+   * If the given `sceneId` is negative, then the nodes that the callback
+   * will be applied to depends on the structure of the glTF model:
+   *
+   * * If the glTF model has a default scene, then it will
+   *   be applied to all nodes of the default scene.
+   * * Otherwise, it will be applied to all nodes of the the first scene.
+   * * Otherwise (if the glTF model does not contain any scenes), it will
+   *   be applied to the first node.
+   * * Otherwise (if there are no scenes and no nodes), then this method will do
+   *   nothing.
+   *
+   * @param sceneID The scene ID (index)
+   * @param callback The callback to apply
+   */
+  void forEachRootNodeInScene(
+      int sceneID,
+      std::function<ForEachRootNodeInSceneCallback>&& callback);
+
+  /** @copydoc Gltf::forEachRootNodeInScene() */
+  void forEachRootNodeInScene(
+      int sceneID,
+      std::function<ForEachRootNodeInSceneConstCallback>&& callback) const;
 
   /**
    * @brief A callback function for {@link forEachPrimitiveInScene}.

--- a/CesiumGltf/src/Model.cpp
+++ b/CesiumGltf/src/Model.cpp
@@ -1,7 +1,10 @@
 #include "CesiumGltf/Model.h"
 
 #include "CesiumGltf/AccessorView.h"
+#include "CesiumGltf/ExtensionExtMeshFeatures.h"
 #include "CesiumGltf/ExtensionKhrDracoMeshCompression.h"
+#include "CesiumGltf/ExtensionMeshPrimitiveExtStructuralMetadata.h"
+#include "CesiumGltf/ExtensionModelExtStructuralMetadata.h"
 
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtx/norm.hpp>
@@ -9,9 +12,14 @@
 #include <gsl/span>
 
 #include <algorithm>
+#include <charconv>
+
+using namespace CesiumUtility;
 
 namespace CesiumGltf {
+
 namespace {
+
 template <typename T>
 size_t copyElements(std::vector<T>& to, std::vector<T>& from) {
   const size_t out = to.size();
@@ -29,9 +37,24 @@ void updateIndex(int32_t& index, size_t offset) noexcept {
   }
   index += int32_t(offset);
 }
+
+void updateIndex(int64_t& index, size_t offset) noexcept {
+  if (index == -1) {
+    return;
+  }
+  index += int64_t(offset);
+}
+
+void mergeSchemas(
+    Schema& lhs,
+    Schema& rhs,
+    std::map<std::string, std::string>& classNameMap);
+
 } // namespace
 
-void Model::merge(Model&& rhs) {
+ErrorList Model::merge(Model&& rhs) {
+  ErrorList result;
+
   // TODO: we could generate this pretty easily if the glTF JSON schema made
   // it clear which index properties refer to which types of objects.
 
@@ -64,6 +87,83 @@ void Model::merge(Model&& rhs) {
   const size_t firstScene = copyElements(this->scenes, rhs.scenes);
   const size_t firstSkin = copyElements(this->skins, rhs.skins);
   const size_t firstTexture = copyElements(this->textures, rhs.textures);
+
+  size_t firstPropertyTable = 0;
+  size_t firstPropertyTexture = 0;
+  size_t firstPropertyAttribute = 0;
+
+  ExtensionModelExtStructuralMetadata* pRhsMetadata =
+      rhs.getExtension<ExtensionModelExtStructuralMetadata>();
+  if (pRhsMetadata) {
+    ExtensionModelExtStructuralMetadata& metadata =
+        this->addExtension<ExtensionModelExtStructuralMetadata>();
+
+    if (metadata.schemaUri && pRhsMetadata->schemaUri &&
+        *metadata.schemaUri != *pRhsMetadata->schemaUri) {
+      // We can't merge schema URIs. So the thing to do here is download both
+      // schemas and merge them. But for now we're just reporting an error.
+      result.emplaceError("Cannot merge EXT_structural_metadata extensions "
+                          "with different schemaUris.");
+    } else if (pRhsMetadata->schemaUri) {
+      metadata.schemaUri = pRhsMetadata->schemaUri;
+    }
+
+    std::map<std::string, std::string> classNameMap;
+
+    if (metadata.schema && pRhsMetadata->schema) {
+      mergeSchemas(*metadata.schema, *pRhsMetadata->schema, classNameMap);
+    } else if (pRhsMetadata->schema) {
+      metadata.schema = std::move(pRhsMetadata->schema);
+    }
+
+    firstPropertyTable =
+        copyElements(metadata.propertyTables, pRhsMetadata->propertyTables);
+    firstPropertyTexture =
+        copyElements(metadata.propertyTextures, pRhsMetadata->propertyTextures);
+    firstPropertyAttribute = copyElements(
+        metadata.propertyAttributes,
+        pRhsMetadata->propertyAttributes);
+
+    for (size_t i = firstPropertyTable; i < metadata.propertyTables.size();
+         ++i) {
+      PropertyTable& propertyTable = metadata.propertyTables[i];
+      auto it = classNameMap.find(propertyTable.classProperty);
+      if (it != classNameMap.end()) {
+        propertyTable.classProperty = it->second;
+      }
+
+      for (std::pair<const std::string, PropertyTableProperty>& pair :
+           propertyTable.properties) {
+        updateIndex(pair.second.values, firstBufferView);
+        updateIndex(pair.second.arrayOffsets, firstBufferView);
+        updateIndex(pair.second.stringOffsets, firstBufferView);
+      }
+    }
+
+    for (size_t i = firstPropertyTexture; i < metadata.propertyTextures.size();
+         ++i) {
+      PropertyTexture& propertyTexture = metadata.propertyTextures[i];
+      auto it = classNameMap.find(propertyTexture.classProperty);
+      if (it != classNameMap.end()) {
+        propertyTexture.classProperty = it->second;
+      }
+
+      for (std::pair<const std::string, PropertyTextureProperty>& pair :
+           propertyTexture.properties) {
+        updateIndex(pair.second.index, firstTexture);
+      }
+    }
+
+    for (size_t i = firstPropertyAttribute;
+         i < metadata.propertyAttributes.size();
+         ++i) {
+      PropertyAttribute& propertyAttribute = metadata.propertyAttributes[i];
+      auto it = classNameMap.find(propertyAttribute.classProperty);
+      if (it != classNameMap.end()) {
+        propertyAttribute.classProperty = it->second;
+      }
+    }
+  }
 
   // Update the copied indices
   for (size_t i = firstAccessor; i < this->accessors.size(); ++i) {
@@ -121,6 +221,32 @@ void Model::merge(Model&& rhs) {
           primitive.getExtension<ExtensionKhrDracoMeshCompression>();
       if (pDraco) {
         updateIndex(pDraco->bufferView, firstBufferView);
+      }
+
+      ExtensionMeshPrimitiveExtStructuralMetadata* pMetadata =
+          primitive.getExtension<ExtensionMeshPrimitiveExtStructuralMetadata>();
+      if (pMetadata) {
+        for (int64_t& propertyTextureID : pMetadata->propertyTextures) {
+          updateIndex(propertyTextureID, firstPropertyTexture);
+        }
+
+        for (int64_t& propertyAttributeID : pMetadata->propertyAttributes) {
+          updateIndex(propertyAttributeID, firstPropertyAttribute);
+        }
+      }
+
+      ExtensionExtMeshFeatures* pMeshFeatures =
+          primitive.getExtension<ExtensionExtMeshFeatures>();
+      if (pMeshFeatures) {
+        for (FeatureId& featureId : pMeshFeatures->featureIds) {
+          if (featureId.propertyTable) {
+            updateIndex(*featureId.propertyTable, firstPropertyTable);
+          }
+
+          if (featureId.texture) {
+            updateIndex(featureId.texture->index, firstTexture);
+          }
+        }
       }
     }
   }
@@ -215,6 +341,8 @@ void Model::merge(Model&& rhs) {
 
     this->scene = int32_t(this->scenes.size() - 1);
   }
+
+  return result;
 }
 
 namespace {
@@ -253,6 +381,10 @@ void forEachPrimitiveInNodeObject(
       0.0,
       0.0,
       1.0};
+
+  // This should just call GltfUtilities::getNodeTransform, but it can't because
+  // it's in CesiumGltfContent. We should merge these two libraries, but until
+  // then, it's duplicated.
 
   glm::dmat4x4 nodeTransform = transform;
   const std::vector<double>& matrix = node.matrix;
@@ -330,7 +462,61 @@ void forEachPrimitiveInSceneObject(
     }
   }
 }
+
+template <typename TCallback>
+void forEachNodeInSceneObject(
+    const Model& model,
+    const Scene& scene,
+    TCallback& callback) {
+  for (int32_t node : scene.nodes) {
+    const Node* pNode = model.getSafe(&model.nodes, node);
+    if (!pNode)
+      continue;
+
+    callback(model, *pNode);
+  }
+}
+
 } // namespace
+
+void Model::forEachRootNodeInScene(
+    int sceneID,
+    std::function<ForEachRootNodeInSceneCallback>&& callback) {
+  return const_cast<const Model*>(this)->forEachRootNodeInScene(
+      sceneID,
+      [&callback](const Model& gltf_, const Node& node) {
+        callback(const_cast<Model&>(gltf_), const_cast<Node&>(node));
+      });
+}
+
+void Model::forEachRootNodeInScene(
+    int sceneID,
+    std::function<ForEachRootNodeInSceneConstCallback>&& callback) const {
+  if (sceneID >= 0) {
+    // Use the user-specified scene if it exists.
+    if (sceneID < static_cast<int>(this->scenes.size())) {
+      forEachNodeInSceneObject(
+          *this,
+          this->scenes[static_cast<size_t>(sceneID)],
+          callback);
+    }
+  } else if (
+      this->scene >= 0 &&
+      this->scene < static_cast<int32_t>(this->scenes.size())) {
+    // Use the default scene
+    forEachNodeInSceneObject(
+        *this,
+        this->scenes[static_cast<size_t>(this->scene)],
+        callback);
+  } else if (!this->scenes.empty()) {
+    // There's no default, so use the first scene
+    const Scene& defaultScene = this->scenes[0];
+    forEachNodeInSceneObject(*this, defaultScene, callback);
+  } else if (!this->nodes.empty()) {
+    // No scenes at all, use the first node as the root node.
+    callback(*this, this->nodes.front());
+  }
+}
 
 void Model::forEachPrimitiveInScene(
     int sceneID,
@@ -693,5 +879,86 @@ bool Model::isExtensionRequired(
              this->extensionsRequired.end(),
              extensionName) != this->extensionsRequired.end();
 }
+
+namespace {
+
+template <typename T>
+std::string findAvailableName(
+    const std::unordered_map<std::string, T>& map,
+    const std::string& name) {
+  auto it = map.find(name);
+  if (it == map.end())
+    return name;
+
+  // Name already exists in the map, so find a numbered name that doesn't.
+
+  uint64_t number = 1;
+  while (number < std::numeric_limits<uint64_t>::max()) {
+    std::string newName = fmt::format("{}_{}", name, number);
+    it = map.find(newName);
+    if (it == map.end()) {
+      return newName;
+    }
+
+    ++number;
+  }
+
+  // Realistically, this can't happen. It would mean we checked all 2^64
+  // possible names and none of them are available.
+  assert(false);
+  return name;
+}
+
+void mergeSchemas(
+    Schema& lhs,
+    Schema& rhs,
+    std::map<std::string, std::string>& classNameMap) {
+  if (!lhs.name)
+    lhs.name = rhs.name;
+  else if (rhs.name && *lhs.name != *rhs.name)
+    lhs.name.emplace("Merged");
+
+  if (!lhs.description)
+    lhs.description = rhs.description;
+  else if (rhs.description && *lhs.description != *rhs.description)
+    lhs.description.emplace("This is a merged schema created by combining "
+                            "together the schemas from multiple glTFs.");
+
+  if (!lhs.version)
+    lhs.version = rhs.version;
+  else if (rhs.version && *lhs.version != *rhs.version)
+    lhs.version.reset();
+
+  std::map<std::string, std::string> enumNameMap;
+
+  for (std::pair<const std::string, Enum>& pair : rhs.enums) {
+    std::string availableName = findAvailableName(lhs.enums, pair.first);
+    lhs.enums[availableName] = std::move(pair.second);
+    if (availableName != pair.first)
+      enumNameMap.emplace(pair.first, availableName);
+  }
+
+  for (std::pair<const std::string, Class>& pair : rhs.classes) {
+    std::string availableName = findAvailableName(lhs.classes, pair.first);
+    Class& klass = lhs.classes[availableName];
+    klass = std::move(pair.second);
+
+    if (availableName != pair.first)
+      classNameMap.emplace(pair.first, availableName);
+
+    // Remap enum names in class properties.
+    for (std::pair<const std::string, ClassProperty>& propertyPair :
+         klass.properties) {
+      if (propertyPair.second.enumType) {
+        auto it = enumNameMap.find(*propertyPair.second.enumType);
+        if (it != enumNameMap.end()) {
+          propertyPair.second.enumType = it->second;
+        }
+      }
+    }
+  }
+}
+
+} // namespace
 
 } // namespace CesiumGltf

--- a/CesiumGltfContent/include/CesiumGltfContent/GltfUtilities.h
+++ b/CesiumGltfContent/include/CesiumGltfContent/GltfUtilities.h
@@ -22,6 +22,28 @@ namespace CesiumGltfContent {
  */
 struct CESIUMGLTFCONTENT_API GltfUtilities {
   /**
+   * @brief Gets the transformation matrix for a given node.
+   *
+   * This does not incorporate the node's parent's transform in any way.
+   *
+   * @param node The node from which to get the transformation matrix.
+   * @return The transformation matrix, or std::nullopt if the node's
+   * transformation is invalid, such as because it has a matrix with fewer than
+   * 16 elements in it.
+   */
+  static std::optional<glm::dmat4x4>
+  getNodeTransform(const CesiumGltf::Node& node);
+
+  /**
+   * @brief Sets the transformation matrix for a given node.
+   *
+   * @param node The node on which to set the transformation matrix.
+   * @param newTransform The new transformation matrix.
+   */
+  static void
+  setNodeTransform(CesiumGltf::Node& node, const glm::dmat4x4& newTransform);
+
+  /**
    * @brief Applies the glTF's RTC_CENTER, if any, to the given transform.
    *
    * If the glTF has a `CESIUM_RTC` extension, this function will multiply the
@@ -121,5 +143,38 @@ struct CESIUMGLTFCONTENT_API GltfUtilities {
       CesiumGltf::Model& gltf,
       CesiumGltf::Buffer& destination,
       CesiumGltf::Buffer& source);
+
+  static void removeUnusedTextures(
+      CesiumGltf::Model& gltf,
+      const std::vector<int32_t>& extraUsedTextureIndices = {});
+  static void removeUnusedSamplers(
+      CesiumGltf::Model& gltf,
+      const std::vector<int32_t>& extraUsedSamplerIndices = {});
+  static void removeUnusedImages(
+      CesiumGltf::Model& gltf,
+      const std::vector<int32_t>& extraUsedImageIndices = {});
+  static void removeUnusedAccessors(
+      CesiumGltf::Model& gltf,
+      const std::vector<int32_t>& extraUsedAccessorIndices = {});
+  static void removeUnusedBufferViews(
+      CesiumGltf::Model& gltf,
+      const std::vector<int32_t>& extraUsedBufferViewIndices = {});
+
+  /**
+   * @brief Shrink buffers by removing any sections that are not referenced by
+   * any BufferView.
+   *
+   * @param gltf The glTF to modify.
+   */
+  static void compactBuffers(CesiumGltf::Model& gltf);
+
+  /**
+   * @brief Shrink a buffer by removing any sections that are not referenced by
+   * any BufferView.
+   *
+   * @param gltf The glTF to modify.
+   * @param bufferIndex The index of the buffer to compact.
+   */
+  static void compactBuffer(CesiumGltf::Model& gltf, int32_t bufferIndex);
 };
 } // namespace CesiumGltfContent

--- a/CesiumGltfContent/src/GltfUtilities.cpp
+++ b/CesiumGltfContent/src/GltfUtilities.cpp
@@ -2,15 +2,121 @@
 #include <CesiumGeometry/Transforms.h>
 #include <CesiumGeospatial/BoundingRegionBuilder.h>
 #include <CesiumGltf/AccessorView.h>
+#include <CesiumGltf/ExtensionCesiumPrimitiveOutline.h>
 #include <CesiumGltf/ExtensionCesiumRTC.h>
+#include <CesiumGltf/ExtensionCesiumTileEdges.h>
+#include <CesiumGltf/ExtensionExtInstanceFeatures.h>
+#include <CesiumGltf/ExtensionExtMeshFeatures.h>
+#include <CesiumGltf/ExtensionExtMeshGpuInstancing.h>
+#include <CesiumGltf/ExtensionKhrDracoMeshCompression.h>
+#include <CesiumGltf/ExtensionKhrTextureBasisu.h>
+#include <CesiumGltf/ExtensionModelExtStructuralMetadata.h>
+#include <CesiumGltf/ExtensionTextureWebp.h>
+#include <CesiumGltf/FeatureId.h>
 #include <CesiumGltfContent/GltfUtilities.h>
 #include <CesiumGltfContent/SkirtMeshMetadata.h>
 
+#include <glm/gtc/quaternion.hpp>
+
+#include <cstring>
+#include <unordered_set>
 #include <vector>
 
 using namespace CesiumGltf;
 
 namespace CesiumGltfContent {
+
+/*static*/ std::optional<glm::dmat4x4>
+GltfUtilities::getNodeTransform(const CesiumGltf::Node& node) {
+  // clang-format off
+  // This is column-major, just like glm and glTF
+  static constexpr std::array<double, 16> identityMatrix = {
+      1.0, 0.0, 0.0, 0.0,
+      0.0, 1.0, 0.0, 0.0,
+      0.0, 0.0, 1.0, 0.0,
+      0.0, 0.0, 0.0, 1.0};
+  // clang-format on
+
+  const std::vector<double>& matrix = node.matrix;
+
+  if (!node.matrix.empty() && node.matrix.size() < 16) {
+    return std::nullopt;
+  } else if (
+      node.matrix.size() >= 16 &&
+      !std::equal(matrix.begin(), matrix.end(), identityMatrix.begin())) {
+    return glm::dmat4x4(
+        glm::dvec4(matrix[0], matrix[1], matrix[2], matrix[3]),
+        glm::dvec4(matrix[4], matrix[5], matrix[6], matrix[7]),
+        glm::dvec4(matrix[8], matrix[9], matrix[10], matrix[11]),
+        glm::dvec4(matrix[12], matrix[13], matrix[14], matrix[15]));
+  } else if (
+      !node.translation.empty() || !node.rotation.empty() ||
+      !node.scale.empty()) {
+    glm::dmat4x4 translation(1.0);
+    if (node.translation.size() >= 3) {
+      translation[3] = glm::dvec4(
+          node.translation[0],
+          node.translation[1],
+          node.translation[2],
+          1.0);
+    } else if (!node.translation.empty()) {
+      return std::nullopt;
+    }
+
+    glm::dquat rotationQuat(1.0, 0.0, 0.0, 0.0);
+    if (node.rotation.size() >= 4) {
+      rotationQuat[0] = node.rotation[0];
+      rotationQuat[1] = node.rotation[1];
+      rotationQuat[2] = node.rotation[2];
+      rotationQuat[3] = node.rotation[3];
+    } else if (!node.rotation.empty()) {
+      return std::nullopt;
+    }
+
+    glm::dmat4x4 scale(1.0);
+    if (node.scale.size() >= 3) {
+      scale[0].x = node.scale[0];
+      scale[1].y = node.scale[1];
+      scale[2].z = node.scale[2];
+    } else if (!node.scale.empty()) {
+      return std::nullopt;
+    }
+
+    return translation * glm::dmat4x4(rotationQuat) * scale;
+  } else {
+    return glm::dmat4x4(1.0);
+  }
+}
+
+/*static*/ void GltfUtilities::setNodeTransform(
+    CesiumGltf::Node& node,
+    const glm::dmat4x4& newTransform) {
+  // Reset these fields to their default, indicating they're not to be used.
+  node.translation = {0.0, 0.0, 0.0};
+  node.scale = {1.0, 1.0, 1.0};
+  node.rotation = {0, 0.0, 0.0, 1.0};
+
+  const glm::dmat4x4& m = newTransform;
+
+  node.matrix.resize(16);
+  node.matrix[0] = m[0].x;
+  node.matrix[1] = m[0].y;
+  node.matrix[2] = m[0].z;
+  node.matrix[3] = m[0].w;
+  node.matrix[4] = m[1].x;
+  node.matrix[5] = m[1].y;
+  node.matrix[6] = m[1].z;
+  node.matrix[7] = m[1].w;
+  node.matrix[8] = m[2].x;
+  node.matrix[9] = m[2].y;
+  node.matrix[10] = m[2].z;
+  node.matrix[11] = m[2].w;
+  node.matrix[12] = m[3].x;
+  node.matrix[13] = m[3].y;
+  node.matrix[14] = m[3].z;
+  node.matrix[15] = m[3].w;
+}
+
 /*static*/ glm::dmat4x4 GltfUtilities::applyRtcCenter(
     const CesiumGltf::Model& gltf,
     const glm::dmat4x4& rootTransform) {
@@ -189,12 +295,19 @@ GltfUtilities::parseGltfCopyright(const CesiumGltf::Model& gltf) {
   }
 
   // Copy the data to the destination and keep track of where we put it.
+  // Align each bufferView to a 4-byte boundary.
   size_t start = destination.cesium.data.size();
 
-  destination.cesium.data.insert(
-      destination.cesium.data.end(),
-      source.cesium.data.begin(),
-      source.cesium.data.end());
+  size_t alignmentRemainder = start % 4;
+  if (alignmentRemainder != 0) {
+    start += 4 - alignmentRemainder;
+  }
+
+  destination.cesium.data.resize(start + source.cesium.data.size());
+  std::memcpy(
+      destination.cesium.data.data() + start,
+      source.cesium.data.data(),
+      source.cesium.data.size());
 
   source.byteLength = 0;
   source.cesium.data.clear();
@@ -210,6 +323,403 @@ GltfUtilities::parseGltfCopyright(const CesiumGltf::Model& gltf) {
 
     bufferView.buffer = int32_t(destinationIndex);
     bufferView.byteOffset += int64_t(start);
+  }
+}
+
+namespace {
+
+struct VisitTextureIds {
+  template <typename Func> void operator()(Model& gltf, Func&& callback) {
+    // Find textures in materials
+    for (Material& material : gltf.materials) {
+      if (material.emissiveTexture)
+        callback(material.emissiveTexture->index);
+      if (material.normalTexture)
+        callback(material.normalTexture->index);
+      if (material.pbrMetallicRoughness) {
+        if (material.pbrMetallicRoughness->baseColorTexture)
+          callback(material.pbrMetallicRoughness->baseColorTexture->index);
+        if (material.pbrMetallicRoughness->metallicRoughnessTexture)
+          callback(
+              material.pbrMetallicRoughness->metallicRoughnessTexture->index);
+      }
+    }
+
+    // Find textures in metadata
+    for (Mesh& mesh : gltf.meshes) {
+      for (MeshPrimitive& primitive : mesh.primitives) {
+        ExtensionExtMeshFeatures* pMeshFeatures =
+            primitive.getExtension<ExtensionExtMeshFeatures>();
+        if (pMeshFeatures) {
+          for (FeatureId& featureId : pMeshFeatures->featureIds) {
+            if (featureId.texture)
+              callback(featureId.texture->index);
+          }
+        }
+      }
+    }
+
+    ExtensionModelExtStructuralMetadata* pMetadata =
+        gltf.getExtension<ExtensionModelExtStructuralMetadata>();
+    if (pMetadata) {
+      for (PropertyTexture& propertyTexture : pMetadata->propertyTextures) {
+        for (auto& pair : propertyTexture.properties) {
+          callback(pair.second.index);
+        }
+      }
+    }
+  }
+};
+
+struct VisitSamplerIds {
+  template <typename Func> void operator()(Model& gltf, Func&& callback) {
+    // Find samplers in textures
+    for (Texture& texture : gltf.textures) {
+      callback(texture.sampler);
+    }
+  }
+};
+
+// Get a map of old IDs to new ones after all the unused IDs have been
+// removed. A removed ID will map to -1.
+std::vector<int32_t> getIndexMap(const std::vector<bool>& usedIndices) {
+  std::vector<int32_t> indexMap;
+  indexMap.reserve(usedIndices.size());
+
+  int32_t nextIndex = 0;
+  for (size_t i = 0; i < usedIndices.size(); ++i) {
+    if (usedIndices[i]) {
+      indexMap.push_back(nextIndex);
+      ++nextIndex;
+    } else {
+      indexMap.push_back(-1);
+    }
+  }
+
+  return indexMap;
+}
+
+struct VisitImageIds {
+  template <typename Func> void operator()(Model& gltf, Func&& callback) {
+    // Find images in textures
+    for (Texture& texture : gltf.textures) {
+      callback(texture.source);
+
+      ExtensionKhrTextureBasisu* pBasis =
+          texture.getExtension<ExtensionKhrTextureBasisu>();
+      if (pBasis)
+        callback(pBasis->source);
+
+      ExtensionTextureWebp* pWebP =
+          texture.getExtension<ExtensionTextureWebp>();
+      if (pWebP)
+        callback(pWebP->source);
+    }
+  }
+};
+
+struct VisitAccessorIds {
+  template <typename Func> void operator()(Model& gltf, Func&& callback) {
+    for (Mesh& mesh : gltf.meshes) {
+      for (MeshPrimitive& primitive : mesh.primitives) {
+        callback(primitive.indices);
+
+        for (auto& pair : primitive.attributes) {
+          callback(pair.second);
+        }
+
+        ExtensionCesiumTileEdges* pTileEdges =
+            primitive.getExtension<ExtensionCesiumTileEdges>();
+        if (pTileEdges) {
+          callback(pTileEdges->left);
+          callback(pTileEdges->bottom);
+          callback(pTileEdges->right);
+          callback(pTileEdges->top);
+        }
+
+        ExtensionCesiumPrimitiveOutline* pPrimitiveOutline =
+            primitive.getExtension<ExtensionCesiumPrimitiveOutline>();
+        if (pPrimitiveOutline) {
+          callback(pPrimitiveOutline->indices);
+        }
+      }
+    }
+
+    for (Animation& animation : gltf.animations) {
+      for (AnimationSampler& sampler : animation.samplers) {
+        callback(sampler.input);
+        callback(sampler.output);
+      }
+    }
+
+    for (Skin& skin : gltf.skins) {
+      callback(skin.inverseBindMatrices);
+    }
+
+    for (Node& node : gltf.nodes) {
+      ExtensionExtMeshGpuInstancing* pInstancing =
+          node.getExtension<ExtensionExtMeshGpuInstancing>();
+      if (pInstancing) {
+        for (auto& pair : pInstancing->attributes) {
+          callback(pair.second);
+        }
+      }
+    }
+  }
+};
+
+struct VisitBufferViewIds {
+  template <typename Func> void operator()(Model& gltf, Func&& callback) {
+    for (Accessor& accessor : gltf.accessors) {
+      callback(accessor.bufferView);
+
+      if (accessor.sparse) {
+        callback(accessor.sparse->indices.bufferView);
+        callback(accessor.sparse->values.bufferView);
+      }
+    }
+
+    for (Image& image : gltf.images) {
+      callback(image.bufferView);
+    }
+
+    for (Mesh& mesh : gltf.meshes) {
+      for (MeshPrimitive& primitive : mesh.primitives) {
+        ExtensionKhrDracoMeshCompression* pDraco =
+            primitive.getExtension<ExtensionKhrDracoMeshCompression>();
+        if (pDraco) {
+          callback(pDraco->bufferView);
+        }
+      }
+    }
+
+    ExtensionModelExtStructuralMetadata* pMetadata =
+        gltf.getExtension<ExtensionModelExtStructuralMetadata>();
+    if (pMetadata) {
+      for (PropertyTable& propertyTable : pMetadata->propertyTables) {
+        for (auto& pair : propertyTable.properties) {
+          callback(pair.second.values);
+          callback(pair.second.arrayOffsets);
+          callback(pair.second.stringOffsets);
+        }
+      }
+    }
+  }
+};
+
+template <typename T, typename TVisitFunction>
+void removeUnusedElements(
+    Model& gltf,
+    const std::vector<int32_t>& extraUsedIndices,
+    std::vector<T>& elements,
+    TVisitFunction&& visitFunction) {
+  std::vector<bool> usedElements(elements.size(), false);
+
+  for (int32_t index : extraUsedIndices) {
+    if (index >= 0 && size_t(index) < usedElements.size())
+      usedElements[size_t(index)] = true;
+  }
+
+  // Determine which elements are used.
+  visitFunction(gltf, [&usedElements](int32_t elementIndex) {
+    if (elementIndex >= 0 && size_t(elementIndex) < usedElements.size())
+      usedElements[size_t(elementIndex)] = true;
+  });
+
+  // Update the element indices based on the unused indices being removed.
+  std::vector<int32_t> indexMap = getIndexMap(usedElements);
+  visitFunction(gltf, [&indexMap](int32_t& elementIndex) {
+    if (elementIndex >= 0 && size_t(elementIndex) < indexMap.size()) {
+      int32_t newIndex = indexMap[size_t(elementIndex)];
+      assert(newIndex >= 0);
+      elementIndex = newIndex;
+    }
+  });
+
+  // Remove the unused elements.
+  elements.erase(
+      std::remove_if(
+          elements.begin(),
+          elements.end(),
+          [&usedElements, &elements](T& element) {
+            int64_t index = &element - &elements[0];
+            assert(index >= 0 && size_t(index) < usedElements.size());
+            return !usedElements[size_t(index)];
+          }),
+      elements.end());
+}
+
+} // namespace
+
+void GltfUtilities::removeUnusedTextures(
+    Model& gltf,
+    const std::vector<int32_t>& extraUsedTextureIndices) {
+  removeUnusedElements(
+      gltf,
+      extraUsedTextureIndices,
+      gltf.textures,
+      VisitTextureIds());
+}
+
+void GltfUtilities::removeUnusedSamplers(
+    Model& gltf,
+    const std::vector<int32_t>& extraUsedSamplerIndices) {
+  removeUnusedElements(
+      gltf,
+      extraUsedSamplerIndices,
+      gltf.samplers,
+      VisitSamplerIds());
+}
+
+void GltfUtilities::removeUnusedImages(
+    Model& gltf,
+    const std::vector<int32_t>& extraUsedImageIndices) {
+  removeUnusedElements(
+      gltf,
+      extraUsedImageIndices,
+      gltf.images,
+      VisitImageIds());
+}
+
+void GltfUtilities::removeUnusedAccessors(
+    CesiumGltf::Model& gltf,
+    const std::vector<int32_t>& extraUsedAccessorIndices) {
+  removeUnusedElements(
+      gltf,
+      extraUsedAccessorIndices,
+      gltf.accessors,
+      VisitAccessorIds());
+}
+
+void GltfUtilities::removeUnusedBufferViews(
+    CesiumGltf::Model& gltf,
+    const std::vector<int32_t>& extraUsedBufferViewIndices) {
+  removeUnusedElements(
+      gltf,
+      extraUsedBufferViewIndices,
+      gltf.bufferViews,
+      VisitBufferViewIds());
+}
+
+void GltfUtilities::compactBuffers(CesiumGltf::Model& gltf) {
+  for (size_t i = 0;
+       i < gltf.buffers.size() && i < std::numeric_limits<int32_t>::max();
+       ++i) {
+    GltfUtilities::compactBuffer(gltf, int32_t(i));
+  }
+}
+
+namespace {
+
+void deleteBufferRange(
+    CesiumGltf::Model& gltf,
+    int32_t bufferIndex,
+    int64_t start,
+    int64_t end) {
+  Buffer* pBuffer = gltf.getSafe(&gltf.buffers, bufferIndex);
+  if (pBuffer == nullptr)
+    return;
+
+  assert(size_t(pBuffer->byteLength) == pBuffer->cesium.data.size());
+
+  int64_t bytesToRemove = end - start;
+
+  // Adjust bufferView offets for the removed bytes.
+  for (BufferView& bufferView : gltf.bufferViews) {
+    if (bufferView.buffer != bufferIndex)
+      continue;
+
+    // Sanity check that we're not removing a part of the buffer used by this
+    // bufferView.
+    assert(
+        bufferView.byteOffset >= end ||
+        (bufferView.byteOffset + bufferView.byteLength) <= start);
+
+    // If this bufferView starts after the bytes we're removing, adjust the
+    // start position accordingly.
+    if (bufferView.byteOffset >= start) {
+      bufferView.byteOffset -= bytesToRemove;
+    }
+  }
+
+  // Actually remove the bytes from the buffer.
+  pBuffer->byteLength -= bytesToRemove;
+  pBuffer->cesium.data.erase(
+      pBuffer->cesium.data.begin() + start,
+      pBuffer->cesium.data.begin() + end);
+}
+
+} // namespace
+
+void GltfUtilities::compactBuffer(
+    CesiumGltf::Model& gltf,
+    int32_t bufferIndex) {
+  Buffer* pBuffer = gltf.getSafe(&gltf.buffers, bufferIndex);
+  if (!pBuffer)
+    return;
+
+  assert(size_t(pBuffer->byteLength) == pBuffer->cesium.data.size());
+
+  struct BufferRange {
+    int64_t start; // first byte
+    int64_t end;   // one past last byte
+
+    // Order ranges by their start
+    bool operator<(const BufferRange& rhs) { return this->start < rhs.start; }
+  };
+
+  std::vector<BufferRange> usedRanges;
+
+  for (BufferView& bufferView : gltf.bufferViews) {
+    if (bufferView.buffer != bufferIndex)
+      continue;
+
+    int64_t start = bufferView.byteOffset;
+    int64_t end = start + bufferView.byteLength;
+
+    auto it = std::lower_bound(
+        usedRanges.begin(),
+        usedRanges.end(),
+        BufferRange{start, end});
+    it = usedRanges.insert(it, BufferRange{start, end});
+
+    // Check if we can merge with the previous range.
+    if (it != usedRanges.begin()) {
+      auto previousIt = it - 1;
+      if (previousIt->end >= it->start) {
+        // New range overlaps the previous, so combine them.
+        previousIt->end = std::max(previousIt->end, it->end);
+        it = usedRanges.erase(it) - 1;
+      }
+    }
+
+    // Check if we can merge with the next range.
+    auto nextIt = it + 1;
+    if (nextIt != usedRanges.end()) {
+      if (it->end >= nextIt->start) {
+        // New range overlaps the next, so combine them.
+        it->end = std::max(it->end, nextIt->end);
+        it = usedRanges.erase(nextIt) - 1;
+      }
+    }
+  }
+
+  // At this point, any gaps in the usedRanges represent buffer bytes that are
+  // not referenced by any bufferView. Work through it backwards so that we
+  // don't need to update the ranges as we delete unused data from the buffer.
+  BufferRange nextRange{pBuffer->byteLength, pBuffer->byteLength};
+  for (int64_t i = int64_t(usedRanges.size()) - 1; i >= 0; --i) {
+    BufferRange& usedRange = usedRanges[size_t(i)];
+    if (usedRange.end < nextRange.start) {
+      // This is a gap.
+      deleteBufferRange(gltf, bufferIndex, usedRange.end, nextRange.start);
+    }
+    nextRange = usedRange;
+  }
+
+  if (nextRange.start > 0) {
+    // There is a gap at the start of the buffer.
+    deleteBufferRange(gltf, bufferIndex, 0, nextRange.start);
   }
 }
 

--- a/CesiumGltfReader/include/CesiumGltfReader/GltfReader.h
+++ b/CesiumGltfReader/include/CesiumGltfReader/GltfReader.h
@@ -178,6 +178,16 @@ public:
       const GltfReaderOptions& options = GltfReaderOptions()) const;
 
   /**
+   * @brief Performs post-load processing on a glTF. The specific operations
+   * performed are controlled by the provided `options`.
+   *
+   * @param readGltf The result of reading the glTF.
+   * @param options The options to use in post-processing.
+   */
+  void
+  postprocessGltf(GltfReaderResult& readGltf, const GltfReaderOptions& options);
+
+  /**
    * @brief Accepts the result of {@link readGltf} and resolves any remaining
    * external buffers and images.
    *

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -430,8 +430,15 @@ CesiumAsync::Future<GltfReaderResult> GltfReader::loadGltf(
       });
 }
 
-/*static*/
-Future<GltfReaderResult> GltfReader::resolveExternalData(
+void CesiumGltfReader::GltfReader::postprocessGltf(
+    GltfReaderResult& readGltf,
+    const GltfReaderOptions& options) {
+  if (readGltf.model) {
+    postprocess(*this, readGltf, options);
+  }
+}
+
+/*static*/ Future<GltfReaderResult> GltfReader::resolveExternalData(
     AsyncSystem asyncSystem,
     const std::string& baseUrl,
     const HttpHeaders& headers,

--- a/CesiumUtility/include/CesiumUtility/ReferenceCounted.h
+++ b/CesiumUtility/include/CesiumUtility/ReferenceCounted.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+#include <cassert>
 #include <cstdint>
 
 #ifndef NDEBUG


### PR DESCRIPTION
This builds on #853 so merge that first.

* Added `forEachRootNodeInScene` to `Model`. This is useful to enumerate the root nodes associated with a scene (whether a particular one or the default), such as when you want to add a transformation to each.
* `Model::merge` now returns an `ErrorList`, so it can report warnings and errors during the merge process.
* Added `getNodeTransform` and `setNodeTransform` to `GltfUtilities`. These make it easy to get/set the local transformation of the `Node` as a `glm::dmat4x4`.
* Added several methods to `GltfUtilities` to remove unused elements from a glTF. Detecting unused elements in glTF requires complete knowledge of all extensions used, as well as a perfectly accurate accounting all the references. Ultimately this information should be expressed in the glTF schema itself, but it's hard coded here for the time being.
* Added `compactBuffers` to `GltfUtilities`. It removes any byte ranges from a Buffer that are not referenced by any BufferView, and updates all other BufferViews accordingly.
* Added `postprocessGltf` to `GltfReader`. This allows all of the post-processing that is optionally done after loading a glTF - such as decoding Draco or images - to be done later, after the main part of the load is complete.