### PR TITLE
Faster `collapseToSingleBuffer`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - Added the following new methods to the `Uri` class: `unescape`, `unixPathToUriPath`, `windowsPathToUriPath`, `nativePathToUriPath`, `uriPathToUnixPath`, `uriPathToWindowsPath`, and `uriPathToNativePath`.
+- Drastically improved the performance of `GltfUtilities::collapseToSingleBuffer` for glTFs with many buffers and bufferViews.
 
 ##### Fixes :wrench:
 


### PR DESCRIPTION
I'm working with a model that has tens of thousands of buffers and buffer views and `collapseToSingleBuffer` started to become a bottleneck. I changed the code so that there's only a single pass over buffer views which dramatically speeds things up.

For a model with 34680 buffers and 34680 buffer views it goes from 49796 ms to 47 ms.