### PR TITLE
Fixed build warning - I3dmToGltfConverter.cpp:634:14: error: ‘positio…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@
 - Added `removeUnusedMeshes` and `removeUnusedMaterials` to `GltfUtilities`.
 - Added `rayEllipsoid` static method to `CesiumGeometry::IntersectionTests`.
 
+##### Fixes :wrench:
+
+- When a 3D Tiles Instanced 3D Mesh (i3dm) file contains an instance transform that cannot be decomposed into position, rotation, and scale, a warning will now be logged and an identity transformation will be used. Previously, an undefined transformation would be used.
+
 ### v0.36.0 - 2024-06-03
 
 ##### Breaking Changes :mega:

--- a/Cesium3DTilesContent/src/I3dmToGltfConverter.cpp
+++ b/Cesium3DTilesContent/src/I3dmToGltfConverter.cpp
@@ -635,10 +635,16 @@ bool copyInstanceToBuffer(
   glm::dvec3 position, scale, skew;
   glm::dquat rotation;
   glm::dvec4 perspective;
-  if (!decompose(instanceTransform, scale, rotation, position, skew, perspective)) {
-    position = glm::dvec3{.0};
-    rotation = glm::quat_identity<double, glm::defaultp>();
-    scale = glm::dvec3{1.0};
+  if (!decompose(
+          instanceTransform,
+          scale,
+          rotation,
+          position,
+          skew,
+          perspective)) {
+    position = glm::dvec3(0.0);
+    rotation = glm::dquat(1.0, 0.0, 0.0, 0.0);
+    scale = glm::dvec3(1.0);
     result = false;
   }
   copyInstanceToBuffer(position, rotation, scale, bufferData, i);
@@ -715,8 +721,13 @@ void instantiateGltfInstances(
           for (const auto& modelInstanceTransform : modelInstanceTransforms) {
             glm::dmat4 finalTransform =
                 instanceTransform * modelInstanceTransform;
-            if (!copyInstanceToBuffer(finalTransform, instanceBuffer.cesium.data, destInstanceIndx++)) {
-              result.errors.emplaceWarning("Matrix decompose failed. Default identity values copied to instance buffer.");
+            if (!copyInstanceToBuffer(
+                    finalTransform,
+                    instanceBuffer.cesium.data,
+                    destInstanceIndx++)) {
+              result.errors.emplaceWarning(
+                  "Matrix decompose failed. Default identity values copied to "
+                  "instance buffer.");
             }
           }
         }


### PR DESCRIPTION
Found a compiler warning that might be problematic. See
I3dmToGltfConverter.cpp:634:14: error: ‘position.glm::vec<3, double, glm::packed_highp>::x’ may be used uninitialized [-Werror=maybe-uninitialized]

copyInstanceToBuffer might return data based on uninitialized variables.

Fixed by adding a check and an error message. The error message might not be good enough but the compiler is happy.