### PR TITLE
Move stb resize function to `Cesium` namespace

### DIFF
--- a/CesiumGltfContent/src/ImageManipulation.cpp
+++ b/CesiumGltfContent/src/ImageManipulation.cpp
@@ -1,12 +1,20 @@
 #include <CesiumGltf/ImageCesium.h>
 #include <CesiumGltfContent/ImageManipulation.h>
 
-#include <stb_image_resize.h>
-
 #include <cassert>
 #include <cstring>
+
+namespace Cesium {
+// Use STB in our own namespace to avoid conflicts from other native
+// implementations, override STBIRDEF to allow this
+#define STBIRDEF
+
+#include <stb_image_resize.h>
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
+}; // namespace Cesium
+
+using namespace Cesium;
 
 namespace CesiumGltfContent {
 

--- a/CesiumGltfContent/src/ImageManipulation.cpp
+++ b/CesiumGltfContent/src/ImageManipulation.cpp
@@ -5,16 +5,16 @@
 #include <cstring>
 
 namespace Cesium {
-// Use STB in our own namespace to avoid conflicts from other native
-// implementations, override STBIRDEF to allow this
+// Use STB resize in our own namespace to avoid conflicts from other libs
 #define STBIRDEF
-
 #include <stb_image_resize.h>
-#define STB_IMAGE_WRITE_IMPLEMENTATION
-#include <stb_image_write.h>
+#undef STBIRDEF
 }; // namespace Cesium
 
 using namespace Cesium;
+
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>
 
 namespace CesiumGltfContent {
 

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -28,17 +28,18 @@
 #include <sstream>
 #include <string>
 
-namespace Cesium {
-// Use STB in our own namespace to avoid conflicts from other native
-// implementations, override STBIRDEF to allow this
-#define STBIRDEF
 #define STBI_FAILURE_USERMSG
-#define STB_IMAGE_IMPLEMENTATION
-#include <stb_image.h>
+
+namespace Cesium {
+// Use STB resize in our own namespace to avoid conflicts from other libs
+#define STBIRDEF
 #define STB_IMAGE_RESIZE_IMPLEMENTATION
 #include <stb_image_resize.h>
+#undef STBIRDEF
 }; // namespace Cesium
 
+#define STB_IMAGE_IMPLEMENTATION
+#include <stb_image.h>
 #include <turbojpeg.h>
 
 using namespace CesiumAsync;

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -28,11 +28,17 @@
 #include <sstream>
 #include <string>
 
-#define STB_IMAGE_IMPLEMENTATION
-#define STB_IMAGE_RESIZE_IMPLEMENTATION
+namespace Cesium {
+// Use STB in our own namespace to avoid conflicts from other native
+// implementations, override STBIRDEF to allow this
+#define STBIRDEF
 #define STBI_FAILURE_USERMSG
+#define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
+#define STB_IMAGE_RESIZE_IMPLEMENTATION
 #include <stb_image_resize.h>
+}; // namespace Cesium
+
 #include <turbojpeg.h>
 
 using namespace CesiumAsync;
@@ -40,6 +46,7 @@ using namespace CesiumGltf;
 using namespace CesiumGltfReader;
 using namespace CesiumJsonReader;
 using namespace CesiumUtility;
+using namespace Cesium;
 
 namespace {
 #pragma pack(push, 1)


### PR DESCRIPTION
Certain STB functions (image processing) are implemented in cesium-native libs, but can also conflict with STB implementations in the native client.

This recently happened with cesium-unreal and Unreal Engine 5.4, but can happen with others as well.

One solution to this problem is to move any related functions into an isolated namespace. This is what I've done in this PR. Should have no effect on the functionality of cesium-native, just how it links with other libraries. 