### PR TITLE
Fix STB library conflicts

### DIFF
--- a/CesiumGltfContent/src/ImageManipulation.cpp
+++ b/CesiumGltfContent/src/ImageManipulation.cpp
@@ -13,6 +13,7 @@ namespace Cesium {
 
 using namespace Cesium;
 
+#define STB_IMAGE_WRITE_STATIC
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
 

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -38,6 +38,7 @@ namespace Cesium {
 #undef STBIRDEF
 }; // namespace Cesium
 
+#define STB_IMAGE_STATIC
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 #include <turbojpeg.h>


### PR DESCRIPTION
[Community contribution](https://github.com/CesiumGS/cesium-native/pull/877) to fix an issue where cesium-native's use of the STB library can conflict with an application's use of it.

STB has more than one implementation that can be defined:
* The community contribution solved a problem with `STB_IMAGE_IMPLEMENTATION`. 
* We solved a similar problem with `STB_IMAGE_RESIZE_IMPLEMENTATION` in #871. 
* I additionally rounded this out by making `STB_IMAGE_WRITE_IMPLEMENTATION` static as well to avoid any similar issues in the future.