### PR TITLE
Add missing include for `CesiumUtility/Assert.h`

### DIFF
--- a/Cesium3DTilesContent/src/BatchTableHierarchyPropertyValues.cpp
+++ b/Cesium3DTilesContent/src/BatchTableHierarchyPropertyValues.cpp
@@ -1,6 +1,6 @@
 #include "BatchTableHierarchyPropertyValues.h"
 
-#include "CesiumUtility/Assert.h"
+#include <CesiumUtility/Assert.h>
 
 #include <glm/common.hpp>
 

--- a/Cesium3DTilesContent/src/BatchTableToGltfStructuralMetadata.cpp
+++ b/Cesium3DTilesContent/src/BatchTableToGltfStructuralMetadata.cpp
@@ -8,6 +8,7 @@
 #include <CesiumGltf/Model.h>
 #include <CesiumGltf/PropertyType.h>
 #include <CesiumGltf/PropertyTypeTraits.h>
+#include <CesiumUtility/Assert.h>
 
 #include <glm/glm.hpp>
 #include <rapidjson/writer.h>

--- a/Cesium3DTilesContent/src/SubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/src/SubtreeAvailability.cpp
@@ -6,6 +6,7 @@
 #include <CesiumAsync/IAssetResponse.h>
 #include <CesiumGeometry/OctreeTileID.h>
 #include <CesiumGeometry/QuadtreeTileID.h>
+#include <CesiumUtility/Assert.h>
 #include <CesiumUtility/ErrorList.h>
 #include <CesiumUtility/Uri.h>
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ViewState.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ViewState.h
@@ -6,6 +6,7 @@
 #include <CesiumGeometry/CullingVolume.h>
 #include <CesiumGeometry/Plane.h>
 #include <CesiumGeospatial/Cartographic.h>
+#include <CesiumGeospatial/Ellipsoid.h>
 
 #include <glm/mat3x3.hpp>
 #include <glm/vec2.hpp>

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
@@ -6,6 +6,7 @@
 #include <Cesium3DTilesContent/ImplicitTilingUtilities.h>
 #include <Cesium3DTilesSelection/Tile.h>
 #include <CesiumAsync/IAssetResponse.h>
+#include <CesiumUtility/Assert.h>
 #include <CesiumUtility/Uri.h>
 
 #include <spdlog/logger.h>

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -7,6 +7,7 @@
 #include <Cesium3DTilesSelection/Tile.h>
 #include <CesiumAsync/IAssetResponse.h>
 #include <CesiumGeometry/QuadtreeTileID.h>
+#include <CesiumUtility/Assert.h>
 #include <CesiumUtility/Uri.h>
 
 #include <spdlog/logger.h>

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
@@ -9,6 +9,7 @@
 #include <CesiumGeometry/QuadtreeRectangleAvailability.h>
 #include <CesiumGeometry/QuadtreeTilingScheme.h>
 #include <CesiumGeospatial/Projection.h>
+#include <CesiumUtility/Assert.h>
 
 #include <rapidjson/fwd.h>
 

--- a/Cesium3DTilesSelection/src/RasterMappedTo3DTile.cpp
+++ b/Cesium3DTilesSelection/src/RasterMappedTo3DTile.cpp
@@ -9,6 +9,7 @@
 #include <Cesium3DTilesSelection/TilesetExternals.h>
 #include <CesiumRasterOverlays/RasterOverlayTileProvider.h>
 #include <CesiumRasterOverlays/RasterOverlayUtilities.h>
+#include <CesiumUtility/Assert.h>
 
 using namespace Cesium3DTilesSelection;
 using namespace CesiumGeometry;

--- a/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
@@ -1,4 +1,5 @@
 #include <Cesium3DTilesSelection/RasterOverlayCollection.h>
+#include <CesiumUtility/Assert.h>
 #include <CesiumUtility/Tracing.h>
 
 using namespace CesiumGeometry;

--- a/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
@@ -7,6 +7,7 @@
 #include <CesiumRasterOverlays/RasterOverlay.h>
 #include <CesiumRasterOverlays/RasterOverlayTileProvider.h>
 #include <CesiumRasterOverlays/RasterOverlayUtilities.h>
+#include <CesiumUtility/Assert.h>
 
 #include <variant>
 

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -11,6 +11,7 @@
 #include <CesiumGeospatial/Cartographic.h>
 #include <CesiumGeospatial/GlobeRectangle.h>
 #include <CesiumRasterOverlays/RasterOverlayTile.h>
+#include <CesiumUtility/Assert.h>
 #include <CesiumUtility/CreditSystem.h>
 #include <CesiumUtility/Math.h>
 #include <CesiumUtility/ScopeGuard.h>

--- a/Cesium3DTilesSelection/src/TilesetContentLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentLoader.cpp
@@ -1,4 +1,5 @@
 #include <Cesium3DTilesSelection/TilesetContentLoader.h>
