### PR TITLE
Fixed crash when writing statically-typed glTF extensions that aren't registered

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - `GltfUtilities::compactBuffer` now accounts for bufferViews with the `EXT_meshopt_compression` when determining unused buffer ranges.
 - When `GltfReader` decodes buffers with data URLs, and the size of the data in the URL does not match the buffer's `byteLength`, the `byteLength` is now updated and a warning is raised. Previously, the mismatch was ignored and would cause problems later when trying to use these buffers.
 - `EXT_meshopt_compression` and `KHR_mesh_quantization` are now removed from `extensionsUsed` and `extensionsRequired` after they are decoded by `GltfReader`.
+- Fixed a crash in `ExtensionWriterContext` when attempting to write statically-typed extensions that aren't registered.
 
 ### v0.35.0 - 2024-05-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,10 @@
 - `GltfUtilities::compactBuffer` now accounts for bufferViews with the `EXT_meshopt_compression` when determining unused buffer ranges.
 - When `GltfReader` decodes buffers with data URLs, and the size of the data in the URL does not match the buffer's `byteLength`, the `byteLength` is now updated and a warning is raised. Previously, the mismatch was ignored and would cause problems later when trying to use these buffers.
 - `EXT_meshopt_compression` and `KHR_mesh_quantization` are now removed from `extensionsUsed` and `extensionsRequired` after they are decoded by `GltfReader`.
-- Fixed a crash in `ExtensionWriterContext` when attempting to write statically-typed extensions that aren't registered.
+- The glTF accessor for the texture coordinates created by `RasterOverlayUtilities::createRasterOverlayTextureCoordinates` now has min/max values that accurately reflect the range of values. Previously, the minimum was always set to 0.0 and the maximum to 1.0.
+- Fixed a bug in the `waitInMainThread` method on `Future` and `SharedFuture` that could cause it to never return if the waited-for future rejected.
+- Moved the small amount of Abseil code embedded into the s2geometry library from the `absl` namespace to the `cesium_s2geometry_absl` namespace, in order to avoid linker errors when linking against both cesium-native and the full Abseil library.
+- Fixed a crash in `ExtensionWriterContext` when attempting to write statically-typed extensions that aren't registered. Now a warning is reported.
 
 ### v0.35.0 - 2024-05-01
 

--- a/Cesium3DTilesWriter/src/SchemaWriter.cpp
+++ b/Cesium3DTilesWriter/src/SchemaWriter.cpp
@@ -39,6 +39,8 @@ SchemaWriterResult SchemaWriter::writeSchema(
 
   SchemaJsonWriter::write(schema, *writer, context);
   result.schemaBytes = writer->toBytes();
+  result.errors = writer->getErrors();
+  result.warnings = writer->getWarnings();
 
   return result;
 }

--- a/Cesium3DTilesWriter/src/SubtreeWriter.cpp
+++ b/Cesium3DTilesWriter/src/SubtreeWriter.cpp
@@ -39,6 +39,8 @@ SubtreeWriterResult SubtreeWriter::writeSubtree(
 
   SubtreeJsonWriter::write(subtree, *writer, context);
   result.subtreeBytes = writer->toBytes();
+  result.errors = writer->getErrors();
+  result.warnings = writer->getWarnings();
 
   return result;
 }

--- a/Cesium3DTilesWriter/src/TilesetWriter.cpp
+++ b/Cesium3DTilesWriter/src/TilesetWriter.cpp
@@ -38,7 +38,6 @@ TilesetWriterResult TilesetWriter::writeTileset(
   }
 
   TilesetJsonWriter::write(tileset, *writer, context);
-
   result.tilesetBytes = writer->toBytes();
   result.errors = writer->getErrors();
   result.warnings = writer->getWarnings();

--- a/Cesium3DTilesWriter/src/TilesetWriter.cpp
+++ b/Cesium3DTilesWriter/src/TilesetWriter.cpp
@@ -38,7 +38,10 @@ TilesetWriterResult TilesetWriter::writeTileset(
   }
 
   TilesetJsonWriter::write(tileset, *writer, context);
+
   result.tilesetBytes = writer->toBytes();
