### PR TITLE
Fix uninitialized value and missing include

### DIFF
--- a/Cesium3DTilesContent/src/I3dmToGltfConverter.cpp
+++ b/Cesium3DTilesContent/src/I3dmToGltfConverter.cpp
@@ -631,9 +631,9 @@ void copyInstanceToBuffer(
     const glm::dmat4& instanceTransform,
     std::vector<std::byte>& bufferData,
     size_t i) {
-  glm::dvec3 position(0.0), scale(0.0), skew(0.0);
-  glm::dquat rotation(0.0, 0.0, 0.0, 0.0);
-  glm::dvec4 perspective(0.0);
+  glm::dvec3 position, scale, skew;
+  glm::dquat rotation;
+  glm::dvec4 perspective;
   decompose(instanceTransform, scale, rotation, position, skew, perspective);
   copyInstanceToBuffer(position, rotation, scale, bufferData, i);
 }

--- a/Cesium3DTilesContent/src/I3dmToGltfConverter.cpp
+++ b/Cesium3DTilesContent/src/I3dmToGltfConverter.cpp
@@ -631,9 +631,9 @@ void copyInstanceToBuffer(
     const glm::dmat4& instanceTransform,
     std::vector<std::byte>& bufferData,
     size_t i) {
-  glm::dvec3 position, scale, skew;
-  glm::dquat rotation;
-  glm::dvec4 perspective;
+  glm::dvec3 position(0.0), scale(0.0), skew(0.0);
+  glm::dquat rotation(0.0, 0.0, 0.0, 0.0);
+  glm::dvec4 perspective(0.0);
   decompose(instanceTransform, scale, rotation, position, skew, perspective);
   copyInstanceToBuffer(position, rotation, scale, bufferData, i);
 }

--- a/CesiumUtility/include/CesiumUtility/ReferenceCounted.h
+++ b/CesiumUtility/include/CesiumUtility/ReferenceCounted.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Assert.h"
+
 #include <atomic>
 #include <cstdint>
 


### PR DESCRIPTION
Minor fix for uninitialized values, which will produce an error if the build is set up to treat certain warnings as errors, and a fix for a missing include.