### PR TITLE
Add method to convert integer `AccessorSpec::ComponentType` to `PropertyComponentType`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Additions :tada:
+
+- Added `convertAccessorComponentTypeToPropertyComponentType`, which converts integer glTF accessor component types to their best-fitting `PropertyComponentType`.
+
 ### v0.37.0 - 2024-07-01
 
 ##### Additions :tada:

--- a/CesiumGltf/include/CesiumGltf/PropertyType.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyType.h
@@ -51,6 +51,9 @@ convertArrayOffsetTypeStringToPropertyComponentType(const std::string& str);
 PropertyComponentType
 convertStringOffsetTypeStringToPropertyComponentType(const std::string& str);
 
+PropertyComponentType
+convertAccessorComponentTypeToPropertyComponentType(int componentType);
+
 bool isPropertyTypeVecN(PropertyType type);
 
 bool isPropertyTypeMatN(PropertyType type);

--- a/CesiumGltf/src/PropertyType.cpp
+++ b/CesiumGltf/src/PropertyType.cpp
@@ -1,5 +1,6 @@
 #include "CesiumGltf/PropertyType.h"
 
+#include "CesiumGltf/AccessorSpec.h"
 #include "CesiumGltf/ClassProperty.h"
 #include "CesiumGltf/PropertyTable.h"
 
@@ -189,6 +190,26 @@ convertStringOffsetTypeStringToPropertyComponentType(const std::string& str) {
   }
 
   return PropertyComponentType::None;
+}
+
+PropertyComponentType
+convertAccessorComponentTypeToPropertyComponentType(int componentType) {
+  switch (componentType) {
+  case AccessorSpec::ComponentType::BYTE:
+    return PropertyComponentType::Int8;
+  case AccessorSpec::ComponentType::UNSIGNED_BYTE:
+    return PropertyComponentType::Uint8;
+  case AccessorSpec::ComponentType::SHORT:
+    return PropertyComponentType::Int16;
+  case AccessorSpec::ComponentType::UNSIGNED_SHORT:
+    return PropertyComponentType::Uint16;
+  case AccessorSpec::ComponentType::UNSIGNED_INT:
+    return PropertyComponentType::Uint32;
+  case AccessorSpec::ComponentType::FLOAT:
+    return PropertyComponentType::Float32;
+  default:
+    return PropertyComponentType::None;
+  }
 }
 
 bool isPropertyTypeVecN(PropertyType type) {

--- a/CesiumGltf/test/TestPropertyType.cpp
+++ b/CesiumGltf/test/TestPropertyType.cpp
@@ -1,3 +1,4 @@
+#include "CesiumGltf/AccessorSpec.h"
 #include "CesiumGltf/ClassProperty.h"
 #include "CesiumGltf/PropertyTableProperty.h"
 #include "CesiumGltf/PropertyType.h"
@@ -231,6 +232,34 @@ TEST_CASE("Test convertStringOffsetTypeStringToPropertyComponentType") {
 
   REQUIRE(
       convertStringOffsetTypeStringToPropertyComponentType("invalid") ==
+      PropertyComponentType::None);
+}
+
+TEST_CASE("Test convertAccessorComponentTypeToPropertyComponentType") {
+  REQUIRE(
+      convertAccessorComponentTypeToPropertyComponentType(
+          AccessorSpec::ComponentType::BYTE) == PropertyComponentType::Int8);
+  REQUIRE(
+      convertAccessorComponentTypeToPropertyComponentType(
+          AccessorSpec::ComponentType::UNSIGNED_BYTE) ==
+      PropertyComponentType::Uint8);
+  REQUIRE(
+      convertAccessorComponentTypeToPropertyComponentType(
+          AccessorSpec::ComponentType::SHORT) == PropertyComponentType::Int16);
+  REQUIRE(
+      convertAccessorComponentTypeToPropertyComponentType(
+          AccessorSpec::ComponentType::UNSIGNED_SHORT) ==
+      PropertyComponentType::Uint16);
+  REQUIRE(
+      convertAccessorComponentTypeToPropertyComponentType(
+          AccessorSpec::ComponentType::UNSIGNED_INT) ==
+      PropertyComponentType::Uint32);
+  REQUIRE(
+      convertAccessorComponentTypeToPropertyComponentType(
+          AccessorSpec::ComponentType::FLOAT) ==
+      PropertyComponentType::Float32);
+  REQUIRE(
+      convertAccessorComponentTypeToPropertyComponentType(-1) ==
       PropertyComponentType::None);
 }
 


### PR DESCRIPTION
This is useful for creating class definitions for `PropertyAttribute` from glTF accessors.

`ClassProperty` uses strings to convey component type, but `AccessorSpec::ComponentType` is an integer. But you can use the new method with `convertPropertyComponentTypeToString` to get the corresponding component type string.