### PR TITLE
Fix a bug with instances that have multiple nodes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 
 - Fixed a bug in `WebMapTileServiceRasterOverlay` that caused it to compute the `TileRow` incorrectly when used with a tiling scheme with multiple tiles in the Y direction at the root.
 - `KHR_texture_transform` is now removed from `extensionsUsed` and `extensionsRequired` after it is applied by `GltfReader`.
+- Fixed a bug in the i3dm loader that caused glTF with multiple nodes to not be instanced correctly.
 
 ### v0.38.0 - 2024-08-01
 

--- a/Cesium3DTilesContent/src/I3dmToGltfConverter.cpp
+++ b/Cesium3DTilesContent/src/I3dmToGltfConverter.cpp
@@ -663,14 +663,18 @@ void copyInstanceToBuffer(
     const glm::dvec3& position,
     const glm::dquat& rotation,
     const glm::dvec3& scale,
-    std::vector<std::byte>& bufferData,
+    std::byte* bufferData,
     size_t i) {
-  copyInstanceToBuffer(position, rotation, scale, &bufferData[i * totalStride]);
+  copyInstanceToBuffer(
+      position,
+      rotation,
+      scale,
+      bufferData + (i * totalStride));
 }
 
 bool copyInstanceToBuffer(
     const glm::dmat4& instanceTransform,
-    std::vector<std::byte>& bufferData,
+    std::byte* bufferData,
     size_t i) {
   bool result = true;
   glm::dvec3 position, scale, skew;
@@ -764,7 +768,7 @@ void instantiateGltfInstances(
                 instanceTransform * modelInstanceTransform;
             if (!copyInstanceToBuffer(
                     finalTransform,
-                    instanceBuffer.cesium.data,
+                    &instanceBuffer.cesium.data[dataBaseOffset],
                     destInstanceIndx++)) {
               result.errors.emplaceWarning(
                   "Matrix decompose failed. Default identity values copied to "

--- a/Cesium3DTilesContent/src/I3dmToGltfConverter.cpp
+++ b/Cesium3DTilesContent/src/I3dmToGltfConverter.cpp
@@ -650,31 +650,31 @@ void copyInstanceToBuffer(
     const glm::dvec3& position,
     const glm::dquat& rotation,
     const glm::dvec3& scale,
-    std::byte* bufferLoc) {
+    std::byte* pBufferLoc) {
   glm::vec3 fposition(position);
-  std::memcpy(bufferLoc, &fposition, sizeof(fposition));
+  std::memcpy(pBufferLoc, &fposition, sizeof(fposition));
   glm::quat frotation(rotation);
-  std::memcpy(bufferLoc + rotOffset, &frotation, sizeof(frotation));
+  std::memcpy(pBufferLoc + rotOffset, &frotation, sizeof(frotation));
   glm::vec3 fscale(scale);
-  std::memcpy(bufferLoc + scaleOffset, &fscale, sizeof(fscale));
+  std::memcpy(pBufferLoc + scaleOffset, &fscale, sizeof(fscale));
 }
 
 void copyInstanceToBuffer(
     const glm::dvec3& position,
     const glm::dquat& rotation,
     const glm::dvec3& scale,
-    std::byte* bufferData,
+    std::byte* pBufferData,
     size_t i) {
   copyInstanceToBuffer(
       position,
       rotation,
       scale,
-      bufferData + (i * totalStride));
+      pBufferData + (i * totalStride));
 }
 
 bool copyInstanceToBuffer(
     const glm::dmat4& instanceTransform,
-    std::byte* bufferData,
+    std::byte* pBufferData,
     size_t i) {
   bool result = true;
   glm::dvec3 position, scale, skew;
@@ -692,7 +692,7 @@ bool copyInstanceToBuffer(
     scale = glm::dvec3(1.0);
     result = false;
   }
-  copyInstanceToBuffer(position, rotation, scale, bufferData, i);
+  copyInstanceToBuffer(position, rotation, scale, pBufferData, i);
   return result;
 }
 

--- a/CesiumGeospatial/include/CesiumGeospatial/S2CellID.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/S2CellID.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cstdint>
+#include <string>
 #include <string_view>
 
 namespace CesiumGeometry {

--- a/CesiumGltfContent/include/CesiumGltfContent/GltfUtilities.h
+++ b/CesiumGltfContent/include/CesiumGltfContent/GltfUtilities.h
@@ -9,6 +9,7 @@
 #include <glm/fwd.hpp>
 
 #include <optional>
+#include <string>
 #include <string_view>
 #include <vector>
 

--- a/CesiumJsonReader/include/CesiumJsonReader/IJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/IJsonHandler.h
@@ -3,6 +3,7 @@
 #include "Library.h"
 
 #include <cstdint>
+#include <string>
 #include <string_view>
 #include <vector>
 

--- a/CesiumJsonWriter/include/CesiumJsonWriter/JsonWriter.h
+++ b/CesiumJsonWriter/include/CesiumJsonWriter/JsonWriter.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <string>
 #include <string_view>
 #include <vector>
 


### PR DESCRIPTION
The i3dm converter was repeatedly overwriting the beginning of the new glTF buffer that holds instance transformations.

Resolves #942 

I would like to add a test case for this and am hoping that the user who reported the issue will give their permission to use their test data.