### PR TITLE
Various glTF fixes, mostly meshopt related

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,10 +8,16 @@
   - `KHR_texture_basisu`
   - `EXT_texture_webp`
   - `EXT_mesh_gpu_instancing`
+  - `EXT_meshopt_compression`
   - `CESIUM_primitive_outline`
   - `CESIUM_tile_edges`
 - Fixed a bug in `GltfUtilities::compactBuffer` where it would not preserve the alignment of the bufferViews.
 - The `collapseToSingleBuffer` and `moveBufferContent` functions in `GltfUtilities` now align to an 8-byte boundary rather than a 4-byte boundary, because bufferViews associated with some glTF extensions require this larger alignment.
+- `GltfUtilities::collapseToSingleBuffer` now works correctly even if some of the buffers in the model have a `uri` property and the data at that URI has not yet been loaded. Such buffers are left unmodified.
+- `GltfUtilities::collapseToSingleBuffer` now works correctly with bufferViews that have the `EXT_meshopt_compression` extension.
+- `GltfUtilities::compactBuffer` now accounts for bufferViews with the `EXT_meshopt_compression` when determining unused buffer ranges.
+- When `GltfReader` decodes buffers with data URLs, and the size of the data in the URL does not match the buffer's `byteLength`, the `byteLength` is now updated and a warning is raised. Previously, the mismatch was ignored and would cause problems later when trying to use these buffers.
+- `EXT_meshopt_compression` and `KHR_mesh_quantization` are now removed from `extensionsUsed` and `extensionsRequired` after they are decoded by `GltfReader`.
 
 ### v0.35.0 - 2024-05-01
 

--- a/CesiumGltf/src/Model.cpp
+++ b/CesiumGltf/src/Model.cpp
@@ -1,6 +1,7 @@
 #include "CesiumGltf/Model.h"
 
 #include "CesiumGltf/AccessorView.h"
+#include "CesiumGltf/ExtensionBufferViewExtMeshoptCompression.h"
 #include "CesiumGltf/ExtensionCesiumPrimitiveOutline.h"
 #include "CesiumGltf/ExtensionCesiumTileEdges.h"
 #include "CesiumGltf/ExtensionExtMeshFeatures.h"
