### PR TITLE
Add `resolveExternalImages` flag to `GltfReaderOptions`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### ? - ?
 
+##### Additions :tada:
+
+- Added `resolveExternalImages` flag to `GltfReaderOptions`. It is true by default.
+
 ##### Fixes :wrench:
 
 - Fixed a bug in `WebMapTileServiceRasterOverlay` that caused it to compute the `TileRow` incorrectly when used with a tiling scheme with multiple tiles in the Y direction at the root.

--- a/CesiumGltfReader/include/CesiumGltfReader/GltfReader.h
+++ b/CesiumGltfReader/include/CesiumGltfReader/GltfReader.h
@@ -96,6 +96,11 @@ struct CESIUMGLTFREADER_API GltfReaderOptions {
   bool decodeEmbeddedImages = true;
 
   /**
+   * @brief Whether external images should be resolved.
+   */
+  bool resolveExternalImages = true;
+
+  /**
    * @brief Whether geometry compressed using the `KHR_draco_mesh_compression`
    * extension should be automatically decoded as part of the load process.
    */

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -535,32 +535,34 @@ void CesiumGltfReader::GltfReader::postprocessGltf(
     }
   }
 
-  for (Image& image : pResult->model->images) {
-    if (image.uri && image.uri->substr(0, dataPrefixLength) != dataPrefix) {
-      resolvedBuffers.push_back(
-          pAssetAccessor
-              ->get(asyncSystem, Uri::resolve(baseUrl, *image.uri), tHeaders)
-              .thenInWorkerThread(
-                  [pImage = &image,
-                   ktx2TranscodeTargets = options.ktx2TranscodeTargets](
-                      std::shared_ptr<IAssetRequest>&& pRequest) {
-                    const IAssetResponse* pResponse = pRequest->response();
+  if (options.resolveExternalImages) {
+    for (Image& image : pResult->model->images) {
+      if (image.uri && image.uri->substr(0, dataPrefixLength) != dataPrefix) {
+        resolvedBuffers.push_back(
+            pAssetAccessor
+                ->get(asyncSystem, Uri::resolve(baseUrl, *image.uri), tHeaders)
+                .thenInWorkerThread(
+                    [pImage = &image,
+                     ktx2TranscodeTargets = options.ktx2TranscodeTargets](
+                        std::shared_ptr<IAssetRequest>&& pRequest) {
+                      const IAssetResponse* pResponse = pRequest->response();
 
-                    std::string imageUri = *pImage->uri;
+                      std::string imageUri = *pImage->uri;
 
-                    if (pResponse) {
-                      pImage->uri = std::nullopt;
+                      if (pResponse) {
+                        pImage->uri = std::nullopt;
 
-                      ImageReaderResult imageResult =
-                          readImage(pResponse->data(), ktx2TranscodeTargets);
-                      if (imageResult.image) {
-                        pImage->cesium = std::move(*imageResult.image);
-                        return ExternalBufferLoadResult{true, imageUri};
+                        ImageReaderResult imageResult =
+                            readImage(pResponse->data(), ktx2TranscodeTargets);
+                        if (imageResult.image) {
+                          pImage->cesium = std::move(*imageResult.image);
+                          return ExternalBufferLoadResult{true, imageUri};
+                        }
                       }
-                    }
 
-                    return ExternalBufferLoadResult{false, imageUri};
-                  }));
+                      return ExternalBufferLoadResult{false, imageUri};
+                    }));
+      }
     }
   }
 


### PR DESCRIPTION
Adds a new option `resolveExternalImages` to `GltfReaderOptions` so that you can load a glTF without resolving and decoding external images. In my case, I'm using `GltfReader` in a pipeline that doesn't need access to texture data.