### PR TITLE
Changed `AccessorWriter` constructor to take `std::byte*` instead of `uint8_t*`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### ? - ?
 
+##### Breaking Changes :mega:
+
+- `AccessorWriter` constructor now takes `std::byte*` instead of `uint8_t*`.
+
 ##### Additions :tada:
 
 - Added `convertAccessorComponentTypeToPropertyComponentType`, which converts integer glTF accessor component types to their best-fitting `PropertyComponentType`.

--- a/CesiumGltf/include/CesiumGltf/AccessorWriter.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorWriter.h
@@ -21,8 +21,8 @@ public:
       : _accessor(accessorView) {}
 
   /** @copydoc AccessorView::AccessorView(const
-   * uint8_t*,int64_t,int64_t,int64_t) */
-  AccessorWriter(uint8_t* pData, int64_t stride, int64_t offset, int64_t size)
+   * std::byte*,int64_t,int64_t,int64_t) */
+  AccessorWriter(std::byte* pData, int64_t stride, int64_t offset, int64_t size)
       : _accessor(pData, stride, offset, size) {}
 
   /** @copydoc AccessorView::AccessorView(const Model&,const Accessor&) */


### PR DESCRIPTION
Changed `AccessorWriter` constructor to take `std::byte*` instead of `uint8_t*` which matches the `AccessorView` constructor and prevents a compilation error.