### PR TITLE
Improvements to the build process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,11 +203,11 @@ endif()
 install(TARGETS GSL)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/extern/GSL/include/gsl TYPE INCLUDE)
 
-# ktx_read's PUBLIC_HEADER has paths relative to its own directory, so the install line below will fail.
+# ktx's PUBLIC_HEADER has paths relative to its own directory, so the install line below will fail.
 # We could fix that, but we don't need the KTX public headers installed anyway (they should be considered
 # private to cesium-native), so just set the PUBLIC_HEADER to an empty string.
-set_target_properties(ktx_read PROPERTIES PUBLIC_HEADER "")
-install(TARGETS ktx_read)
+set_target_properties(ktx PROPERTIES PUBLIC_HEADER "")
+install(TARGETS ktx)
 
 install(TARGETS webpdecoder)
 

--- a/CesiumGltfContent/src/ImageManipulation.cpp
+++ b/CesiumGltfContent/src/ImageManipulation.cpp
@@ -4,7 +4,6 @@
 #include <cassert>
 #include <cstring>
 
-#define STB_IMAGE_RESIZE_IMPLEMENTATION
 #include <stb_image_resize.h>
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>

--- a/CesiumGltfContent/src/ImageManipulation.cpp
+++ b/CesiumGltfContent/src/ImageManipulation.cpp
@@ -1,10 +1,10 @@
 #include <CesiumGltf/ImageCesium.h>
 #include <CesiumGltfContent/ImageManipulation.h>
 
+#include <stb_image_resize.h>
+
 #include <cassert>
 #include <cstring>
-
-#include <stb_image_resize.h>
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
 

--- a/CesiumGltfReader/CMakeLists.txt
+++ b/CesiumGltfReader/CMakeLists.txt
@@ -62,7 +62,7 @@ target_link_libraries(CesiumGltfReader
         modp_b64
         ${CESIUM_NATIVE_DRACO_LIBRARY}
     PRIVATE
-        ktx_read
+        ktx
         webp
         webpdecoder
         turbojpeg

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -29,6 +29,7 @@
 #include <string>
 
 #define STB_IMAGE_IMPLEMENTATION
+#define STB_IMAGE_RESIZE_IMPLEMENTATION
 #define STBI_FAILURE_USERMSG
 #include <stb_image.h>
 #include <stb_image_resize.h>

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -16,6 +16,7 @@ if(IOS)
   set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "12.0" CACHE STRING "iOS Deployment Target")
 endif()
 
+set(KTX_FEATURE_TOOLS off)
 add_subdirectory(KTX-Software)
 
 option(WEBP_BUILD_ANIM_UTILS "" off)


### PR DESCRIPTION
* Upgrade KTX-Software to v4.3.2. See https://github.com/CesiumGS/KTX-Software/pull/1.
* Use the `ktx` library instead of `ktx_read`. While cesium-native currently only needs the read functionality, by depending on `ktx_read` cesium-native prevents anything that uses cesium-native from bringing in the write functionality. This is because there's no `ktx_write`. The only options are `ktx_read` which is read-only, and `ktx` which includes both. If you try to link against both `ktx` and `ktx_read`, you'll end up with multiply-defined symbols.
* Move the STB image resize implementation code into CesiumGltfReader (instead of CesiumGltfContent). This fixes a weird situation where applications that only depend on `CesiumGltfReader` would get linker errors.
* Disable compilation of the KTX CLI by setting `KTX_FEATURE_TOOLS` to off. This saves a bit of time, and also stops KTX from bringing in its only implementation of cxxopts.