### PR TITLE
Preserve alignment in GltfUtilities::compactBuffer.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
   - `EXT_mesh_gpu_instancing`
   - `CESIUM_primitive_outline`
   - `CESIUM_tile_edges`
+- Fixed a bug in `GltfUtilities::compactBuffer` where it would not preserve the alignment of the bufferViews.
 
 ### v0.35.0 - 2024-05-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
   - `CESIUM_primitive_outline`
   - `CESIUM_tile_edges`
 - Fixed a bug in `GltfUtilities::compactBuffer` where it would not preserve the alignment of the bufferViews.
+- The `collapseToSingleBuffer` and `moveBufferContent` functions in `GltfUtilities` now align to an 8-byte boundary rather than a 4-byte boundary, because bufferViews associated with some glTF extensions require this larger alignment.
 
 ### v0.35.0 - 2024-05-01
 

--- a/CesiumGltfContent/src/GltfUtilities.cpp
+++ b/CesiumGltfContent/src/GltfUtilities.cpp
@@ -299,12 +299,12 @@ GltfUtilities::parseGltfCopyright(const CesiumGltf::Model& gltf) {
   }
 
   // Copy the data to the destination and keep track of where we put it.
-  // Align each bufferView to a 4-byte boundary.
+  // Align each bufferView to an 8-byte boundary.
   size_t start = destination.cesium.data.size();
 
-  size_t alignmentRemainder = start % 4;
+  size_t alignmentRemainder = start % 8;
   if (alignmentRemainder != 0) {
-    start += 4 - alignmentRemainder;
+    start += 8 - alignmentRemainder;
   }
 
   destination.cesium.data.resize(start + source.cesium.data.size());
