### PR TITLE
Improve raster overlay error reporting and handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Change Log
 
+### Not Released Yet
+
+##### Breaking Changes :mega:
+
+- `LoadedRasterOverlayImage` now has a single `errorList` property instead of separate `errors` and `warnings` properties.
+
+##### Fixes :wrench:
+
+- Errors while loading raster overlays are now logged. Previously, they were silently ignored in many cases.
+- A raster overlay image failing to load will no longer completely prevent the geometry tile to which it is attached from rendering. Instead, once the raster overlay fails, the geometry tile will be shown without the raster overlay.
+
 ### v0.39.0 - 2024-09-02
 
 ##### Breaking Changes :mega:

--- a/Cesium3DTilesSelection/src/EmptyRasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/src/EmptyRasterOverlayTileProvider.cpp
@@ -1,0 +1,27 @@
+#include "EmptyRasterOverlayTileProvider.h"
+
+using namespace CesiumRasterOverlays;
+
+namespace Cesium3DTilesSelection {
+
+EmptyRasterOverlayTileProvider::EmptyRasterOverlayTileProvider(
+    const CesiumUtility::IntrusivePointer<const RasterOverlay>& pOwner,
+    const CesiumAsync::AsyncSystem& asyncSystem) noexcept
+    : RasterOverlayTileProvider(
+          pOwner,
+          asyncSystem,
+          nullptr,
+          std::nullopt,
+          nullptr,
+          nullptr,
+          CesiumGeospatial::GeographicProjection(),
+          CesiumGeometry::Rectangle()) {}
+
+CesiumAsync::Future<CesiumRasterOverlays::LoadedRasterOverlayImage>
+EmptyRasterOverlayTileProvider::loadTileImage(
+    CesiumRasterOverlays::RasterOverlayTile& /*overlayTile*/) {
+  return this->getAsyncSystem()
+      .createResolvedFuture<CesiumRasterOverlays::LoadedRasterOverlayImage>({});
+}
+
+} // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/EmptyRasterOverlayTileProvider.h
+++ b/Cesium3DTilesSelection/src/EmptyRasterOverlayTileProvider.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <CesiumRasterOverlays/RasterOverlayTileProvider.h>
+
+namespace Cesium3DTilesSelection {
+
+class EmptyRasterOverlayTileProvider
+    : public CesiumRasterOverlays::RasterOverlayTileProvider {
+public:
+  EmptyRasterOverlayTileProvider(
+      const CesiumUtility::IntrusivePointer<
+          const CesiumRasterOverlays::RasterOverlay>& pOwner,
+      const CesiumAsync::AsyncSystem& asyncSystem) noexcept;
+
+protected:
+  virtual CesiumAsync::Future<CesiumRasterOverlays::LoadedRasterOverlayImage>
+  loadTileImage(CesiumRasterOverlays::RasterOverlayTile& overlayTile) override;
+};
+
+} // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/test/TestTilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/test/TestTilesetContentManager.cpp
@@ -1309,7 +1309,6 @@ TEST_CASE("Test the tileset content manager's post processing for gltf") {
                 overlayTile.getRectangle(),
                 {},
                 {},
-                {},
                 true});
       }
     };

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
@@ -54,7 +54,7 @@ struct CESIUMRASTEROVERLAYS_API LoadedRasterOverlayImage {
    * If the image was loaded successfully, there should not be any errors (but
    * there may be warnings).
    */
-  CesiumUtility::ErrorList errors{};
+  CesiumUtility::ErrorList errorList{};
 
   /**
    * @brief Whether more detailed data, beyond this image, is available within

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
@@ -7,6 +7,7 @@
 #include <CesiumGltfReader/GltfReader.h>
 #include <CesiumUtility/Assert.h>
 #include <CesiumUtility/CreditSystem.h>
+#include <CesiumUtility/ErrorList.h>
 #include <CesiumUtility/IntrusivePointer.h>
 #include <CesiumUtility/ReferenceCounted.h>
 #include <CesiumUtility/Tracing.h>
@@ -48,19 +49,12 @@ struct CESIUMRASTEROVERLAYS_API LoadedRasterOverlayImage {
   std::vector<CesiumUtility::Credit> credits{};
 
   /**
-   * @brief Error messages from loading the image.
+   * @brief Errors and warnings from loading the image.
    *
-   * If the image was loaded successfully, this should be empty.
+   * If the image was loaded successfully, there should not be any errors (but
+   * there may be warnings).
    */
-  std::vector<std::string> errors{};
-
-  /**
-   * @brief Warnings from loading the image.
-   */
-  // Implementation note: In the current implementation, this will
-  // always be empty, but it might contain warnings in the future,
-  // when other image types or loaders are used.
-  std::vector<std::string> warnings{};
+  CesiumUtility::ErrorList errors{};
 
   /**
    * @brief Whether more detailed data, beyond this image, is available within

--- a/CesiumRasterOverlays/src/QuadtreeRasterOverlayTileProvider.cpp
+++ b/CesiumRasterOverlays/src/QuadtreeRasterOverlayTileProvider.cpp
@@ -319,7 +319,7 @@ QuadtreeRasterOverlayTileProvider::getQuadtreeTile(
           .catchImmediately([](std::exception&& e) {
             // Turn an exception into an error.
             LoadedRasterOverlayImage result;
-            result.errors.emplaceError(e.what());
+            result.errorList.emplaceError(e.what());
             return result;
           })
           .thenImmediately([&cachedBytes = this->_cachedBytes,
@@ -328,7 +328,7 @@ QuadtreeRasterOverlayTileProvider::getQuadtreeTile(
                             asyncSystem = this->getAsyncSystem(),
                             loadParentTile = std::move(loadParentTile)](
                                LoadedRasterOverlayImage&& loaded) {
-            if (loaded.image && !loaded.errors.hasErrors() &&
+            if (loaded.image && !loaded.errorList.hasErrors() &&
                 loaded.image->width > 0 && loaded.image->height > 0) {
               // Successfully loaded, continue.
               cachedBytes += int64_t(loaded.image->pixelData.size());
@@ -475,7 +475,7 @@ QuadtreeRasterOverlayTileProvider::loadTileImage(
           ErrorList errors;
           for (LoadedQuadtreeImage& image : images) {
             if (image.pLoaded) {
-              errors.merge(image.pLoaded->errors);
+              errors.merge(image.pLoaded->errorList);
             }
           }
           return LoadedRasterOverlayImage{
@@ -654,7 +654,7 @@ QuadtreeRasterOverlayTileProvider::combineImages(
   ErrorList errors;
   for (LoadedQuadtreeImage& image : images) {
     if (image.pLoaded) {
-      errors.merge(std::move(image.pLoaded->errors));
+      errors.merge(std::move(image.pLoaded->errorList));
     }
   }
 
@@ -680,7 +680,7 @@ QuadtreeRasterOverlayTileProvider::combineImages(
   LoadedRasterOverlayImage result;
   result.rectangle = measurements.rectangle;
   result.moreDetailAvailable = false;
-  result.errors = std::move(errors);
+  result.errorList = std::move(errors);
 
   ImageCesium& target = result.image.emplace();
   target.bytesPerChannel = measurements.bytesPerChannel;

--- a/CesiumRasterOverlays/src/RasterOverlayTileProvider.cpp
+++ b/CesiumRasterOverlays/src/RasterOverlayTileProvider.cpp
@@ -248,18 +248,20 @@ static LoadResult createLoadResultFromLoadedImage(
     LoadedRasterOverlayImage&& loadedImage,
     const std::any& rendererOptions) {
   if (!loadedImage.image.has_value()) {
-    loadedImage.errors.logError(pLogger, "Failed to load image for tile");
+    loadedImage.errorList.logError(pLogger, "Failed to load image for tile");
     LoadResult result;
     result.state = RasterOverlayTile::LoadState::Failed;
     return result;
   }
 
-  if (loadedImage.errors.hasErrors()) {
-    loadedImage.errors.logError(pLogger, "Errors while loading image for tile");
+  if (loadedImage.errorList.hasErrors()) {
+    loadedImage.errorList.logError(
+        pLogger,
+        "Errors while loading image for tile");
   }
 
-  if (!loadedImage.errors.warnings.empty()) {
-    loadedImage.errors.logWarning(
+  if (!loadedImage.errorList.warnings.empty()) {
+    loadedImage.errorList.logWarning(
         pLogger,
         "Warnings while loading image for tile");
   }

--- a/CesiumRasterOverlays/src/RasterOverlayTileProvider.cpp
+++ b/CesiumRasterOverlays/src/RasterOverlayTileProvider.cpp
@@ -254,6 +254,10 @@ static LoadResult createLoadResultFromLoadedImage(
     return result;
   }
 
+  if (loadedImage.errors.hasErrors()) {
+    loadedImage.errors.logError(pLogger, "Errors while loading image for tile");
+  }
+
   if (!loadedImage.errors.warnings.empty()) {
     loadedImage.errors.logWarning(
         pLogger,

--- a/CesiumRasterOverlays/src/RasterOverlayTileProvider.cpp
+++ b/CesiumRasterOverlays/src/RasterOverlayTileProvider.cpp
@@ -203,8 +203,9 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
                 loadedImage.image,
                 options.rectangle,
                 std::move(options.credits),
-                std::move(loadedImage.errors),
-                std::move(loadedImage.warnings),
+                ErrorList{
+                    std::move(loadedImage.errors),
+                    std::move(loadedImage.warnings)},
                 options.moreDetailAvailable};
           });
 }

--- a/CesiumRasterOverlays/src/TileMapServiceRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/TileMapServiceRasterOverlay.cpp
@@ -91,13 +91,14 @@ protected:
           this->_headers,
           std::move(options));
     } else {
+      ErrorList errors;
+      errors.emplaceError("Failed to load image from TMS.");
       return this->getAsyncSystem()
           .createResolvedFuture<LoadedRasterOverlayImage>(
               {std::nullopt,
                options.rectangle,
                {},
-               {"Failed to load image from TMS."},
-               {},
+               std::move(errors),
                options.moreDetailAvailable});
     }
   }

--- a/CesiumRasterOverlays/test/TestQuadtreeRasterOverlayTileProvider.cpp
+++ b/CesiumRasterOverlays/test/TestQuadtreeRasterOverlayTileProvider.cpp
@@ -59,7 +59,7 @@ public:
 
     if (std::find(errorTiles.begin(), errorTiles.end(), tileID) !=
         errorTiles.end()) {
-      result.errors.emplaceError("Tile errored.");
+      result.errorList.emplaceError("Tile errored.");
     } else {
       // Return an image where every component of every pixel is equal to the
       // tile level.

--- a/CesiumRasterOverlays/test/TestQuadtreeRasterOverlayTileProvider.cpp
+++ b/CesiumRasterOverlays/test/TestQuadtreeRasterOverlayTileProvider.cpp
@@ -59,7 +59,7 @@ public:
 
     if (std::find(errorTiles.begin(), errorTiles.end(), tileID) !=
         errorTiles.end()) {
-      result.errors.emplace_back("Tile errored.");
+      result.errors.emplaceError("Tile errored.");
     } else {
       // Return an image where every component of every pixel is equal to the
       // tile level.


### PR DESCRIPTION
Previously, if a raster overlay tile provider ran into an error while loading overlay images (for example, if a WMS server returned an error because it didn't support EPSG:4236), those errors were ignored, and the tileset wouldn't show up at all. This was pretty unhelpful for users, who had no way to learn what was happening except by using the debugger. With this PR:
1. Errors loading raster overlays are logged.
2. Raster overlay failures will no longer stop the geometry tile they're attached to from rendering. Instead, once the image load fails, the geometry tile will simply be rendered without any raster overlay.