### PR TITLE
Add check for ellipsoid radii = 0 in `IntersectionTests`

### DIFF
--- a/CesiumGeometry/include/CesiumGeometry/IntersectionTests.h
+++ b/CesiumGeometry/include/CesiumGeometry/IntersectionTests.h
@@ -29,12 +29,17 @@ public:
   rayPlane(const Ray& ray, const Plane& plane) noexcept;
 
   /**
-   * @brief Computes the intersection of a ray and a ellipsoid.
+   * @brief Computes the intersection of a ray and an ellipsoid with the given
+   * radii, centered at the origin.
+   *
+   * Returns false if any of the radii are 0.
    *
    * @param ray The ray.
    * @param radii The radii of ellipsoid.
-   * @return The start and stop of intersection, x is start, y is stop, or
-   * `std::nullopt` if there is no intersection.
+   * @return The distances along the ray where it intersects the ellipsoid, or
+   * `std::nullopt` if there are no intersections. X is the entry, and y is the
+   * exit.
+   *
    */
   static std::optional<glm::dvec2>
   rayEllipsoid(const Ray& ray, const glm::dvec3& radii) noexcept;

--- a/CesiumGeometry/src/IntersectionTests.cpp
+++ b/CesiumGeometry/src/IntersectionTests.cpp
@@ -35,6 +35,10 @@ IntersectionTests::rayPlane(const Ray& ray, const Plane& plane) noexcept {
 std::optional<glm::dvec2> IntersectionTests::rayEllipsoid(
     const Ray& ray,
     const glm::dvec3& radii) noexcept {
+  if (radii.x == 0 || radii.y == 0 || radii.z == 0) {
+    return std::nullopt;
+  }
+
   glm::dvec3 inverseRadii = 1.0 / radii;
 
   glm::dvec3 origin = ray.getOrigin();

--- a/CesiumGeometry/src/IntersectionTests.cpp
+++ b/CesiumGeometry/src/IntersectionTests.cpp
@@ -35,7 +35,7 @@ IntersectionTests::rayPlane(const Ray& ray, const Plane& plane) noexcept {
 std::optional<glm::dvec2> IntersectionTests::rayEllipsoid(
     const Ray& ray,
     const glm::dvec3& radii) noexcept {
-  if (radii.x == 0 || radii.y == 0 || radii.z == 0) {
+  if (radii.x == 0.0 || radii.y == 0.0 || radii.z == 0.0) {
     return std::nullopt;
   }
 

--- a/CesiumGeometry/test/TestIntersectionTests.cpp
+++ b/CesiumGeometry/test/TestIntersectionTests.cpp
@@ -53,6 +53,11 @@ TEST_CASE("IntersectionTests::rayEllipsoid") {
   };
 
   auto testCase = GENERATE(
+      // Degenerate ellipsoid
+      TestCase{
+          Ray(glm::dvec3(2.0, 0.0, 0.0), glm::dvec3(-1.0, 0.0, 0)),
+          glm::dvec3(0),
+          std::nullopt},
       // RayEllipsoid outside intersections
       TestCase{
           Ray(glm::dvec3(2.0, 0.0, 0.0), glm::dvec3(-1.0, 0.0, 0.0)),


### PR DESCRIPTION
After merging #901, I realized we needed to account for the possibility that radii = 0, leading to a division by 0 error. Completely forgot to think of it, so I've opened this PR with a fix. And some doc tweaks as well