### PR TITLE
Some quantized-mesh related improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@
 - `GltfUtilities::compactBuffer` now accounts for bufferViews with the `EXT_meshopt_compression` when determining unused buffer ranges.
 - When `GltfReader` decodes buffers with data URLs, and the size of the data in the URL does not match the buffer's `byteLength`, the `byteLength` is now updated and a warning is raised. Previously, the mismatch was ignored and would cause problems later when trying to use these buffers.
 - `EXT_meshopt_compression` and `KHR_mesh_quantization` are now removed from `extensionsUsed` and `extensionsRequired` after they are decoded by `GltfReader`.
-- The glTF accessor for the texture coordinates created by `RasterOverlayUtilities::createRasterOverlayTextureCoordinates` now have min/max values that accurately reflect the range of values. Previously, the minimum was always set to 0.0 and the maximum to 1.0.
+- The glTF accessor for the texture coordinates created by `RasterOverlayUtilities::createRasterOverlayTextureCoordinates` now has min/max values that accurately reflect the range of values. Previously, the minimum was always set to 0.0 and the maximum to 1.0.
 - Fixed a bug in the `waitInMainThread` method on `Future` and `SharedFuture` that could cause it to never return if the waited-for future rejected.
 
 ### v0.35.0 - 2024-05-01

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - Added the following new methods to the `Uri` class: `unescape`, `unixPathToUriPath`, `windowsPathToUriPath`, `nativePathToUriPath`, `uriPathToUnixPath`, `uriPathToWindowsPath`, and `uriPathToNativePath`.
+- Added `LayerWriter` to the `CesiumQuantizedMeshTerrain` library and namespace.
 
 ##### Fixes :wrench:
 
@@ -22,6 +23,7 @@
 - `GltfUtilities::compactBuffer` now accounts for bufferViews with the `EXT_meshopt_compression` when determining unused buffer ranges.
 - When `GltfReader` decodes buffers with data URLs, and the size of the data in the URL does not match the buffer's `byteLength`, the `byteLength` is now updated and a warning is raised. Previously, the mismatch was ignored and would cause problems later when trying to use these buffers.
 - `EXT_meshopt_compression` and `KHR_mesh_quantization` are now removed from `extensionsUsed` and `extensionsRequired` after they are decoded by `GltfReader`.
+- The glTF accessor for the texture coordinates created by `RasterOverlayUtilities::createRasterOverlayTextureCoordinates` now have min/max values that accurately reflect the range of values. Previously, the minimum was always set to 0.0 and the maximum to 1.0.
 
 ### v0.35.0 - 2024-05-01
 

--- a/CesiumGeospatial/include/CesiumGeospatial/GlobeRectangle.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/GlobeRectangle.h
@@ -254,7 +254,7 @@ public:
   std::pair<GlobeRectangle, std::optional<GlobeRectangle>>
   splitAtAntiMeridian() const noexcept;
 
-  /*
+  /**
    * @brief Checks whether two globe rectangles are exactly equal.
    *
    * @param left The first rectangle.

--- a/CesiumQuantizedMeshTerrain/include/CesiumQuantizedMeshTerrain/LayerWriter.h
+++ b/CesiumQuantizedMeshTerrain/include/CesiumQuantizedMeshTerrain/LayerWriter.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "CesiumQuantizedMeshTerrain/Library.h"
+
+#include <CesiumJsonWriter/ExtensionWriterContext.h>
+
+#include <gsl/span>
+
+// forward declarations
+namespace CesiumQuantizedMeshTerrain {
+struct Layer;
+}
+
+namespace CesiumQuantizedMeshTerrain {
+
+/**
+ * @brief The result of writing a layer.json with {@link LayerWriter::write}.
+ */
+struct CESIUMQUANTIZEDMESHTERRAIN_API LayerWriterResult {
+  /**
+   * @brief The final generated std::vector<std::byte> of the layer.json.
+   */
+  std::vector<std::byte> bytes;
+
+  /**
+   * @brief Errors, if any, that occurred during the write process.
+   */
+  std::vector<std::string> errors;
+
+  /**
+   * @brief Warnings, if any, that occurred during the write process.
+   */
+  std::vector<std::string> warnings;
+};
+
+/**
+ * @brief Options for how to write a layer.json.
+ */
+struct CESIUMQUANTIZEDMESHTERRAIN_API LayerWriterOptions {
+  /**
+   * @brief If the layer.json should be pretty printed.
+   */
+  bool prettyPrint = false;
+};
+
+/**
+ * @brief Writes layer.json.
+ */
+class CESIUMQUANTIZEDMESHTERRAIN_API LayerWriter {
+public:
+  /**
+   * @brief Constructs a new instance.
+   */
+  LayerWriter();
+
+  /**
+   * @brief Gets the context used to control how layer.json extensions are
+   * written.
+   */
+  CesiumJsonWriter::ExtensionWriterContext& getExtensions();
+
+  /**
+   * @brief Gets the context used to control how layer.json extensions are
+   * written.
+   */
+  const CesiumJsonWriter::ExtensionWriterContext& getExtensions() const;
+
+  /**
+   * @brief Serializes the provided `Layer` into a layer.json byte vector.
+   *
+   * @param layer The layer.
+   * @param options Options for how to write the layer.json.
+   * @return The result of writing the layer.json.
+   */
+  LayerWriterResult write(
+      const CesiumQuantizedMeshTerrain::Layer& layer,
+      const LayerWriterOptions& options = LayerWriterOptions()) const;
+
+private:
+  CesiumJsonWriter::ExtensionWriterContext _context;
+};
+
+} // namespace CesiumQuantizedMeshTerrain