@@ -629,13 +629,16 @@ void deleteBufferRange(
   int64_t bytesToRemove = end - start;
 
   // In order to ensure that we can't disrupt glTF's alignment requirements,
-  // only remove multiples of 8 bytes. Round down to the nearest multiple of 8
-  // by clearing the lowest three bits.
-  bytesToRemove = bytesToRemove & ~0b111;
-  if (bytesToRemove == 0)
-    return;
+  // only remove multiples of 8 bytes from within the buffer (removing any
+  // number of bytes from the end is fine).
+  if (end < pBuffer->byteLength) {
+    // Round down to the nearest multiple of 8 by clearing the low three bits.
+    bytesToRemove = bytesToRemove & ~0b111;
+    if (bytesToRemove == 0)
+      return;
 
-  end = start + bytesToRemove;
+    end = start + bytesToRemove;
+  }
 
   // Adjust bufferView offets for the removed bytes.
   for (BufferView& bufferView : gltf.bufferViews) {

--- a/CesiumGltfContent/src/GltfUtilities.cpp
+++ b/CesiumGltfContent/src/GltfUtilities.cpp
@@ -628,6 +628,15 @@ void deleteBufferRange(
 
   int64_t bytesToRemove = end - start;
 
+  // In order to ensure that we can't disrupt glTF's alignment requirements,
+  // only remove multiples of 8 bytes. Round down to the nearest multiple of 8
+  // by clearing the lowest three bits.
+  bytesToRemove = bytesToRemove & ~0b111;
+  if (bytesToRemove == 0)
+    return;
+
+  end = start + bytesToRemove;
+
   // Adjust bufferView offets for the removed bytes.
   for (BufferView& bufferView : gltf.bufferViews) {
     if (bufferView.buffer != bufferIndex)

--- a/CesiumGltfContent/test/TestGltfUtilities.cpp
+++ b/CesiumGltfContent/test/TestGltfUtilities.cpp
@@ -383,12 +383,12 @@ TEST_CASE("GltfUtilities::compactBuffers") {
 
     GltfUtilities::compactBuffers(m);
 
-    CHECK(buffer.byteLength == 113);
-    REQUIRE(buffer.cesium.data.size() == 113);
-    CHECK(bv.byteOffset == 0);
+    CHECK(buffer.byteLength == 123 - 8);
+    REQUIRE(buffer.cesium.data.size() == 123 - 8);
+    CHECK(bv.byteOffset == 2);
 
-    for (size_t i = 0; i < buffer.cesium.data.size(); ++i) {
-      CHECK(buffer.cesium.data[i] == std::byte(i + 10));
+    for (size_t i = bv.byteOffset; i < buffer.cesium.data.size(); ++i) {
+      CHECK(buffer.cesium.data[i] == std::byte(i + 8));
     }
   }
 
@@ -400,10 +400,10 @@ TEST_CASE("GltfUtilities::compactBuffers") {
 
     GltfUtilities::compactBuffers(m);
 
-    CHECK(buffer.byteLength == 113);
-    REQUIRE(buffer.cesium.data.size() == 113);
+    CHECK(buffer.byteLength == 123 - 8);
+    REQUIRE(buffer.cesium.data.size() == 123 - 8);
 
-    for (size_t i = 0; i < buffer.cesium.data.size(); ++i) {
+    for (size_t i = 0; i < buffer.cesium.data.size() - 2; ++i) {
       CHECK(buffer.cesium.data[i] == std::byte(i));
     }
   }
@@ -416,12 +416,12 @@ TEST_CASE("GltfUtilities::compactBuffers") {
 
     GltfUtilities::compactBuffers(m);
 
-    CHECK(buffer.byteLength == 103);
-    REQUIRE(buffer.cesium.data.size() == 103);
-    CHECK(bv.byteOffset == 0);
+    CHECK(buffer.byteLength == 123 - 8 - 8);
+    REQUIRE(buffer.cesium.data.size() == 123 - 8 - 8);
+    CHECK(bv.byteOffset == 2);
 
-    for (size_t i = 0; i < buffer.cesium.data.size(); ++i) {
-      CHECK(buffer.cesium.data[i] == std::byte(i + 10));
+    for (size_t i = 2; i < buffer.cesium.data.size() - 2; ++i) {
+      CHECK(buffer.cesium.data[i] == std::byte(i + 8));
     }
   }
 }

--- a/CesiumGltfContent/test/TestGltfUtilities.cpp
+++ b/CesiumGltfContent/test/TestGltfUtilities.cpp
@@ -400,10 +400,11 @@ TEST_CASE("GltfUtilities::compactBuffers") {
 
     GltfUtilities::compactBuffers(m);
 
-    CHECK(buffer.byteLength == 123 - 8);
-    REQUIRE(buffer.cesium.data.size() == 123 - 8);
+    // Any number of bytes can be removed from the end (no alignment impact)
+    CHECK(buffer.byteLength == 123 - 10);
+    REQUIRE(buffer.cesium.data.size() == 123 - 10);
 
-    for (size_t i = 0; i < buffer.cesium.data.size() - 2; ++i) {
+    for (size_t i = 0; i < buffer.cesium.data.size(); ++i) {
       CHECK(buffer.cesium.data[i] == std::byte(i));
     }
   }
@@ -416,12 +417,35 @@ TEST_CASE("GltfUtilities::compactBuffers") {
 
     GltfUtilities::compactBuffers(m);
 
-    CHECK(buffer.byteLength == 123 - 8 - 8);
-    REQUIRE(buffer.cesium.data.size() == 123 - 8 - 8);
+    CHECK(buffer.byteLength == 123 - 8 - 10);
+    REQUIRE(buffer.cesium.data.size() == 123 - 8 - 10);
     CHECK(bv.byteOffset == 2);
 
-    for (size_t i = 2; i < buffer.cesium.data.size() - 2; ++i) {
+    for (size_t i = 2; i < buffer.cesium.data.size(); ++i) {
       CHECK(buffer.cesium.data[i] == std::byte(i + 8));
+    }
+  }
+
+  SECTION("does not remove gaps less than 8 bytes") {
+    BufferView& bv1 = m.bufferViews.emplace_back();
+    bv1.buffer = 0;
+    bv1.byteOffset = 1;
+    bv1.byteLength = 99;
+
+    BufferView& bv2 = m.bufferViews.emplace_back();
+    bv2.buffer = 0;
+    bv2.byteOffset = 105;
+    bv2.byteLength = 10;
+
+    GltfUtilities::compactBuffers(m);
+
+    CHECK(buffer.byteLength == 115);
+    REQUIRE(buffer.cesium.data.size() == 115);
+    CHECK(m.bufferViews[0].byteOffset == 1);
+    CHECK(m.bufferViews[1].byteOffset == 105);
+
+    for (size_t i = 0; i < buffer.cesium.data.size(); ++i) {
+      CHECK(buffer.cesium.data[i] == std::byte(i));
     }
   }
 }

--- a/CesiumGltfContent/test/TestGltfUtilities.cpp
+++ b/CesiumGltfContent/test/TestGltfUtilities.cpp
@@ -387,7 +387,7 @@ TEST_CASE("GltfUtilities::compactBuffers") {
     REQUIRE(buffer.cesium.data.size() == 123 - 8);
     CHECK(bv.byteOffset == 2);
 
-    for (size_t i = bv.byteOffset; i < buffer.cesium.data.size(); ++i) {
+    for (size_t i = size_t(bv.byteOffset); i < buffer.cesium.data.size(); ++i) {
       CHECK(buffer.cesium.data[i] == std::byte(i + 8));
     }
   }


### PR DESCRIPTION
Fixes #862 

This is pretty much the simplest possible approach. When deleting bytes from the buffer, it only deletes multiples of 8 bytes.