### PR TITLE
Updates to generate updated HTML documentation

### DIFF
--- a/CesiumIonClient/include/CesiumIonClient/Library.h
+++ b/CesiumIonClient/include/CesiumIonClient/Library.h
@@ -1,0 +1,16 @@
+#pragma once
+
+/**
+ * @brief Classes for working with Cesium ion clients
+ */
+namespace CesiumIonClient {}
+
+#if defined(_WIN32) && defined(CESIUM_SHARED)
+#ifdef CESIUMIONCLIENT_BUILDING
+#define CESIUMIONCLIENT_API __declspec(dllexport)
+#else
+#define CESIUMIONCLIENT_API __declspec(dllimport)
+#endif
+#else
+#define CESIUMIONCLIENT_API
+#endif

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -15,8 +15,12 @@ if (DOXYGEN_FOUND)
         ../CesiumGltf/generated/include
         ../CesiumGltfReader/include
         ../CesiumGltfWriter/include
-        ../CesiumUtility/include
+        ../CesiumIonClient/include
+        ../CesiumJsonReader/include
+        ../CesiumJsonWriter/include
+        ../CesiumQuantizedMeshTerrain/include
         ../CesiumRasterOverlays/include
+        ../CesiumUtility/include
     )
 
     set(DOXYGEN_STRIP_FROM_INC_PATH ${LIB_DIRS})
@@ -32,8 +36,12 @@ if (DOXYGEN_FOUND)
         ../CesiumGltf/test
         ../CesiumGltfReader/test
         ../CesiumGltfWriter/test
-        ../CesiumUtility/test
+        ../CesiumIonClient/test
+        ../CesiumJsonReader/test
+        ../CesiumJsonWriter/test
+        ../CesiumQuantizedMeshTerrain/test        
         ../CesiumRasterOverlays/test
+        ../CesiumUtility/test
     )
 
     # These macro definitions confuse doxygen, causing it


### PR DESCRIPTION
A few of the more recent namespaces weren't being generated in the documentation:

![image](https://github.com/user-attachments/assets/5f473795-f863-4262-bd75-406cf214dfbb)
