### PR TITLE
Prepare v0.38 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,9 @@
 # Change Log
 
-### ? - ?
+### v0.38.0 - 2024-08-01
 
 ##### Breaking Changes :mega:
 
-- `ForEachPrimitiveInSceneCallback` now passes `meshId` and `primitiveId` to the caller. Existing callbacks will need to add these new parameters
 - `AccessorWriter` constructor now takes `std::byte*` instead of `uint8_t*`.
 
 ##### Additions :tada:
@@ -12,6 +11,10 @@
 - Added `rayTriangle` intersection function that returns the intersection point between a ray and a triangle.
 - Added `intersectRayGltfModel` intersection function that returns the first intersection point between a ray and a glTF model.
 - Added `convertAccessorComponentTypeToPropertyComponentType`, which converts integer glTF accessor component types to their best-fitting `PropertyComponentType`.
+
+##### Fixes :wrench:
+
+- Fixed a bug that prevented raster overlays from being correctly applied when a non-standard "glTF up axis" is in use.
 
 ### v0.37.0 - 2024-07-01
 
@@ -34,7 +37,6 @@
   - Extraneous spaces at the end of an external glTF URI are now ignored. These are sometimes added as padding in order to meet alignment requirements.
 - Removed an overly-eager degenerate triangle test in the 2D version of `IntersectionTests::pointInTriangle` that could discard intersections in small - but valid - triangles.
 - Fixed a bug while upsampling tiles for raster overlays that could cause them to have an incorrect bounding box, which in some cases would lead to the raster overlay being missing entirely from the upsampled tile.
-- Fixed a bug that prevented raster overlays from being correctly applied when a non-standard "glTF up axis" is in use.
 
 ### v0.36.0 - 2024-06-03
 

--- a/CesiumGltfContent/src/GltfUtilities.cpp
+++ b/CesiumGltfContent/src/GltfUtilities.cpp
@@ -1219,6 +1219,8 @@ void GltfUtilities::compactBuffer(
   }
 }
 
+namespace {
+
 template <typename TCallback>
 std::invoke_result_t<TCallback, AccessorView<AccessorTypes::VEC3<float>>>
 createPositionView(
@@ -1369,6 +1371,8 @@ std::optional<glm::dvec3> intersectRayScenePrimitive(
   // should instead compare world distances.
   return transformedRay.pointFromDistance(tClosest);
 }
+
+} // namespace
 
 GltfUtilities::IntersectResult GltfUtilities::intersectRayGltfModel(
     const CesiumGeometry::Ray& ray,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium-native",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Cesium 3D Geospatial for C++",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
* Bump the version.
* Update the changelog.
* Move a couple of unnecessarily global functions into the anonymous namespace. I just happened to notice this while looking at the changes since last release.

I'm going to insta-merge this. It's a PR just for visibility.