### PR TITLE
Regenerate glTF schemas for metadata extensions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@
 
 ##### Breaking Changes :mega:
 
+- `ExtensionMeshPrimitiveExtStructuralMetadata::propertyTextures` and `ExtensionMeshPrimitiveExtStructuralMetadata::propertyAttributes` are now vectors of `int32_t` instead of `int64_t`.
+- `FeatureId::propertyTable` is now `int32_t` instead of `std::optional<int64_t>`
 - Moved `upsampleGltfForRasterOverlays` into `RasterOverlayUtilities`. Previously it was a global function. Also added two new parameters to it, prior to the existing `textureCoordinateIndex` parameter.
 - Moved `QuantizedMeshLoader` from `Cesium3DTilesContent` to `CesiumQuantizedMeshTerrain`. If experiencing related linker errors, add `CesiumQuantizedMeshTerrain` to the libraries you link against.
 - `Connection::authorize` now requires an `ApplicationData` parameter, which represents the `appData` retrieved from a Cesium ion server.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### ? - ?
 
+##### Breaking Changes :mega:
+
+- `FeatureId::propertyTable` is now `int32_t` instead of `std::optional<int64_t>`
+
 ##### Additions :tada:
 
 - Added the following new methods to the `Uri` class: `unescape`, `unixPathToUriPath`, `windowsPathToUriPath`, `nativePathToUriPath`, `uriPathToUnixPath`, `uriPathToWindowsPath`, and `uriPathToNativePath`.
@@ -25,10 +29,7 @@
 
 ### v0.35.0 - 2024-05-01
 
-##### Breaking Changes :mega:
-
 - `ExtensionMeshPrimitiveExtStructuralMetadata::propertyTextures` and `ExtensionMeshPrimitiveExtStructuralMetadata::propertyAttributes` are now vectors of `int32_t` instead of `int64_t`.
-- `FeatureId::propertyTable` is now `int32_t` instead of `std::optional<int64_t>`
 - Moved `upsampleGltfForRasterOverlays` into `RasterOverlayUtilities`. Previously it was a global function. Also added two new parameters to it, prior to the existing `textureCoordinateIndex` parameter.
 - Moved `QuantizedMeshLoader` from `Cesium3DTilesContent` to `CesiumQuantizedMeshTerrain`. If experiencing related linker errors, add `CesiumQuantizedMeshTerrain` to the libraries you link against.
 - `Connection::authorize` now requires an `ApplicationData` parameter, which represents the `appData` retrieved from a Cesium ion server.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Breaking Changes :mega:
 
 - `FeatureId::propertyTable` is now `int32_t` instead of `std::optional<int64_t>`
+- `ExtensionMeshPrimitiveExtStructuralMetadata::propertyTextures` and `ExtensionMeshPrimitiveExtStructuralMetadata::propertyAttributes` are now vectors of `int32_t` instead of `int64_t`.
 
 ##### Additions :tada:
 
@@ -29,7 +30,8 @@
 
 ### v0.35.0 - 2024-05-01
 
-- `ExtensionMeshPrimitiveExtStructuralMetadata::propertyTextures` and `ExtensionMeshPrimitiveExtStructuralMetadata::propertyAttributes` are now vectors of `int32_t` instead of `int64_t`.
+##### Breaking Changes :mega:
+
 - Moved `upsampleGltfForRasterOverlays` into `RasterOverlayUtilities`. Previously it was a global function. Also added two new parameters to it, prior to the existing `textureCoordinateIndex` parameter.
 - Moved `QuantizedMeshLoader` from `Cesium3DTilesContent` to `CesiumQuantizedMeshTerrain`. If experiencing related linker errors, add `CesiumQuantizedMeshTerrain` to the libraries you link against.
 - `Connection::authorize` now requires an `ApplicationData` parameter, which represents the `appData` retrieved from a Cesium ion server.

