### PR TITLE
Move Abseil code in s2geometry to an isolated namespace.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
 - When `GltfReader` decodes buffers with data URLs, and the size of the data in the URL does not match the buffer's `byteLength`, the `byteLength` is now updated and a warning is raised. Previously, the mismatch was ignored and would cause problems later when trying to use these buffers.
 - `EXT_meshopt_compression` and `KHR_mesh_quantization` are now removed from `extensionsUsed` and `extensionsRequired` after they are decoded by `GltfReader`.
 - Fixed a bug in the `waitInMainThread` method on `Future` and `SharedFuture` that could cause it to never return if the waited-for future rejected.
+- Moved the small amount of Abseil code embedded into the s2geometry library from the `absl` namespace to the `cesium_s2geometry_absl` namespace, in order to avoid linker errors when linking against both cesium-native and the full Abseil library.
 
 ### v0.35.0 - 2024-05-01
 

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -112,6 +112,10 @@ if (MSVC)
   target_compile_definitions(s2geometry PRIVATE NOMINMAX _USE_MATH_DEFINES)
 endif()
 
+# S2 embeds Abseil, which may be used elsewhere as well.
+# So force it into an alternative namespace using the preprocessor.
+target_compile_definitions(s2geometry PRIVATE absl=cesium_s2geometry_absl)
+
 set(HTTPLIB_USE_BROTLI_IF_AVAILABLE OFF CACHE BOOL "Don't use Brotli")
 set(HTTPLIB_USE_ZLIB_IF_AVAILABLE OFF CACHE BOOL "Don't use Zlib")
 set(HTTPLIB_USE_OPENSSL_IF_AVAILABLE OFF CACHE BOOL "Don't use OpenSSL")


### PR DESCRIPTION
This builds on #891 so merge that first.

This PR moves the Abseil functionality embedded in the s2geometry library into an isolated namespace (`cesium_s2geometry_absl`). This avoids linker errors when packaging an Unreal Engine 5.4 game that includes both the Cesium for Unreal and Pixel Streaming plugins, because the Pixel Streaming plugin also embeds some Abseil code.

Fixes CesiumGS/cesium-unreal#1420
