### PR TITLE
Added `forEachNodeInScene`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ##### Additions :tada:
 
+- Added `forEachNodeInScene` to `CesiumGltf::Model`.
 - Added the following new methods to the `Uri` class: `unescape`, `unixPathToUriPath`, `windowsPathToUriPath`, `nativePathToUriPath`, `uriPathToUnixPath`, `uriPathToWindowsPath`, and `uriPathToNativePath`.
 
 ##### Fixes :wrench:

--- a/CesiumGltf/include/CesiumGltf/Model.h
+++ b/CesiumGltf/include/CesiumGltf/Model.h
@@ -217,7 +217,7 @@ struct CESIUMGLTF_API Model : public ModelSpec {
    */
   template <typename T>
   static T* getSafe(std::vector<T>* pItems, int32_t index) noexcept {
-    if (index < 0 || index >= pItems->size()) {
+    if (index < 0 || size_t(index) >= pItems->size()) {
       return nullptr;
     } else {
       return &(*pItems)[size_t(index)];

--- a/CesiumGltf/include/CesiumGltf/Model.h
+++ b/CesiumGltf/include/CesiumGltf/Model.h
@@ -57,12 +57,12 @@ struct CESIUMGLTF_API Model : public ModelSpec {
    * @param callback The callback to apply
    */
   void forEachRootNodeInScene(
-      int sceneID,
+      int32_t sceneID,
       std::function<ForEachRootNodeInSceneCallback>&& callback);
 
   /** @copydoc Gltf::forEachRootNodeInScene() */
   void forEachRootNodeInScene(
-      int sceneID,
+      int32_t sceneID,
       std::function<ForEachRootNodeInSceneConstCallback>&& callback) const;
 
   /**
@@ -94,7 +94,7 @@ struct CESIUMGLTF_API Model : public ModelSpec {
    * @param callback The callback to apply
    */
   void forEachNodeInScene(
-      int sceneID,
+      int32_t sceneID,
       std::function<ForEachNodeInSceneCallback>&& callback);
 
   /**
@@ -107,7 +107,7 @@ struct CESIUMGLTF_API Model : public ModelSpec {
 
   /** @copydoc Gltf::forEachNodeInScene() */
   void forEachNodeInScene(
-      int sceneID,
+      int32_t sceneID,
       std::function<ForEachNodeInSceneConstCallback>&& callback) const;
 
   /**
@@ -142,7 +142,7 @@ struct CESIUMGLTF_API Model : public ModelSpec {
    * @param callback The callback to apply
    */
   void forEachPrimitiveInScene(
-      int sceneID,
+      int32_t sceneID,
       std::function<ForEachPrimitiveInSceneCallback>&& callback);
 
   /**
@@ -157,7 +157,7 @@ struct CESIUMGLTF_API Model : public ModelSpec {
 
   /** @copydoc Gltf::forEachPrimitiveInScene() */
   void forEachPrimitiveInScene(
-      int sceneID,
+      int32_t sceneID,
       std::function<ForEachPrimitiveInSceneConstCallback>&& callback) const;
 
   /**
@@ -178,10 +178,10 @@ struct CESIUMGLTF_API Model : public ModelSpec {
   template <typename T>
   static const T& getSafe(const std::vector<T>& items, int32_t index) {
     static T defaultObject;
-    if (index < 0 || static_cast<size_t>(index) >= items.size()) {
+    if (index < 0 || size_t(index) >= items.size()) {
       return defaultObject;
     } else {
-      return items[static_cast<size_t>(index)];
+      return items[size_t(index)];
     }
   }
 
@@ -198,10 +198,10 @@ struct CESIUMGLTF_API Model : public ModelSpec {
   template <typename T>
   static const T*
   getSafe(const std::vector<T>* pItems, int32_t index) noexcept {
-    if (index < 0 || static_cast<size_t>(index) >= pItems->size()) {
+    if (index < 0 || size_t(index) >= pItems->size()) {
       return nullptr;
     } else {
-      return &(*pItems)[static_cast<size_t>(index)];
+      return &(*pItems)[size_t(index)];
     }
   }
 
@@ -217,10 +217,10 @@ struct CESIUMGLTF_API Model : public ModelSpec {
    */
   template <typename T>
   static T* getSafe(std::vector<T>* pItems, int32_t index) noexcept {
-    if (index < 0 || static_cast<size_t>(index) >= pItems->size()) {
+    if (index < 0 || index >= pItems->size()) {
       return nullptr;
     } else {
-      return &(*pItems)[static_cast<size_t>(index)];
+      return &(*pItems)[size_t(index)];
     }
   }
 

--- a/CesiumGltf/include/CesiumGltf/Model.h
+++ b/CesiumGltf/include/CesiumGltf/Model.h
@@ -40,14 +40,14 @@ struct CESIUMGLTF_API Model : public ModelSpec {
    * @brief Apply the given callback to the root nodes of the scene.
    *
    * If the given `sceneID` is non-negative and exists in the given glTF,
-   * then the given callback will be applied to all nodes of this scene.
+   * then the given callback will be applied to all root nodes of this scene.
    *
    * If the given `sceneId` is negative, then the nodes that the callback
    * will be applied to depends on the structure of the glTF model:
    *
    * * If the glTF model has a default scene, then it will
-   *   be applied to all nodes of the default scene.
-   * * Otherwise, it will be applied to all nodes of the the first scene.
+   *   be applied to all root nodes of the default scene.
+   * * Otherwise, it will be applied to all root nodes of the first scene.
    * * Otherwise (if the glTF model does not contain any scenes), it will
    *   be applied to the first node.
    * * Otherwise (if there are no scenes and no nodes), then this method will do
@@ -64,6 +64,51 @@ struct CESIUMGLTF_API Model : public ModelSpec {
   void forEachRootNodeInScene(
       int sceneID,
       std::function<ForEachRootNodeInSceneConstCallback>&& callback) const;
+
+  /**
+   * @brief A callback function for {@link forEachNodeInScene}.
+   */
+  typedef void ForEachNodeInSceneCallback(
+      Model& gltf,
+      Node& node,
+      const glm::dmat4& transform);
+
+  /**
+   * @brief Apply the given callback to all nodes in the scene.
+   *
+   * If the given `sceneID` is non-negative and exists in the given glTF,
+   * then the given callback will be applied to all nodes in this scene.
+   *
+   * If the given `sceneId` is negative, then the nodes that the callback
+   * will be applied to depends on the structure of the glTF model:
+   *
+   * * If the glTF model has a default scene, then it will
+   *   be applied to all nodes in the default scene.
+   * * Otherwise, it will be applied to all nodes in the first scene.
+   * * Otherwise (if the glTF model does not contain any scenes), it will
+   *   be applied to the first node.
+   * * Otherwise (if there are no scenes and no nodes), then this method will do
+   *   nothing.
+   *
+   * @param sceneID The scene ID (index)
+   * @param callback The callback to apply
+   */
+  void forEachNodeInScene(
+      int sceneID,
+      std::function<ForEachNodeInSceneCallback>&& callback);
+
+  /**
+   * @brief A callback function for {@link forEachNodeInScene}.
+   */
+  typedef void ForEachNodeInSceneConstCallback(
+      const Model& gltf,
+      const Node& node,
+      const glm::dmat4& transform);
+
+  /** @copydoc Gltf::forEachNodeInScene() */
+  void forEachNodeInScene(
+      int sceneID,
+      std::function<ForEachNodeInSceneConstCallback>&& callback) const;
 
   /**
    * @brief A callback function for {@link forEachPrimitiveInScene}.

--- a/CesiumGltf/src/Model.cpp
+++ b/CesiumGltf/src/Model.cpp
@@ -802,21 +802,21 @@ void generateSmoothNormals(
 
   const size_t normalBufferId = gltf.buffers.size();
   Buffer& normalBuffer = gltf.buffers.emplace_back();
-  normalBuffer.byteLength = int64_t(normalBufferSize);
+  normalBuffer.byteLength = static_cast<int64_t>(normalBufferSize);
   normalBuffer.cesium.data = std::move(normalByteBuffer);
 
   const size_t normalBufferViewId = gltf.bufferViews.size();
   BufferView& normalBufferView = gltf.bufferViews.emplace_back();
-  normalBufferView.buffer = int32_t(normalBufferId);
-  normalBufferView.byteLength = int64_t(normalBufferSize);
+  normalBufferView.buffer = static_cast<int32_t>(normalBufferId);
+  normalBufferView.byteLength = static_cast<int64_t>(normalBufferSize);
   normalBufferView.byteOffset = 0;
-  normalBufferView.byteStride = int64_t(normalBufferStride);
+  normalBufferView.byteStride = static_cast<int64_t>(normalBufferStride);
   normalBufferView.target = BufferView::Target::ARRAY_BUFFER;
 
   const size_t normalAccessorId = gltf.accessors.size();
   Accessor& normalAccessor = gltf.accessors.emplace_back();
   normalAccessor.byteOffset = 0;
-  normalAccessor.bufferView = int32_t(normalBufferViewId);
+  normalAccessor.bufferView = static_cast<int32_t>(normalBufferViewId);
   normalAccessor.componentType = Accessor::ComponentType::FLOAT;
   normalAccessor.count = positionView.size();
   normalAccessor.type = Accessor::Type::VEC3;

--- a/CesiumGltf/src/Model.cpp
+++ b/CesiumGltf/src/Model.cpp
@@ -402,75 +402,83 @@ void forEachPrimitiveInMeshObject(
   }
 }
 
+std::optional<glm::dmat4x4> getNodeTransform(const CesiumGltf::Node& node) {
+  if (!node.matrix.empty() && node.matrix.size() < 16) {
+    return std::nullopt;
+  }
+
+  // clang-format off
+  // This is column-major, just like glm and glTF
+  static constexpr std::array<double, 16> identityMatrix = {
+      1.0, 0.0, 0.0, 0.0,
+      0.0, 1.0, 0.0, 0.0,
+      0.0, 0.0, 1.0, 0.0,
+      0.0, 0.0, 0.0, 1.0};
+  // clang-format on
+
+  const std::vector<double>& matrix = node.matrix;
+
+  if (node.matrix.size() >= 16 && !std::equal(
+                                      identityMatrix.begin(),
+                                      identityMatrix.end(),
+                                      matrix.begin())) {
+    return glm::dmat4x4(
+        glm::dvec4(matrix[0], matrix[1], matrix[2], matrix[3]),
+        glm::dvec4(matrix[4], matrix[5], matrix[6], matrix[7]),
+        glm::dvec4(matrix[8], matrix[9], matrix[10], matrix[11]),
+        glm::dvec4(matrix[12], matrix[13], matrix[14], matrix[15]));
+  }
+
+  if (!node.translation.empty() || !node.rotation.empty() ||
+      !node.scale.empty()) {
+    glm::dmat4x4 translation(1.0);
+    if (node.translation.size() >= 3) {
+      translation[3] = glm::dvec4(
+          node.translation[0],
+          node.translation[1],
+          node.translation[2],
+          1.0);
+    } else if (!node.translation.empty()) {
+      return std::nullopt;
+    }
+
+    glm::dquat rotationQuat(1.0, 0.0, 0.0, 0.0);
+    if (node.rotation.size() >= 4) {
+      rotationQuat[0] = node.rotation[0];
+      rotationQuat[1] = node.rotation[1];
+      rotationQuat[2] = node.rotation[2];
+      rotationQuat[3] = node.rotation[3];
+    } else if (!node.rotation.empty()) {
+      return std::nullopt;
+    }
+
+    glm::dmat4x4 scale(1.0);
+    if (node.scale.size() >= 3) {
+      scale[0].x = node.scale[0];
+      scale[1].y = node.scale[1];
+      scale[2].z = node.scale[2];
+    } else if (!node.scale.empty()) {
+      return std::nullopt;
+    }
+
+    return translation * glm::dmat4x4(rotationQuat) * scale;
+  }
+
+  return glm::dmat4x4(1.0);
+}
+
 template <typename TCallback>
 void forEachPrimitiveInNodeObject(
     const glm::dmat4x4& transform,
     const Model& model,
     const Node& node,
     TCallback& callback) {
-  static constexpr std::array<double, 16> identityMatrix = {
-      1.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      1.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      1.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      1.0};
 
   // This should just call GltfUtilities::getNodeTransform, but it can't because
   // it's in CesiumGltfContent. We should merge these two libraries, but until
   // then, it's duplicated.
-
-  glm::dmat4x4 nodeTransform = transform;
-  const std::vector<double>& matrix = node.matrix;
-
-  if (node.matrix.size() == 16 &&
-      !std::equal(matrix.begin(), matrix.end(), identityMatrix.begin())) {
-
-    const glm::dmat4& nodeTransformGltf =
-        *reinterpret_cast<const glm::dmat4*>(matrix.data());
-
-    nodeTransform = nodeTransform * nodeTransformGltf;
-  } else if (
-      !node.translation.empty() || !node.rotation.empty() ||
-      !node.scale.empty()) {
-
-    glm::dmat4 translation(1.0);
-    if (node.translation.size() == 3) {
-      translation[3] = glm::dvec4(
-          node.translation[0],
-          node.translation[1],
-          node.translation[2],
-          1.0);
-    }
-
-    glm::dquat rotationQuat(1.0, 0.0, 0.0, 0.0);
-    if (node.rotation.size() == 4) {
-      rotationQuat[0] = node.rotation[0];
-      rotationQuat[1] = node.rotation[1];
-      rotationQuat[2] = node.rotation[2];
-      rotationQuat[3] = node.rotation[3];
-    }
-
-    glm::dmat4 scale(1.0);
-    if (node.scale.size() == 3) {
-      scale[0].x = node.scale[0];
-      scale[1].y = node.scale[1];
-      scale[2].z = node.scale[2];
-    }
-
-    nodeTransform =
-        nodeTransform * translation * glm::dmat4(rotationQuat) * scale;
-  }
+  glm::dmat4x4 nodeTransform =
+      transform * getNodeTransform(node).value_or(glm::dmat4x4(1.0));
 
   const int meshId = node.mesh;
   if (meshId >= 0 && meshId < static_cast<int>(model.meshes.size())) {
@@ -482,6 +490,30 @@ void forEachPrimitiveInNodeObject(
     if (childNodeId >= 0 &&
         childNodeId < static_cast<int>(model.nodes.size())) {
       forEachPrimitiveInNodeObject(
+          nodeTransform,
+          model,
+          model.nodes[static_cast<size_t>(childNodeId)],
+          callback);
+    }
+  }
+}
+
+template <typename TCallback>
+void forEachNode(
+    const glm::dmat4x4& transform,
+    const Model& model,
+    const Node& node,
+    TCallback& callback) {
+
+  glm::dmat4x4 nodeTransform =
+      transform * getNodeTransform(node).value_or(glm::dmat4x4(1.0));
+
+  callback(model, node, nodeTransform);
+
+  for (const int childNodeId : node.children) {
+    if (childNodeId >= 0 &&
+        childNodeId < static_cast<int>(model.nodes.size())) {
+      forEachNode(
           nodeTransform,
           model,
           model.nodes[static_cast<size_t>(childNodeId)],
@@ -511,8 +543,8 @@ void Model::forEachRootNodeInScene(
     std::function<ForEachRootNodeInSceneCallback>&& callback) {
   return const_cast<const Model*>(this)->forEachRootNodeInScene(
       sceneID,
-      [&callback](const Model& gltf_, const Node& node) {
-        callback(const_cast<Model&>(gltf_), const_cast<Node&>(node));
+      [&callback](const Model& gltf, const Node& node) {
+        callback(const_cast<Model&>(gltf), const_cast<Node&>(node));
       });
 }
 
@@ -545,19 +577,42 @@ void Model::forEachRootNodeInScene(
   }
 }
 
+void Model::forEachNodeInScene(
+    int sceneID,
+    std::function<ForEachNodeInSceneCallback>&& callback) {
+  return const_cast<const Model*>(this)->forEachNodeInScene(
+      sceneID,
+      [&callback](
+          const Model& gltf,
+          const Node& node,
+          const glm::dmat4& transform) {
+        callback(const_cast<Model&>(gltf), const_cast<Node&>(node), transform);
+      });
+}
+
+void Model::forEachNodeInScene(
+    int sceneID,
+    std::function<ForEachNodeInSceneConstCallback>&& callback) const {
+  this->forEachRootNodeInScene(
+      sceneID,
+      [callback = std::move(callback)](const Model& model, const Node& node) {
+        forEachNode(glm::dmat4x4(1.0), model, node, callback);
+      });
+}
+
 void Model::forEachPrimitiveInScene(
     int sceneID,
     std::function<ForEachPrimitiveInSceneCallback>&& callback) {
   return const_cast<const Model*>(this)->forEachPrimitiveInScene(
       sceneID,
       [&callback](
-          const Model& gltf_,
+          const Model& gltf,
           const Node& node,
           const Mesh& mesh,
           const MeshPrimitive& primitive,
           const glm::dmat4& transform) {
         callback(
-            const_cast<Model&>(gltf_),
+            const_cast<Model&>(gltf),
             const_cast<Node&>(node),
             const_cast<Mesh&>(mesh),
             const_cast<MeshPrimitive&>(primitive),
@@ -822,7 +877,7 @@ void generateSmoothNormals(
 void Model::generateMissingNormalsSmooth() {
   forEachPrimitiveInScene(
       -1,
-      [](Model& gltf_,
+      [](Model& gltf,
          Node& /*node*/,
          Mesh& /*mesh*/,
          MeshPrimitive& primitive,
@@ -840,18 +895,18 @@ void Model::generateMissingNormalsSmooth() {
         }
 
         const int positionAccessorId = positionIt->second;
-        const AccessorView<glm::vec3> positionView(gltf_, positionAccessorId);
+        const AccessorView<glm::vec3> positionView(gltf, positionAccessorId);
         if (positionView.status() != AccessorViewStatus::Valid) {
           return;
         }
 
         if (primitive.indices < 0 ||
-            static_cast<size_t>(primitive.indices) >= gltf_.accessors.size()) {
-          generateSmoothNormals(gltf_, primitive, positionView, std::nullopt);
+            static_cast<size_t>(primitive.indices) >= gltf.accessors.size()) {
+          generateSmoothNormals(gltf, primitive, positionView, std::nullopt);
         } else {
           Accessor& indexAccessor =
-              gltf_.accessors[static_cast<size_t>(primitive.indices)];
-          generateSmoothNormals(gltf_, primitive, positionView, indexAccessor);
+              gltf.accessors[static_cast<size_t>(primitive.indices)];
+          generateSmoothNormals(gltf, primitive, positionView, indexAccessor);
         }
       });
 }

--- a/CesiumGltf/src/Model.cpp
+++ b/CesiumGltf/src/Model.cpp
@@ -480,19 +480,18 @@ void forEachPrimitiveInNodeObject(
   glm::dmat4x4 nodeTransform =
       transform * getNodeTransform(node).value_or(glm::dmat4x4(1.0));
 
-  const int meshId = node.mesh;
-  if (meshId >= 0 && meshId < static_cast<int>(model.meshes.size())) {
-    const Mesh& mesh = model.meshes[static_cast<size_t>(meshId)];
+  const int32_t meshId = node.mesh;
+  if (meshId >= 0 && size_t(meshId) < model.meshes.size()) {
+    const Mesh& mesh = model.meshes[size_t(meshId)];
     forEachPrimitiveInMeshObject(nodeTransform, model, node, mesh, callback);
   }
 
-  for (const int childNodeId : node.children) {
-    if (childNodeId >= 0 &&
-        childNodeId < static_cast<int>(model.nodes.size())) {
+  for (const int32_t childNodeId : node.children) {
+    if (childNodeId >= 0 && size_t(childNodeId) < model.nodes.size()) {
       forEachPrimitiveInNodeObject(
           nodeTransform,
           model,
-          model.nodes[static_cast<size_t>(childNodeId)],
+          model.nodes[size_t(childNodeId)],
           callback);
     }
   }
@@ -510,13 +509,12 @@ void forEachNode(
 
   callback(model, node, nodeTransform);
 
-  for (const int childNodeId : node.children) {
-    if (childNodeId >= 0 &&
-        childNodeId < static_cast<int>(model.nodes.size())) {
+  for (const int32_t childNodeId : node.children) {
+    if (childNodeId >= 0 && size_t(childNodeId) < model.nodes.size()) {
       forEachNode(
           nodeTransform,
           model,
-          model.nodes[static_cast<size_t>(childNodeId)],
+          model.nodes[size_t(childNodeId)],
           callback);
     }
   }
@@ -539,7 +537,7 @@ void forEachNodeInSceneObject(
 } // namespace
 
 void Model::forEachRootNodeInScene(
-    int sceneID,
+    int32_t sceneID,
     std::function<ForEachRootNodeInSceneCallback>&& callback) {
   return const_cast<const Model*>(this)->forEachRootNodeInScene(
       sceneID,
@@ -549,23 +547,18 @@ void Model::forEachRootNodeInScene(
 }
 
 void Model::forEachRootNodeInScene(
-    int sceneID,
+    int32_t sceneID,
     std::function<ForEachRootNodeInSceneConstCallback>&& callback) const {
   if (sceneID >= 0) {
     // Use the user-specified scene if it exists.
-    if (sceneID < static_cast<int>(this->scenes.size())) {
-      forEachNodeInSceneObject(
-          *this,
-          this->scenes[static_cast<size_t>(sceneID)],
-          callback);
+    if (size_t(sceneID) < this->scenes.size()) {
+      forEachNodeInSceneObject(*this, this->scenes[size_t(sceneID)], callback);
     }
-  } else if (
-      this->scene >= 0 &&
-      this->scene < static_cast<int32_t>(this->scenes.size())) {
+  } else if (this->scene >= 0 && size_t(this->scene) < this->scenes.size()) {
     // Use the default scene
     forEachNodeInSceneObject(
         *this,
-        this->scenes[static_cast<size_t>(this->scene)],
+        this->scenes[size_t(this->scene)],
         callback);
   } else if (!this->scenes.empty()) {
     // There's no default, so use the first scene
@@ -578,7 +571,7 @@ void Model::forEachRootNodeInScene(
 }
 
 void Model::forEachNodeInScene(
-    int sceneID,
+    int32_t sceneID,
     std::function<ForEachNodeInSceneCallback>&& callback) {
   return const_cast<const Model*>(this)->forEachNodeInScene(
       sceneID,
@@ -591,7 +584,7 @@ void Model::forEachNodeInScene(
 }
 
 void Model::forEachNodeInScene(
-    int sceneID,
+    int32_t sceneID,
     std::function<ForEachNodeInSceneConstCallback>&& callback) const {
   this->forEachRootNodeInScene(
       sceneID,
@@ -601,7 +594,7 @@ void Model::forEachNodeInScene(
 }
 
 void Model::forEachPrimitiveInScene(
-    int sceneID,
+    int32_t sceneID,
     std::function<ForEachPrimitiveInSceneCallback>&& callback) {
   return const_cast<const Model*>(this)->forEachPrimitiveInScene(
       sceneID,
@@ -621,7 +614,7 @@ void Model::forEachPrimitiveInScene(
 }
 
 void Model::forEachPrimitiveInScene(
-    int sceneID,
+    int32_t sceneID,
     std::function<ForEachPrimitiveInSceneConstCallback>&& callback) const {
   bool anythingVisited = false;
   this->forEachRootNodeInScene(
@@ -809,28 +802,26 @@ void generateSmoothNormals(
 
   const size_t normalBufferId = gltf.buffers.size();
   Buffer& normalBuffer = gltf.buffers.emplace_back();
-  normalBuffer.byteLength = static_cast<int64_t>(normalBufferSize);
+  normalBuffer.byteLength = int64_t(normalBufferSize);
   normalBuffer.cesium.data = std::move(normalByteBuffer);
 
   const size_t normalBufferViewId = gltf.bufferViews.size();
   BufferView& normalBufferView = gltf.bufferViews.emplace_back();
-  normalBufferView.buffer = static_cast<int32_t>(normalBufferId);
-  normalBufferView.byteLength = static_cast<int64_t>(normalBufferSize);
+  normalBufferView.buffer = int32_t(normalBufferId);
+  normalBufferView.byteLength = int64_t(normalBufferSize);
   normalBufferView.byteOffset = 0;
-  normalBufferView.byteStride = static_cast<int64_t>(normalBufferStride);
+  normalBufferView.byteStride = int64_t(normalBufferStride);
   normalBufferView.target = BufferView::Target::ARRAY_BUFFER;
 
   const size_t normalAccessorId = gltf.accessors.size();
   Accessor& normalAccessor = gltf.accessors.emplace_back();
   normalAccessor.byteOffset = 0;
-  normalAccessor.bufferView = static_cast<int32_t>(normalBufferViewId);
+  normalAccessor.bufferView = int32_t(normalBufferViewId);
   normalAccessor.componentType = Accessor::ComponentType::FLOAT;
   normalAccessor.count = positionView.size();
   normalAccessor.type = Accessor::Type::VEC3;
 
-  primitive.attributes.emplace(
-      "NORMAL",
-      static_cast<int32_t>(normalAccessorId));
+  primitive.attributes.emplace("NORMAL", int32_t(normalAccessorId));
 }
 
 void generateSmoothNormals(
@@ -894,18 +885,17 @@ void Model::generateMissingNormalsSmooth() {
           return;
         }
 
-        const int positionAccessorId = positionIt->second;
+        const int32_t positionAccessorId = positionIt->second;
         const AccessorView<glm::vec3> positionView(gltf, positionAccessorId);
         if (positionView.status() != AccessorViewStatus::Valid) {
           return;
         }
 
         if (primitive.indices < 0 ||
-            static_cast<size_t>(primitive.indices) >= gltf.accessors.size()) {
+            size_t(primitive.indices) >= gltf.accessors.size()) {
           generateSmoothNormals(gltf, primitive, positionView, std::nullopt);
         } else {
-          Accessor& indexAccessor =
-              gltf.accessors[static_cast<size_t>(primitive.indices)];
+          Accessor& indexAccessor = gltf.accessors[size_t(primitive.indices)];
           generateSmoothNormals(gltf, primitive, positionView, indexAccessor);
         }
       });


### PR DESCRIPTION
I found myself needing a function like `forEachPrimitiveInScene` but without drilling into meshes / primitives and just traversing over nodes.