### PR TITLE
Add `NormalAccessorType` to `AccessorUtility.h`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ##### Additions :tada:
 
+- Added `NormalAccessorType`, which is a type definition for a normal accessor. It can be constructed using `getNormalAccessorView`.
 - Added `Uri::getPath` and `Uri::setPath`.
 - Added `TileTransform::setTransform`.
 - Added a new `CesiumQuantizedMeshTerrain` library and namespace, containing classes for working with terrain in the `quantized-mesh-1.0` format and its `layer.json` file.

--- a/CesiumGltf/include/CesiumGltf/AccessorUtility.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorUtility.h
@@ -50,6 +50,19 @@ PositionAccessorType
 getPositionAccessorView(const Model& model, const MeshPrimitive& primitive);
 
 /**
+ * Type definition for normal accessor.
+ */
+typedef AccessorView<AccessorTypes::VEC3<float>> NormalAccessorType;
+
+/**
+ * Retrieves an accessor view for the normal attribute from the given glTF
+ * primitive and model. This verifies that the accessor is of a valid type. If
+ * not, the returned accessor view will be invalid.
+ */
+NormalAccessorType
+getNormalAccessorView(const Model& model, const MeshPrimitive& primitive);
+
+/**
  * Type definition for all kinds of feature ID attribute accessors.
  */
 typedef std::variant<

--- a/CesiumGltf/src/AccessorUtility.cpp
+++ b/CesiumGltf/src/AccessorUtility.cpp
@@ -20,6 +20,23 @@ getPositionAccessorView(const Model& model, const MeshPrimitive& primitive) {
   return PositionAccessorType(model, *pAccessor);
 }
 
+NormalAccessorType
+getNormalAccessorView(const Model& model, const MeshPrimitive& primitive) {
+  auto normalAttribute = primitive.attributes.find("NORMAL");
+  if (normalAttribute == primitive.attributes.end()) {
+    return NormalAccessorType();
+  }
+
+  const Accessor* pAccessor =
+      model.getSafe<Accessor>(&model.accessors, normalAttribute->second);
+  if (!pAccessor || pAccessor->type != Accessor::Type::VEC3 ||
+      pAccessor->componentType != Accessor::ComponentType::FLOAT) {
+    return NormalAccessorType();
+  }
+
+  return NormalAccessorType(model, *pAccessor);
+}
+
 FeatureIdAccessorType getFeatureIdAccessorView(
     const Model& model,
     const MeshPrimitive& primitive,


### PR DESCRIPTION
Adds `NormalAccessorType` and `getNormalAccessorView`, similar to https://github.com/CesiumGS/cesium-native/pull/827