### PR TITLE
Add missing header in UWP build.

### DIFF
--- a/CesiumIonClient/src/fillWithRandomBytes.cpp
+++ b/CesiumIonClient/src/fillWithRandomBytes.cpp
@@ -17,6 +17,8 @@
 #endif
 
 #if IS_UWP
+#include <CesiumUtility/Assert.h>
+
 #include <cstdlib>
 #else
 #include <duthomhas/csprng.hpp>


### PR DESCRIPTION
Ran into this while working in Cesium for Unity. I'm going to self merge it.