+  result.errors = writer->getErrors();
+  result.warnings = writer->getWarnings();
 
   return result;
 }

--- a/CesiumGltfWriter/src/GltfWriter.cpp
+++ b/CesiumGltfWriter/src/GltfWriter.cpp
@@ -142,6 +142,8 @@ GltfWriterResult GltfWriter::writeGltf(
 
   ModelJsonWriter::write(model, *writer, context);
   result.gltfBytes = writer->toBytes();
+  result.errors = writer->getErrors();
+  result.warnings = writer->getWarnings();
 
   return result;
 }
@@ -156,7 +158,6 @@ GltfWriterResult GltfWriter::writeGlb(
       this->getExtensions();
 
   GltfWriterResult result;
-
   std::unique_ptr<CesiumJsonWriter::JsonWriter> writer;
 
   if (options.prettyPrint) {
@@ -173,6 +174,16 @@ GltfWriterResult GltfWriter::writeGlb(
       gsl::span(jsonData),
       bufferData,
       options.binaryChunkByteAlignment);
+
+  result.errors.insert(
+      result.errors.end(),
+      writer->getErrors().begin(),
+      writer->getErrors().end());
+
+  result.warnings.insert(
+      result.warnings.end(),
+      writer->getWarnings().begin(),
+      writer->getWarnings().end());
 
   return result;
 }

--- a/CesiumGltfWriter/test/TestGltfWriter.cpp
+++ b/CesiumGltfWriter/test/TestGltfWriter.cpp
@@ -47,7 +47,6 @@ bool hasSpaces(const std::string& input) {
 }
 
 struct ExtensionModelTest final : public CesiumUtility::ExtensibleObject {
-  static inline constexpr const char* TypeName = "ExtensionModelTest";
   static inline constexpr const char* ExtensionName = "PRIVATE_model_test";
 };
 

--- a/CesiumGltfWriter/test/TestGltfWriter.cpp
+++ b/CesiumGltfWriter/test/TestGltfWriter.cpp
@@ -45,6 +45,12 @@ bool hasSpaces(const std::string& input) {
     return std::isspace(c);
   });
 }
+
+struct ExtensionModelTest final : public CesiumUtility::ExtensibleObject {
+  static inline constexpr const char* TypeName = "ExtensionModelTest";
+  static inline constexpr const char* ExtensionName = "PRIVATE_model_test";
+};
+
 } // namespace
 
 TEST_CASE("Writes glTF") {
@@ -594,4 +600,24 @@ TEST_CASE("Reports an error if asked to write a GLB larger than 4GB") {
       writer.writeGlb(model, buffer.cesium.data);
   REQUIRE(!result.errors.empty());
   CHECK(result.gltfBytes.empty());
+}
+
+TEST_CASE("Handles models with unregistered extension") {
+  CesiumGltf::Model model;
+  model.addExtension<ExtensionModelTest>();
+
+  SECTION("Reports a warning if the extension is enabled") {
+    CesiumGltfWriter::GltfWriter writer;
+    CesiumGltfWriter::GltfWriterResult result = writer.writeGltf(model);
+    REQUIRE(!result.warnings.empty());
+  }
+
+  SECTION("Does not report a warning if the extension is disabled") {
+    CesiumGltfWriter::GltfWriter writer;
+    writer.getExtensions().setExtensionState(
+        ExtensionModelTest::ExtensionName,
+        CesiumJsonWriter::ExtensionState::Disabled);
+    CesiumGltfWriter::GltfWriterResult result = writer.writeGltf(model);
+    REQUIRE(result.warnings.empty());
+  }
 }

--- a/CesiumJsonReader/include/CesiumJsonReader/JsonReaderOptions.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/JsonReaderOptions.h
@@ -109,6 +109,15 @@ public:
   }
 
   /**
+   * @brief Returns whether an extension is enabled or disabled.
+   *
+   * By default, all extensions are enabled.
+   *
+   * @param extensionName The name of the extension.
+   */
+  ExtensionState getExtensionState(const std::string& extensionName) const;
+
+  /**
    * @brief Enables or disables an extension.
    *
    * By default, all extensions are enabled. When an enabled extension is

--- a/CesiumJsonReader/src/JsonReaderOptions.cpp
+++ b/CesiumJsonReader/src/JsonReaderOptions.cpp
@@ -28,6 +28,16 @@ public:
   virtual IJsonHandler& getHandler() override { return *this; }
 };
 
+ExtensionState
+JsonReaderOptions::getExtensionState(const std::string& extensionName) const {
+  auto stateIt = this->_extensionStates.find(extensionName);
+  if (stateIt == this->_extensionStates.end()) {
+    return ExtensionState::Enabled;
+  }
+
+  return stateIt->second;
+}
+
 void JsonReaderOptions::setExtensionState(
     const std::string& extensionName,
     ExtensionState newState) {

--- a/CesiumJsonWriter/include/CesiumJsonWriter/ExtensionWriterContext.h
+++ b/CesiumJsonWriter/include/CesiumJsonWriter/ExtensionWriterContext.h
@@ -18,25 +18,16 @@ enum class ExtensionState {
   /**
    * @brief The extension is enabled.
    *
-   * If a statically-typed class is available for the extension, it will be
-   * used. Otherwise the extension will be represented as a
-   * {@link CesiumUtility::JsonValue}.
+   * If the extension is a {@link CesiumUtility::JsonValue} or a registered
+   * statically-typed class it will be written to the serialized model;
+   * otherwise it will be ignored.
    */
   Enabled,
 
   /**
-   * @brief The extension is enabled but will always be deserialized as a
-   * {@link CesiumUtility::JsonValue}.
-   *
-   * Even if a statically-typed class is available for the extension, it will
-   * not be used.
-   */
-  JsonOnly,
-
-  /**
    * @brief The extension is disabled.
    *
-   * It will not be represented in the loaded model at all.
+   * It will not be represented in the serialized model at all.
    */
   Disabled
 };
