### PR TITLE
Fix unit tests failing for macOS (arm64)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
           cd build-release
           ctest -V
   macOS:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
           cd build-release
           ctest -V
   macOS:
-    runs-on: macos-14
+    runs-on: macos-12
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/CesiumGltf/test/TestJsonValue.cpp
+++ b/CesiumGltf/test/TestJsonValue.cpp
@@ -41,6 +41,11 @@ TEST_CASE(
 
 TEST_CASE("JsonValue::getSafeNumber() throws if narrowing conversion error "
           "would occur") {
+  SECTION("2^64 - 1 cannot be converted back to a double") {
+    auto value = JsonValue(std::numeric_limits<std::uint64_t>::max());
+    REQUIRE_THROWS(value.getSafeNumber<double>());
+  }
+
   SECTION("-2^64 cannot be converted back to a double") {
     // -9223372036854775807L cannot be represented exactly as a double
     auto value = JsonValue(std::numeric_limits<std::int64_t>::min() + 1);

--- a/CesiumGltf/test/TestJsonValue.cpp
+++ b/CesiumGltf/test/TestJsonValue.cpp
@@ -41,11 +41,6 @@ TEST_CASE(
 
 TEST_CASE("JsonValue::getSafeNumber() throws if narrowing conversion error "
           "would occur") {
-  SECTION("2^64 - 1 cannot be converted back to a double") {
-    auto value = JsonValue(std::numeric_limits<std::uint64_t>::max());
-    REQUIRE_THROWS(value.getSafeNumber<double>());
-  }
-
   SECTION("-2^64 cannot be converted back to a double") {
     // -9223372036854775807L cannot be represented exactly as a double
     auto value = JsonValue(std::numeric_limits<std::int64_t>::min() + 1);


### PR DESCRIPTION
Fixes macOS build failure in latest merge to main, [here](https://github.com/CesiumGS/cesium-native/actions/runs/8802908193).

Also fixes any other macOS builds that happen to use a runner configured with `Image: macos-14-arm64`.

Configure runner for `macos-12` explicitly, instead of `macos-latest`. When choosing the latest, it could actually choose an arm64 variant, which our unit tests fail on (at least 3 related to narrowing). In addition, even specifying `macos-14` can lead to `macos-14-arm64` being chosen.

After review, and we go this direction, we should write an issue to support the latest builds (14, arm64) on CI.
