### PR TITLE
Don't create an invalid GLB when the buffer is too large.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@
 - After a glTF has been Draco-decoded, the `KHR_draco_mesh_compression` extension is now removed from the primitives, as well as from `extensionsUsed` and `extensionsRequired`.
 - For glTFs converted from quantized-mesh tiles, accessors created for the position attribute now have their minimum and maximum values set correctly to include the vertices that form the skirt around the edge of the tile.
 - Fixed some glTF validation problems with the mode produced by `upsampleGltfForRasterOverlays`.
+- Fixed a bug that caused `GltfWriter` to create an invalid GLB if its total size would be greater than or equal to 4 GiB. Because it is not possible to produce a valid GLB of this size, GltfWriter now reports an error instead.
 
 ### v0.34.0 - 2024-04-01
 

--- a/CesiumGltfWriter/test/TestGltfWriter.cpp
+++ b/CesiumGltfWriter/test/TestGltfWriter.cpp
@@ -579,3 +579,19 @@ TEST_CASE("Writes glb with binaryChunkByteAlignment of 8") {
 
   REQUIRE(glbBytesExtraPadding.size() == 88);
 }
+
+TEST_CASE("Reports an error if asked to write a GLB larger than 4GB") {
+  CesiumGltf::Model model;
+  model.asset.version = "2.0";
+  CesiumGltf::Buffer& buffer = model.buffers.emplace_back();
+  buffer.byteLength = int64_t(std::numeric_limits<uint32_t>::max()) + 1;
+
+  // Hope you have some extra memory!
+  buffer.cesium.data.resize(size_t(buffer.byteLength));
+
+  CesiumGltfWriter::GltfWriter writer;
+  CesiumGltfWriter::GltfWriterResult result =
+      writer.writeGlb(model, buffer.cesium.data);
+  REQUIRE(!result.errors.empty());
+  CHECK(result.gltfBytes.empty());
+}


### PR DESCRIPTION
Because the GLB format includes its own length as a uint32 field inside itself, it's not possible to create a valid GLB file that is 4GiB or larger. Previously GltfWriter would try, and end up producing an invalid GLB; the length fields would end up being the actual length modulo 2^32. With this PR, GLB creation now fails with an error.