### PR TITLE
Add `removeExtensionUsed` and `removeExtensionRequired`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,15 @@
 
 ### ? - ?
 
+##### Additions :tada:
+
+- Added `removeExtensionUsed` and `removeExtensionRequired` methods to `CesiumGltf::Model`.
+
 ##### Fixes :wrench:
 
 - Fixed a bug in `WebMapTileServiceRasterOverlay` that caused it to compute the `TileRow` incorrectly when used with a tiling scheme with multiple tiles in the Y direction at the root.
+- `KHR_texture_transform` is now removed from `extensionsUsed` and `extensionsRequired` after it is decoded by `GltfReader`.
+
 
 ### v0.38.0 - 2024-08-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug in `WebMapTileServiceRasterOverlay` that caused it to compute the `TileRow` incorrectly when used with a tiling scheme with multiple tiles in the Y direction at the root.
-- `KHR_texture_transform` is now removed from `extensionsUsed` and `extensionsRequired` after it is decoded by `GltfReader`.
+- `KHR_texture_transform` is now removed from `extensionsUsed` and `extensionsRequired` after it is applied by `GltfReader`.
 
 
 ### v0.38.0 - 2024-08-01

--- a/CesiumGltf/include/CesiumGltf/Model.h
+++ b/CesiumGltf/include/CesiumGltf/Model.h
@@ -244,6 +244,24 @@ struct CESIUMGLTF_API Model : public ModelSpec {
   void addExtensionRequired(const std::string& extensionName);
 
   /**
+   * @brief Removes an extension from the {@link ModelSpec::extensionsUsed}
+   * property.
+   *
+   * @param extensionName The name of the used extension.
+   */
+  void removeExtensionUsed(const std::string& extensionName);
+
+  /**
+   * @brief Removes an extension from the {@link ModelSpec::extensionsRequired}
+   * property.
+   *
+   * Calling this function also removes the extension from `extensionsUsed`.
+   *
+   * @param extensionName The name of the required extension.
+   */
+  void removeExtensionRequired(const std::string& extensionName);
+
+  /**
    * @brief Determines whether a given extension name is listed in the model's
    * {@link ModelSpec::extensionsUsed} property.
    *

--- a/CesiumGltf/src/Model.cpp
+++ b/CesiumGltf/src/Model.cpp
@@ -908,6 +908,26 @@ void Model::addExtensionRequired(const std::string& extensionName) {
   }
 }
 
+void Model::removeExtensionUsed(const std::string& extensionName) {
+  this->extensionsUsed.erase(
+      std::remove(
+          this->extensionsUsed.begin(),
+          this->extensionsUsed.end(),
+          extensionName),
+      this->extensionsUsed.end());
+}
+
+void Model::removeExtensionRequired(const std::string& extensionName) {
+  this->removeExtensionUsed(extensionName);
+
+  this->extensionsRequired.erase(
+      std::remove(
+          this->extensionsRequired.begin(),
+          this->extensionsRequired.end(),
+          extensionName),
+      this->extensionsRequired.end());
+}
+
 bool Model::isExtensionUsed(const std::string& extensionName) const noexcept {
   return std::find(
              this->extensionsUsed.begin(),

--- a/CesiumGltf/test/TestModel.cpp
+++ b/CesiumGltf/test/TestModel.cpp
@@ -584,6 +584,66 @@ TEST_CASE("Model::addExtensionRequired") {
   }
 }
 
+TEST_CASE("Model::removeExtensionUsed") {
+  SECTION("removes an extension") {
+    Model m;
+    m.extensionsUsed = {"Foo", "Bar"};
+
+    m.removeExtensionUsed("Foo");
+
+    CHECK(m.extensionsUsed == std::vector<std::string>{"Bar"});
+
+    m.removeExtensionUsed("Bar");
+
+    CHECK(m.extensionsUsed.empty());
+
+    m.removeExtensionUsed("Other");
+
+    CHECK(m.extensionsUsed.empty());
+  }
+
+  SECTION("does not also remove the extension from extensionsRequired") {
+    Model m;
+    m.extensionsUsed = {"Foo"};
+    m.extensionsRequired = {"Foo"};
+
+    m.removeExtensionUsed("Foo");
+
+    CHECK(m.extensionsUsed.empty());
+    CHECK(!m.extensionsRequired.empty());
+  }
+}
+
+TEST_CASE("Model::removeExtensionRequired") {
+  SECTION("removes an extension") {
+    Model m;
+    m.extensionsRequired = {"Foo", "Bar"};
+
+    m.removeExtensionRequired("Foo");
+
+    CHECK(m.extensionsRequired == std::vector<std::string>{"Bar"});
+
+    m.removeExtensionRequired("Bar");
+
+    CHECK(m.extensionsRequired.empty());
+
+    m.removeExtensionRequired("Other");
+
+    CHECK(m.extensionsRequired.empty());
+  }
+
+  SECTION("also removes the extension from extensionsUsed if present") {
+    Model m;
+    m.extensionsUsed = {"Foo"};
+    m.extensionsRequired = {"Foo"};
+
+    m.removeExtensionRequired("Foo");
+
+    CHECK(m.extensionsUsed.empty());
+    CHECK(m.extensionsRequired.empty());
+  }
+}
+
 TEST_CASE("Model::merge") {
   SECTION("performs a simple merge") {
     Model m1;

--- a/CesiumGltfReader/src/applyKhrTextureTransform.cpp
+++ b/CesiumGltfReader/src/applyKhrTextureTransform.cpp
@@ -118,5 +118,7 @@ void applyKhrTextureTransform(Model& model) {
       }
     }
   }
+
+  model.removeExtensionRequired(ExtensionKhrTextureTransform::ExtensionName);
 }
 } // namespace CesiumGltfReader

--- a/CesiumGltfReader/src/decodeDraco.cpp
+++ b/CesiumGltfReader/src/decodeDraco.cpp
@@ -350,19 +350,8 @@ void decodeDraco(CesiumGltfReader::GltfReaderResult& readGltf) {
     }
   }
 
-  model.extensionsRequired.erase(
-      std::remove(
-          model.extensionsRequired.begin(),
-          model.extensionsRequired.end(),
-          CesiumGltf::ExtensionKhrDracoMeshCompression::ExtensionName),
-      model.extensionsRequired.end());
-
-  model.extensionsUsed.erase(
-      std::remove(
-          model.extensionsUsed.begin(),
-          model.extensionsUsed.end(),
-          CesiumGltf::ExtensionKhrDracoMeshCompression::ExtensionName),
-      model.extensionsUsed.end());
+  model.removeExtensionRequired(
+      CesiumGltf::ExtensionKhrDracoMeshCompression::ExtensionName);
 }
 
 } // namespace CesiumGltfReader

--- a/CesiumGltfReader/src/decodeMeshOpt.cpp
+++ b/CesiumGltfReader/src/decodeMeshOpt.cpp
@@ -155,18 +155,7 @@ void decodeMeshOpt(Model& model, CesiumGltfReader::GltfReaderResult& readGltf) {
     }
   }
 
-  model.extensionsUsed.erase(
-      std::remove(
-          model.extensionsUsed.begin(),
-          model.extensionsUsed.end(),
-          CesiumGltf::ExtensionBufferViewExtMeshoptCompression::ExtensionName),
-      model.extensionsUsed.end());
-
-  model.extensionsRequired.erase(
-      std::remove(
-          model.extensionsRequired.begin(),
-          model.extensionsRequired.end(),
-          CesiumGltf::ExtensionBufferViewExtMeshoptCompression::ExtensionName),
-      model.extensionsRequired.end());
+  model.removeExtensionRequired(
+      CesiumGltf::ExtensionBufferViewExtMeshoptCompression::ExtensionName);
 }
 } // namespace CesiumGltfReader

--- a/CesiumGltfReader/src/dequantizeMeshData.cpp
+++ b/CesiumGltfReader/src/dequantizeMeshData.cpp
@@ -178,18 +178,6 @@ void dequantizeMeshData(Model& model) {
     }
   }
 
-  model.extensionsUsed.erase(
-      std::remove(
-          model.extensionsUsed.begin(),
-          model.extensionsUsed.end(),
-          "KHR_mesh_quantization"),
-      model.extensionsUsed.end());
-
-  model.extensionsRequired.erase(
-      std::remove(
-          model.extensionsRequired.begin(),
-          model.extensionsRequired.end(),
-          "KHR_mesh_quantization"),
-      model.extensionsRequired.end());
+  model.removeExtensionRequired("KHR_mesh_quantization");
 }
 } // namespace CesiumGltfReader


### PR DESCRIPTION
Adds helper functions for removing extensions from `extensionsUsed` and `extensionsRequired` and fixes a bug where `KHR_texture_transform` wasn't removed in `applyKhrTextureTransform`.