--- a/CesiumQuantizedMeshTerrain/src/LayerWriter.cpp
+++ b/CesiumQuantizedMeshTerrain/src/LayerWriter.cpp
@@ -1,0 +1,46 @@
+#include "CesiumQuantizedMeshTerrain/LayerWriter.h"
+
+#include "LayerJsonWriter.h"
+#include "registerWriterExtensions.h"
+
+#include <CesiumJsonWriter/JsonWriter.h>
+#include <CesiumJsonWriter/PrettyJsonWriter.h>
+#include <CesiumUtility/Tracing.h>
+
+namespace CesiumQuantizedMeshTerrain {
+
+LayerWriter::LayerWriter() { registerWriterExtensions(this->_context); }
+
+CesiumJsonWriter::ExtensionWriterContext& LayerWriter::getExtensions() {
+  return this->_context;
+}
+
+const CesiumJsonWriter::ExtensionWriterContext&
+LayerWriter::getExtensions() const {
+  return this->_context;
+}
+
+LayerWriterResult LayerWriter::write(
+    const Layer& layer,
+    const LayerWriterOptions& options) const {
+  CESIUM_TRACE("LayerWriter::write");
+
+  const CesiumJsonWriter::ExtensionWriterContext& context =
+      this->getExtensions();
+
+  LayerWriterResult result;
+  std::unique_ptr<CesiumJsonWriter::JsonWriter> writer;
+
+  if (options.prettyPrint) {
+    writer = std::make_unique<CesiumJsonWriter::PrettyJsonWriter>();
+  } else {
+    writer = std::make_unique<CesiumJsonWriter::JsonWriter>();
+  }
+
+  LayerJsonWriter::write(layer, *writer, context);
+  result.bytes = writer->toBytes();
+
+  return result;
+}
+
+} // namespace CesiumQuantizedMeshTerrain

--- a/CesiumQuantizedMeshTerrain/src/QuantizedMeshLoader.cpp
+++ b/CesiumQuantizedMeshTerrain/src/QuantizedMeshLoader.cpp
@@ -57,11 +57,6 @@ struct QuantizedMeshHeader {
   uint32_t vertexCount;
 };
 
