### PR TITLE
Remove EarthGravitationalModel1996Grid::fromFile

### DIFF
--- a/CesiumGeospatial/include/CesiumGeospatial/EarthGravitationalModel1996Grid.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/EarthGravitationalModel1996Grid.h
@@ -24,19 +24,6 @@ class Cartographic;
 class CESIUMGEOSPATIAL_API EarthGravitationalModel1996Grid final {
 public:
   /**
-   * @brief Attempts to create a {@link EarthGravitationalModel1996Grid} from the given file.
-   *
-   * This method expects a file in the format of the WW15MGH.DAC 15-arcminute
-   * grid. The file must be at least 721 * 1440 * 2 = 2,076,480 bytes.
-   * Any additional bytes at the end of the file are ignored.
-   *
-   * @returns The instance created from the file, or `std::nullopt` if the file
-   * could not be loaded or is invalid.
-   */
-  static std::optional<EarthGravitationalModel1996Grid>
-  fromFile(const std::string& filename);
-
-  /**
    * @brief Attempts to create a {@link EarthGravitationalModel1996Grid} from the given buffer.
    *
    * This method expects the buffer to contain the contents of the WW15MGH.DAC

--- a/CesiumGeospatial/src/EarthGravitationalModel1996Grid.cpp
+++ b/CesiumGeospatial/src/EarthGravitationalModel1996Grid.cpp
@@ -27,24 +27,6 @@ constexpr size_t TOTAL_BYTES = TOTAL_VALUES * sizeof(int16_t);
 } // namespace
 
 std::optional<EarthGravitationalModel1996Grid>
-CesiumGeospatial::EarthGravitationalModel1996Grid::fromFile(
-    const std::string& filename) {
-  std::ifstream file(
-      std::filesystem::u8path(filename),
-      std::ios::binary | std::ios::ate);
-  if (!file.good()) {
-    return std::nullopt;
-  }
-
-  size_t size = std::min(size_t(file.tellg()), size_t(TOTAL_BYTES));
-  file.seekg(0, std::ios::beg);
-
-  std::vector<std::byte> buffer(size);
-  file.read(reinterpret_cast<char*>(buffer.data()), std::streamsize(size));
-  return fromBuffer(buffer);
-}
-
-std::optional<EarthGravitationalModel1996Grid>
 CesiumGeospatial::EarthGravitationalModel1996Grid::fromBuffer(
     const gsl::span<const std::byte>& buffer) {
   if (buffer.size_bytes() < TOTAL_BYTES) {

--- a/CesiumGeospatial/test/TestEarthGravitationalModel1996Grid.cpp
+++ b/CesiumGeospatial/test/TestEarthGravitationalModel1996Grid.cpp
@@ -193,36 +193,6 @@ const Egm96TestCase boundsCases[] = {
 
 const std::byte zeroByte{0};
 
-TEST_CASE("EarthGravitationalModel1996Grid::fromFile") {
-  SECTION("Loads a valid WW15MGH.DAC from file") {
-    auto grid =
-        EarthGravitationalModel1996Grid::fromFile(testFilePath.u8string());
-    CHECK(grid.has_value());
-  }
-
-  SECTION("Fails on missing file") {
-    auto grid = EarthGravitationalModel1996Grid::fromFile("_does_not_exist");
-    CHECK(!grid.has_value());
-  }
-
-  SECTION("Fails on too-short file") {
-    OwnedTempFile file(std::vector<std::byte>(4, zeroByte));
-    auto grid =
-        EarthGravitationalModel1996Grid::fromFile(file.getPath().u8string());
-    CHECK(!grid.has_value());
-  }
-
-  // While EGM96 is meant to only parse the one WW15MGH.DAC file, there's no
-  // reason it shouldn't be able to parse any file that meets the same
-  // requirements.
-  SECTION("Loads an arbitrary correctly-formed file") {
-    OwnedTempFile file(std::vector<std::byte>(3000000, zeroByte));
-    auto grid =
-        EarthGravitationalModel1996Grid::fromFile(file.getPath().u8string());
-    CHECK(grid.has_value());
-  }
-}
-
 TEST_CASE("EarthGravitationalModel1996Grid::fromBuffer") {
   SECTION("Loads a valid WW15MGH.DAC from buffer") {
     auto grid =
@@ -245,7 +215,7 @@ TEST_CASE("EarthGravitationalModel1996Grid::fromBuffer") {
 
 TEST_CASE("EarthGravitationalModel1996Grid::sampleHeight") {
   std::optional<EarthGravitationalModel1996Grid> grid =
-      EarthGravitationalModel1996Grid::fromFile(testFilePath.u8string());
+      EarthGravitationalModel1996Grid::fromBuffer(readFile(testFilePath));
 
   SECTION("Correct values at bounds") {
     REQUIRE(grid.has_value());


### PR DESCRIPTION
This function is - perhaps surprisingly - the only thing in cesium-native that does file I/O (other than via an IAssetAccessor, and other than in the tests). By removing it, we're forcing users to read the WW15MGH.DAC file themselves and provide the  contents as a buffer. It's a slight burden, but not too bad. 

The immediate motivation here is that iOS prior to version 13 doesn't support `ifstream`, so the code removed by this PR won't compile there. Unity supports these older iOS versions, so cesium-unity does as well. This is fixable, but it's tricky, especially if we also want to support UTF-8 filenames on Windows, too. We could use fopen/fread on iOS, but on Windows if we pass a `char*` to those functions, it's treated as the current codepage instead of UTF-8. So we'd have to convert it to UTF-16 instead and then call `_wfopen`. Or something. It's just not worth the trouble, when any application using cesium-native probably has its own way to read files.

This is not a breaking change because we haven't shipped a version of cesium-native with this class yet.
