### PR TITLE
Add new functions to Uri class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### ? - ?
 
+##### Additions :tada:
+
+- Added the following new methods to the `Uri` class: `unescape`, `unixPathToUriPath`, `windowsPathToUriPath`, `nativePathToUriPath`, `uriPathToUnixPath`, `uriPathToWindowsPath`, and `uriPathToNativePath`.
+
 ##### Fixes :wrench:
 
 - Added support for the following glTF extensions to `Model::merge`. Previously these extensions could end up broken after merging.

--- a/CesiumUtility/include/CesiumUtility/Uri.h
+++ b/CesiumUtility/include/CesiumUtility/Uri.h
@@ -24,7 +24,104 @@ public:
       const std::string& templateUri,
       const std::function<SubstitutionCallbackSignature>& substitutionCallback);
 
+  /**
+   * @brief Escapes a portion of a URI, percent-encoding disallowed characters.
+   *
+   * @param s The string to escape.
+   * @return The escaped string.
+   */
   static std::string escape(const std::string& s);
+
+  /**
+   * @brief Unescapes a portion of a URI, decoding any percent-encoded
+   * characters.
+   *
+   * @param s The string to unescape.
+   * @return The unescaped string.
+   */
+  static std::string unescape(const std::string& s);
+
+  /**
+   * @brief Converts a Unix file system path to a string suitable for use as the
+   * path portion of a URI. Characters that are not allowed in the path portion
+   * of a URI are percent-encoded as necessary.
+   *
+   * If the path is absolute (it starts with a slash), then the URI will start
+   * with a slash as well.
+   *
+   * @param unixPath The file system path.
+   * @return The URI path.
+   */
+  static std::string unixPathToUriPath(const std::string& unixPath);
+
+  /**
+   * @brief Converts a Windows file system path to a string suitable for use as
+   * the path portion of a URI. Characters that are not allowed in the path
+   * portion of a URI are percent-encoded as necessary.
+   *
+   * Either `/` or `\` may be used as a path separator on input, but the output
+   * will contain only `/`.
+   *
+   * If the path is absolute (it starts with a slash or with C:\ or similar),
+   * then the URI will start with a slash well.
+   *
+   * @param windowsPath The file system path.
+   * @return The URI path.
+   */
+  static std::string windowsPathToUriPath(const std::string& windowsPath);
+
+  /**
+   * @brief Converts a file system path on the current system to a string
+   * suitable for use as the path portion of a URI. Characters that are not
+   * allowed in the path portion of a URI are percent-encoded as necessary.
+   *
+   * If `std::filesystem::path::preferred_separator` is backslash (`\`), this is
+   * assumed to be a Windows-like system and this function calls
+   * {@link windowsPathToUriPath}. Otherwise, this is assumed to be a Unix-like
+   * system and this function calls {@link unixPathToUriPath}.
+   *
+   * @param nativePath The file system path.
+   * @return The URI path.
+   */
+  static std::string nativePathToUriPath(const std::string& nativePath);
+
+  /**
+   * @brief Converts the path portion of a URI to a Unix file system path.
+   * Percent-encoded characters in the URI are decoded.
+   *
+   * If the URI path is absolute (it starts with a slash), then the file system
+   * path will start with a slash as well.
+   *
+   * @param uriPath The URI path.
+   * @return The file system path.
+   */
+  static std::string uriPathToUnixPath(const std::string& uriPath);
+
+  /**
+   * @brief Converts the path portion of a URI to a Windows file system path.
+   * Percent-encoded characters in the URI are decoded.
+   *
+   * If the URI path is absolute (it starts with a slash), then the file system
+   * path will start with a slash or a drive letter.
+   *
+   * @param uriPath The URI path.
+   * @return The file system path.
+   */
+  static std::string uriPathToWindowsPath(const std::string& uriPath);
+
+  /**
+   * @brief Converts the path portion of a URI to a file system path on the
+   * current system. Percent-encoded characters in the URI are decoded.
+   *
+   * If `std::filesystem::path::preferred_separator` is backslash (`\`), this is
+   * assumed to be a Windows-like system and this function calls
+   * {@link uriPathToWindowsPath}. Otherwise, this is assumed to be a Unix-like
+   * system and this function calls {@link uriPathToUnixPath}.
+   *
+   * @param uriPath The URI path.
+   * @return The file system path.
+   */
+  static std::string uriPathToNativePath(const std::string& uriPath);
 
   /**
    * @brief Gets the path portion of the URI. This will not include path

--- a/CesiumUtility/src/Uri.cpp
+++ b/CesiumUtility/src/Uri.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <stdexcept>
 #include <vector>
 
@@ -198,6 +199,131 @@ std::string Uri::escape(const std::string& s) {
       URI_FALSE);
   result.resize(size_t(pTerminator - result.data()));
   return result;
+}
+
+std::string Uri::unescape(const std::string& s) {
+  std::string result = s;
+  const char* pNewNull =
+      uriUnescapeInPlaceExA(result.data(), URI_FALSE, URI_BR_DONT_TOUCH);
+  result.resize(size_t(pNewNull - result.data()));
+  return result;
+}
+
+std::string Uri::unixPathToUriPath(const std::string& unixPath) {
+  // UriParser docs:
+  //   The destination buffer must be large enough to hold 7 + 3 * len(filename)
+  //   + 1 characters in case of an absolute filename or 3 * len(filename) + 1
+  //   in case of a relative filename.
+  std::string result(7 + 3 * unixPath.size() + 1, '\0');
+  if (uriUnixFilenameToUriStringA(unixPath.data(), result.data()) != 0) {
+    // Error - return original string.
+    return unixPath;
+  } else {
+    // An absolute URI will start with "file://". Remove this.
+    if (result.find("file://", 0, 7) != std::string::npos) {
+      result.erase(0, 7);
+    }
+
+    // Truncate at first null character
+    result.resize(std::strlen(result.data()));
+    return result;
+  }
+}
+
+std::string Uri::windowsPathToUriPath(const std::string& windowsPath) {
+  // uriWindowsFilenameToUriStringA doesn't allow `/` character in the path (it
+  // percent encodes them) even though that's a perfectly valid path separator
+  // on Windows. So convert all forward slashes to back slashes before calling
+  // it.
+  std::string windowsPathClean;
+  windowsPathClean.resize(windowsPath.size());
+  std::replace_copy(
+      windowsPath.begin(),
+      windowsPath.end(),
+      windowsPathClean.begin(),
+      '/',
+      '\\');
+
+  // UriParser docs:
+  //   The destination buffer must be large enough to hold 8 + 3 * len(filename)
+  //   + 1 characters in case of an absolute filename or 3 * len(filename) + 1
+  //   in case of a relative filename.
+  std::string result(8 + 3 * windowsPathClean.size() + 1, '\0');
+
+  if (uriWindowsFilenameToUriStringA(windowsPathClean.data(), result.data()) !=
+      0) {
+    // Error - return original string.
+    return windowsPath;
+  } else {
+    // An absolute URI will start with "file://". Remove this.
+    if (result.find("file://", 0, 7) != std::string::npos) {
+      result.erase(0, 7);
+    }
+
+    // Truncate at first null character
+    result.resize(std::strlen(result.data()));
+    return result;
+  }
+}
+
+std::string Uri::nativePathToUriPath(const std::string& nativePath) {
+  if constexpr (std::filesystem::path::preferred_separator == '\\') {
+    return windowsPathToUriPath(nativePath);
+  } else {
+    return unixPathToUriPath(nativePath);
+  }
+}
+
+std::string Uri::uriPathToUnixPath(const std::string& uriPath) {
+  // UriParser docs:
+  //   The destination buffer must be large enough to hold len(uriString) + 1
+  //   - 5 characters in case of an absolute URI or len(uriString) + 1 in case
+  //   of a relative URI.
+  // However, the above seems to assume that uriPath starts with "file:", which
+  // is not required.
+  std::string result(uriPath.size() + 1, '\0');
+  if (uriUriStringToUnixFilenameA(uriPath.data(), result.data()) != 0) {
+    // Error - return original string.
+    return uriPath;
+  } else {
+    // Truncate at first null character
+    result.resize(std::strlen(result.data()));
+    return result;
+  }
+}
+
+std::string Uri::uriPathToWindowsPath(const std::string& uriPath) {
+  // If the URI starts with `/c:` or similar, remove the initial slash.
+  size_t skip = 0;
+  if (uriPath.size() >= 3 && uriPath[0] == '/' && uriPath[1] != '/' &&
+      uriPath[2] == ':') {
+    skip = 1;
+  }
+
+  // UriParser docs:
+  //   The destination buffer must be large enough to hold len(uriString) + 1
+  //   - 5 characters in case of an absolute URI or len(uriString) + 1 in case
+  //   of a relative URI.
+  // However, the above seems to assume that uriPath starts with "file:", which
+  // is not required.
+  std::string result(uriPath.size() + 1, '\0');
+  if (uriUriStringToWindowsFilenameA(uriPath.data() + skip, result.data()) !=
+      0) {
+    // Error - return original string.
+    return uriPath;
+  } else {
+    // Truncate at first null character
+    result.resize(std::strlen(result.data()));
+    return result;
+  }
+}
+
+std::string Uri::uriPathToNativePath(const std::string& nativePath) {
+  if constexpr (std::filesystem::path::preferred_separator == '\\') {
+    return uriPathToWindowsPath(nativePath);
+  } else {
+    return uriPathToUnixPath(nativePath);
+  }
 }
 
 std::string Uri::getPath(const std::string& uri) {

--- a/CesiumUtility/test/TestUri.cpp
+++ b/CesiumUtility/test/TestUri.cpp
@@ -96,3 +96,65 @@ TEST_CASE("Uri::resolve") {
           false,
           false) == "http://www.example.com/page/test");
 }
+
+TEST_CASE("Uri::escape") {
+  CHECK(Uri::escape("foo") == "foo");
+  CHECK(Uri::escape("foo/bar") == "foo%2Fbar");
+  CHECK(Uri::escape("🤞") == "%F0%9F%A4%9E");
+}
+
+TEST_CASE("Uri::unescape") {
+  CHECK(Uri::unescape("foo") == "foo");
+  CHECK(Uri::unescape("foo%2Fbar") == "foo/bar");
+  CHECK(Uri::unescape("%F0%9F%A4%9E") == "🤞");
+}
+
+TEST_CASE("Uri::unixPathToUriPath") {
+  CHECK(Uri::unixPathToUriPath("/wat") == "/wat");
+  CHECK(Uri::unixPathToUriPath("wat") == "wat");
+  CHECK(Uri::unixPathToUriPath("wat/the") == "wat/the");
+  CHECK(Uri::unixPathToUriPath("/foo/bar") == "/foo/bar");
+  CHECK(Uri::unixPathToUriPath("/some:file") == "/some%3Afile");
+  CHECK(Uri::unixPathToUriPath("/🤞/😱/") == "/%F0%9F%A4%9E/%F0%9F%98%B1/");
+}
+
+TEST_CASE("Uri::windowsPathToUriPath") {
+  CHECK(Uri::windowsPathToUriPath("c:\\wat") == "/c:/wat");
+  CHECK(Uri::windowsPathToUriPath("c:/wat") == "/c:/wat");
+  CHECK(Uri::windowsPathToUriPath("wat") == "wat");
+  CHECK(Uri::windowsPathToUriPath("/foo/bar") == "/foo/bar");
+  CHECK(Uri::windowsPathToUriPath("d:\\foo/bar\\") == "/d:/foo/bar/");
+  CHECK(Uri::windowsPathToUriPath("e:\\some:file") == "/e:/some%3Afile");
+  CHECK(
+      Uri::windowsPathToUriPath("c:/🤞/😱/") ==
+      "/c:/%F0%9F%A4%9E/%F0%9F%98%B1/");
+  CHECK(
+      Uri::windowsPathToUriPath("notadriveletter:\\file") ==
+      "notadriveletter%3A/file");
+  CHECK(
+      Uri::windowsPathToUriPath("\\notadriveletter:\\file") ==
+      "/notadriveletter%3A/file");
+}
+
+TEST_CASE("Uri::uriPathToUnixPath") {
+  CHECK(Uri::uriPathToUnixPath("/wat") == "/wat");
+  CHECK(Uri::uriPathToUnixPath("wat") == "wat");
+  CHECK(Uri::uriPathToUnixPath("wat/the") == "wat/the");
+  CHECK(Uri::uriPathToUnixPath("/foo/bar") == "/foo/bar");
+  CHECK(Uri::uriPathToUnixPath("/some%3Afile") == "/some:file");
+  CHECK(Uri::uriPathToUnixPath("/%F0%9F%A4%9E/%F0%9F%98%B1/") == "/🤞/😱/");
+}
+
+TEST_CASE("Uri::uriPathToWindowsPath") {
+  CHECK(Uri::uriPathToWindowsPath("/c:/wat") == "c:\\wat");
+  CHECK(Uri::uriPathToWindowsPath("wat") == "wat");
+  CHECK(Uri::uriPathToWindowsPath("/foo/bar") == "\\foo\\bar");
+  CHECK(Uri::uriPathToWindowsPath("/d:/foo/bar/") == "d:\\foo\\bar\\");
+  CHECK(Uri::uriPathToWindowsPath("/e:/some%3Afile") == "e:\\some:file");
+  CHECK(
+      Uri::uriPathToWindowsPath("/c:/%F0%9F%A4%9E/%F0%9F%98%B1/") ==
+      "c:\\🤞\\😱\\");
+  CHECK(
+      Uri::uriPathToWindowsPath("/notadriveletter:/file") ==
+      "\\notadriveletter:\\file");
+}


### PR DESCRIPTION
Adds several new functions to the `Uri` class:

* `unescape`
* `unixPathToUriPath`
* `windowsPathToUriPath`
* `nativePathToUriPath`
* `uriPathToUnixPath`
* `uriPathToWindowsPath`
* `uriPathToNativePath`
