### PR TITLE
Gltf Reader: use STB_IMAGE_STATIC to avoid conflicts with other libs

### DIFF
--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -38,6 +38,7 @@ namespace Cesium {
 #undef STBIRDEF
 }; // namespace Cesium
 
+#define STB_IMAGE_STATIC
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 #include <turbojpeg.h>


### PR DESCRIPTION
The problem: `CesiumGltfReader` always uses `STB_IMAGE_IMPLEMENTATION`. If client application also uses `stb_image`, this results in duplicate symbol link errors.
Moving `stb_image.h` into a namespace does not work because all functions are always defined as `extern "C"`.
(BTW, `stb_image_resize.h` includes quite a few standard headers (`stdint.h`,  `string.h`, `math.h`, etc.). I am pretty sure that including standard headers from a namespace is not allowed in C++)

Solution: to add an option to disable `STB_IMAGE_IMPLEMENTATION`. With this, the problem can be solved as follows:

```
set(CESIUM_NO_STB_IMAGE_IMPLEMENTATION ON)
add_subdirectory(cesium-native)
```


