### PR TITLE
setMightHaveLatentChildren(false) even if a tile has real children.

### DIFF
--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -1076,7 +1076,11 @@ void TilesetContentManager::updateTileContent(
 void TilesetContentManager::createLatentChildrenIfNecessary(
     Tile& tile,
     const TilesetOptions& tilesetOptions) {
-  if (tile.getChildren().empty() && tile.getMightHaveLatentChildren()) {
+  if (!tile.getMightHaveLatentChildren())
+    return;
+
+  // If this tile has no children yet, attempt to create them.
+  if (tile.getChildren().empty()) {
     TileChildrenResult childrenResult =
         this->_pLoader->createTileChildren(tile, tilesetOptions.ellipsoid);
     if (childrenResult.state == TileLoadResultState::Success) {
@@ -1086,6 +1090,9 @@ void TilesetContentManager::createLatentChildrenIfNecessary(
     bool mightStillHaveLatentChildren =
         childrenResult.state == TileLoadResultState::RetryLater;
     tile.setMightHaveLatentChildren(mightStillHaveLatentChildren);
+  } else {
+    // A tile with real children can't have latent children.
+    tile.setMightHaveLatentChildren(false);
   }
 }
 


### PR DESCRIPTION
Fixes CesiumGS/cesium-unreal#1529

In #783, I renamed `shouldContinueUpdating` to `mightHaveLatentChildren` in an attempt to be more descriptive about what it actually does. I also implemented what I thought was a very slight tweak to the logic for creating explicit children from latent ones.

Previously, when we called `updateTileContent` on a tile that `mightHaveLatentChildren` (which is all tiles to start), we would give the `TilesetContentLoader` associated with the tile a chance to create explicit children. While looking at this in the above PR, I noted this was a bit dangerous in the case that the tile already has explicit children. It could end up clobbering the existing children, which would be very likely to lead to a hard to debug crash.

Of course, none of our current loaders actually have this problem. Our current implicit loaders create one tile at a time, so every tile has no children to start, and so this situation never arises. Still, `TilesetContentLoader` is meant to be a generic interface, so I thought it was a good idea to defensively avoid this possibility.

So I added a check: if the tile already has real children, don't call the loader to create more. It seemed like a good idea, and I thought it was safe.

Unfortunately this `mightHaveLatentChildren` flag has a side effect that I didn't consider, and my logic change meant that this flag stayed `true` for tiles with real children where previously it flipped to `false` the first time the tiles were accessed. And as a result, some logic in `updateDoneState` that turned placeholder raster overlays into real ones never executed. And that, in turn, would cause tilesets with raster overlays to never load at all in some cases, as in CesiumGS/cesium-unreal#1529.

The fix in this PR simply makes `createLatentChildrenIfNecessary` set `mightHaveLatentChildren` to false when it sees a tile that already has real children. That allows the placeholder replacement logic to run, which unblocks loading.