@@ -198,6 +199,12 @@ ErrorList Model::merge(Model&& rhs) {
   for (size_t i = firstBufferView; i < this->bufferViews.size(); ++i) {
     BufferView& bufferView = this->bufferViews[i];
     updateIndex(bufferView.buffer, firstBuffer);
+
+    ExtensionBufferViewExtMeshoptCompression* pMeshOpt =
+        bufferView.getExtension<ExtensionBufferViewExtMeshoptCompression>();
+    if (pMeshOpt) {
+      updateIndex(pMeshOpt->buffer, firstBuffer);
+    }
   }
 
   for (size_t i = firstImage; i < this->images.size(); ++i) {

--- a/CesiumGltf/test/TestModel.cpp
+++ b/CesiumGltf/test/TestModel.cpp
@@ -1,6 +1,7 @@
 #include "CesiumGltf/AccessorView.h"
 #include "CesiumGltf/Model.h"
 
+#include <CesiumGltf/ExtensionBufferViewExtMeshoptCompression.h>
 #include <CesiumGltf/ExtensionCesiumPrimitiveOutline.h>
 #include <CesiumGltf/ExtensionCesiumTileEdges.h>
 #include <CesiumGltf/ExtensionExtMeshFeatures.h>
@@ -1273,6 +1274,31 @@ TEST_CASE("Model::merge") {
     auto it = pMerged->attributes.find("foo");
     REQUIRE(it != pMerged->attributes.end());
     CHECK(it->second == 1);
+  }
+
+  SECTION("updates buffer indices in EXT_meshopt_compression") {
+    Model m1;
+    m1.buffers.emplace_back();
+
+    Model m2;
+    m2.buffers.emplace_back();
+    BufferView& bufferView = m2.bufferViews.emplace_back();
+
+    ExtensionBufferViewExtMeshoptCompression& extension =
+        bufferView.addExtension<ExtensionBufferViewExtMeshoptCompression>();
+    extension.buffer = 0;
+
+    m1.merge(std::move(m2));
+
+    REQUIRE(m1.buffers.size() == 2);
+    REQUIRE(m1.bufferViews.size() == 1);
+
+    ExtensionBufferViewExtMeshoptCompression* pMerged =
+        m1.bufferViews[0]
+            .getExtension<ExtensionBufferViewExtMeshoptCompression>();
+    REQUIRE(pMerged);
+
+    CHECK(pMerged->buffer == 1);
   }
 }
 

--- a/CesiumGltfContent/src/GltfUtilities.cpp
+++ b/CesiumGltfContent/src/GltfUtilities.cpp
@@ -2,6 +2,7 @@
 #include <CesiumGeometry/Transforms.h>
 #include <CesiumGeospatial/BoundingRegionBuilder.h>
 #include <CesiumGltf/AccessorView.h>
+#include <CesiumGltf/ExtensionBufferExtMeshoptCompression.h>
 #include <CesiumGltf/ExtensionBufferViewExtMeshoptCompression.h>
 #include <CesiumGltf/ExtensionCesiumPrimitiveOutline.h>
 #include <CesiumGltf/ExtensionCesiumRTC.h>
@@ -281,7 +282,12 @@ GltfUtilities::parseGltfCopyright(const CesiumGltf::Model& gltf) {
     Buffer& sourceBuffer = gltf.buffers[i];
 
     // Leave intact any buffers that have a URI and no data.
-    if (sourceBuffer.uri && sourceBuffer.cesium.data.empty()) {
+    // Also leave intact meshopt fallback buffers without any data.
+    ExtensionBufferExtMeshoptCompression* pMeshOpt =
+        sourceBuffer.getExtension<ExtensionBufferExtMeshoptCompression>();
+    bool isMeshOptFallback = pMeshOpt && pMeshOpt->fallback;
+    if (sourceBuffer.cesium.data.empty() &&
+        (sourceBuffer.uri || isMeshOptFallback)) {
       keepBuffer[i] = true;
       continue;
     }

--- a/CesiumGltfContent/test/TestGltfUtilities.cpp
+++ b/CesiumGltfContent/test/TestGltfUtilities.cpp
@@ -1,3 +1,4 @@
+#include <CesiumGltf/ExtensionBufferExtMeshoptCompression.h>
 #include <CesiumGltf/Model.h>
 #include <CesiumGltf/Node.h>
 #include <CesiumGltfContent/GltfUtilities.h>
@@ -447,5 +448,135 @@ TEST_CASE("GltfUtilities::compactBuffers") {
     for (size_t i = 0; i < buffer.cesium.data.size(); ++i) {
       CHECK(buffer.cesium.data[i] == std::byte(i));
     }
+  }
+}
+
+TEST_CASE("GltfUtilities::collapseToSingleBuffer") {
+  SECTION("merges two buffers into one") {
+    Model m;
+    m.buffers.emplace_back();
+    m.buffers.emplace_back();
+    m.bufferViews.emplace_back();
+    m.bufferViews.emplace_back();
+
+    Buffer& buffer1 = m.buffers[0];
+    buffer1.byteLength = 10;
+    buffer1.cesium.data.resize(10, std::byte('1'));
+
+    Buffer& buffer2 = m.buffers[1];
+    buffer2.byteLength = 12;
+    buffer2.cesium.data.resize(12, std::byte('2'));
+
+    BufferView& bufferView1 = m.bufferViews[0];
+    bufferView1.buffer = 1;
+    bufferView1.byteLength = 12;
+    BufferView& bufferView2 = m.bufferViews[1];
+    bufferView2.buffer = 0;
+    bufferView2.byteLength = 10;
+
+    GltfUtilities::collapseToSingleBuffer(m);
+
+    REQUIRE(m.buffers.size() == 1);
+    CHECK(m.bufferViews[0].buffer == 0);
+    // expect 8-byte alignment
+    CHECK(m.bufferViews[0].byteOffset == 16);
+    CHECK(m.bufferViews[0].byteLength == 12);
+    CHECK(m.bufferViews[1].buffer == 0);
+    CHECK(m.bufferViews[1].byteOffset == 0);
+    CHECK(m.bufferViews[1].byteLength == 10);
+  }
+
+  SECTION("leaves buffer with a URI and no data intact") {
+    Model m;
+    m.buffers.emplace_back();
+    m.buffers.emplace_back();
+    m.buffers.emplace_back();
+    m.bufferViews.emplace_back();
+    m.bufferViews.emplace_back();
+    m.bufferViews.emplace_back();
+
+    Buffer& buffer1 = m.buffers[0];
+    buffer1.byteLength = 10;
+    buffer1.cesium.data.resize(10, std::byte('1'));
+
+    Buffer& buffer2 = m.buffers[1];
+    buffer2.byteLength = 100;
+    buffer2.uri = "foo";
+
+    Buffer& buffer3 = m.buffers[2];
+    buffer3.byteLength = 12;
+    buffer3.cesium.data.resize(12, std::byte('2'));
+
+    BufferView& bufferView1 = m.bufferViews[0];
+    bufferView1.buffer = 2;
+    bufferView1.byteLength = 12;
+    BufferView& bufferView2 = m.bufferViews[1];
+    bufferView2.buffer = 0;
+    bufferView2.byteLength = 10;
+    BufferView& bufferView3 = m.bufferViews[2];
+    bufferView3.buffer = 1;
+    bufferView3.byteLength = 100;
+
+    GltfUtilities::collapseToSingleBuffer(m);
+
+    REQUIRE(m.buffers.size() == 2);
+    CHECK(m.bufferViews[0].buffer == 0);
+    // expect 8-byte alignment
+    CHECK(m.bufferViews[0].byteOffset == 16);
+    CHECK(m.bufferViews[0].byteLength == 12);
+    CHECK(m.bufferViews[1].buffer == 0);
+    CHECK(m.bufferViews[1].byteOffset == 0);
+    CHECK(m.bufferViews[1].byteLength == 10);
+    CHECK(m.bufferViews[2].buffer == 1);
+    CHECK(m.bufferViews[2].byteLength == 100);
+  }
+
+  SECTION("leaves a meshopt fallback buffer with no data intact even if it has "
+          "no URI") {
+    Model m;
+    m.buffers.emplace_back();
+    m.buffers.emplace_back();
+    m.buffers.emplace_back();
+    m.bufferViews.emplace_back();
+    m.bufferViews.emplace_back();
+    m.bufferViews.emplace_back();
+
+    Buffer& buffer1 = m.buffers[0];
+    buffer1.byteLength = 10;
+    buffer1.cesium.data.resize(10, std::byte('1'));
+
+    Buffer& buffer2 = m.buffers[1];
+    buffer2.byteLength = 100;
+    ExtensionBufferExtMeshoptCompression& extension =
+        buffer2.addExtension<ExtensionBufferExtMeshoptCompression>();
+    extension.fallback = true;
+
+    Buffer& buffer3 = m.buffers[2];
+    buffer3.byteLength = 12;
+    buffer3.cesium.data.resize(12, std::byte('2'));
+
+    BufferView& bufferView1 = m.bufferViews[0];
+    bufferView1.buffer = 2;
+    bufferView1.byteLength = 12;
+    BufferView& bufferView2 = m.bufferViews[1];
+    bufferView2.buffer = 0;
+    bufferView2.byteLength = 10;
+    BufferView& bufferView3 = m.bufferViews[2];
+    bufferView3.buffer = 1;
+    bufferView3.byteLength = 100;
+
+    GltfUtilities::collapseToSingleBuffer(m);
+
+    REQUIRE(m.buffers.size() == 2);
+    CHECK(m.buffers[1].hasExtension<ExtensionBufferExtMeshoptCompression>());
+    CHECK(m.bufferViews[0].buffer == 0);
+    // expect 8-byte alignment
+    CHECK(m.bufferViews[0].byteOffset == 16);
+    CHECK(m.bufferViews[0].byteLength == 12);
+    CHECK(m.bufferViews[1].buffer == 0);
+    CHECK(m.bufferViews[1].byteOffset == 0);
+    CHECK(m.bufferViews[1].byteLength == 10);
+    CHECK(m.bufferViews[2].buffer == 1);
+    CHECK(m.bufferViews[2].byteLength == 100);
   }
 }

--- a/CesiumGltfReader/src/decodeDataUrls.cpp
+++ b/CesiumGltfReader/src/decodeDataUrls.cpp
@@ -112,6 +112,16 @@ void decodeDataUrls(
     if (options.clearDecodedDataUrls) {
       buffer.uri.reset();
     }
+
+    if (buffer.byteLength != int64_t(buffer.cesium.data.size())) {
+      readGltf.warnings.emplace_back(fmt::format(
+          "The size of the data decoded from a `data:` URL ({} bytes) "
+          "does not match the declared byteLength of the buffer "
+          "({} bytes). The byteLength has been updated to match.",
+          buffer.cesium.data.size(),
+          buffer.byteLength));
+      buffer.byteLength = int64_t(buffer.cesium.data.size());
+    }
   }
 
   for (CesiumGltf::Image& image : model.images) {

--- a/CesiumGltfReader/src/decodeMeshOpt.cpp
+++ b/CesiumGltfReader/src/decodeMeshOpt.cpp
@@ -154,5 +154,19 @@ void decodeMeshOpt(Model& model, CesiumGltfReader::GltfReaderResult& readGltf) {
           ExtensionBufferViewExtMeshoptCompression::ExtensionName);
     }
   }
+
+  model.extensionsUsed.erase(
+      std::remove(
+          model.extensionsUsed.begin(),
+          model.extensionsUsed.end(),
+          CesiumGltf::ExtensionBufferViewExtMeshoptCompression::ExtensionName),
+      model.extensionsUsed.end());
+
+  model.extensionsRequired.erase(
+      std::remove(
+          model.extensionsRequired.begin(),
+          model.extensionsRequired.end(),
+          CesiumGltf::ExtensionBufferViewExtMeshoptCompression::ExtensionName),
+      model.extensionsRequired.end());
 }
 } // namespace CesiumGltfReader