@@ -52,8 +43,7 @@ public:
    * @brief Registers an extension for an object.
    *
    * @tparam TExtended The object to extend.
-   * @tparam TExtensionHandler The extension's
-   * {@link CesiumJsonReader::JsonHandler}.
+   * @tparam TExtensionHandler The extension's writer.
    * @param extensionName The name of the extension.
    */
   template <typename TExtended, typename TExtensionHandler>
@@ -80,8 +70,7 @@ public:
    * The extension name is obtained from `TExtensionHandler::ExtensionName`.
    *
    * @tparam TExtended The object to extend.
-   * @tparam TExtensionHandler The extension's
-   * {@link CesiumJsonReader::JsonHandler}.
+   * @tparam TExtensionHandler The extension's writer.
    */
   template <typename TExtended, typename TExtensionHandler>
   void registerExtension() {
@@ -92,17 +81,10 @@ public:
   /**
    * @brief Enables or disables an extension.
    *
-   * By default, all extensions are enabled. When an enabled extension is
-   * encountered in the source JSON, it is read into a statically-typed
-   * extension class, if one is registered, or into a
-   * {@link CesiumUtility::JsonValue} if not.
+   * By default, all extensions are enabled. However, if the extension is a
+   * statically-typed class and is not registered it will be ignored.
    *
-   * When a disabled extension is encountered in the source JSON, it is ignored
-   * completely.
-   *
-   * An extension may also be set to `ExtensionState::JsonOnly`, in which case
-   * it will be read into a {@link CesiumUtility::JsonValue} even if a
-   * statically-typed extension class is registered.
+   * When a disabled extension is encountered, it is ignored completely.
    *
    * @param extensionName The name of the extension to be enabled or disabled.
    * @param newState The new state for the extension.
@@ -112,6 +94,7 @@ public:
 
   ExtensionHandler<std::any> createExtensionHandler(
       const std::string_view& extensionName,
+      const std::any& obj,
       const std::string& extendedObjectType) const;
 
 private:

--- a/CesiumJsonWriter/include/CesiumJsonWriter/ExtensionWriterContext.h
+++ b/CesiumJsonWriter/include/CesiumJsonWriter/ExtensionWriterContext.h
@@ -20,7 +20,7 @@ enum class ExtensionState {
    *
    * If the extension is a {@link CesiumUtility::JsonValue} or a registered
    * statically-typed class it will be written to the serialized model;
-   * otherwise it will be ignored.
+   * otherwise it will be ignored and a warning will be reported.
    */
   Enabled,
 
@@ -79,10 +79,20 @@ public:
   }
 
   /**
+   * @brief Returns whether an extension is enabled or disabled.
+   *
+   * By default, all extensions are enabled.
+   *
+   * @param extensionName The name of the extension.
+   */
+  ExtensionState getExtensionState(const std::string& extensionName) const;
+
+  /**
    * @brief Enables or disables an extension.
    *
    * By default, all extensions are enabled. However, if the extension is a
-   * statically-typed class and is not registered it will be ignored.
+   * statically-typed class and is not registered it will be ignored and a
+   * warning will be reported.
    *
    * When a disabled extension is encountered, it is ignored completely.
    *

--- a/CesiumJsonWriter/include/CesiumJsonWriter/JsonWriter.h
+++ b/CesiumJsonWriter/include/CesiumJsonWriter/JsonWriter.h
@@ -12,9 +12,6 @@
 
 namespace CesiumJsonWriter {
 class JsonWriter {
-  rapidjson::StringBuffer _compactBuffer;
-  std::unique_ptr<rapidjson::Writer<rapidjson::StringBuffer>> compact;
-
 public:
   JsonWriter();
   virtual ~JsonWriter() {}
@@ -71,5 +68,24 @@ public:
   virtual std::string toString();
   virtual std::string_view toStringView();
   virtual std::vector<std::byte> toBytes();
+
+  template <typename ErrorStr> void emplaceError(ErrorStr&& error) {
+    _errors.emplace_back(std::forward<ErrorStr>(error));
+  }
+
+  template <typename WarningStr> void emplaceWarning(WarningStr&& warning) {
+    _warnings.emplace_back(std::forward<WarningStr>(warning));
+  }
+
+  const std::vector<std::string>& getErrors() const { return _errors; }
+  const std::vector<std::string>& getWarnings() const { return _warnings; }
+
+private:
+  rapidjson::StringBuffer _compactBuffer;
+  std::unique_ptr<rapidjson::Writer<rapidjson::StringBuffer>> _compact;
+
+  std::vector<std::string> _errors;
+  std::vector<std::string> _warnings;
 };
+
 } // namespace CesiumJsonWriter

--- a/CesiumJsonWriter/include/CesiumJsonWriter/JsonWriter.h
+++ b/CesiumJsonWriter/include/CesiumJsonWriter/JsonWriter.h
@@ -87,5 +87,4 @@ private:
   std::vector<std::string> _errors;
   std::vector<std::string> _warnings;
 };
-
 } // namespace CesiumJsonWriter

--- a/CesiumJsonWriter/include/CesiumJsonWriter/writeJsonExtensions.h
+++ b/CesiumJsonWriter/include/CesiumJsonWriter/writeJsonExtensions.h
@@ -3,6 +3,8 @@
 #include "CesiumJsonWriter/ExtensionWriterContext.h"
 #include "CesiumJsonWriter/JsonWriter.h"
 
+#include <spdlog/fmt/fmt.h>
+
 namespace CesiumJsonWriter {
 template <typename TExtended>
 void writeJsonExtensions(
@@ -19,6 +21,13 @@ void writeJsonExtensions(
         item.second,
         TExtended::TypeName);
     if (!handler) {
+      if (context.getExtensionState(item.first) != ExtensionState::Disabled) {
+        jsonWriter.emplaceWarning(fmt::format(
+            "Encountered unregistered extension {}. This extension will be "
+            "ignored. To silence this warning, disable the extension with "
+            "ExtensionWriterContext::setExtensionState.",
+            item.first));
+      }
       continue;
     }
     jsonWriter.Key(item.first);

--- a/CesiumJsonWriter/include/CesiumJsonWriter/writeJsonExtensions.h
+++ b/CesiumJsonWriter/include/CesiumJsonWriter/writeJsonExtensions.h
@@ -14,8 +14,10 @@ void writeJsonExtensions(
   }
   jsonWriter.StartObject();
   for (const auto& item : obj.extensions) {
-    auto handler =
-        context.createExtensionHandler(item.first, TExtended::TypeName);
+    auto handler = context.createExtensionHandler(
+        item.first,
+        item.second,
+        TExtended::TypeName);
     if (!handler) {
       continue;
     }

--- a/CesiumJsonWriter/src/ExtensionWriterContext.cpp
+++ b/CesiumJsonWriter/src/ExtensionWriterContext.cpp
@@ -20,6 +20,7 @@ void objWriter(
 ExtensionWriterContext::ExtensionHandler<std::any>
 ExtensionWriterContext::createExtensionHandler(
     const std::string_view& extensionName,
+    const std::any& obj,
     const std::string& extendedObjectType) const {
 
   std::string extensionNameString{extensionName};
@@ -28,19 +29,21 @@ ExtensionWriterContext::createExtensionHandler(
   if (stateIt != this->_extensionStates.end()) {
     if (stateIt->second == ExtensionState::Disabled) {
       return nullptr;
-    } else if (stateIt->second == ExtensionState::JsonOnly) {
-      return objWriter;
     }
+  }
+
+  if (std::any_cast<CesiumUtility::JsonValue>(&obj) != nullptr) {
+    return objWriter;
   }
 
   auto extensionNameIt = this->_extensions.find(extensionNameString);
   if (extensionNameIt == this->_extensions.end()) {
-    return objWriter;
+    return nullptr;
   }
 
   auto objectTypeIt = extensionNameIt->second.find(extendedObjectType);
   if (objectTypeIt == extensionNameIt->second.end()) {
-    return objWriter;
+    return nullptr;
   }
 
   return objectTypeIt->second;

--- a/CesiumJsonWriter/src/ExtensionWriterContext.cpp
+++ b/CesiumJsonWriter/src/ExtensionWriterContext.cpp
@@ -17,6 +17,22 @@ void objWriter(
 }
 } // namespace
 
+ExtensionState ExtensionWriterContext::getExtensionState(
+    const std::string& extensionName) const {
+  auto stateIt = this->_extensionStates.find(extensionName);
+  if (stateIt == this->_extensionStates.end()) {
+    return ExtensionState::Enabled;
+  }
+
+  return stateIt->second;
+}
+
+void ExtensionWriterContext::setExtensionState(
+    const std::string& extensionName,
+    ExtensionState newState) {
+  this->_extensionStates[extensionName] = newState;
+}
+
 ExtensionWriterContext::ExtensionHandler<std::any>
 ExtensionWriterContext::createExtensionHandler(
     const std::string_view& extensionName,

--- a/CesiumJsonWriter/src/JsonWriter.cpp
+++ b/CesiumJsonWriter/src/JsonWriter.cpp
@@ -7,63 +7,63 @@
 
 namespace CesiumJsonWriter {
 JsonWriter::JsonWriter()
-    : compact(std::make_unique<rapidjson::Writer<rapidjson::StringBuffer>>(
+    : _compact(std::make_unique<rapidjson::Writer<rapidjson::StringBuffer>>(
           _compactBuffer)) {}
 
-bool JsonWriter::Null() { return compact->Null(); }
+bool JsonWriter::Null() { return _compact->Null(); }
 
-bool JsonWriter::Bool(bool b) { return compact->Bool(b); }
+bool JsonWriter::Bool(bool b) { return _compact->Bool(b); }
 
-bool JsonWriter::Int(int i) { return compact->Int(i); }
+bool JsonWriter::Int(int i) { return _compact->Int(i); }
 
-bool JsonWriter::Uint(unsigned int i) { return compact->Uint(i); }
+bool JsonWriter::Uint(unsigned int i) { return _compact->Uint(i); }
 
-bool JsonWriter::Uint64(std::uint64_t i) { return compact->Uint64(i); }
+bool JsonWriter::Uint64(std::uint64_t i) { return _compact->Uint64(i); }
 
-bool JsonWriter::Int64(std::int64_t i) { return compact->Int64(i); }
+bool JsonWriter::Int64(std::int64_t i) { return _compact->Int64(i); }
 
-bool JsonWriter::Double(double d) { return compact->Double(d); }
+bool JsonWriter::Double(double d) { return _compact->Double(d); }
 
 bool JsonWriter::RawNumber(const char* str, unsigned int length, bool copy) {
-  return compact->RawNumber(str, length, copy);
+  return _compact->RawNumber(str, length, copy);
 }
 
 bool JsonWriter::String(std::string_view string) {
-  return compact->String(
+  return _compact->String(
       string.data(),
       static_cast<unsigned int>(string.size()));
 }
 
 bool JsonWriter::Key(std::string_view key) {
-  return compact->Key(key.data(), static_cast<unsigned int>(key.size()));
+  return _compact->Key(key.data(), static_cast<unsigned int>(key.size()));
 }
 
-bool JsonWriter::StartObject() { return compact->StartObject(); }
+bool JsonWriter::StartObject() { return _compact->StartObject(); }
 
-bool JsonWriter::EndObject() { return compact->EndObject(); }
+bool JsonWriter::EndObject() { return _compact->EndObject(); }
 
-bool JsonWriter::StartArray() { return compact->StartArray(); }
+bool JsonWriter::StartArray() { return _compact->StartArray(); }
 
-bool JsonWriter::EndArray() { return compact->EndArray(); }
+bool JsonWriter::EndArray() { return _compact->EndArray(); }
 
-void JsonWriter::Primitive(std::int32_t value) { compact->Int(value); }
+void JsonWriter::Primitive(std::int32_t value) { _compact->Int(value); }
 
-void JsonWriter::Primitive(std::uint32_t value) { compact->Uint(value); }
+void JsonWriter::Primitive(std::uint32_t value) { _compact->Uint(value); }
 
-void JsonWriter::Primitive(std::int64_t value) { compact->Int64(value); }
+void JsonWriter::Primitive(std::int64_t value) { _compact->Int64(value); }
 
-void JsonWriter::Primitive(std::uint64_t value) { compact->Uint64(value); }
+void JsonWriter::Primitive(std::uint64_t value) { _compact->Uint64(value); }
 
 void JsonWriter::Primitive(float value) {
-  compact->Double(static_cast<double>(value));
+  _compact->Double(static_cast<double>(value));
 }
 
-void JsonWriter::Primitive(double value) { compact->Double(value); }
+void JsonWriter::Primitive(double value) { _compact->Double(value); }
 
-void JsonWriter::Primitive(std::nullptr_t) { compact->Null(); }
+void JsonWriter::Primitive(std::nullptr_t) { _compact->Null(); }
 
 void JsonWriter::Primitive(std::string_view string) {
-  compact->String(string.data(), static_cast<unsigned int>(string.size()));
+  _compact->String(string.data(), static_cast<unsigned int>(string.size()));
 }
 
 // Integral
@@ -116,18 +116,18 @@ void JsonWriter::KeyArray(
     std::string_view keyName,
     std::function<void(void)> insideArray) {
   Key(keyName);
-  compact->StartArray();
+  _compact->StartArray();
   insideArray();
-  compact->EndArray();
+  _compact->EndArray();
 }
 
 void JsonWriter::KeyObject(
     std::string_view keyName,
     std::function<void(void)> insideObject) {
   Key(keyName);
-  compact->StartObject();
+  _compact->StartObject();
   insideObject();
-  compact->EndObject();
+  _compact->EndObject();
 }
 
 std::string JsonWriter::toString() {

--- a/CesiumQuantizedMeshTerrain/src/LayerWriter.cpp
+++ b/CesiumQuantizedMeshTerrain/src/LayerWriter.cpp
@@ -39,6 +39,8 @@ LayerWriterResult LayerWriter::write(
 
   LayerJsonWriter::write(layer, *writer, context);
   result.bytes = writer->toBytes();
+  result.errors = writer->getErrors();
+  result.warnings = writer->getWarnings();
 
   return result;
 }


### PR DESCRIPTION
I'm using some statically-typed glTF extensions that are custom to my application. Previously the code assumed that if an extension wasn't registered it must be a `JsonValue`, which would cause a crash due to a bad `any_cast`. Now statically-typed extensions that haven't been registered are ignored.