--- a/CesiumGltf/generated/include/CesiumGltf/ExtensionMeshPrimitiveExtStructuralMetadata.h
+++ b/CesiumGltf/generated/include/CesiumGltf/ExtensionMeshPrimitiveExtStructuralMetadata.h
@@ -23,12 +23,12 @@ struct CESIUMGLTF_API ExtensionMeshPrimitiveExtStructuralMetadata final
    * @brief An array of indexes of property textures in the root
    * `EXT_structural_metadata` object.
    */
-  std::vector<int64_t> propertyTextures;
+  std::vector<int32_t> propertyTextures;
 
   /**
    * @brief An array of indexes of property attributes in the root
    * `EXT_structural_metadata` object.
    */
-  std::vector<int64_t> propertyAttributes;
+  std::vector<int32_t> propertyAttributes;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/generated/include/CesiumGltf/FeatureId.h
+++ b/CesiumGltf/generated/include/CesiumGltf/FeatureId.h
@@ -52,6 +52,6 @@ struct CESIUMGLTF_API FeatureId final : public CesiumUtility::ExtensibleObject {
    * @brief The index of the property table containing per-feature property
    * values. Only applicable when using the `EXT_structural_metadata` extension.
    */
-  std::optional<int64_t> propertyTable;
+  int32_t propertyTable = -1;
 };
 } // namespace CesiumGltf

--- a/CesiumGltf/src/Model.cpp
+++ b/CesiumGltf/src/Model.cpp
@@ -44,13 +44,6 @@ void updateIndex(int32_t& index, size_t offset) noexcept {
   index += int32_t(offset);
 }
 
