### PR TITLE
Add `CesiumGltfWriter::SchemaWriter`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### ? - ?
 
+##### Additions :tada:
+
+- Added `CesiumGltfWriter::SchemaWriter` for serializing schemas in [EXT_structural_metadata](https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_structural_metadata).
+
 ##### Fixes :wrench:
 
 - Fixed a bug in `WebMapTileServiceRasterOverlay` that caused it to compute the `TileRow` incorrectly when used with a tiling scheme with multiple tiles in the Y direction at the root.

--- a/CesiumGltfWriter/include/CesiumGltfWriter/SchemaWriter.h
+++ b/CesiumGltfWriter/include/CesiumGltfWriter/SchemaWriter.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "CesiumGltfWriter/Library.h"
+
+#include <CesiumJsonWriter/ExtensionWriterContext.h>
+
+// forward declarations
+namespace CesiumGltf {
+struct Schema;
+}
+
+namespace CesiumGltfWriter {
+
+/**
+ * @brief The result of writing a schema with
+ * {@link SchemaWriterWriter::writeSchema}.
+ */
+struct CESIUMGLTFWRITER_API SchemaWriterResult {
+  /**
+   * @brief The final generated std::vector<std::byte> of the schema JSON.
+   */
+  std::vector<std::byte> schemaBytes;
+
+  /**
+   * @brief Errors, if any, that occurred during the write process.
+   */
+  std::vector<std::string> errors;
+
+  /**
+   * @brief Warnings, if any, that occurred during the write process.
+   */
+  std::vector<std::string> warnings;
+};
+
+/**
+ * @brief Options for how to write a schema.
+ */
+struct CESIUMGLTFWRITER_API SchemaWriterOptions {
+  /**
+   * @brief If the schema JSON should be pretty printed.
+   */
+  bool prettyPrint = false;
+};
+
+/**
+ * @brief Writes schemas.
+ */
+class CESIUMGLTFWRITER_API SchemaWriter {
+public:
+  /**
+   * @brief Constructs a new instance.
+   */
+  SchemaWriter();
+
+  /**
+   * @brief Gets the context used to control how schema extensions are written.
+   */
+  CesiumJsonWriter::ExtensionWriterContext& getExtensions();
+
+  /**
+   * @brief Gets the context used to control how schema extensions are written.
+   */
+  const CesiumJsonWriter::ExtensionWriterContext& getExtensions() const;
+
+  /**
+   * @brief Serializes the provided schema object into a byte vector using the
+   * provided flags to convert.
+   *
+   * @param schema The schema.
+   * @param options Options for how to write the schema.
+   * @return The result of writing the schema.
+   */
+  SchemaWriterResult writeSchema(
+      const CesiumGltf::Schema& schema,
+      const SchemaWriterOptions& options = SchemaWriterOptions()) const;
+
+private:
+  CesiumJsonWriter::ExtensionWriterContext _context;
+};
+
+} // namespace CesiumGltfWriter

--- a/CesiumGltfWriter/src/SchemaWriter.cpp
+++ b/CesiumGltfWriter/src/SchemaWriter.cpp
@@ -1,0 +1,47 @@
+#include "CesiumGltfWriter/SchemaWriter.h"
+
+#include "ModelJsonWriter.h"
+#include "registerWriterExtensions.h"
+
+#include <CesiumJsonWriter/JsonWriter.h>
+#include <CesiumJsonWriter/PrettyJsonWriter.h>
+#include <CesiumUtility/Tracing.h>
+
+namespace CesiumGltfWriter {
+
+SchemaWriter::SchemaWriter() { registerWriterExtensions(this->_context); }
+
+CesiumJsonWriter::ExtensionWriterContext& SchemaWriter::getExtensions() {
+  return this->_context;
+}
+
+const CesiumJsonWriter::ExtensionWriterContext&
+SchemaWriter::getExtensions() const {
+  return this->_context;
+}
+
+SchemaWriterResult SchemaWriter::writeSchema(
+    const CesiumGltf::Schema& schema,
+    const SchemaWriterOptions& options) const {
+  CESIUM_TRACE("SchemaWriter::writeSchema");
+
+  const CesiumJsonWriter::ExtensionWriterContext& context =
+      this->getExtensions();
+
+  SchemaWriterResult result;
+  std::unique_ptr<CesiumJsonWriter::JsonWriter> writer;
+
+  if (options.prettyPrint) {
+    writer = std::make_unique<CesiumJsonWriter::PrettyJsonWriter>();
+  } else {
+    writer = std::make_unique<CesiumJsonWriter::JsonWriter>();
+  }
+
+  SchemaJsonWriter::write(schema, *writer, context);
+  result.schemaBytes = writer->toBytes();
+  result.errors = writer->getErrors();
+  result.warnings = writer->getWarnings();
+
+  return result;
+}
+} // namespace CesiumGltfWriter


### PR DESCRIPTION
Adds a serializer for `CesiumGltf::Schema` objects.

This is essentially the same as `Cesium3DTilesWriter::SchemaWriter` but I wasn't sure how to unify them in a simple way...