### PR TITLE
Fix typo in ThirdParty.json

### DIFF
--- a/ThirdParty.json
+++ b/ThirdParty.json
@@ -105,7 +105,7 @@
   {
     "name": "spdlog",
     "url": "https://github.com/gabime/spdlog",
-    "versions": "1.10.0",
+    "version": "1.10.0",
     "license": ["MIT"]
   },
   {


### PR DESCRIPTION
All other objects use `version`, this one was written as `versions` (prural).