### PR TITLE
When tileset fails to load, report all heights not sampled

### DIFF
--- a/Cesium3DTilesSelection/src/TilesetHeightQuery.cpp
+++ b/Cesium3DTilesSelection/src/TilesetHeightQuery.cpp
@@ -226,7 +226,16 @@ void Cesium3DTilesSelection::TilesetHeightRequest::failHeightRequests(
     std::list<TilesetHeightRequest>& heightRequests,
     const std::string& message) {
   for (TilesetHeightRequest& request : heightRequests) {
-    request.promise.reject(std::runtime_error(message));
+    SampleHeightResult result;
+    result.warnings.emplace_back(message);
+    result.sampleSuccess.resize(request.queries.size(), false);
+
+    result.positions.reserve(request.queries.size());
+    for (const TilesetHeightQuery& query : request.queries) {
+      result.positions.emplace_back(query.inputPosition);
+    }
+
+    request.promise.resolve(std::move(result));
   }
 
   heightRequests.clear();

--- a/Cesium3DTilesSelection/test/TestTilesetHeightQueries.cpp
+++ b/Cesium3DTilesSelection/test/TestTilesetHeightQueries.cpp
@@ -223,6 +223,11 @@ TEST_CASE("Tileset height queries") {
       tileset.updateView({});
     }
 
-    REQUIRE_THROWS(future.waitInMainThread());
+    SampleHeightResult results = future.waitInMainThread();
+    REQUIRE(results.warnings.size() == 1);
+    REQUIRE(results.positions.size() == 1);
+    REQUIRE(results.sampleSuccess.size() == 1);
+    CHECK(!results.sampleSuccess[0]);
+    CHECK(results.warnings[0].find("failed to load") != std::string::npos);
   }
 }


### PR DESCRIPTION
Previously, we rejected the future. Now, we resolve it, and report all heights as having failed to sample. This should be easier for users to deal with because they don't need to handle two different types of errors in their height queries.