### PR TITLE
Fix cmake issue with KTX and iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,9 @@ endif()
 install(TARGETS GSL)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/extern/GSL/include/gsl TYPE INCLUDE)
 
-install(TARGETS ktx)
+install(TARGETS ktx
+		FRAMEWORK
+			DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 install(TARGETS webpdecoder)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,7 @@ endif()
 install(TARGETS GSL)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/extern/GSL/include/gsl TYPE INCLUDE)
 
+# Install with framework destination specified (needed for iOS)
 install(TARGETS ktx
 		FRAMEWORK
 			DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,10 +203,6 @@ endif()
 install(TARGETS GSL)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/extern/GSL/include/gsl TYPE INCLUDE)
 
-# ktx's PUBLIC_HEADER has paths relative to its own directory, so the install line below will fail.
-# We could fix that, but we don't need the KTX public headers installed anyway (they should be considered
-# private to cesium-native), so just set the PUBLIC_HEADER to an empty string.
-set_target_properties(ktx PROPERTIES PUBLIC_HEADER "")
 install(TARGETS ktx)
 
 install(TARGETS webpdecoder)


### PR DESCRIPTION
Showed up in cesium-unreal as this cmake error...

`CMake Error at cesium-native/CMakeLists.txt:210 (install): install TARGETS given no FRAMEWORK DESTINATION for static library FRAMEWORK target "ktx".`
([link to CI run](https://github.com/CesiumGS/cesium-unreal/actions/runs/8838079866))

Setting FRAMEWORK DESTINATION explicitly seems to fix it.

Also remove previous line that set `PROPERTIES PUBLIC_HEADER` to fix the install. This doesn't seem to be needed anymore as the cmake generation works without it