### PR TITLE
Add `getComponentCountFromPropertyType`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 ##### Additions :tada:
 
+- Added `getComponentCountFromPropertyType` to `PropertyType`.
 - Added `removeExtension` to `ExtensibleObject`.
 - Added `NormalAccessorType`, which is a type definition for a normal accessor. It can be constructed using `getNormalAccessorView`.
 - Added `Uri::getPath` and `Uri::setPath`.

--- a/CesiumGltf/include/CesiumGltf/PropertyType.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyType.h
@@ -59,6 +59,8 @@ bool isPropertyComponentTypeInteger(PropertyComponentType componentType);
 
 glm::length_t getDimensionsFromPropertyType(PropertyType type);
 
+glm::length_t getComponentCountFromPropertyType(PropertyType type);
+
 size_t getSizeOfComponentType(PropertyComponentType componentType);
 
 } // namespace CesiumGltf

--- a/CesiumGltf/src/PropertyType.cpp
+++ b/CesiumGltf/src/PropertyType.cpp
@@ -230,6 +230,26 @@ glm::length_t getDimensionsFromPropertyType(PropertyType type) {
   }
 }
 
+glm::length_t getComponentCountFromPropertyType(PropertyType type) {
+  switch (type) {
+  case PropertyType::Scalar:
+    return 1;
+  case PropertyType::Vec2:
+    return 2;
+  case PropertyType::Vec3:
+    return 3;
+  case PropertyType::Vec4:
+  case PropertyType::Mat2:
+    return 4;
+  case PropertyType::Mat3:
+    return 9;
+  case PropertyType::Mat4:
+    return 16;
+  default:
+    return 0;
+  }
+}
+
 size_t getSizeOfComponentType(PropertyComponentType componentType) {
   switch (componentType) {
   case PropertyComponentType::Int8:

--- a/CesiumGltf/test/TestPropertyType.cpp
+++ b/CesiumGltf/test/TestPropertyType.cpp
@@ -295,6 +295,23 @@ TEST_CASE("Test getDimensionsFromPropertyType") {
   REQUIRE(getDimensionsFromPropertyType(PropertyType::Invalid) == 0);
 }
 
+TEST_CASE("Test getComponentCountFromPropertyType") {
+  REQUIRE(getComponentCountFromPropertyType(PropertyType::Scalar) == 1);
+
+  REQUIRE(getComponentCountFromPropertyType(PropertyType::Vec2) == 2);
+  REQUIRE(getComponentCountFromPropertyType(PropertyType::Vec3) == 3);
+  REQUIRE(getComponentCountFromPropertyType(PropertyType::Vec4) == 4);
+
+  REQUIRE(getComponentCountFromPropertyType(PropertyType::Mat2) == 4);
+  REQUIRE(getComponentCountFromPropertyType(PropertyType::Mat3) == 9);
+  REQUIRE(getComponentCountFromPropertyType(PropertyType::Mat4) == 16);
+
+  REQUIRE(getComponentCountFromPropertyType(PropertyType::Boolean) == 0);
+  REQUIRE(getComponentCountFromPropertyType(PropertyType::String) == 0);
+  REQUIRE(getComponentCountFromPropertyType(PropertyType::Enum) == 0);
+  REQUIRE(getComponentCountFromPropertyType(PropertyType::Invalid) == 0);
+}
+
 TEST_CASE("Test getSizeOfComponentType") {
   REQUIRE(
       getSizeOfComponentType(PropertyComponentType::Int8) == sizeof(int8_t));


### PR DESCRIPTION
Added `getComponentCountFromPropertyType`. It's a bit similar to `getDimensionsFromPropertyType`, but more convenient in certain situations.