-void updateIndex(int64_t& index, size_t offset) noexcept {
-  if (index == -1) {
-    return;
-  }
-  index += int64_t(offset);
-}
-
 void mergeSchemas(
     Schema& lhs,
     Schema& rhs,
@@ -238,11 +231,11 @@ ErrorList Model::merge(Model&& rhs) {
       ExtensionMeshPrimitiveExtStructuralMetadata* pMetadata =
           primitive.getExtension<ExtensionMeshPrimitiveExtStructuralMetadata>();
       if (pMetadata) {
-        for (int64_t& propertyTextureID : pMetadata->propertyTextures) {
+        for (int32_t& propertyTextureID : pMetadata->propertyTextures) {
           updateIndex(propertyTextureID, firstPropertyTexture);
         }
 
-        for (int64_t& propertyAttributeID : pMetadata->propertyAttributes) {
+        for (int32_t& propertyAttributeID : pMetadata->propertyAttributes) {
           updateIndex(propertyAttributeID, firstPropertyAttribute);
         }
       }
@@ -252,7 +245,7 @@ ErrorList Model::merge(Model&& rhs) {
       if (pMeshFeatures) {
         for (FeatureId& featureId : pMeshFeatures->featureIds) {
           if (featureId.propertyTable) {
-            updateIndex(*featureId.propertyTable, firstPropertyTable);
+            updateIndex(featureId.propertyTable, firstPropertyTable);
           }
 
           if (featureId.texture) {

--- a/CesiumGltf/src/Model.cpp
+++ b/CesiumGltf/src/Model.cpp
@@ -244,9 +244,7 @@ ErrorList Model::merge(Model&& rhs) {
           primitive.getExtension<ExtensionExtMeshFeatures>();
       if (pMeshFeatures) {
         for (FeatureId& featureId : pMeshFeatures->featureIds) {
-          if (featureId.propertyTable) {
-            updateIndex(featureId.propertyTable, firstPropertyTable);
-          }
+          updateIndex(featureId.propertyTable, firstPropertyTable);
 
           if (featureId.texture) {
             updateIndex(featureId.texture->index, firstTexture);

--- a/CesiumGltf/test/TestModel.cpp
+++ b/CesiumGltf/test/TestModel.cpp
@@ -235,22 +235,22 @@ static Model createCubeGltf() {
 
                                       3, 2, 6, 3, 6, 7};
 
-  size_t vertexbyteStride = sizeof(glm::vec3);
-  size_t vertexbyteLength = 8 * vertexbyteStride;
+  size_t vertexByteStride = sizeof(glm::vec3);
+  size_t vertexByteLength = 8 * vertexByteStride;
 
   Buffer& vertexBuffer = model.buffers.emplace_back();
-  vertexBuffer.byteLength = static_cast<int64_t>(vertexbyteLength);
-  vertexBuffer.cesium.data.resize(vertexbyteLength);
+  vertexBuffer.byteLength = static_cast<int64_t>(vertexByteLength);
+  vertexBuffer.cesium.data.resize(vertexByteLength);
   std::memcpy(
       vertexBuffer.cesium.data.data(),
       &cubeVertices[0],
-      vertexbyteLength);
+      vertexByteLength);
 
   BufferView& vertexBufferView = model.bufferViews.emplace_back();
   vertexBufferView.buffer = 0;
   vertexBufferView.byteLength = vertexBuffer.byteLength;
   vertexBufferView.byteOffset = 0;
-  vertexBufferView.byteStride = static_cast<int64_t>(vertexbyteStride);
+  vertexBufferView.byteStride = static_cast<int64_t>(vertexByteStride);
   vertexBufferView.target = BufferView::Target::ARRAY_BUFFER;
 
   Accessor& vertexAccessor = model.accessors.emplace_back();

--- a/CesiumGltfReader/generated/src/ExtensionMeshPrimitiveExtStructuralMetadataJsonHandler.h
+++ b/CesiumGltfReader/generated/src/ExtensionMeshPrimitiveExtStructuralMetadataJsonHandler.h
@@ -44,10 +44,10 @@ protected:
 private:
   CesiumGltf::ExtensionMeshPrimitiveExtStructuralMetadata* _pObject = nullptr;
   CesiumJsonReader::
-      ArrayJsonHandler<int64_t, CesiumJsonReader::IntegerJsonHandler<int64_t>>
+      ArrayJsonHandler<int32_t, CesiumJsonReader::IntegerJsonHandler<int32_t>>
           _propertyTextures;
   CesiumJsonReader::
-      ArrayJsonHandler<int64_t, CesiumJsonReader::IntegerJsonHandler<int64_t>>
+      ArrayJsonHandler<int32_t, CesiumJsonReader::IntegerJsonHandler<int32_t>>
           _propertyAttributes;
 };
 } // namespace CesiumGltfReader

--- a/CesiumGltfReader/generated/src/FeatureIdJsonHandler.h
+++ b/CesiumGltfReader/generated/src/FeatureIdJsonHandler.h
@@ -38,6 +38,6 @@ private:
   CesiumJsonReader::StringJsonHandler _label;
   CesiumJsonReader::IntegerJsonHandler<int64_t> _attribute;
   FeatureIdTextureJsonHandler _texture;
-  CesiumJsonReader::IntegerJsonHandler<int64_t> _propertyTable;
+  CesiumJsonReader::IntegerJsonHandler<int32_t> _propertyTable;
 };
 } // namespace CesiumGltfReader

--- a/CesiumGltfWriter/generated/src/ModelJsonWriter.cpp
+++ b/CesiumGltfWriter/generated/src/ModelJsonWriter.cpp
@@ -1474,7 +1474,7 @@ void writeJson(
     writeJson(obj.texture, jsonWriter, context);
   }
 
-  if (obj.propertyTable.has_value()) {
+  if (obj.propertyTable > -1) {
     jsonWriter.Key("propertyTable");
     writeJson(obj.propertyTable, jsonWriter, context);
   }


### PR DESCRIPTION
There have been a few corrections to the `EXT_mesh_features` and `EXT_structural_metadata` schemas which affect the generated code.

* https://github.com/CesiumGS/glTF/pull/67
* https://github.com/CesiumGS/glTF/pull/68

