### PR TITLE
Change Windows detection for URI methods.

### DIFF
--- a/CesiumUtility/src/Uri.cpp
+++ b/CesiumUtility/src/Uri.cpp
@@ -267,11 +267,11 @@ std::string Uri::windowsPathToUriPath(const std::string& windowsPath) {
 }
 
 std::string Uri::nativePathToUriPath(const std::string& nativePath) {
-  if constexpr (std::filesystem::path::preferred_separator == '\\') {
-    return windowsPathToUriPath(nativePath);
-  } else {
-    return unixPathToUriPath(nativePath);
-  }
+#ifdef _WIN32
+  return windowsPathToUriPath(nativePath);
+#else
+  return unixPathToUriPath(nativePath);
+#endif
 }
 
 std::string Uri::uriPathToUnixPath(const std::string& uriPath) {
@@ -319,11 +319,11 @@ std::string Uri::uriPathToWindowsPath(const std::string& uriPath) {
 }
 
 std::string Uri::uriPathToNativePath(const std::string& nativePath) {
-  if constexpr (std::filesystem::path::preferred_separator == '\\') {
-    return uriPathToWindowsPath(nativePath);
-  } else {
-    return uriPathToUnixPath(nativePath);
-  }
+#ifdef _WIN32
+  return uriPathToWindowsPath(nativePath);
+#else
+  return uriPathToUnixPath(nativePath);
+#endif
 }
 
 std::string Uri::getPath(const std::string& uri) {


### PR DESCRIPTION
Instead of:

```cpp
if constexpr (std::filesystem::path::preferred_separator == '\\')`
```

We now do:

```cpp
#ifdef _WIN32
```

Because the former won't work on versions of iOS prior to 13.0.

See CesiumGS/cesium-unreal#1431

I considered fixing this by ifdef'ing for an old version of iOS specifically, but it would be more complicated and the benefit is vanishingly small.

@csciguy8 originally suggested just using `#ifdef _WIN32` [here](https://github.com/CesiumGS/cesium-native/pull/879#discussion_r1607312347), but I tried to be clever.
