### PR TITLE
add ray ellipsoid for intersection tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - Added `removeUnusedMeshes` and `removeUnusedMaterials` to `GltfUtilities`.
+- Added `rayEllipsoid` static method to `CesiumGeometry::IntersectionTests`.
 
 ### v0.36.0 - 2024-06-03
 

--- a/CesiumGeometry/include/CesiumGeometry/IntersectionTests.h
+++ b/CesiumGeometry/include/CesiumGeometry/IntersectionTests.h
@@ -29,6 +29,17 @@ public:
   rayPlane(const Ray& ray, const Plane& plane) noexcept;
 
   /**
+   * @brief Computes the intersection of a ray and a ellipsoid.
+   *
+   * @param ray The ray.
+   * @param inverseRadii The inverse Radii of ellipsoid.
+   * @return The start and stop of intersection, x is start, y is stop, or
+   * `std::nullopt` if there is no intersection.
+   */
+  static std::optional<glm::dvec2>
+  rayEllipsoid(const Ray& ray, const glm::dvec3& inverseRadii) noexcept;
+
+  /**
    * @brief Determines whether a given point is completely inside a triangle
    * defined by three 2D points.
    *

--- a/CesiumGeometry/src/IntersectionTests.cpp
+++ b/CesiumGeometry/src/IntersectionTests.cpp
@@ -32,6 +32,72 @@ IntersectionTests::rayPlane(const Ray& ray, const Plane& plane) noexcept {
   return ray.getOrigin() + ray.getDirection() * t;
 }
 
+std::optional<glm::dvec2> IntersectionTests::rayEllipsoid(
+    const Ray& ray,
+    const glm::dvec3& inverseRadii) noexcept {
+  glm::dvec3 origin = ray.getOrigin();
+  glm::dvec3 direction = ray.getDirection();
+
+  glm::dvec3 q = inverseRadii * origin;
+  glm::dvec3 w = inverseRadii * direction;
+
+  const double q2 = pow(length(q), 2);
+  const double qw = dot(q, w);
+
+  double difference, w2, product, discriminant, temp;
+  if (q2 > 1.0) {
+    // Outside ellipsoid.
+    if (qw >= 0.0) {
+      // Looking outward or tangent (0 intersections).
+      return std::optional<glm::dvec2>();
+    }
+
+    // qw < 0.0.
+    const double qw2 = qw * qw;
+    difference = q2 - 1.0; // Positively valued.
+    w2 = pow(length(w), 2);
+    product = w2 * difference;
+
+    if (qw2 < product) {
+      // Imaginary roots (0 intersections).
+      return std::optional<glm::dvec2>();
+    }
+    if (qw2 > product) {
+      // Distinct roots (2 intersections).
+      discriminant = qw * qw - product;
+      temp = -qw + sqrt(discriminant); // Avoid cancellation.
+      const double root0 = temp / w2;
+      const double root1 = difference / temp;
+      if (root0 < root1) {
+        return glm::dvec2(root0, root1);
+      }
+
+      return glm::dvec2(root1, root0);
+    }
+    // qw2 == product.  Repeated roots (2 intersections).
+    const double root = sqrt(difference / w2);
+    return glm::dvec2(root, root);
+  }
+  if (q2 < 1.0) {
+    // Inside ellipsoid (2 intersections).
+    difference = q2 - 1.0; // Negatively valued.
+    w2 = pow(length(w), 2);
+    product = w2 * difference; // Negatively valued.
+
+    discriminant = qw * qw - product;
+    temp = -qw + sqrt(discriminant); // Positively valued.
+    return glm::dvec2(0.0, temp / w2);
+  }
+  // q2 == 1.0. On ellipsoid.
+  if (qw < 0.0) {
+    // Looking inward.
+    w2 = pow(length(w), 2);
+    return glm::dvec2(0.0, -qw / w2);
+  }
+  // qw >= 0.0.  Looking outward or tangent.
+  return std::optional<glm::dvec2>();
+}
+
 bool IntersectionTests::pointInTriangle(
     const glm::dvec2& point,
     const glm::dvec2& triangleVertA,

--- a/CesiumGeometry/test/TestIntersectionTests.cpp
+++ b/CesiumGeometry/test/TestIntersectionTests.cpp
@@ -1,6 +1,7 @@
 #include "CesiumGeometry/IntersectionTests.h"
 #include "CesiumGeometry/Plane.h"
 #include "CesiumGeometry/Ray.h"
+#include "CesiumGeospatial/Ellipsoid.h"
 
 #include <catch2/catch.hpp>
 #include <glm/glm.hpp>
@@ -8,6 +9,7 @@
 #include <array>
 
 using namespace CesiumGeometry;
+using namespace CesiumGeospatial;
 
 TEST_CASE("IntersectionTests::rayPlane") {
   struct TestCase {
@@ -38,9 +40,11 @@ TEST_CASE("IntersectionTests::rayPlane") {
   CHECK(intersectionPoint == testCase.expectedIntersectionPoint);
 }
 
+namespace {
 const glm::dvec3 unitInverseRadii(1.0, 1.0, 1.0);
-const glm::dvec3 wgs84Radii(6378137.0, 6378137.0, 6356752.3142451793);
+const glm::dvec3 wgs84Radii = Ellipsoid::WGS84.getRadii();
 const glm::dvec3 wgs84InverseRadii = 1.0 / wgs84Radii;
+} // namespace
 
 TEST_CASE("IntersectionTests::rayEllipsoid") {
   struct TestCase {


### PR DESCRIPTION
since I promise to [fulfill screen space for cesium unreal](https://community.cesium.com/t/screenspacecontroller-for-cesiumunreal/32267) first I need to support ray ellipsoid for intersection tests.

