### PR TITLE
Better styling and other improvements for Doxygen

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
           submodules: recursive
       - name: Generate Documentation
         run: |
+          npm install
           cmake -B build -S .
           cmake --build build --target cesium-native-docs
       - name: Publish Documentation Artifact

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ endif()
 include("cmake/defaults.cmake")
 
 project(cesium-native
-    VERSION 0.1.0
+    VERSION 0.40.1
     LANGUAGES CXX C
 )
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Cesium Native powers Cesium's runtime integrations for [Cesium for Unreal](https
 ![Cesium Platform and Ecosystem](./doc/integration-ecosystem-diagram.jpg)
 *<p align="center">A high-level Cesium platform architecture with the runtime integrations powered by Cesium Native and streaming content from Cesium ion.</p>*
 
-### :card_file_box:Libraries Overview
+### 🗃️Libraries Overview
 
 | Library | Description |
 | -- | -- |
@@ -34,7 +34,7 @@ Cesium Native powers Cesium's runtime integrations for [Cesium for Unreal](https
 | **CesiumUtility** | Utility functions for JSON parsing, URI processing, etc. |
 
 
-### :green_book:License
+### 📗License
 
 [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.html). Cesium Native is free for both commercial and non-commercial use.
 
@@ -46,7 +46,7 @@ Cesium Native powers Cesium's runtime integrations for [Cesium for Unreal](https
 * CMake 3.15+
 * For best JPEG-decoding performance, you must have [nasm](https://www.nasm.us/) installed so that CMake can find it. Everything will work fine without it, just slower.
 
-### :rocket:Getting Started
+### 🚀Getting Started
 
 #### Clone the repo
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(Doxygen)
 
-if (DOXYGEN_FOUND)
+if(DOXYGEN_FOUND)
     set(
         LIB_DIRS
         ../Cesium3DTiles/include
@@ -39,7 +39,7 @@ if (DOXYGEN_FOUND)
         ../CesiumIonClient/test
         ../CesiumJsonReader/test
         ../CesiumJsonWriter/test
-        ../CesiumQuantizedMeshTerrain/test        
+        ../CesiumQuantizedMeshTerrain/test
         ../CesiumRasterOverlays/test
         ../CesiumUtility/test
     )
@@ -51,9 +51,20 @@ if (DOXYGEN_FOUND)
     set(DOXYGEN_MACRO_EXPANSION YES)
     set(DOXYGEN_EXPAND_ONLY_PREDEF YES)
     set(DOXYGEN_PREDEFINED "CESIUM3DTILESSELECTION_API" "CESIUMGEOMETRY_API" "CESIUMUTILITY_API" "CESIUMGEOSPATIAL_API")
+    set(DOXYGEN_HTML_EXTRA_STYLESHEET "${CMAKE_CURRENT_LIST_DIR}/../node_modules/doxygen-awesome-css/doxygen-awesome.css")
+    set(DOXYGEN_GENERATE_TREEVIEW YES)
+    set(DOXYGEN_DISABLE_INDEX NO)
+    set(DOXYGEN_FULL_SIDEBAR NO)
+    set(DOXYGEN_HTML_COLORSTYLE LIGHT)
+    set(DOXYGEN_SOURCE_BROWSER YES)
+    set(DOXYGEN_BUILTIN_STL_SUPPORT YES)
+    set(DOXYGEN_USE_MDFILE_AS_MAINPAGE "../README.md")
+    set(DOXYGEN_EXCLUDE_PATTERNS "*/node_modules/*")
+    set(DOXYGEN_IMAGE_PATH "./")
 
     doxygen_add_docs(
         cesium-native-docs
+        "../README.md"
         ${LIB_DIRS}
     )
 endif()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "cesium-native",
-  "version": "0.36.0",
+  "version": "0.40.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cesium-native",
-      "version": "0.36.0",
+      "version": "0.40.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "clang-format": "^1.5.0"
+        "clang-format": "^1.5.0",
+        "doxygen-awesome-css": "https://github.com/jothepro/doxygen-awesome-css#v2.3.4"
       }
     },
     "node_modules/async": {
@@ -55,6 +56,13 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/doxygen-awesome-css": {
+      "name": "@jothepro/doxygen-awesome-css",
+      "version": "2.3.4",
+      "resolved": "git+ssh://git@github.com/jothepro/doxygen-awesome-css.git#568f56cde6ac78b6dfcc14acd380b2e745c301ea",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/CesiumGS/cesium-native#readme",
   "devDependencies": {
-    "clang-format": "^1.5.0"
+    "clang-format": "^1.5.0",
+    "doxygen-awesome-css": "https://github.com/jothepro/doxygen-awesome-css#v2.3.4"
   }
 }


### PR DESCRIPTION
Decided to take a crack at improving the generated documentation, with the aim of eventually publishing it. This change adopts the [doxygen-awesome-css](https://github.com/jothepro/doxygen-awesome-css) theme for our docs, as well as using the README file as the main page of the documentation.

It wouldn't be that much work to apply this to Unity and Unreal docs too, but I want to see how people feel about this change before going through and applying it to everything else.

| Before | After |
| -- | -- |
| ![15-07-03-chrome_2eQYrJ0ZJ7](https://github.com/user-attachments/assets/ffdde3f2-dd08-4f57-8461-2cec894e484e) | ![15-04-24-chrome_BYDeBjm98N](https://github.com/user-attachments/assets/63a1ea70-d73e-4722-a29c-74f31cdc9c58) |
| ![15-07-26-chrome_sky7f3PC2z](https://github.com/user-attachments/assets/91e072a2-8182-46e4-b859-b7263c03c01a) | ![15-04-42-chrome_4Yvdbz1z9k](https://github.com/user-attachments/assets/b9e9363a-890c-4124-a591-dc73a61f0e83) |
![15-07-45-chrome_21kTjsj6UO](https://github.com/user-attachments/assets/e3dfb302-055b-4ba2-8d48-5eaedcefaaec) | ![15-05-13-chrome_F62Yi8kVQe](https://github.com/user-attachments/assets/e1abcee3-32f2-4ff0-9cd8-a290b2005ef6) |