-struct ExtensionHeader {
-  uint8_t extensionId;
-  uint32_t extensionLength;
-};
-
 enum class QuantizedMeshIndexType { UnsignedShort, UnsignedInt };
 
 struct QuantizedMeshView {

--- a/CesiumQuantizedMeshTerrain/test/TestLayerWriter.cpp
+++ b/CesiumQuantizedMeshTerrain/test/TestLayerWriter.cpp
@@ -1,0 +1,91 @@
+#include <CesiumQuantizedMeshTerrain/Layer.h>
+#include <CesiumQuantizedMeshTerrain/LayerReader.h>
+#include <CesiumQuantizedMeshTerrain/LayerWriter.h>
+
+#include <catch2/catch.hpp>
+
+using namespace CesiumJsonReader;
+using namespace CesiumQuantizedMeshTerrain;
+
+TEST_CASE("LayerWriter") {
+  Layer layer;
+  layer.attribution = "attribution";
+  layer.bounds = {1.0, 2.0, 3.0, 4.0};
+  layer.description = "description";
+  layer.format = "format";
+  layer.maxzoom = 8;
+  layer.metadataAvailability = 10;
+  layer.minzoom = 1;
+  layer.name = "name";
+  layer.parentUrl = "parent";
+  layer.projection = "projection";
+  layer.scheme = "scheme";
+  layer.tiles = {"tiles1", "tiles2"};
+  layer.version = "version";
+
+  auto& availableLevel0 = layer.available.emplace_back();
+
+  auto& availableLevel0Item0 = availableLevel0.emplace_back();
+  availableLevel0Item0.startX = 0;
+  availableLevel0Item0.startY = 0;
+  availableLevel0Item0.endX = 1;
+  availableLevel0Item0.endY = 1;
+
+  auto& availableLevel0Item1 = availableLevel0.emplace_back();
+  availableLevel0Item1.startX = 2;
+  availableLevel0Item1.startY = 3;
+  availableLevel0Item1.endX = 4;
+  availableLevel0Item1.endY = 5;
+
+  auto& availableLevel1 = layer.available.emplace_back();
+  auto& availableLevel1Item0 = availableLevel1.emplace_back();
+  availableLevel1Item0.startX = 10;
+  availableLevel1Item0.startY = 20;
+  availableLevel1Item0.endX = 30;
+  availableLevel1Item0.endY = 40;
+
+  LayerWriter writer;
+  LayerWriterResult writeResult = writer.write(layer, {});
+
+  CHECK(writeResult.errors.empty());
+  CHECK(writeResult.warnings.empty());
+  CHECK(!writeResult.bytes.empty());
+
+  LayerReader reader;
+  ReadJsonResult<Layer> readResult = reader.readFromJson(writeResult.bytes);
+  CHECK(readResult.errors.empty());
+  CHECK(readResult.warnings.empty());
+  REQUIRE(readResult.value);
+
+  Layer& readLayer = *readResult.value;
+
+  CHECK(readLayer.attribution == "attribution");
+  CHECK(readLayer.bounds == std::vector{1.0, 2.0, 3.0, 4.0});
+  CHECK(readLayer.description == "description");
+  CHECK(readLayer.format == "format");
+  CHECK(readLayer.maxzoom == 8);
+  CHECK(readLayer.metadataAvailability == 10);
+  CHECK(readLayer.minzoom == 1);
+  CHECK(readLayer.name == "name");
+  CHECK(readLayer.parentUrl == "parent");
+  CHECK(readLayer.projection == "projection");
+  CHECK(readLayer.scheme == "scheme");
+  CHECK(readLayer.tiles == std::vector<std::string>{"tiles1", "tiles2"});
+  CHECK(readLayer.version == "version");
+
+  CHECK(readLayer.available.size() == 2);
+  CHECK(readLayer.available[0].size() == 2);
+  CHECK(readLayer.available[0][0].startX == 0);
+  CHECK(readLayer.available[0][0].startY == 0);
+  CHECK(readLayer.available[0][0].endX == 1);
+  CHECK(readLayer.available[0][0].endY == 1);
+  CHECK(readLayer.available[0][1].startX == 2);
+  CHECK(readLayer.available[0][1].startY == 3);
+  CHECK(readLayer.available[0][1].endX == 4);
+  CHECK(readLayer.available[0][1].endY == 5);
+  CHECK(readLayer.available[1].size() == 1);
+  CHECK(readLayer.available[1][0].startX == 10);
+  CHECK(readLayer.available[1][0].startY == 20);
+  CHECK(readLayer.available[1][0].endX == 30);
+  CHECK(readLayer.available[1][0].endY == 40);
+}


### PR DESCRIPTION
From the changelog:

- Added `LayerWriter` to the `CesiumQuantizedMeshTerrain` library and namespace.
- The glTF accessor for the texture coordinates created by `RasterOverlayUtilities::createRasterOverlayTextureCoordinates` now have min/max values that accurately reflect the range of values. Previously, the minimum was always set to 0.0 and the maximum to 1.0.

Also:

- Removed an unused struct from `QuantizedMeshLoader.cpp`.
- Fixed incorrect doc comment syntax in `GlobeRectangle.h`.