--- a/CesiumGltfReader/src/dequantizeMeshData.cpp
+++ b/CesiumGltfReader/src/dequantizeMeshData.cpp
@@ -110,6 +110,7 @@ void dequantizeAccessor(Model& model, Accessor& accessor) {
   accessor.componentType = AccessorSpec::ComponentType::FLOAT;
   accessor.byteOffset = 0;
   accessor.bufferView = static_cast<int32_t>(model.bufferViews.size());
+  accessor.normalized = false;
 
   BufferView& bufferView = model.bufferViews.emplace_back(*pBufferView);
   bufferView.byteOffset = 0;
@@ -176,5 +177,19 @@ void dequantizeMeshData(Model& model) {
       }
     }
   }
+
+  model.extensionsUsed.erase(
+      std::remove(
+          model.extensionsUsed.begin(),
+          model.extensionsUsed.end(),
+          "KHR_mesh_quantization"),
+      model.extensionsUsed.end());
+
+  model.extensionsRequired.erase(
+      std::remove(
+          model.extensionsRequired.begin(),
+          model.extensionsRequired.end(),
+          "KHR_mesh_quantization"),
+      model.extensionsRequired.end());
 }
 } // namespace CesiumGltfReader

--- a/CesiumGltfReader/test/TestGltfReader.cpp
+++ b/CesiumGltfReader/test/TestGltfReader.cpp
@@ -2,6 +2,7 @@
 
 #include <CesiumAsync/AsyncSystem.h>
 #include <CesiumGltf/AccessorView.h>