+#include <CesiumUtility/Assert.h>
 
 namespace Cesium3DTilesSelection {
 TileLoadInput::TileLoadInput(

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -15,6 +15,7 @@
 #include <CesiumGeometry/OrientedBoundingBox.h>
 #include <CesiumGeospatial/BoundingRegion.h>
 #include <CesiumGeospatial/S2CellBoundingVolume.h>
+#include <CesiumUtility/Assert.h>
 #include <CesiumUtility/JsonHelpers.h>
 #include <CesiumUtility/Uri.h>
 #include <CesiumUtility/joinToString.h>

--- a/CesiumGltf/include/CesiumGltf/PropertyAttributePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyAttributePropertyView.h
@@ -6,6 +6,8 @@
 #include "CesiumGltf/PropertyTypeTraits.h"
 #include "CesiumGltf/PropertyView.h"
 
+#include <CesiumUtility/Assert.h>
+
 #include <cmath>
 #include <cstdint>
 

--- a/CesiumGltf/include/CesiumGltf/PropertyTablePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTablePropertyView.h
@@ -5,6 +5,8 @@
 #include "CesiumGltf/PropertyTypeTraits.h"
 #include "CesiumGltf/PropertyView.h"
 
+#include <CesiumUtility/Assert.h>
+
 #include <gsl/span>
 
 #include <cstddef>

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -9,6 +9,8 @@
 #include "CesiumGltf/Sampler.h"
 #include "CesiumGltf/TextureView.h"
 
+#include <CesiumUtility/Assert.h>
+
 #include <array>
 #include <cmath>
 #include <cstdint>

--- a/CesiumGltf/test/TestPropertyAttributePropertyView.cpp
+++ b/CesiumGltf/test/TestPropertyAttributePropertyView.cpp
@@ -1,5 +1,7 @@
 #include "CesiumGltf/PropertyAttributePropertyView.h"
 
+#include <CesiumUtility/Assert.h>
+
 #include <catch2/catch.hpp>
 #include <gsl/span>
 

--- a/CesiumGltf/test/TestPropertyAttributeView.cpp
+++ b/CesiumGltf/test/TestPropertyAttributeView.cpp
@@ -1,5 +1,7 @@
 #include "CesiumGltf/PropertyAttributeView.h"
 
+#include <CesiumUtility/Assert.h>
+
 #include <catch2/catch.hpp>
 #include <gsl/span>
 

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -15,6 +15,7 @@
 #include <CesiumJsonReader/JsonHandler.h>
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
+#include <CesiumUtility/Assert.h>
 #include <CesiumUtility/Tracing.h>
 #include <CesiumUtility/Uri.h>
 

--- a/CesiumGltfWriter/src/GltfWriter.cpp
+++ b/CesiumGltfWriter/src/GltfWriter.cpp
@@ -7,6 +7,7 @@
 #include <CesiumJsonWriter/PrettyJsonWriter.h>
 #include <CesiumUtility/Assert.h>
 #include <CesiumUtility/Tracing.h>
+
 namespace CesiumGltfWriter {
 
 namespace {

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
@@ -5,6 +5,7 @@
 #include <CesiumAsync/IAssetAccessor.h>
 #include <CesiumGeospatial/Projection.h>
 #include <CesiumGltfReader/GltfReader.h>
+#include <CesiumUtility/Assert.h>
 #include <CesiumUtility/CreditSystem.h>
 #include <CesiumUtility/IntrusivePointer.h>
 #include <CesiumUtility/ReferenceCounted.h>

--- a/CesiumRasterOverlays/src/RasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/RasterOverlay.cpp
@@ -1,6 +1,7 @@
 #include <CesiumRasterOverlays/RasterOverlay.h>
 #include <CesiumRasterOverlays/RasterOverlayLoadFailureDetails.h>
 #include <CesiumRasterOverlays/RasterOverlayTileProvider.h>
+#include <CesiumUtility/Assert.h>
 
 #include <spdlog/fwd.h>
 

--- a/CesiumUtility/include/CesiumUtility/ReferenceCounted.h
+++ b/CesiumUtility/include/CesiumUtility/ReferenceCounted.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <CesiumUtility/Assert.h>
+
 #include <atomic>
 #include <cstdint>
 

--- a/CesiumUtility/src/Tracing.cpp
+++ b/CesiumUtility/src/Tracing.cpp
@@ -1,7 +1,8 @@
 
 #ifndef CESIUM_OVERRIDE_TRACING
-
 #include "CesiumUtility/Tracing.h"
+
+#include <CesiumUtility/Assert.h>
 
 #include <algorithm>
 

--- a/CesiumUtility/src/Tracing.cpp
+++ b/CesiumUtility/src/Tracing.cpp
@@ -1,5 +1,6 @@
 
 #ifndef CESIUM_OVERRIDE_TRACING
+
 #include "CesiumUtility/Tracing.h"
 
 #include <CesiumUtility/Assert.h>


### PR DESCRIPTION
A lot of the files that used `CESIUM_ASSERT` (as of #874) were missing the include for the file that actually contains the macro. This would sometimes result in compilation errors.