### PR TITLE
Fix missing ellipsoid parameters

### DIFF
--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -154,7 +154,8 @@ getTileBoundingRegionForUpsampling(const Tile& parent) {
           CesiumGeospatial::BoundingRegion(
               globeRectangle,
               details.boundingRegion.getMinimumHeight(),
-              details.boundingRegion.getMaximumHeight()),
+              details.boundingRegion.getMaximumHeight(),
+              getProjectionEllipsoid(projection)),
           center};
     }
   }

--- a/Cesium3DTilesSelection/src/TilesetHeightQuery.h
+++ b/Cesium3DTilesSelection/src/TilesetHeightQuery.h
@@ -43,6 +43,11 @@ public:
   CesiumGeometry::Ray ray;
 
   /**
+   * @brief The ellipsoid on which the input position is defined.
+   */
+  CesiumGeospatial::Ellipsoid ellipsoid;
+
+  /**
    * @brief The current intersection of the ray with the tileset. If there are
    * multiple intersections, this will be the one closest to the origin of the
    * ray.

--- a/CesiumRasterOverlays/test/TestAddRasterOverlayToGltf.cpp
+++ b/CesiumRasterOverlays/test/TestAddRasterOverlayToGltf.cpp
@@ -142,7 +142,8 @@ TEST_CASE("Add raster overlay to glTF") {
                     geometricError,
                     16.0, // the Max SSE used to render the geometry
                     details->rasterOverlayProjections[0],
-                    details->rasterOverlayRectangles[0]);
+                    details->rasterOverlayRectangles[0],
+                    Ellipsoid::WGS84);
 
             // Get a raster overlay texture of the proper dimensions.
             IntrusivePointer<RasterOverlayTile> pRasterTile =


### PR DESCRIPTION
As Sean noted in #953, there's a few places in the codebase we're currently missing an ellipsoid parameter. These compile fine unless `CESIUM_DISABLE_DEFAULT_ELLIPSOID` is enabled, but they will cause incorrect results if not fixed. We should consider enabling `CESIUM_DISABLE_DEFAULT_ELLIPSOID` on CI to catch these issues in the future.