+#include <CesiumGltf/ExtensionBufferViewExtMeshoptCompression.h>
 #include <CesiumGltf/ExtensionCesiumRTC.h>
 #include <CesiumGltf/ExtensionKhrDracoMeshCompression.h>
 #include <CesiumNativeTests/SimpleAssetAccessor.h>
@@ -191,6 +192,15 @@ TEST_CASE("Can decompress meshes using EXT_meshopt_compression") {
         CesiumGltfReader_TEST_DATA_DIR +
         std::string("/DucksMeshopt/Duck.glb")));
     const Model& model = result.model.value();
+
+    // These extensions should be removed during the load process.
+    CHECK(!model.isExtensionRequired(
+        ExtensionBufferViewExtMeshoptCompression::ExtensionName));
+    CHECK(!model.isExtensionUsed(
+        ExtensionBufferViewExtMeshoptCompression::ExtensionName));
+    CHECK(!model.isExtensionRequired("KHR_mesh_quantization"));
+    CHECK(!model.isExtensionUsed("KHR_mesh_quantization"));
+
     originalVar = getVertexAttributeRange(model);
   }
 

--- a/CesiumGltfReader/test/TestGltfReader.cpp
+++ b/CesiumGltfReader/test/TestGltfReader.cpp
@@ -775,7 +775,9 @@ TEST_CASE("GltfReader::postprocessGltf") {
 
     Model& model = readerResult.model.emplace();
 
-    model.buffers.emplace_back().uri = "data:;base64,dGVzdA==";
+    Buffer& buffer = model.buffers.emplace_back();
+    buffer.uri = "data:;base64,dGVzdA==";
+    buffer.byteLength = 4;
 
     reader.postprocessGltf(readerResult, options);
 


### PR DESCRIPTION
`EXT_meshopt_compression` is fun because it is, as far as I'm aware, the only thing other than a regular `bufferView` that can reference a `buffer`. This wasn't being accounted for in a lot of the glTF manipulation code.

From the changelog:

- Added support for the following glTF extensions to `Model::merge`. Previously these extensions could end up broken after merging.
  -  ...
  - `EXT_meshopt_compression`
- `GltfUtilities::collapseToSingleBuffer` now works correctly even if some of the buffers in the model have a `uri` property and the data at that URI has not yet been loaded. Such buffers are left unmodified.
- `GltfUtilities::collapseToSingleBuffer` now works correctly with bufferViews that have the `EXT_meshopt_compression` extension.
- `GltfUtilities::compactBuffer` now accounts for bufferViews with the `EXT_meshopt_compression` when determining unused buffer ranges.
- When `GltfReader` decodes buffers with data URLs, and the size of the data in the URL does not match the buffer's `byteLength`, the `byteLength` is now updated and a warning is raised. Previously, the mismatch was ignored and would cause problems later when trying to use these buffers.
- `EXT_meshopt_compression` and `KHR_mesh_quantization` are now removed from `extensionsUsed` and `extensionsRequired` after they are decoded by `GltfReader`.

Draft because I need to write tests for a lot of this, though I have empirical evidence in another project that these changes are necessary and that they are working well.