### PR TITLE
Remove use of the GSL library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ message(STATUS "VCPKG_OVERLAY_TRIPLETS ${VCPKG_OVERLAY_TRIPLETS}")
 # with the installation
 # Note that fmt is a public dependency of the vcpkg version of spdlog
 # STB and uriparser aren't technically part of the public interface, but they're used by the downstream Cesium for Unreal project
-set(PACKAGES_PUBLIC asyncplusplus expected-lite fmt glm ms-gsl rapidjson spdlog stb uriparser)
+set(PACKAGES_PUBLIC asyncplusplus expected-lite fmt glm rapidjson spdlog stb uriparser)
 # These packages are used in the code and produce binaries, but are not part of the public interface.  Therefore we need
 # to distribute the binaries for linking, but not the headers, as downstream consumers don't need them
 # OpenSSL and abseil are both dependencies of s2geometry
@@ -223,7 +223,6 @@ find_package(draco CONFIG REQUIRED)
 find_package(expected-lite CONFIG REQUIRED)
 find_package(glm CONFIG REQUIRED)
 find_package(meshoptimizer CONFIG REQUIRED)
-find_package(Microsoft.GSL REQUIRED)
 find_package(httplib CONFIG REQUIRED)
 find_package(Ktx CONFIG REQUIRED)
 find_package(libmorton CONFIG REQUIRED)

--- a/Cesium3DTiles/CMakeLists.txt
+++ b/Cesium3DTiles/CMakeLists.txt
@@ -54,5 +54,4 @@ target_include_directories(
 target_link_libraries(Cesium3DTiles
     PUBLIC
         CesiumUtility
-        Microsoft.GSL::GSL
 )

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/B3dmToGltfConverter.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/B3dmToGltfConverter.h
@@ -6,16 +6,15 @@
 #include <CesiumGltf/Model.h>
 #include <CesiumGltfReader/GltfReader.h>
 
-#include <gsl/span>
-
 #include <optional>
+#include <span>
 
 namespace Cesium3DTilesContent {
 struct AssetFetcher;
 
 struct B3dmToGltfConverter {
   static CesiumAsync::Future<GltfConverterResult> convert(
-      const gsl::span<const std::byte>& b3dmBinary,
+      const std::span<const std::byte>& b3dmBinary,
       const CesiumGltfReader::GltfReaderOptions& options,
       const AssetFetcher& assetFetcher);
 };

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/BinaryToGltfConverter.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/BinaryToGltfConverter.h
@@ -4,9 +4,8 @@
 #include <CesiumAsync/Future.h>
 #include <CesiumGltfReader/GltfReader.h>
 
-#include <gsl/span>
-
 #include <cstddef>
+#include <span>
 
 namespace Cesium3DTilesContent {
 struct AssetFetcher;
@@ -14,13 +13,13 @@ struct AssetFetcher;
 struct BinaryToGltfConverter {
 public:
   static CesiumAsync::Future<GltfConverterResult> convert(
-      const gsl::span<const std::byte>& gltfBinary,
+      const std::span<const std::byte>& gltfBinary,
       const CesiumGltfReader::GltfReaderOptions& options,
       const AssetFetcher& assetFetcher);
 
 private:
   static GltfConverterResult convertImmediate(
-      const gsl::span<const std::byte>& gltfBinary,
+      const std::span<const std::byte>& gltfBinary,
       const CesiumGltfReader::GltfReaderOptions& options,
       const AssetFetcher& assetFetcher);
   static CesiumGltfReader::GltfReader _gltfReader;

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/CmptToGltfConverter.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/CmptToGltfConverter.h
@@ -4,16 +4,15 @@
 #include <CesiumAsync/Future.h>
 #include <CesiumGltfReader/GltfReader.h>
 
-#include <gsl/span>
-
 #include <cstddef>
+#include <span>
 
 namespace Cesium3DTilesContent {
 struct AssetFetcher;
 
 struct CmptToGltfConverter {
   static CesiumAsync::Future<GltfConverterResult> convert(
-      const gsl::span<const std::byte>& cmptBinary,
+      const std::span<const std::byte>& cmptBinary,
       const CesiumGltfReader::GltfReaderOptions& options,
       const AssetFetcher& assetFetcher);
 };

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/GltfConverters.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/GltfConverters.h
@@ -8,9 +8,8 @@
 #include <CesiumGeometry/Axis.h>
 #include <CesiumGltfReader/GltfReader.h>
 
-#include <gsl/span>
-
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 
@@ -72,7 +71,7 @@ public:
    * tile binary content.
    */
   using ConverterFunction = CesiumAsync::Future<GltfConverterResult> (*)(
-      const gsl::span<const std::byte>& content,
+      const std::span<const std::byte>& content,
       const CesiumGltfReader::GltfReaderOptions& options,
       const AssetFetcher& subprocessor);
 
@@ -132,7 +131,7 @@ public:
    * @return The {@link ConverterFunction} that is registered with the magic header.
    */
   static ConverterFunction
-  getConverterByMagic(const gsl::span<const std::byte>& content);
+  getConverterByMagic(const std::span<const std::byte>& content);
 
   /**
    * @brief Creates the {@link GltfConverterResult} from the given
@@ -164,7 +163,7 @@ public:
    */
   static CesiumAsync::Future<GltfConverterResult> convert(
       const std::string& filePath,
-      const gsl::span<const std::byte>& content,
+      const std::span<const std::byte>& content,
       const CesiumGltfReader::GltfReaderOptions& options,
       const AssetFetcher& assetFetcher);
 
@@ -191,7 +190,7 @@ public:
    * @return The {@link GltfConverterResult} that stores the gltf model converted from the binary data.
    */
   static CesiumAsync::Future<GltfConverterResult> convert(
-      const gsl::span<const std::byte>& content,
+      const std::span<const std::byte>& content,
       const CesiumGltfReader::GltfReaderOptions& options,
       const AssetFetcher& assetFetcher);
 
@@ -205,7 +204,7 @@ private:
       std::string& fileExtension);
 
   static ConverterFunction getConverterByMagic(
-      const gsl::span<const std::byte>& content,
+      const std::span<const std::byte>& content,
       std::string& magic);
 
   static std::unordered_map<std::string, ConverterFunction> _loadersByMagic;

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/I3dmToGltfConverter.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/I3dmToGltfConverter.h
@@ -5,16 +5,15 @@
 #include <CesiumGltf/Model.h>
 #include <CesiumGltfReader/GltfReader.h>
 
-#include <gsl/span>
-
 #include <optional>
+#include <span>
 
 namespace Cesium3DTilesContent {
 struct AssetFetcher;
 
 struct I3dmToGltfConverter {
   static CesiumAsync::Future<GltfConverterResult> convert(
-      const gsl::span<const std::byte>& instancesBinary,
+      const std::span<const std::byte>& instancesBinary,
       const CesiumGltfReader::GltfReaderOptions& options,
       const AssetFetcher& assetFetcher);
 };

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/PntsToGltfConverter.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/PntsToGltfConverter.h
@@ -6,16 +6,15 @@
 #include <CesiumGltf/Model.h>
 #include <CesiumGltfReader/GltfReader.h>
 
-#include <gsl/span>
-
 #include <optional>
+#include <span>
 
 namespace Cesium3DTilesContent {
 struct AssetFetcher;
 
 struct PntsToGltfConverter {
   static CesiumAsync::Future<GltfConverterResult> convert(
-      const gsl::span<const std::byte>& pntsBinary,
+      const std::span<const std::byte>& pntsBinary,
       const CesiumGltfReader::GltfReaderOptions& options,
       const AssetFetcher& assetFetcher);
 };

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
@@ -114,7 +114,7 @@ public:
     /**
      * @brief The buffer from which to read and write availability information.
      */
-    gsl::span<std::byte> view;
+    std::span<std::byte> view;
   };
 
   /**

--- a/Cesium3DTilesContent/src/B3dmToGltfConverter.cpp
+++ b/Cesium3DTilesContent/src/B3dmToGltfConverter.cpp
@@ -36,7 +36,7 @@ struct B3dmHeaderLegacy2 {
 };
 
 void parseB3dmHeader(
-    const gsl::span<const std::byte>& b3dmBinary,
+    const std::span<const std::byte>& b3dmBinary,
     B3dmHeader& header,
     uint32_t& headerLength,
     GltfConverterResult& result) {
@@ -113,7 +113,7 @@ void parseB3dmHeader(
 }
 
 CesiumAsync::Future<GltfConverterResult> convertB3dmContentToGltf(
-    const gsl::span<const std::byte>& b3dmBinary,
+    const std::span<const std::byte>& b3dmBinary,
     const B3dmHeader& header,
     uint32_t headerLength,
     const CesiumGltfReader::GltfReaderOptions& options,
@@ -132,14 +132,14 @@ CesiumAsync::Future<GltfConverterResult> convertB3dmContentToGltf(
     return assetFetcher.asyncSystem.createResolvedFuture(std::move(result));
   }
 
-  const gsl::span<const std::byte> glbData =
+  const std::span<const std::byte> glbData =
       b3dmBinary.subspan(glbStart, glbEnd - glbStart);
 
   return BinaryToGltfConverter::convert(glbData, options, assetFetcher);
 }
 
 rapidjson::Document parseFeatureTableJsonData(
-    const gsl::span<const std::byte>& featureTableJsonData,
+    const std::span<const std::byte>& featureTableJsonData,
     GltfConverterResult& result) {
   rapidjson::Document document;
   document.Parse(
@@ -174,14 +174,14 @@ rapidjson::Document parseFeatureTableJsonData(
 }
 
 void convertB3dmMetadataToGltfStructuralMetadata(
-    const gsl::span<const std::byte>& b3dmBinary,
+    const std::span<const std::byte>& b3dmBinary,
     const B3dmHeader& header,
     uint32_t headerLength,
     GltfConverterResult& result) {
   if (result.model && header.featureTableJsonByteLength > 0) {
     CesiumGltf::Model& gltf = result.model.value();
 
-    const gsl::span<const std::byte> featureTableJsonData =
+    const std::span<const std::byte> featureTableJsonData =
         b3dmBinary.subspan(headerLength, header.featureTableJsonByteLength);
     rapidjson::Document featureTableJson =
         parseFeatureTableJsonData(featureTableJsonData, result);
@@ -193,10 +193,10 @@ void convertB3dmMetadataToGltfStructuralMetadata(
         header.batchTableBinaryByteLength + header.batchTableJsonByteLength;
 
     if (batchTableLength > 0) {
-      const gsl::span<const std::byte> batchTableJsonData = b3dmBinary.subspan(
+      const std::span<const std::byte> batchTableJsonData = b3dmBinary.subspan(
           static_cast<size_t>(batchTableStart),
           header.batchTableJsonByteLength);
-      const gsl::span<const std::byte> batchTableBinaryData =
+      const std::span<const std::byte> batchTableBinaryData =
           b3dmBinary.subspan(
               static_cast<size_t>(
                   batchTableStart + header.batchTableJsonByteLength),
@@ -228,7 +228,7 @@ void convertB3dmMetadataToGltfStructuralMetadata(
 } // namespace
 
 CesiumAsync::Future<GltfConverterResult> B3dmToGltfConverter::convert(
-    const gsl::span<const std::byte>& b3dmBinary,
+    const std::span<const std::byte>& b3dmBinary,
     const CesiumGltfReader::GltfReaderOptions& options,
     const AssetFetcher& assetFetcher) {
   GltfConverterResult result;

--- a/Cesium3DTilesContent/src/BatchTableToGltfStructuralMetadata.cpp
+++ b/Cesium3DTilesContent/src/BatchTableToGltfStructuralMetadata.cpp
@@ -1708,7 +1708,7 @@ void updateExtensionWithBatchTableHierarchy(
 
 void convertBatchTableToGltfStructuralMetadataExtension(
     const rapidjson::Document& batchTableJson,
-    const gsl::span<const std::byte>& batchTableBinaryData,
+    const std::span<const std::byte>& batchTableBinaryData,
     CesiumGltf::Model& gltf,
     const int64_t featureCount,
     ErrorList& result) {
@@ -1820,7 +1820,7 @@ void convertBatchTableToGltfStructuralMetadataExtension(
 ErrorList BatchTableToGltfStructuralMetadata::convertFromB3dm(
     const rapidjson::Document& featureTableJson,
     const rapidjson::Document& batchTableJson,
-    const gsl::span<const std::byte>& batchTableBinaryData,
+    const std::span<const std::byte>& batchTableBinaryData,
     CesiumGltf::Model& gltf) {
   // Check to make sure a char of rapidjson is 1 byte
   static_assert(
@@ -1899,7 +1899,7 @@ ErrorList BatchTableToGltfStructuralMetadata::convertFromB3dm(
 ErrorList BatchTableToGltfStructuralMetadata::convertFromPnts(
     const rapidjson::Document& featureTableJson,
     const rapidjson::Document& batchTableJson,
-    const gsl::span<const std::byte>& batchTableBinaryData,
+    const std::span<const std::byte>& batchTableBinaryData,
     CesiumGltf::Model& gltf) {
   // Check to make sure a char of rapidjson is 1 byte
   static_assert(

--- a/Cesium3DTilesContent/src/BatchTableToGltfStructuralMetadata.h
+++ b/Cesium3DTilesContent/src/BatchTableToGltfStructuralMetadata.h
@@ -3,23 +3,23 @@
 #include <CesiumGltf/Model.h>
 #include <CesiumUtility/ErrorList.h>
 
-#include <gsl/span>
 #include <rapidjson/document.h>
 
 #include <cstddef>
+#include <span>
 
 namespace Cesium3DTilesContent {
 struct BatchTableToGltfStructuralMetadata {
   static CesiumUtility::ErrorList convertFromB3dm(
       const rapidjson::Document& featureTableJson,
       const rapidjson::Document& batchTableJson,
-      const gsl::span<const std::byte>& batchTableBinaryData,
+      const std::span<const std::byte>& batchTableBinaryData,
       CesiumGltf::Model& gltf);
 
   static CesiumUtility::ErrorList convertFromPnts(
       const rapidjson::Document& featureTableJson,
       const rapidjson::Document& batchTableJson,
-      const gsl::span<const std::byte>& batchTableBinaryData,
+      const std::span<const std::byte>& batchTableBinaryData,
       CesiumGltf::Model& gltf);
 };
 } // namespace Cesium3DTilesContent

--- a/Cesium3DTilesContent/src/BinaryToGltfConverter.cpp
+++ b/Cesium3DTilesContent/src/BinaryToGltfConverter.cpp
@@ -5,7 +5,7 @@ namespace Cesium3DTilesContent {
 CesiumGltfReader::GltfReader BinaryToGltfConverter::_gltfReader;
 
 GltfConverterResult BinaryToGltfConverter::convertImmediate(
-    const gsl::span<const std::byte>& gltfBinary,
+    const std::span<const std::byte>& gltfBinary,
     const CesiumGltfReader::GltfReaderOptions& options,
     const AssetFetcher& assetFetcher) {
   CesiumGltfReader::GltfReaderResult loadedGltf =
@@ -24,7 +24,7 @@ GltfConverterResult BinaryToGltfConverter::convertImmediate(
 }
 
 CesiumAsync::Future<GltfConverterResult> BinaryToGltfConverter::convert(
-    const gsl::span<const std::byte>& gltfBinary,
+    const std::span<const std::byte>& gltfBinary,
     const CesiumGltfReader::GltfReaderOptions& options,
     const AssetFetcher& assetFetcher) {
   return assetFetcher.asyncSystem.createResolvedFuture(

--- a/Cesium3DTilesContent/src/CmptToGltfConverter.cpp
+++ b/Cesium3DTilesContent/src/CmptToGltfConverter.cpp
@@ -23,7 +23,7 @@ static_assert(sizeof(InnerHeader) == 12);
 } // namespace
 
 CesiumAsync::Future<GltfConverterResult> CmptToGltfConverter::convert(
-    const gsl::span<const std::byte>& cmptBinary,
+    const std::span<const std::byte>& cmptBinary,
     const CesiumGltfReader::GltfReaderOptions& options,
     const AssetFetcher& assetFetcher) {
   GltfConverterResult result;
@@ -73,7 +73,7 @@ CesiumAsync::Future<GltfConverterResult> CmptToGltfConverter::convert(
       break;
     }
 
-    const gsl::span<const std::byte> innerData(
+    const std::span<const std::byte> innerData(
         cmptBinary.data() + pos,
         pInner->byteLength);
 

--- a/Cesium3DTilesContent/src/GltfConverters.cpp
+++ b/Cesium3DTilesContent/src/GltfConverters.cpp
@@ -34,14 +34,14 @@ GltfConverters::getConverterByFileExtension(const std::string& filePath) {
 }
 
 GltfConverters::ConverterFunction
-GltfConverters::getConverterByMagic(const gsl::span<const std::byte>& content) {
+GltfConverters::getConverterByMagic(const std::span<const std::byte>& content) {
   std::string magic;
   return getConverterByMagic(content, magic);
 }
 
 CesiumAsync::Future<GltfConverterResult> GltfConverters::convert(
     const std::string& filePath,
-    const gsl::span<const std::byte>& content,
+    const std::span<const std::byte>& content,
     const CesiumGltfReader::GltfReaderOptions& options,
     const AssetFetcher& assetFetcher) {
   std::string magic;
@@ -68,7 +68,7 @@ CesiumAsync::Future<GltfConverterResult> GltfConverters::convert(
 }
 
 CesiumAsync::Future<GltfConverterResult> GltfConverters::convert(
-    const gsl::span<const std::byte>& content,
+    const std::span<const std::byte>& content,
     const CesiumGltfReader::GltfReaderOptions& options,
     const AssetFetcher& assetFetcher) {
   std::string magic;
@@ -122,7 +122,7 @@ GltfConverters::ConverterFunction GltfConverters::getConverterByFileExtension(
 }
 
 GltfConverters::ConverterFunction GltfConverters::getConverterByMagic(
-    const gsl::span<const std::byte>& content,
+    const std::span<const std::byte>& content,
     std::string& magic) {
   if (content.size() >= 4) {
     magic = std::string(reinterpret_cast<const char*>(content.data()), 4);
@@ -162,7 +162,7 @@ AssetFetcher::get(const std::string& relativeUrl) const {
               return asyncSystem.createResolvedFuture(
                   std::move(assetFetcherResult));
             }
-            gsl::span<const std::byte> asset = pResponse->data();
+            std::span<const std::byte> asset = pResponse->data();
             std::copy(
                 asset.begin(),
                 asset.end(),

--- a/Cesium3DTilesContent/src/I3dmToGltfConverter.cpp
+++ b/Cesium3DTilesContent/src/I3dmToGltfConverter.cpp
@@ -82,7 +82,7 @@ void repositionInstances(DecodedInstances& decodedInstances) {
 }
 
 void parseI3dmHeader(
-    const gsl::span<const std::byte>& instancesBinary,
+    const std::span<const std::byte>& instancesBinary,
     I3dmHeader& header,
     uint32_t& headerLength,
     GltfConverterResult& result) {
@@ -189,7 +189,7 @@ struct ConvertedI3dm {
 */
 
 std::optional<I3dmContent> parseI3dmJson(
-    const gsl::span<const std::byte> featureTableJsonData,
+    const std::span<const std::byte> featureTableJsonData,
     CesiumUtility::ErrorList& errors) {
   rapidjson::Document featureTableJson;
   featureTableJson.Parse(
@@ -301,7 +301,7 @@ std::optional<I3dmContent> parseI3dmJson(
 }
 
 CesiumAsync::Future<ConvertedI3dm> convertI3dmContent(
-    const gsl::span<const std::byte>& instancesBinary,
+    const std::span<const std::byte>& instancesBinary,
     const I3dmHeader& header,
     uint32_t headerLength,
     const CesiumGltfReader::GltfReaderOptions& options,
@@ -341,13 +341,13 @@ CesiumAsync::Future<ConvertedI3dm> convertI3dmContent(
   const uint32_t numInstances = parsedContent.instancesLength;
   decodedInstances.positions.resize(numInstances, glm::vec3(0.0f, 0.0f, 0.0f));
   if (parsedContent.position.has_value()) {
-    gsl::span<const glm::vec3> rawPositions(
+    std::span<const glm::vec3> rawPositions(
         reinterpret_cast<const glm::vec3*>(
             pBinaryData + *parsedContent.position),
         numInstances);
     decodedInstances.positions.assign(rawPositions.begin(), rawPositions.end());
   } else {
-    gsl::span<const uint16_t[3]> rawQuantizedPositions(
+    std::span<const uint16_t[3]> rawQuantizedPositions(
         reinterpret_cast<const uint16_t(*)[3]>(
             pBinaryData + *parsedContent.positionQuantized),
         numInstances);
@@ -371,11 +371,11 @@ CesiumAsync::Future<ConvertedI3dm> convertI3dmContent(
       glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
   if (parsedContent.normalUp.has_value() &&
       parsedContent.normalRight.has_value()) {
-    gsl::span<const glm::vec3> rawUp(
+    std::span<const glm::vec3> rawUp(
         reinterpret_cast<const glm::vec3*>(
             pBinaryData + *parsedContent.normalUp),
         numInstances);
-    gsl::span<const glm::vec3> rawRight(
+    std::span<const glm::vec3> rawRight(
         reinterpret_cast<const glm::vec3*>(
             pBinaryData + *parsedContent.normalRight),
         numInstances);
@@ -390,11 +390,11 @@ CesiumAsync::Future<ConvertedI3dm> convertI3dmContent(
       parsedContent.normalUpOct32p.has_value() &&
       parsedContent.normalRightOct32p.has_value()) {
 
-    gsl::span<const uint16_t[2]> rawUpOct(
+    std::span<const uint16_t[2]> rawUpOct(
         reinterpret_cast<const uint16_t(*)[2]>(
             pBinaryData + *parsedContent.normalUpOct32p),
         numInstances);
-    gsl::span<const uint16_t[2]> rawRightOct(
+    std::span<const uint16_t[2]> rawRightOct(
         reinterpret_cast<const uint16_t(*)[2]>(
             pBinaryData + *parsedContent.normalRightOct32p),
         numInstances);
@@ -434,7 +434,7 @@ CesiumAsync::Future<ConvertedI3dm> convertI3dmContent(
   }
   decodedInstances.scales.resize(numInstances, glm::vec3(1.0, 1.0, 1.0));
   if (parsedContent.scale.has_value()) {
-    gsl::span<const float> rawScales(
+    std::span<const float> rawScales(
         reinterpret_cast<const float*>(pBinaryData + *parsedContent.scale),
         numInstances);
     std::transform(
@@ -444,7 +444,7 @@ CesiumAsync::Future<ConvertedI3dm> convertI3dmContent(
         [](float scaleVal) { return glm::vec3(scaleVal); });
   }
   if (parsedContent.scaleNonUniform.has_value()) {
-    gsl::span<const glm::vec3> rawScalesNonUniform(
+    std::span<const glm::vec3> rawScalesNonUniform(
         reinterpret_cast<const glm::vec3*>(
             pBinaryData + *parsedContent.scaleNonUniform),
         numInstances);
@@ -819,7 +819,7 @@ void instantiateGltfInstances(
 } // namespace
 
 CesiumAsync::Future<GltfConverterResult> I3dmToGltfConverter::convert(
-    const gsl::span<const std::byte>& instancesBinary,
+    const std::span<const std::byte>& instancesBinary,
     const CesiumGltfReader::GltfReaderOptions& options,
     const AssetFetcher& assetFetcher) {
   ConvertedI3dm convertedI3dm;

--- a/Cesium3DTilesContent/src/PntsToGltfConverter.cpp
+++ b/Cesium3DTilesContent/src/PntsToGltfConverter.cpp
@@ -43,7 +43,7 @@ struct PntsHeader {
 };
 
 void parsePntsHeader(
-    const gsl::span<const std::byte>& pntsBinary,
+    const std::span<const std::byte>& pntsBinary,
     PntsHeader& header,
     uint32_t& headerLength,
     GltfConverterResult& result) {
@@ -608,7 +608,7 @@ void parseDracoExtensionFromFeatureTableJson(
 }
 
 rapidjson::Document parseFeatureTableJson(
-    const gsl::span<const std::byte>& featureTableJsonData,
+    const std::span<const std::byte>& featureTableJsonData,
     PntsContent& parsedContent) {
   rapidjson::Document document;
   document.Parse(
@@ -773,7 +773,7 @@ void parseDracoExtensionFromBatchTableJson(
 }
 
 rapidjson::Document parseBatchTableJson(
-    const gsl::span<const std::byte>& batchTableJsonData,
+    const std::span<const std::byte>& batchTableJsonData,
     PntsContent& parsedContent) {
   rapidjson::Document document;
   document.Parse(
@@ -835,7 +835,7 @@ void getDracoData(
 
   const uint8_t* pSource = decodedBuffer->data() + decodedByteOffset;
   if (dataElementSize != static_cast<size_t>(decodedByteStride)) {
-    gsl::span<T> outData(reinterpret_cast<T*>(data.data()), pointsLength);
+    std::span<T> outData(reinterpret_cast<T*>(data.data()), pointsLength);
     for (uint32_t i = 0; i < pointsLength; ++i) {
       outData[i] = *reinterpret_cast<const T*>(pSource + decodedByteStride * i);
     }
@@ -907,9 +907,9 @@ void decodeDracoMetadata(
 }
 
 void decodeDraco(
-    const gsl::span<const std::byte>& featureTableBinaryData,
+    const std::span<const std::byte>& featureTableBinaryData,
     rapidjson::Document& batchTableJson,
-    const gsl::span<const std::byte>& batchTableBinaryData,
+    const std::span<const std::byte>& batchTableBinaryData,
     PntsContent& parsedContent) {
   if (!parsedContent.dracoByteOffset || !parsedContent.dracoByteLength) {
     return;
@@ -946,7 +946,7 @@ void decodeDraco(
     std::vector<std::byte>& positionData = parsedContent.position.data;
     positionData.resize(pointsLength * sizeof(glm::vec3));
 
-    gsl::span<glm::vec3> outPositions(
+    std::span<glm::vec3> outPositions(
         reinterpret_cast<glm::vec3*>(positionData.data()),
         pointsLength);
 
@@ -974,7 +974,7 @@ void decodeDraco(
           validateDracoAttribute(pColorAttribute, draco::DT_UINT8, 4)) {
         colorData.resize(pointsLength * sizeof(glm::vec4));
 
-        gsl::span<glm::vec4> outColors(
+        std::span<glm::vec4> outColors(
             reinterpret_cast<glm::vec4*>(colorData.data()),
             pointsLength);
 
@@ -993,7 +993,7 @@ void decodeDraco(
           validateDracoAttribute(pColorAttribute, draco::DT_UINT8, 3)) {
         colorData.resize(pointsLength * sizeof(glm::vec3));
 
-        gsl::span<glm::vec3> outColors(
+        std::span<glm::vec3> outColors(
             reinterpret_cast<glm::vec3*>(colorData.data()),
             pointsLength);
 
@@ -1085,7 +1085,7 @@ void decodeDraco(
 }
 
 void parsePositionsFromFeatureTableBinary(
-    const gsl::span<const std::byte>& featureTableBinaryData,
+    const std::span<const std::byte>& featureTableBinaryData,
     PntsContent& parsedContent) {
   std::vector<std::byte>& positionData = parsedContent.position.data;
   if (positionData.size() > 0) {
@@ -1098,7 +1098,7 @@ void parsePositionsFromFeatureTableBinary(
   const size_t positionsByteLength = pointsLength * positionsByteStride;
   positionData.resize(positionsByteLength);
 
-  gsl::span<glm::vec3> outPositions(
+  std::span<glm::vec3> outPositions(
       reinterpret_cast<glm::vec3*>(positionData.data()),
       pointsLength);
 
@@ -1106,7 +1106,7 @@ void parsePositionsFromFeatureTableBinary(
     // PERFORMANCE_IDEA: In the future, it might be more performant to detect
     // if the recipient engine can handle dequantization itself, and if so, use
     // the KHR_mesh_quantization extension to avoid dequantizing here.
-    const gsl::span<const glm::u16vec3> quantizedPositions(
+    const std::span<const glm::u16vec3> quantizedPositions(
         reinterpret_cast<const glm::u16vec3*>(
             featureTableBinaryData.data() + parsedContent.position.byteOffset),
         pointsLength);
@@ -1135,7 +1135,7 @@ void parsePositionsFromFeatureTableBinary(
   } else {
     // The position accessor min / max is required by the glTF spec, so
     // use a for loop instead of std::memcpy.
-    const gsl::span<const glm::vec3> positions(
+    const std::span<const glm::vec3> positions(
         reinterpret_cast<const glm::vec3*>(
             featureTableBinaryData.data() + parsedContent.position.byteOffset),
         pointsLength);
@@ -1149,7 +1149,7 @@ void parsePositionsFromFeatureTableBinary(
 }
 
 void parseColorsFromFeatureTableBinary(
-    const gsl::span<const std::byte>& featureTableBinaryData,
+    const std::span<const std::byte>& featureTableBinaryData,
     PntsContent& parsedContent) {
   PntsSemantic& color = parsedContent.color.value();
   std::vector<std::byte>& colorData = color.data;
@@ -1166,11 +1166,11 @@ void parseColorsFromFeatureTableBinary(
   colorData.resize(colorsByteLength);
 
   if (parsedContent.colorType == PntsColorType::RGBA) {
-    const gsl::span<const glm::u8vec4> rgbaColors(
+    const std::span<const glm::u8vec4> rgbaColors(
         reinterpret_cast<const glm::u8vec4*>(
             featureTableBinaryData.data() + color.byteOffset),
         pointsLength);
-    gsl::span<glm::vec4> outColors(
+    std::span<glm::vec4> outColors(
         reinterpret_cast<glm::vec4*>(colorData.data()),
         pointsLength);
 
@@ -1179,11 +1179,11 @@ void parseColorsFromFeatureTableBinary(
       outColors[i] = srgbToLinear(normalizedColor);
     }
   } else if (parsedContent.colorType == PntsColorType::RGB) {
-    const gsl::span<const glm::u8vec3> rgbColors(
+    const std::span<const glm::u8vec3> rgbColors(
         reinterpret_cast<const glm::u8vec3*>(
             featureTableBinaryData.data() + color.byteOffset),
         pointsLength);
-    gsl::span<glm::vec3> outColors(
+    std::span<glm::vec3> outColors(
         reinterpret_cast<glm::vec3*>(colorData.data()),
         pointsLength);
 
@@ -1193,11 +1193,11 @@ void parseColorsFromFeatureTableBinary(
     }
   } else if (parsedContent.colorType == PntsColorType::RGB565) {
 
-    const gsl::span<const uint16_t> compressedColors(
+    const std::span<const uint16_t> compressedColors(
         reinterpret_cast<const uint16_t*>(
             featureTableBinaryData.data() + color.byteOffset),
         pointsLength);
-    gsl::span<glm::vec3> outColors(
+    std::span<glm::vec3> outColors(
         reinterpret_cast<glm::vec3*>(colorData.data()),
         pointsLength);
 
@@ -1211,7 +1211,7 @@ void parseColorsFromFeatureTableBinary(
 }
 
 void parseNormalsFromFeatureTableBinary(
-    const gsl::span<const std::byte>& featureTableBinaryData,
+    const std::span<const std::byte>& featureTableBinaryData,
     PntsContent& parsedContent) {
   PntsSemantic& normal = parsedContent.normal.value();
   std::vector<std::byte>& normalData = normal.data;
@@ -1226,12 +1226,12 @@ void parseNormalsFromFeatureTableBinary(
   normalData.resize(normalsByteLength);
 
   if (parsedContent.normalOctEncoded) {
-    const gsl::span<const glm::u8vec2> encodedNormals(
+    const std::span<const glm::u8vec2> encodedNormals(
         reinterpret_cast<const glm::u8vec2*>(
             featureTableBinaryData.data() + normal.byteOffset),
         pointsLength);
 
-    gsl::span<glm::vec3> outNormals(
+    std::span<glm::vec3> outNormals(
         reinterpret_cast<glm::vec3*>(normalData.data()),
         pointsLength);
 
@@ -1250,7 +1250,7 @@ void parseNormalsFromFeatureTableBinary(
 }
 
 void parseBatchIdsFromFeatureTableBinary(
-    const gsl::span<const std::byte>& featureTableBinaryData,
+    const std::span<const std::byte>& featureTableBinaryData,
     PntsContent& parsedContent) {
   PntsSemantic& batchId = parsedContent.batchId.value();
   std::vector<std::byte>& batchIdData = batchId.data;
@@ -1275,9 +1275,9 @@ void parseBatchIdsFromFeatureTableBinary(
 }
 
 void parseFeatureTableBinary(
-    const gsl::span<const std::byte>& featureTableBinaryData,
+    const std::span<const std::byte>& featureTableBinaryData,
     rapidjson::Document& batchTableJson,
-    const gsl::span<const std::byte>& batchTableBinaryData,
+    const std::span<const std::byte>& batchTableBinaryData,
     PntsContent& parsedContent) {
   decodeDraco(
       featureTableBinaryData,
@@ -1548,7 +1548,7 @@ void createGltfFromParsedContent(
 }
 
 void convertPntsContentToGltf(
-    const gsl::span<const std::byte>& pntsBinary,
+    const std::span<const std::byte>& pntsBinary,
     const PntsHeader& header,
     uint32_t headerLength,
     GltfConverterResult& result) {
@@ -1556,7 +1556,7 @@ void convertPntsContentToGltf(
       header.featureTableBinaryByteLength > 0) {
     PntsContent parsedContent;
 
-    const gsl::span<const std::byte> featureTableJsonData =
+    const std::span<const std::byte> featureTableJsonData =
         pntsBinary.subspan(headerLength, header.featureTableJsonByteLength);
     rapidjson::Document featureTableJson =
         parseFeatureTableJson(featureTableJsonData, parsedContent);
@@ -1574,19 +1574,19 @@ void convertPntsContentToGltf(
                                     header.featureTableBinaryByteLength;
     rapidjson::Document batchTableJson;
     if (header.batchTableJsonByteLength > 0) {
-      const gsl::span<const std::byte> batchTableJsonData = pntsBinary.subspan(
+      const std::span<const std::byte> batchTableJsonData = pntsBinary.subspan(
           static_cast<size_t>(batchTableStart),
           header.batchTableJsonByteLength);
       batchTableJson = parseBatchTableJson(batchTableJsonData, parsedContent);
     }
 
-    const gsl::span<const std::byte> featureTableBinaryData =
+    const std::span<const std::byte> featureTableBinaryData =
         pntsBinary.subspan(
             static_cast<size_t>(
                 headerLength + header.featureTableJsonByteLength),
             header.featureTableBinaryByteLength);
 
-    gsl::span<const std::byte> batchTableBinaryData;
+    std::span<const std::byte> batchTableBinaryData;
     if (header.batchTableBinaryByteLength > 0) {
       batchTableBinaryData = pntsBinary.subspan(
           static_cast<size_t>(
@@ -1618,7 +1618,7 @@ void convertPntsContentToGltf(
       // values, then dracoBatchTableBinary will contain both the original
       // batch table binary and the Draco decoded values.
       batchTableBinaryData =
-          gsl::span<const std::byte>(parsedContent.dracoBatchTableBinary);
+          std::span<const std::byte>(parsedContent.dracoBatchTableBinary);
     }
 
     result.errors.merge(BatchTableToGltfStructuralMetadata::convertFromPnts(
@@ -1631,7 +1631,7 @@ void convertPntsContentToGltf(
 } // namespace
 
 CesiumAsync::Future<GltfConverterResult> PntsToGltfConverter::convert(
-    const gsl::span<const std::byte>& pntsBinary,
+    const std::span<const std::byte>& pntsBinary,
     const CesiumGltfReader::GltfReaderOptions& /*options*/,
     const AssetFetcher& assetFetcher) {
   GltfConverterResult result;

--- a/Cesium3DTilesContent/src/SubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/src/SubtreeAvailability.cpp
@@ -10,11 +10,11 @@
 #include <CesiumUtility/ErrorList.h>
 #include <CesiumUtility/Uri.h>
 
-#include <gsl/span>
 #include <rapidjson/document.h>
 
 #include <cstddef>
 #include <optional>
+#include <span>
 #include <string>
 
 using namespace Cesium3DTiles;
@@ -63,7 +63,7 @@ std::optional<SubtreeAvailability::AvailabilityView> parseAvailabilityView(
       if (bufferView.byteLength >= 0 &&
           bufferView.byteOffset + bufferView.byteLength <= bufferSize) {
         return SubtreeAvailability::SubtreeBufferViewAvailability{
-            gsl::span<std::byte>(
+            std::span<std::byte>(
                 data.data() + bufferView.byteOffset,
                 size_t(bufferView.byteLength))};
       }
@@ -415,7 +415,7 @@ void convertConstantAvailabilityToBitstream(
       size_t(buffer.byteLength),
       oldValue ? std::byte(0xFF) : std::byte(0x00));
 
-  gsl::span<std::byte> view(
+  std::span<std::byte> view(
       buffer.cesium.data.data() + start,
       buffer.cesium.data.data() + end);
   availabilityView = SubtreeAvailability::SubtreeBufferViewAvailability{view};

--- a/Cesium3DTilesContent/test/TestSkirtMeshMetadata.cpp
+++ b/Cesium3DTilesContent/test/TestSkirtMeshMetadata.cpp
@@ -42,31 +42,35 @@ TEST_CASE("Test converting skirt mesh metadata to gltf extras") {
       skirtMeshMetadata.meshCenter.z,
       Math::Epsilon7));
 
-  const auto pSkirtWestHeight =
+  const std::optional<double> maybeSkirtWestHeight =
       gltfSkirt.getSafeNumericalValueForKey<double>("skirtWestHeight");
+  REQUIRE(maybeSkirtWestHeight);
   REQUIRE(Math::equalsEpsilon(
-      pSkirtWestHeight,
+      *maybeSkirtWestHeight,
       skirtMeshMetadata.skirtWestHeight,
       Math::Epsilon7));
 
-  const auto pSkirtSouthHeight =
+  const std::optional<double> maybeSkirtSouthHeight =
       gltfSkirt.getSafeNumericalValueForKey<double>("skirtSouthHeight");
+  REQUIRE(maybeSkirtSouthHeight);
   REQUIRE(Math::equalsEpsilon(
-      pSkirtSouthHeight,
+      *maybeSkirtSouthHeight,
       skirtMeshMetadata.skirtSouthHeight,
       Math::Epsilon7));
 
-  const auto pSkirtEastHeight =
+  const std::optional<double> maybeSkirtEastHeight =
       gltfSkirt.getSafeNumericalValueForKey<double>("skirtEastHeight");
+  REQUIRE(maybeSkirtEastHeight);
   REQUIRE(Math::equalsEpsilon(
-      pSkirtEastHeight,
+      *maybeSkirtEastHeight,
       skirtMeshMetadata.skirtEastHeight,
       Math::Epsilon7));
 
-  const auto pSkirtNorthHeight =
+  const std::optional<double> maybeSkirtNorthHeight =
       gltfSkirt.getSafeNumericalValueForKey<double>("skirtNorthHeight");
+  REQUIRE(maybeSkirtNorthHeight);
   REQUIRE(Math::equalsEpsilon(
-      pSkirtNorthHeight,
+      *maybeSkirtNorthHeight,
       skirtMeshMetadata.skirtNorthHeight,
       Math::Epsilon7));
 }

--- a/Cesium3DTilesContent/test/TestSubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/test/TestSubtreeAvailability.cpp
@@ -44,7 +44,7 @@ uint64_t calculateTotalNumberOfTilesForQuadtree(uint64_t subtreeLevels) {
 
 void markTileAvailableForQuadtree(
     const CesiumGeometry::QuadtreeTileID& tileID,
-    gsl::span<std::byte> available) {
+    std::span<std::byte> available) {
   // This function assumes that subtree tile ID is (0, 0, 0).
   // TileID must be within the subtree
   uint64_t numOfTilesFromRootToParentLevel =
@@ -59,7 +59,7 @@ void markTileAvailableForQuadtree(
 
 void markSubtreeAvailableForQuadtree(
     const CesiumGeometry::QuadtreeTileID& tileID,
-    gsl::span<std::byte> available) {
+    std::span<std::byte> available) {
   uint64_t availabilityBitIndex =
       libmorton::morton2D_64_encode(tileID.x, tileID.y);
   const uint64_t byteIndex = availabilityBitIndex / 8;
@@ -80,13 +80,13 @@ SubtreeBuffers createSubtreeBuffers(
   std::vector<std::byte> availabilityBuffer(
       bufferSize + bufferSize + subtreeBufferSize);
 
-  gsl::span<std::byte> contentAvailabilityBuffer(
+  std::span<std::byte> contentAvailabilityBuffer(
       availabilityBuffer.data(),
       bufferSize);
-  gsl::span<std::byte> tileAvailabilityBuffer(
+  std::span<std::byte> tileAvailabilityBuffer(
       availabilityBuffer.data() + bufferSize,
       bufferSize);
-  gsl::span<std::byte> subtreeAvailabilityBuffer(
+  std::span<std::byte> subtreeAvailabilityBuffer(
       availabilityBuffer.data() + bufferSize + bufferSize,
       subtreeBufferSize);
   for (const auto& tileID : tileAvailabilities) {

--- a/Cesium3DTilesContent/test/TestUpgradeBatchTableToExtStructuralMetadata.cpp
+++ b/Cesium3DTilesContent/test/TestUpgradeBatchTableToExtStructuralMetadata.cpp
@@ -169,7 +169,7 @@ static void createTestForNonArrayJson(
   auto errors = BatchTableToGltfStructuralMetadata::convertFromB3dm(
       featureTableJson,
       batchTableJson,
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(),
       model);
 
   const ExtensionModelExtStructuralMetadata* pMetadata =
@@ -245,7 +245,7 @@ static void createTestForNonArrayJson(
   auto errors = BatchTableToGltfStructuralMetadata::convertFromB3dm(
       featureTableJson,
       batchTableJson,
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(),
       model);
 
   const ExtensionModelExtStructuralMetadata* pMetadata =
@@ -325,7 +325,7 @@ static void createTestForArrayJson(
   auto errors = BatchTableToGltfStructuralMetadata::convertFromB3dm(
       featureTableJson,
       batchTableJson,
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(),
       model);
 
   const ExtensionModelExtStructuralMetadata* pMetadata =
@@ -1343,7 +1343,7 @@ TEST_CASE("Upgrade JSON booleans to binary") {
   auto errors = BatchTableToGltfStructuralMetadata::convertFromB3dm(
       featureTableJson,
       batchTableJson,
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(),
       model);
 
   const ExtensionModelExtStructuralMetadata* pMetadata =
@@ -1945,7 +1945,7 @@ TEST_CASE("Defaults to string if no sentinel values are available") {
     auto errors = BatchTableToGltfStructuralMetadata::convertFromB3dm(
         featureTableJson,
         batchTableJson,
-        gsl::span<const std::byte>(),
+        std::span<const std::byte>(),
         model);
 
     const ExtensionModelExtStructuralMetadata* pMetadata =
@@ -2031,7 +2031,7 @@ TEST_CASE("Defaults to string if no sentinel values are available") {
     auto errors = BatchTableToGltfStructuralMetadata::convertFromB3dm(
         featureTableJson,
         batchTableJson,
-        gsl::span<const std::byte>(),
+        std::span<const std::byte>(),
         model);
 
     const ExtensionModelExtStructuralMetadata* pMetadata =
@@ -2279,7 +2279,7 @@ TEST_CASE("Converts \"Feature Classes\" 3DTILES_batch_table_hierarchy example "
   auto errors = BatchTableToGltfStructuralMetadata::convertFromB3dm(
       featureTableParsed,
       batchTableParsed,
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(),
       gltf);
 
   ExtensionModelExtStructuralMetadata* pExtension =
@@ -2427,7 +2427,7 @@ TEST_CASE("Omits value-less properties when converting "
   auto errors = BatchTableToGltfStructuralMetadata::convertFromB3dm(
       featureTableParsed,
       batchTableParsed,
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(),
       gltf);
 
   ExtensionModelExtStructuralMetadata* pExtension =
@@ -2524,7 +2524,7 @@ TEST_CASE(
   BatchTableToGltfStructuralMetadata::convertFromB3dm(
       featureTableParsed,
       batchTableParsed,
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(),
       gltf);
 
   ExtensionModelExtStructuralMetadata* pExtension =
@@ -2724,7 +2724,7 @@ TEST_CASE("3DTILES_batch_table_hierarchy with parentCounts is okay if all "
   BatchTableToGltfStructuralMetadata::convertFromB3dm(
       featureTableParsed,
       batchTableParsed,
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(),
       gltf);
 
   // There should not be any log messages about parentCounts, since they're
@@ -2816,7 +2816,7 @@ TEST_CASE("3DTILES_batch_table_hierarchy with parentCounts values != 1 is "
   auto errors = BatchTableToGltfStructuralMetadata::convertFromB3dm(
       featureTableParsed,
       batchTableParsed,
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(),
       gltf);
 
   // There should be a log message about parentCounts, and no properties.

--- a/Cesium3DTilesReader/CMakeLists.txt
+++ b/Cesium3DTilesReader/CMakeLists.txt
@@ -56,5 +56,4 @@ target_link_libraries(Cesium3DTilesReader
         Cesium3DTiles
         CesiumAsync
         CesiumJsonReader
-        Microsoft.GSL::GSL
 )

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/AssetReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/AssetReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Asset>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Asset from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/AvailabilityReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/AvailabilityReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Availability>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Availability from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/BoundingVolumeReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/BoundingVolumeReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::BoundingVolume>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of BoundingVolume from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/BufferReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/BufferReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Buffer>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Buffer from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/BufferViewReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/BufferViewReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::BufferView>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of BufferView from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/ClassPropertyReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/ClassPropertyReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::ClassProperty>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ClassProperty from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/ClassReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/ClassReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Class>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Class from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/ClassStatisticsReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/ClassStatisticsReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::ClassStatistics>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ClassStatistics from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/ContentReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/ContentReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Content>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Content from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/EnumReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/EnumReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Enum>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Enum from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/EnumValueReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/EnumValueReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::EnumValue>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of EnumValue from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/Extension3dTilesBoundingVolumeS2Reader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/Extension3dTilesBoundingVolumeS2Reader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -47,7 +47,7 @@ public:
    */
   CesiumJsonReader::ReadJsonResult<
       Cesium3DTiles::Extension3dTilesBoundingVolumeS2>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Extension3dTilesBoundingVolumeS2 from a

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/GroupMetadataReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/GroupMetadataReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::GroupMetadata>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of GroupMetadata from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/ImplicitTilingReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/ImplicitTilingReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::ImplicitTiling>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ImplicitTiling from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/MetadataEntityReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/MetadataEntityReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::MetadataEntity>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of MetadataEntity from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/PropertiesReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/PropertiesReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Properties>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Properties from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/PropertyStatisticsReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/PropertyStatisticsReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::PropertyStatistics>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of PropertyStatistics from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/PropertyTablePropertyReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/PropertyTablePropertyReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::PropertyTableProperty>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of PropertyTableProperty from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/PropertyTableReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/PropertyTableReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::PropertyTable>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of PropertyTable from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/SchemaReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/SchemaReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Schema>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Schema from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/StatisticsReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/StatisticsReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Statistics>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Statistics from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/SubtreeReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/SubtreeReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtree>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Subtree from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/SubtreesReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/SubtreesReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtrees>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Subtrees from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/TileReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/TileReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Tile>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Tile from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/TilesetReader.h
+++ b/Cesium3DTilesReader/generated/include/Cesium3DTilesReader/TilesetReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace Cesium3DTiles {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Tileset>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Tileset from a rapidJson::Value.

--- a/Cesium3DTilesReader/generated/src/GeneratedJsonHandlers.cpp
+++ b/Cesium3DTilesReader/generated/src/GeneratedJsonHandlers.cpp
@@ -87,7 +87,7 @@ Extension3dTilesBoundingVolumeS2Reader::getOptions() const {
 CesiumJsonReader::ReadJsonResult<
     Cesium3DTiles::Extension3dTilesBoundingVolumeS2>
 Extension3dTilesBoundingVolumeS2Reader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   Extension3dTilesBoundingVolumeS2JsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -174,7 +174,7 @@ StatisticsReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Statistics>
-StatisticsReader::readFromJson(const gsl::span<const std::byte>& data) const {
+StatisticsReader::readFromJson(const std::span<const std::byte>& data) const {
   StatisticsJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -261,7 +261,7 @@ ClassStatisticsReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::ClassStatistics>
 ClassStatisticsReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ClassStatisticsJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -370,7 +370,7 @@ PropertyStatisticsReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::PropertyStatistics>
 PropertyStatisticsReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   PropertyStatisticsJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -466,7 +466,7 @@ const CesiumJsonReader::JsonReaderOptions& SchemaReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Schema>
-SchemaReader::readFromJson(const gsl::span<const std::byte>& data) const {
+SchemaReader::readFromJson(const std::span<const std::byte>& data) const {
   SchemaJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -553,7 +553,7 @@ const CesiumJsonReader::JsonReaderOptions& EnumReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Enum>
-EnumReader::readFromJson(const gsl::span<const std::byte>& data) const {
+EnumReader::readFromJson(const std::span<const std::byte>& data) const {
   EnumJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -637,7 +637,7 @@ const CesiumJsonReader::JsonReaderOptions& EnumValueReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::EnumValue>
-EnumValueReader::readFromJson(const gsl::span<const std::byte>& data) const {
+EnumValueReader::readFromJson(const std::span<const std::byte>& data) const {
   EnumValueJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -722,7 +722,7 @@ const CesiumJsonReader::JsonReaderOptions& ClassReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Class>
-ClassReader::readFromJson(const gsl::span<const std::byte>& data) const {
+ClassReader::readFromJson(const std::span<const std::byte>& data) const {
   ClassJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -850,7 +850,7 @@ ClassPropertyReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::ClassProperty>
 ClassPropertyReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ClassPropertyJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -968,7 +968,7 @@ const CesiumJsonReader::JsonReaderOptions& SubtreeReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtree>
-SubtreeReader::readFromJson(const gsl::span<const std::byte>& data) const {
+SubtreeReader::readFromJson(const std::span<const std::byte>& data) const {
   SubtreeJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1054,7 +1054,7 @@ MetadataEntityReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::MetadataEntity>
 MetadataEntityReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   MetadataEntityJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1143,7 +1143,7 @@ AvailabilityReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Availability>
-AvailabilityReader::readFromJson(const gsl::span<const std::byte>& data) const {
+AvailabilityReader::readFromJson(const std::span<const std::byte>& data) const {
   AvailabilityJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1236,7 +1236,7 @@ PropertyTableReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::PropertyTable>
 PropertyTableReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   PropertyTableJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1350,7 +1350,7 @@ PropertyTablePropertyReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::PropertyTableProperty>
 PropertyTablePropertyReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   PropertyTablePropertyJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1444,7 +1444,7 @@ BufferViewReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::BufferView>
-BufferViewReader::readFromJson(const gsl::span<const std::byte>& data) const {
+BufferViewReader::readFromJson(const std::span<const std::byte>& data) const {
   BufferViewJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1529,7 +1529,7 @@ const CesiumJsonReader::JsonReaderOptions& BufferReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Buffer>
-BufferReader::readFromJson(const gsl::span<const std::byte>& data) const {
+BufferReader::readFromJson(const std::span<const std::byte>& data) const {
   BufferJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1640,7 +1640,7 @@ const CesiumJsonReader::JsonReaderOptions& TilesetReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Tileset>
-TilesetReader::readFromJson(const gsl::span<const std::byte>& data) const {
+TilesetReader::readFromJson(const std::span<const std::byte>& data) const {
   TilesetJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1748,7 +1748,7 @@ const CesiumJsonReader::JsonReaderOptions& TileReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Tile>
-TileReader::readFromJson(const gsl::span<const std::byte>& data) const {
+TileReader::readFromJson(const std::span<const std::byte>& data) const {
   TileJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1846,7 +1846,7 @@ ImplicitTilingReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::ImplicitTiling>
 ImplicitTilingReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ImplicitTilingJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1924,7 +1924,7 @@ const CesiumJsonReader::JsonReaderOptions& SubtreesReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtrees>
-SubtreesReader::readFromJson(const gsl::span<const std::byte>& data) const {
+SubtreesReader::readFromJson(const std::span<const std::byte>& data) const {
   SubtreesJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -2012,7 +2012,7 @@ const CesiumJsonReader::JsonReaderOptions& ContentReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Content>
-ContentReader::readFromJson(const gsl::span<const std::byte>& data) const {
+ContentReader::readFromJson(const std::span<const std::byte>& data) const {
   ContentJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -2101,7 +2101,7 @@ BoundingVolumeReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::BoundingVolume>
 BoundingVolumeReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   BoundingVolumeJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -2183,7 +2183,7 @@ GroupMetadataReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::GroupMetadata>
 GroupMetadataReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   GroupMetadataJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -2268,7 +2268,7 @@ PropertiesReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Properties>
-PropertiesReader::readFromJson(const gsl::span<const std::byte>& data) const {
+PropertiesReader::readFromJson(const std::span<const std::byte>& data) const {
   PropertiesJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -2350,7 +2350,7 @@ const CesiumJsonReader::JsonReaderOptions& AssetReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Asset>
-AssetReader::readFromJson(const gsl::span<const std::byte>& data) const {
+AssetReader::readFromJson(const std::span<const std::byte>& data) const {
   AssetJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }

--- a/Cesium3DTilesReader/include/Cesium3DTilesReader/SubtreeFileReader.h
+++ b/Cesium3DTilesReader/include/Cesium3DTilesReader/SubtreeFileReader.h
@@ -75,7 +75,7 @@ public:
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const std::string& url,
       const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders,
-      const gsl::span<const std::byte>& data) const noexcept;
+      const std::span<const std::byte>& data) const noexcept;
 
 private:
   CesiumAsync::Future<CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtree>>
@@ -84,14 +84,14 @@ private:
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const std::string& url,
       const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders,
-      const gsl::span<const std::byte>& data) const noexcept;
+      const std::span<const std::byte>& data) const noexcept;
   CesiumAsync::Future<CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtree>>
   loadJson(
       const CesiumAsync::AsyncSystem& asyncSystem,
       const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const std::string& url,
       const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders,
-      const gsl::span<const std::byte>& data) const noexcept;
+      const std::span<const std::byte>& data) const noexcept;
   CesiumAsync::Future<CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtree>>
   postprocess(
       const CesiumAsync::AsyncSystem& asyncSystem,

--- a/Cesium3DTilesReader/src/SubtreeFileReader.cpp
+++ b/Cesium3DTilesReader/src/SubtreeFileReader.cpp
@@ -70,7 +70,7 @@ Future<ReadJsonResult<Subtree>> SubtreeFileReader::load(
     const std::shared_ptr<IAssetAccessor>& pAssetAccessor,
     const std::string& url,
     const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders,
-    const gsl::span<const std::byte>& data) const noexcept {
+    const std::span<const std::byte>& data) const noexcept {
   if (data.size() < 4) {
     CesiumJsonReader::ReadJsonResult<Subtree> result;
     result.errors.emplace_back(fmt::format(
@@ -113,7 +113,7 @@ Future<ReadJsonResult<Subtree>> SubtreeFileReader::loadBinary(
     const std::shared_ptr<IAssetAccessor>& pAssetAccessor,
     const std::string& url,
     const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders,
-    const gsl::span<const std::byte>& data) const noexcept {
+    const std::span<const std::byte>& data) const noexcept {
   if (data.size() < sizeof(SubtreeHeader)) {
     CesiumJsonReader::ReadJsonResult<Subtree> result;
     result.errors.emplace_back(fmt::format(
@@ -148,7 +148,7 @@ Future<ReadJsonResult<Subtree>> SubtreeFileReader::loadBinary(
       data.subspan(sizeof(SubtreeHeader), header->jsonByteLength));
 
   if (result.value) {
-    gsl::span<const std::byte> binaryChunk = data.subspan(
+    std::span<const std::byte> binaryChunk = data.subspan(
         sizeof(SubtreeHeader) + header->jsonByteLength,
         header->binaryByteLength);
 
@@ -200,7 +200,7 @@ CesiumAsync::Future<ReadJsonResult<Subtree>> SubtreeFileReader::loadJson(
     const std::shared_ptr<IAssetAccessor>& pAssetAccessor,
     const std::string& url,
     const std::vector<CesiumAsync::IAssetAccessor::THeader>& requestHeaders,
-    const gsl::span<const std::byte>& data) const noexcept {
+    const std::span<const std::byte>& data) const noexcept {
   ReadJsonResult<Subtree> result = this->_reader.readFromJson(data);
   return postprocess(
       asyncSystem,
@@ -238,7 +238,7 @@ CesiumAsync::Future<RequestedSubtreeBuffer> requestBuffer(
               return RequestedSubtreeBuffer{bufferIdx, {}};
             }
 
-            const gsl::span<const std::byte>& data = pResponse->data();
+            const std::span<const std::byte>& data = pResponse->data();
             return RequestedSubtreeBuffer{
                 bufferIdx,
                 std::vector<std::byte>(data.begin(), data.end())};

--- a/Cesium3DTilesReader/test/TestTilesetReader.cpp
+++ b/Cesium3DTilesReader/test/TestTilesetReader.cpp
@@ -5,11 +5,11 @@
 
 #include <catch2/catch.hpp>
 #include <glm/vec3.hpp>
-#include <gsl/span>
 #include <rapidjson/reader.h>
 
 #include <filesystem>
 #include <fstream>
+#include <span>
 #include <string>
 
 TEST_CASE("Reads tileset JSON") {
@@ -132,7 +132,7 @@ TEST_CASE("Reads extras") {
 
   Cesium3DTilesReader::TilesetReader reader;
   auto result = reader.readFromJson(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()));
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()));
   REQUIRE(result.errors.empty());
   REQUIRE(result.warnings.empty());
   REQUIRE(result.value.has_value());
@@ -210,7 +210,7 @@ TEST_CASE("Reads 3DTILES_content_gltf") {
 
   Cesium3DTilesReader::TilesetReader reader;
   auto result = reader.readFromJson(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()));
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()));
   REQUIRE(result.errors.empty());
   REQUIRE(result.warnings.empty());
   REQUIRE(result.value.has_value());
@@ -260,7 +260,7 @@ TEST_CASE("Reads custom extension") {
 
   Cesium3DTilesReader::TilesetReader reader;
   auto withCustomExt = reader.readFromJson(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()));
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()));
   REQUIRE(withCustomExt.errors.empty());
   REQUIRE(withCustomExt.value.has_value());
 
@@ -287,7 +287,7 @@ TEST_CASE("Reads custom extension") {
       CesiumJsonReader::ExtensionState::Disabled);
 
   auto withoutCustomExt = reader.readFromJson(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()));
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()));
 
   auto& zeroExtensions = withoutCustomExt.value->extensions;
   REQUIRE(zeroExtensions.empty());

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/IPrepareRendererResources.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/IPrepareRendererResources.h
@@ -7,9 +7,9 @@
 #include <CesiumRasterOverlays/IPrepareRasterOverlayRendererResources.h>
 
 #include <glm/vec2.hpp>
-#include <gsl/span>
 
 #include <any>
+#include <span>
 
 namespace CesiumAsync {
 class AsyncSystem;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayCollection.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayCollection.h
@@ -10,9 +10,8 @@
 #include <CesiumUtility/ReferenceCounted.h>
 #include <CesiumUtility/Tracing.h>
 
-#include <gsl/span>
-
 #include <memory>
+#include <span>
 #include <vector>
 
 namespace Cesium3DTilesSelection {

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
@@ -11,12 +11,12 @@
 #include <CesiumUtility/DoublyLinkedList.h>
 
 #include <glm/common.hpp>
-#include <gsl/span>
 
 #include <atomic>
 #include <limits>
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -178,13 +178,13 @@ public:
    *
    * @return The children of this tile.
    */
-  gsl::span<Tile> getChildren() noexcept {
-    return gsl::span<Tile>(this->_children);
+  std::span<Tile> getChildren() noexcept {
+    return std::span<Tile>(this->_children);
   }
 
   /** @copydoc Tile::getChildren() */
-  gsl::span<const Tile> getChildren() const noexcept {
-    return gsl::span<const Tile>(this->_children);
+  std::span<const Tile> getChildren() const noexcept {
+    return std::span<const Tile>(this->_children);
   }
 
   /**

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
@@ -49,7 +49,7 @@ std::string createEndpointResource(
 std::optional<std::string> getNewAccessToken(
     const CesiumAsync::IAssetResponse* pIonResponse,
     const std::shared_ptr<spdlog::logger>& pLogger) {
-  const gsl::span<const std::byte> data = pIonResponse->data();
+  const std::span<const std::byte> data = pIonResponse->data();
   rapidjson::Document ionResponse;
   ionResponse.Parse(reinterpret_cast<const char*>(data.data()), data.size());
   if (ionResponse.HasParseError()) {
@@ -242,7 +242,7 @@ mainThreadHandleEndpointResponse(
     return externals.asyncSystem.createResolvedFuture(std::move(result));
   }
 
-  const gsl::span<const std::byte> data = pResponse->data();
+  const std::span<const std::byte> data = pResponse->data();
 
   rapidjson::Document ionResponse;
   ionResponse.Parse(reinterpret_cast<const char*>(data.data()), data.size());

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
@@ -380,7 +380,7 @@ Future<LoadLayersResult> loadLayersRecursive(
                     std::move(loadLayersResult));
               }
 
-              gsl::span<const std::byte> layerJsonBinary = pResponse->data();
+              std::span<const std::byte> layerJsonBinary = pResponse->data();
 
               rapidjson::Document layerJson;
               layerJson.Parse(
@@ -485,7 +485,7 @@ Future<LoadLayersResult> loadLayerJson(
     const std::shared_ptr<IAssetAccessor>& pAssetAccessor,
     const std::string& baseUrl,
     const std::vector<IAssetAccessor::THeader>& requestHeaders,
-    const gsl::span<const std::byte>& layerJsonBinary,
+    const std::span<const std::byte>& layerJsonBinary,
     bool useWaterMask,
     const CesiumGeospatial::Ellipsoid& ellipsoid) {
   rapidjson::Document layerJson;

--- a/Cesium3DTilesSelection/src/TileContentLoadInfo.h
+++ b/Cesium3DTilesSelection/src/TileContentLoadInfo.h
@@ -11,11 +11,11 @@
 #include <CesiumAsync/IAssetAccessor.h>
 #include <CesiumGeometry/Axis.h>
 
-#include <gsl/span>
 #include <spdlog/fwd.h>
 
 #include <cstddef>
 #include <memory>
+#include <span>
 
 namespace Cesium3DTilesSelection {
 struct TileContentLoadInfo {

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -1457,7 +1457,7 @@ Tileset::TraversalDetails Tileset::_visitVisibleChildrenNearToFar(
   TraversalDetails traversalDetails;
 
   // TODO: actually visit near-to-far, rather than in order of occurrence.
-  gsl::span<Tile> children = tile.getChildren();
+  std::span<Tile> children = tile.getChildren();
   for (Tile& child : children) {
     const TraversalDetails childTraversal = this->_visitTileIfNeeded(
         frameState,

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -223,7 +223,7 @@ void createQuadtreeSubdividedChildren(
   parent.createChildTiles(std::move(children));
 
   // populate children metadata
-  gsl::span<Tile> childrenView = parent.getChildren();
+  std::span<Tile> childrenView = parent.getChildren();
   Tile& sw = childrenView[0];
   Tile& se = childrenView[1];
   Tile& nw = childrenView[2];
@@ -744,7 +744,7 @@ TilesetContentManager::TilesetContentManager(
               }
 
               // Parse Json response
-              gsl::span<const std::byte> tilesetJsonBinary = pResponse->data();
+              std::span<const std::byte> tilesetJsonBinary = pResponse->data();
               rapidjson::Document tilesetJson;
               tilesetJson.Parse(
                   reinterpret_cast<const char*>(tilesetJsonBinary.data()),

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -791,7 +791,7 @@ TilesetJsonLoader::createLoader(
           return asyncSystem.createResolvedFuture(std::move(result));
         }
 
-        gsl::span<const std::byte> data = pResponse->data();
+        std::span<const std::byte> data = pResponse->data();
 
         rapidjson::Document tilesetJson;
         tilesetJson.Parse(

--- a/Cesium3DTilesSelection/test/TestImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/test/TestImplicitOctreeLoader.cpp
@@ -204,7 +204,7 @@ TEST_CASE("Test implicit octree loader") {
 namespace {
 
 const Tile&
-findTile(const gsl::span<const Tile>& children, const OctreeTileID& tileID) {
+findTile(const std::span<const Tile>& children, const OctreeTileID& tileID) {
   auto it = std::find_if(
       children.begin(),
       children.end(),
@@ -220,7 +220,7 @@ findTile(const gsl::span<const Tile>& children, const OctreeTileID& tileID) {
 
 const Tile&
 findTile(const std::vector<Tile>& children, const OctreeTileID& tileID) {
-  return findTile(gsl::span<const Tile>(children), tileID);
+  return findTile(std::span<const Tile>(children), tileID);
 }
 
 } // namespace

--- a/Cesium3DTilesSelection/test/TestImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/test/TestImplicitQuadtreeLoader.cpp
@@ -204,7 +204,7 @@ TEST_CASE("Test implicit quadtree loader") {
 namespace {
 
 const Tile&
-findTile(const gsl::span<const Tile>& children, const QuadtreeTileID& tileID) {
+findTile(const std::span<const Tile>& children, const QuadtreeTileID& tileID) {
   auto it = std::find_if(
       children.begin(),
       children.end(),
@@ -221,7 +221,7 @@ findTile(const gsl::span<const Tile>& children, const QuadtreeTileID& tileID) {
 
 const Tile&
 findTile(const std::vector<Tile>& children, const QuadtreeTileID& tileID) {
-  return findTile(gsl::span<const Tile>(children), tileID);
+  return findTile(std::span<const Tile>(children), tileID);
 }
 
 } // namespace

--- a/Cesium3DTilesSelection/test/TestTilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/test/TestTilesetContentManager.cpp
@@ -375,7 +375,7 @@ TEST_CASE("Test the manager can be initialized with correct loaders") {
     CHECK(pRootTile);
     CHECK(pRootTile->getRefine() == TileRefine::Replace);
 
-    const gsl::span<const Tile> children = pRootTile->getChildren();
+    const std::span<const Tile> children = pRootTile->getChildren();
     CHECK(
         std::get<QuadtreeTileID>(children[0].getTileID()) ==
         QuadtreeTileID(0, 0, 0));

--- a/Cesium3DTilesWriter/CMakeLists.txt
+++ b/Cesium3DTilesWriter/CMakeLists.txt
@@ -55,5 +55,4 @@ target_link_libraries(Cesium3DTilesWriter
     PUBLIC
         Cesium3DTiles
         CesiumJsonWriter
-        Microsoft.GSL::GSL
 )

--- a/Cesium3DTilesWriter/test/TestTilesetWriter.cpp
+++ b/Cesium3DTilesWriter/test/TestTilesetWriter.cpp
@@ -11,7 +11,7 @@
 namespace {
 void check(const std::string& input, const std::string& expectedOutput) {
   Cesium3DTilesReader::TilesetReader reader;
-  auto readResult = reader.readFromJson(gsl::span(
+  auto readResult = reader.readFromJson(std::span(
       reinterpret_cast<const std::byte*>(input.c_str()),
       input.size()));
   REQUIRE(readResult.errors.empty());

--- a/CesiumAsync/CMakeLists.txt
+++ b/CesiumAsync/CMakeLists.txt
@@ -40,7 +40,6 @@ target_include_directories(
 target_link_libraries(CesiumAsync
     PUBLIC
         CesiumUtility
-        Microsoft.GSL::GSL
         spdlog::spdlog spdlog::spdlog_header_only
         Async++
     PRIVATE

--- a/CesiumAsync/include/CesiumAsync/CacheItem.h
+++ b/CesiumAsync/include/CesiumAsync/CacheItem.h
@@ -3,12 +3,11 @@
 #include "HttpHeaders.h"
 #include "Library.h"
 
-#include <gsl/span>
-
 #include <cstddef>
 #include <cstdint>
 #include <ctime>
 #include <map>
+#include <span>
 #include <vector>
 
 namespace CesiumAsync {

--- a/CesiumAsync/include/CesiumAsync/CachingAssetAccessor.h
+++ b/CesiumAsync/include/CesiumAsync/CachingAssetAccessor.h
@@ -55,7 +55,7 @@ public:
       const std::string& verb,
       const std::string& url,
       const std::vector<THeader>& headers,
-      const gsl::span<const std::byte>& contentPayload) override;
+      const std::span<const std::byte>& contentPayload) override;
 
   /** @copydoc IAssetAccessor::tick */
   virtual void tick() noexcept override;

--- a/CesiumAsync/include/CesiumAsync/GunzipAssetAccessor.h
+++ b/CesiumAsync/include/CesiumAsync/GunzipAssetAccessor.h
@@ -33,7 +33,7 @@ public:
       const std::string& verb,
       const std::string& url,
       const std::vector<THeader>& headers,
-      const gsl::span<const std::byte>& contentPayload) override;
+      const std::span<const std::byte>& contentPayload) override;
 
   /** @copydoc IAssetAccessor::tick */
   virtual void tick() noexcept override;

--- a/CesiumAsync/include/CesiumAsync/IAssetAccessor.h
+++ b/CesiumAsync/include/CesiumAsync/IAssetAccessor.h
@@ -4,10 +4,9 @@
 #include "IAssetRequest.h"
 #include "Library.h"
 
-#include <gsl/span>
-
 #include <cstddef>
 #include <memory>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -60,7 +59,7 @@ public:
       const std::string& verb,
       const std::string& url,
       const std::vector<THeader>& headers = std::vector<THeader>(),
-      const gsl::span<const std::byte>& contentPayload = {}) = 0;
+      const std::span<const std::byte>& contentPayload = {}) = 0;
 
   /**
    * @brief Ticks the asset accessor system while the main thread is blocked.

--- a/CesiumAsync/include/CesiumAsync/IAssetResponse.h
+++ b/CesiumAsync/include/CesiumAsync/IAssetResponse.h
@@ -3,11 +3,10 @@
 #include "HttpHeaders.h"
 #include "Library.h"
 
-#include <gsl/span>
-
 #include <cstddef>
 #include <cstdint>
 #include <map>
+#include <span>
 #include <string>
 
 namespace CesiumAsync {
@@ -40,7 +39,7 @@ public:
   /**
    * @brief Returns the data of this response
    */
-  virtual gsl::span<const std::byte> data() const = 0;
+  virtual std::span<const std::byte> data() const = 0;
 };
 
 } // namespace CesiumAsync

--- a/CesiumAsync/include/CesiumAsync/ICacheDatabase.h
+++ b/CesiumAsync/include/CesiumAsync/ICacheDatabase.h
@@ -51,7 +51,7 @@ public:
       const HttpHeaders& requestHeaders,
       uint16_t statusCode,
       const HttpHeaders& responseHeaders,
-      const gsl::span<const std::byte>& responseData) = 0;
+      const std::span<const std::byte>& responseData) = 0;
 
   /**
    * @brief Remove cache entries from the database to satisfy the database

--- a/CesiumAsync/include/CesiumAsync/SqliteCache.h
+++ b/CesiumAsync/include/CesiumAsync/SqliteCache.h
@@ -47,7 +47,7 @@ public:
       const HttpHeaders& requestHeaders,
       uint16_t statusCode,
       const HttpHeaders& responseHeaders,
-      const gsl::span<const std::byte>& responseData) override;
+      const std::span<const std::byte>& responseData) override;
 
   /** @copydoc ICacheDatabase::prune*/
   virtual bool prune() override;

--- a/CesiumAsync/src/CachingAssetAccessor.cpp
+++ b/CesiumAsync/src/CachingAssetAccessor.cpp
@@ -35,8 +35,8 @@ public:
     return this->_pCacheItem->cacheResponse.headers;
   }
 
-  virtual gsl::span<const std::byte> data() const noexcept override {
-    return gsl::span<const std::byte>(
+  virtual std::span<const std::byte> data() const noexcept override {
+    return std::span<const std::byte>(
         this->_pCacheItem->cacheResponse.data.data(),
         this->_pCacheItem->cacheResponse.data.size());
   }
@@ -258,7 +258,7 @@ Future<std::shared_ptr<IAssetRequest>> CachingAssetAccessor::request(
     const std::string& verb,
     const std::string& url,
     const std::vector<THeader>& headers,
-    const gsl::span<const std::byte>& contentPayload) {
+    const std::span<const std::byte>& contentPayload) {
   return this->_pAssetAccessor
       ->request(asyncSystem, verb, url, headers, contentPayload);
 }

--- a/CesiumAsync/src/GunzipAssetAccessor.cpp
+++ b/CesiumAsync/src/GunzipAssetAccessor.cpp
@@ -29,7 +29,7 @@ public:
     return this->_pAssetResponse->headers();
   }
 
-  virtual gsl::span<const std::byte> data() const noexcept override {
+  virtual std::span<const std::byte> data() const noexcept override {
     return this->_dataValid ? this->_gunzippedData
                             : this->_pAssetResponse->data();
   }
@@ -105,7 +105,7 @@ Future<std::shared_ptr<IAssetRequest>> GunzipAssetAccessor::request(
     const std::string& verb,
     const std::string& url,
     const std::vector<THeader>& headers,
-    const gsl::span<const std::byte>& contentPayload) {
+    const std::span<const std::byte>& contentPayload) {
   return this->_pAssetAccessor
       ->request(asyncSystem, verb, url, headers, contentPayload)
       .thenImmediately(

--- a/CesiumAsync/src/SqliteCache.cpp
+++ b/CesiumAsync/src/SqliteCache.cpp
@@ -462,7 +462,7 @@ bool SqliteCache::storeEntry(
     const HttpHeaders& requestHeaders,
     uint16_t statusCode,
     const HttpHeaders& responseHeaders,
-    const gsl::span<const std::byte>& responseData) {
+    const std::span<const std::byte>& responseData) {
   CESIUM_TRACE("SqliteCache::storeEntry");
   std::lock_guard<std::mutex> guard(this->_pImpl->_mutex);
 

--- a/CesiumAsync/test/MockAssetAccessor.h
+++ b/CesiumAsync/test/MockAssetAccessor.h
@@ -27,7 +27,7 @@ public:
       const std::string& /* verb */,
       const std::string& /* url */,
       const std::vector<THeader>& /* headers */,
-      const gsl::span<const std::byte>& /* contentPayload */
+      const std::span<const std::byte>& /* contentPayload */
       ) override {
     return asyncSystem.createResolvedFuture(
         std::shared_ptr<CesiumAsync::IAssetRequest>(testRequest));

--- a/CesiumAsync/test/MockAssetResponse.h
+++ b/CesiumAsync/test/MockAssetResponse.h
@@ -27,8 +27,8 @@ public:
     return this->_headers;
   }
 
-  virtual gsl::span<const std::byte> data() const override {
-    return gsl::span<const std::byte>(_data.data(), _data.size());
+  virtual std::span<const std::byte> data() const override {
+    return std::span<const std::byte>(_data.data(), _data.size());
   }
 
 private:

--- a/CesiumAsync/test/TestCacheAssetAccessor.cpp
+++ b/CesiumAsync/test/TestCacheAssetAccessor.cpp
@@ -51,7 +51,7 @@ public:
       const HttpHeaders& requestHeaders,
       uint16_t statusCode,
       const HttpHeaders& responseHeaders,
-      const gsl::span<const std::byte>& responseData) override {
+      const std::span<const std::byte>& responseData) override {
     this->storeRequestParam = StoreRequestParameters{
         key,
         expiryTime,

--- a/CesiumGeometry/include/CesiumGeometry/Availability.h
+++ b/CesiumGeometry/include/CesiumGeometry/Availability.h
@@ -2,11 +2,10 @@
 
 #include "Library.h"
 
-#include <gsl/span>
-
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <span>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -15,7 +14,7 @@ namespace CesiumGeometry {
 
 namespace AvailabilityUtilities {
 uint8_t countOnesInByte(uint8_t _byte);
-uint32_t countOnesInBuffer(gsl::span<const std::byte> buffer);
+uint32_t countOnesInBuffer(std::span<const std::byte> buffer);
 } // namespace AvailabilityUtilities
 
 struct CESIUMGEOMETRY_API ConstantAvailability {
@@ -96,7 +95,7 @@ public:
   /**
    * @brief Unsafe is isBufferView is false.
    */
-  const gsl::span<const std::byte>& getBufferAccessor() const {
+  const std::span<const std::byte>& getBufferAccessor() const {
     return *bufferAccessor;
   }
 
@@ -115,6 +114,6 @@ public:
 private:
   const SubtreeBufferView* pBufferView;
   const ConstantAvailability* pConstant;
-  std::optional<gsl::span<const std::byte>> bufferAccessor;
+  std::optional<std::span<const std::byte>> bufferAccessor;
 };
 } // namespace CesiumGeometry

--- a/CesiumGeometry/include/CesiumGeometry/OctreeAvailability.h
+++ b/CesiumGeometry/include/CesiumGeometry/OctreeAvailability.h
@@ -5,10 +5,9 @@
 #include "OctreeTileID.h"
 #include "TileAvailabilityFlags.h"
 
-#include <gsl/span>
-
 #include <cstddef>
 #include <memory>
+#include <span>
 #include <vector>
 
 namespace CesiumGeometry {

--- a/CesiumGeometry/include/CesiumGeometry/QuadtreeAvailability.h
+++ b/CesiumGeometry/include/CesiumGeometry/QuadtreeAvailability.h
@@ -5,10 +5,9 @@
 #include "QuadtreeTileID.h"
 #include "TileAvailabilityFlags.h"
 
-#include <gsl/span>
-
 #include <cstddef>
 #include <memory>
+#include <span>
 #include <vector>
 
 namespace CesiumGeometry {

--- a/CesiumGeometry/src/Availability.cpp
+++ b/CesiumGeometry/src/Availability.cpp
@@ -19,7 +19,7 @@ static const uint8_t ones_in_byte[] = {
 
 uint8_t countOnesInByte(uint8_t _byte) { return ones_in_byte[_byte]; }
 
-uint32_t countOnesInBuffer(gsl::span<const std::byte> buffer) {
+uint32_t countOnesInBuffer(std::span<const std::byte> buffer) {
   uint32_t count = 0;
   for (const std::byte& byte : buffer) {
     count += countOnesInByte((uint8_t)byte);
@@ -67,7 +67,7 @@ AvailabilityAccessor::AvailabilityAccessor(
           subtree.buffers[this->pBufferView->buffer];
       if (this->pBufferView->byteOffset + this->pBufferView->byteLength <=
           buffer.size()) {
-        this->bufferAccessor = gsl::span<const std::byte>(
+        this->bufferAccessor = std::span<const std::byte>(
             reinterpret_cast<const std::byte*>(buffer.data()) +
                 this->pBufferView->byteOffset,
             this->pBufferView->byteLength);

--- a/CesiumGeometry/src/OctreeAvailability.cpp
+++ b/CesiumGeometry/src/OctreeAvailability.cpp
@@ -137,7 +137,7 @@ uint8_t OctreeAvailability::computeAvailability(
       uint8_t bitIndex = static_cast<uint8_t>(childSubtreeMortonIndex & 7);
       uint8_t bitMask = static_cast<uint8_t>(1 << bitIndex);
 
-      gsl::span<const std::byte> clippedSubtreeAvailability =
+      std::span<const std::byte> clippedSubtreeAvailability =
           subtreeAvailabilityAccessor.getBufferAccessor().subspan(0, byteIndex);
       uint8_t availabilityByte =
           (uint8_t)subtreeAvailabilityAccessor[byteIndex];
@@ -244,7 +244,7 @@ bool OctreeAvailability::addSubtree(
       uint8_t bitIndex = static_cast<uint8_t>(childSubtreeMortonIndex & 7);
       uint8_t bitMask = static_cast<uint8_t>(1 << bitIndex);
 
-      gsl::span<const std::byte> clippedSubtreeAvailability =
+      std::span<const std::byte> clippedSubtreeAvailability =
           subtreeAvailabilityAccessor.getBufferAccessor().subspan(0, byteIndex);
       uint8_t availabilityByte =
           (uint8_t)subtreeAvailabilityAccessor[byteIndex];
@@ -420,7 +420,7 @@ AvailabilityNode* OctreeAvailability::addNode(
     uint8_t bitIndex = static_cast<uint8_t>(mortonIndex & 7);
     uint8_t bitMask = static_cast<uint8_t>(1 << bitIndex);
 
-    gsl::span<const std::byte> clippedSubtreeAvailability =
+    std::span<const std::byte> clippedSubtreeAvailability =
         subtreeAvailabilityAccessor.getBufferAccessor().subspan(0, byteIndex);
     uint8_t availabilityByte = (uint8_t)subtreeAvailabilityAccessor[byteIndex];
 
@@ -491,7 +491,7 @@ std::optional<uint32_t> OctreeAvailability::findChildNodeIndex(
     uint8_t bitIndex = static_cast<uint8_t>(mortonIndex & 7);
     uint8_t bitMask = static_cast<uint8_t>(1 << bitIndex);
 
-    gsl::span<const std::byte> clippedSubtreeAvailability =
+    std::span<const std::byte> clippedSubtreeAvailability =
         subtreeAvailabilityAccessor.getBufferAccessor().subspan(0, byteIndex);
     uint8_t availabilityByte = (uint8_t)subtreeAvailabilityAccessor[byteIndex];
 

--- a/CesiumGeometry/src/QuadtreeAvailability.cpp
+++ b/CesiumGeometry/src/QuadtreeAvailability.cpp
@@ -149,7 +149,7 @@ uint8_t QuadtreeAvailability::computeAvailability(
       uint8_t bitIndex = static_cast<uint8_t>(childSubtreeMortonIndex & 7);
       uint8_t bitMask = static_cast<uint8_t>(1 << bitIndex);
 
-      gsl::span<const std::byte> clippedSubtreeAvailability =
+      std::span<const std::byte> clippedSubtreeAvailability =
           subtreeAvailabilityAccessor.getBufferAccessor().subspan(0, byteIndex);
       uint8_t availabilityByte =
           (uint8_t)subtreeAvailabilityAccessor[byteIndex];
@@ -255,7 +255,7 @@ bool QuadtreeAvailability::addSubtree(
       uint8_t bitIndex = static_cast<uint8_t>(childSubtreeMortonIndex & 7);
       uint8_t bitMask = static_cast<uint8_t>(1 << bitIndex);
 
-      gsl::span<const std::byte> clippedSubtreeAvailability =
+      std::span<const std::byte> clippedSubtreeAvailability =
           subtreeAvailabilityAccessor.getBufferAccessor().subspan(0, byteIndex);
       uint8_t availabilityByte =
           (uint8_t)subtreeAvailabilityAccessor[byteIndex];
@@ -429,7 +429,7 @@ AvailabilityNode* QuadtreeAvailability::addNode(
     uint8_t bitIndex = static_cast<uint8_t>(mortonIndex & 7);
     uint8_t bitMask = static_cast<uint8_t>(1 << bitIndex);
 
-    gsl::span<const std::byte> clippedSubtreeAvailability =
+    std::span<const std::byte> clippedSubtreeAvailability =
         subtreeAvailabilityAccessor.getBufferAccessor().subspan(0, byteIndex);
     uint8_t availabilityByte = (uint8_t)subtreeAvailabilityAccessor[byteIndex];
 
@@ -499,7 +499,7 @@ std::optional<uint32_t> QuadtreeAvailability::findChildNodeIndex(
     uint8_t bitIndex = static_cast<uint8_t>(mortonIndex & 7);
     uint8_t bitMask = static_cast<uint8_t>(1 << bitIndex);
 
-    gsl::span<const std::byte> clippedSubtreeAvailability =
+    std::span<const std::byte> clippedSubtreeAvailability =
         subtreeAvailabilityAccessor.getBufferAccessor().subspan(0, byteIndex);
     uint8_t availabilityByte = (uint8_t)subtreeAvailabilityAccessor[byteIndex];
 

--- a/CesiumGeometry/test/TestAvailability.cpp
+++ b/CesiumGeometry/test/TestAvailability.cpp
@@ -9,10 +9,10 @@
 #include "CesiumGeometry/TileAvailabilityFlags.h"
 
 #include <catch2/catch.hpp>
-#include <gsl/span>
 
 #include <algorithm>
 #include <memory>
+#include <span>
 #include <vector>
 
 using namespace CesiumGeometry;
@@ -36,7 +36,7 @@ TEST_CASE("Test AvailabilityUtilities") {
     // Each byte is 0xFC which has 6 ones.
     // This means there are 6 x 64 = 384 ones total in the buffer.
     uint32_t onesInBuffer = AvailabilityUtilities::countOnesInBuffer(
-        gsl::span<std::byte>(&buffer[0], 64));
+        std::span<std::byte>(&buffer[0], 64));
     REQUIRE(onesInBuffer == 384U);
   }
 }

--- a/CesiumGeospatial/include/CesiumGeospatial/EarthGravitationalModel1996Grid.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/EarthGravitationalModel1996Grid.h
@@ -2,10 +2,9 @@
 
 #include "Library.h"
 
-#include <gsl/span>
-
 #include <cstdint>
 #include <optional>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -34,7 +33,7 @@ public:
    * buffer cannot be interpreted as an EGM96 grid.
    */
   static std::optional<EarthGravitationalModel1996Grid>
-  fromBuffer(const gsl::span<const std::byte>& buffer);
+  fromBuffer(const std::span<const std::byte>& buffer);
 
   /**
    * @brief Samples the height at the given position.

--- a/CesiumGeospatial/include/CesiumGeospatial/S2CellBoundingVolume.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/S2CellBoundingVolume.h
@@ -8,9 +8,9 @@
 #include <CesiumGeometry/Plane.h>
 
 #include <glm/vec3.hpp>
-#include <gsl/span>
 
 #include <array>
+#include <span>
 #include <string_view>
 
 namespace CesiumGeospatial {
@@ -60,7 +60,7 @@ public:
    *
    * @return An array of positions with a `size()` of 8.
    */
-  gsl::span<const glm::dvec3> getVertices() const noexcept;
+  std::span<const glm::dvec3> getVertices() const noexcept;
 
   /**
    * @brief Determines on which side of a plane the bounding volume is located.
@@ -93,7 +93,7 @@ public:
    *
    * @return An array of planes with a `size()` of 6.
    */
-  gsl::span<const CesiumGeometry::Plane> getBoundingPlanes() const noexcept;
+  std::span<const CesiumGeometry::Plane> getBoundingPlanes() const noexcept;
 
   /**
    * @brief Computes the bounding begion that best fits this S2 cell volume.

--- a/CesiumGeospatial/src/EarthGravitationalModel1996Grid.cpp
+++ b/CesiumGeospatial/src/EarthGravitationalModel1996Grid.cpp
@@ -28,7 +28,7 @@ constexpr size_t TOTAL_BYTES = TOTAL_VALUES * sizeof(int16_t);
 
 std::optional<EarthGravitationalModel1996Grid>
 CesiumGeospatial::EarthGravitationalModel1996Grid::fromBuffer(
-    const gsl::span<const std::byte>& buffer) {
+    const std::span<const std::byte>& buffer) {
   if (buffer.size_bytes() < TOTAL_BYTES) {
     // Not enough data - is this a valid WW15MGH.DAC?
     return std::nullopt;

--- a/CesiumGeospatial/src/S2CellBoundingVolume.cpp
+++ b/CesiumGeospatial/src/S2CellBoundingVolume.cpp
@@ -149,7 +149,7 @@ glm::dvec3 S2CellBoundingVolume::getCenter() const noexcept {
   return this->_center;
 }
 
-gsl::span<const glm::dvec3> S2CellBoundingVolume::getVertices() const noexcept {
+std::span<const glm::dvec3> S2CellBoundingVolume::getVertices() const noexcept {
   return this->_vertices;
 }
 
@@ -419,7 +419,7 @@ double S2CellBoundingVolume::computeDistanceSquaredToPosition(
       this->_vertices[4 + ((selectedPlaneIndices[1] - 2 + skip) % 4)]);
 }
 
-gsl::span<const CesiumGeometry::Plane>
+std::span<const CesiumGeometry::Plane>
 S2CellBoundingVolume::getBoundingPlanes() const noexcept {
   return this->_boundingPlanes;
 }

--- a/CesiumGeospatial/test/TestS2CellBoundingVolume.cpp
+++ b/CesiumGeospatial/test/TestS2CellBoundingVolume.cpp
@@ -26,7 +26,7 @@ TEST_CASE("S2CellBoundingVolume") {
       "Case I - distanceToCamera works when camera is facing only one plane") {
     const double testDistance = 100.0;
 
-    gsl::span<const Plane> bvPlanes = tileS2Cell.getBoundingPlanes();
+    std::span<const Plane> bvPlanes = tileS2Cell.getBoundingPlanes();
 
     // Test against the top plane.
     Plane topPlane(
@@ -45,7 +45,7 @@ TEST_CASE("S2CellBoundingVolume") {
         bvPlanes[2].getNormal(),
         bvPlanes[2].getDistance() - testDistance);
 
-    gsl::span<const glm::dvec3> vertices = tileS2Cell.getVertices();
+    std::span<const glm::dvec3> vertices = tileS2Cell.getVertices();
     glm::dvec3 faceCenter = ((vertices[0] + vertices[1]) * 0.5 +
                              (vertices[4] + vertices[5]) * 0.5) *
                             0.5;

--- a/CesiumGltf/CMakeLists.txt
+++ b/CesiumGltf/CMakeLists.txt
@@ -54,7 +54,6 @@ target_include_directories(
 target_link_libraries(CesiumGltf
     PUBLIC
         CesiumUtility
-        Microsoft.GSL::GSL
 )
 
 target_compile_definitions(CesiumGltf PRIVATE GLM_ENABLE_EXPERIMENTAL)

--- a/CesiumGltf/include/CesiumGltf/AccessorUtility.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorUtility.h
@@ -6,6 +6,7 @@
 
 #include <glm/common.hpp>
 
+#include <array>
 #include <variant>
 
 namespace CesiumGltf {

--- a/CesiumGltf/include/CesiumGltf/PropertyArrayView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyArrayView.h
@@ -5,10 +5,9 @@
 
 #include <CesiumUtility/SpanHelper.h>
 
-#include <gsl/span>
-
 #include <cstddef>
 #include <cstring>
+#include <span>
 #include <variant>
 #include <vector>
 
@@ -33,7 +32,7 @@ public:
    *
    * @param buffer The buffer containing the values.
    */
-  PropertyArrayView(const gsl::span<const std::byte>& buffer) noexcept
+  PropertyArrayView(const std::span<const std::byte>& buffer) noexcept
       : _values{CesiumUtility::reintepretCastSpan<const ElementType>(buffer)} {}
 
   const ElementType& operator[](int64_t index) const noexcept {
@@ -48,7 +47,7 @@ public:
   auto end() const { return this->_values.end(); }
 
 private:
-  gsl::span<const ElementType> _values;
+  std::span<const ElementType> _values;
 };
 
 /**
@@ -142,7 +141,7 @@ public:
    * @param size The number of values in the array.
    */
   PropertyArrayView(
-      const gsl::span<const std::byte>& buffer,
+      const std::span<const std::byte>& buffer,
       int64_t bitOffset,
       int64_t size) noexcept
       : _values{buffer}, _bitOffset{bitOffset}, _size{size} {}
@@ -158,7 +157,7 @@ public:
   int64_t size() const noexcept { return _size; }
 
 private:
-  gsl::span<const std::byte> _values;
+  std::span<const std::byte> _values;
   int64_t _bitOffset;
   int64_t _size;
 };
@@ -183,8 +182,8 @@ public:
    * @param size The number of values in the array.
    */
   PropertyArrayView(
-      const gsl::span<const std::byte>& values,
-      const gsl::span<const std::byte>& stringOffsets,
+      const std::span<const std::byte>& values,
+      const std::span<const std::byte>& stringOffsets,
       PropertyComponentType stringOffsetType,
       int64_t size) noexcept
       : _values{values},
@@ -207,8 +206,8 @@ public:
   int64_t size() const noexcept { return _size; }
 
 private:
-  gsl::span<const std::byte> _values;
-  gsl::span<const std::byte> _stringOffsets;
+  std::span<const std::byte> _values;
+  std::span<const std::byte> _stringOffsets;
   PropertyComponentType _stringOffsetType;
   int64_t _size;
 };

--- a/CesiumGltf/include/CesiumGltf/PropertyTablePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTablePropertyView.h
@@ -7,10 +7,9 @@
 
 #include <CesiumUtility/Assert.h>
 
-#include <gsl/span>
-
 #include <cstddef>
 #include <cstdint>
+#include <span>
 #include <string_view>
 #include <type_traits>
 
@@ -245,7 +244,7 @@ public:
       const PropertyTableProperty& property,
       const ClassProperty& classProperty,
       int64_t size,
-      gsl::span<const std::byte> values) noexcept
+      std::span<const std::byte> values) noexcept
       : PropertyView<ElementType>(classProperty, property),
         _values{values},
         _size{
@@ -273,9 +272,9 @@ public:
       const PropertyTableProperty& property,
       const ClassProperty& classProperty,
       int64_t size,
-      gsl::span<const std::byte> values,
-      gsl::span<const std::byte> arrayOffsets,
-      gsl::span<const std::byte> stringOffsets,
+      std::span<const std::byte> values,
+      std::span<const std::byte> arrayOffsets,
+      std::span<const std::byte> stringOffsets,
       PropertyComponentType arrayOffsetType,
       PropertyComponentType stringOffsetType) noexcept
       : PropertyView<ElementType>(classProperty, property),
@@ -412,7 +411,7 @@ private:
     // Handle fixed-length arrays
     if (count > 0) {
       size_t arraySize = count * sizeof(T);
-      const gsl::span<const std::byte> values(
+      const std::span<const std::byte> values(
           _values.data() + index * arraySize,
           arraySize);
       return PropertyArrayView<T>{values};
@@ -426,7 +425,7 @@ private:
     const size_t nextOffset =
         getOffsetFromOffsetsBuffer(index + 1, _arrayOffsets, _arrayOffsetType) *
         sizeof(T);
-    const gsl::span<const std::byte> values(
+    const std::span<const std::byte> values(
         _values.data() + currentOffset,
         nextOffset - currentOffset);
     return PropertyArrayView<T>{values};
@@ -439,7 +438,7 @@ private:
     if (count > 0) {
       // Copy the corresponding string offsets to pass to the PropertyArrayView.
       const size_t arraySize = count * _stringOffsetTypeSize;
-      const gsl::span<const std::byte> stringOffsetValues(
+      const std::span<const std::byte> stringOffsetValues(
           _stringOffsets.data() + index * arraySize,
           arraySize + _stringOffsetTypeSize);
       return PropertyArrayView<std::string_view>(
@@ -455,7 +454,7 @@ private:
     const size_t nextArrayOffset =
         getOffsetFromOffsetsBuffer(index + 1, _arrayOffsets, _arrayOffsetType);
     const size_t arraySize = nextArrayOffset - currentArrayOffset;
-    const gsl::span<const std::byte> stringOffsetValues(
+    const std::span<const std::byte> stringOffsetValues(
         _stringOffsets.data() + currentArrayOffset,
         arraySize + _arrayOffsetTypeSize);
     return PropertyArrayView<std::string_view>(
@@ -471,7 +470,7 @@ private:
     if (count > 0) {
       const size_t offsetBits = count * index;
       const size_t nextOffsetBits = count * (index + 1);
-      const gsl::span<const std::byte> buffer(
+      const std::span<const std::byte> buffer(
           _values.data() + offsetBits / 8,
           (nextOffsetBits / 8 - offsetBits / 8 + 1));
       return PropertyArrayView<bool>(buffer, offsetBits % 8, count);
@@ -483,20 +482,20 @@ private:
     const size_t nextOffset =
         getOffsetFromOffsetsBuffer(index + 1, _arrayOffsets, _arrayOffsetType);
     const size_t totalBits = nextOffset - currentOffset;
-    const gsl::span<const std::byte> buffer(
+    const std::span<const std::byte> buffer(
         _values.data() + currentOffset / 8,
         (nextOffset / 8 - currentOffset / 8 + 1));
     return PropertyArrayView<bool>(buffer, currentOffset % 8, totalBits);
   }
 
-  gsl::span<const std::byte> _values;
+  std::span<const std::byte> _values;
   int64_t _size;
 
-  gsl::span<const std::byte> _arrayOffsets;
+  std::span<const std::byte> _arrayOffsets;
   PropertyComponentType _arrayOffsetType;
   int64_t _arrayOffsetTypeSize;
 
-  gsl::span<const std::byte> _stringOffsets;
+  std::span<const std::byte> _stringOffsets;
   PropertyComponentType _stringOffsetType;
   int64_t _stringOffsetTypeSize;
 };
@@ -597,7 +596,7 @@ public:
       const PropertyTableProperty& property,
       const ClassProperty& classProperty,
       int64_t size,
-      gsl::span<const std::byte> values) noexcept
+      std::span<const std::byte> values) noexcept
       : PropertyView<ElementType, true>(classProperty, property),
         _values{values},
         _size{
@@ -621,8 +620,8 @@ public:
       const PropertyTableProperty& property,
       const ClassProperty& classProperty,
       int64_t size,
-      gsl::span<const std::byte> values,
-      gsl::span<const std::byte> arrayOffsets,
+      std::span<const std::byte> values,
+      std::span<const std::byte> arrayOffsets,
       PropertyComponentType arrayOffsetType) noexcept
       : PropertyView<ElementType, true>(classProperty, property),
         _values{values},
@@ -758,7 +757,7 @@ private:
     // Handle fixed-length arrays
     if (count > 0) {
       size_t arraySize = count * sizeof(T);
-      const gsl::span<const std::byte> values(
+      const std::span<const std::byte> values(
           _values.data() + index * arraySize,
           arraySize);
       return PropertyArrayView<T>{values};
@@ -772,16 +771,16 @@ private:
     const size_t nextOffset =
         getOffsetFromOffsetsBuffer(index + 1, _arrayOffsets, _arrayOffsetType) *
         sizeof(T);
-    const gsl::span<const std::byte> values(
+    const std::span<const std::byte> values(
         _values.data() + currentOffset,
         nextOffset - currentOffset);
     return PropertyArrayView<T>{values};
   }
 
-  gsl::span<const std::byte> _values;
+  std::span<const std::byte> _values;
   int64_t _size;
 
-  gsl::span<const std::byte> _arrayOffsets;
+  std::span<const std::byte> _arrayOffsets;
   PropertyComponentType _arrayOffsetType;
   int64_t _arrayOffsetTypeSize;
 };

--- a/CesiumGltf/include/CesiumGltf/PropertyTableView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTableView.h
@@ -1111,7 +1111,7 @@ private:
           PropertyTablePropertyViewStatus::ErrorNormalizationMismatch);
     }
 
-    gsl::span<const std::byte> values;
+    std::span<const std::byte> values;
     const auto status = getBufferSafe(propertyTableProperty.values, values);
     if (status != PropertyTablePropertyViewStatus::Valid) {
       return PropertyTablePropertyView<T, Normalized>(status);
@@ -1182,7 +1182,7 @@ private:
           PropertyTablePropertyViewStatus::ErrorNormalizationMismatch);
     }
 
-    gsl::span<const std::byte> values;
+    std::span<const std::byte> values;
     auto status = getBufferSafe(propertyTableProperty.values, values);
     if (status != PropertyTablePropertyViewStatus::Valid) {
       return PropertyTablePropertyView<PropertyArrayView<T>, Normalized>(
@@ -1236,7 +1236,7 @@ private:
     }
 
     constexpr bool checkBitsSize = false;
-    gsl::span<const std::byte> arrayOffsets;
+    std::span<const std::byte> arrayOffsets;
     status = getArrayOffsetsBufferSafe(
         propertyTableProperty.arrayOffsets,
         arrayOffsetType,
@@ -1264,7 +1264,7 @@ private:
           _pPropertyTable->count,
           values,
           arrayOffsets,
-          gsl::span<const std::byte>(),
+          std::span<const std::byte>(),
           arrayOffsetType,
           PropertyComponentType::None);
     }
@@ -1277,7 +1277,7 @@ private:
 
   PropertyViewStatusType getBufferSafe(
       int32_t bufferView,
-      gsl::span<const std::byte>& buffer) const noexcept;
+      std::span<const std::byte>& buffer) const noexcept;
 
   PropertyViewStatusType getArrayOffsetsBufferSafe(
       int32_t arrayOffsetsBufferView,
@@ -1285,14 +1285,14 @@ private:
       size_t valuesBufferSize,
       size_t propertyTableCount,
       bool checkBitsSize,
-      gsl::span<const std::byte>& arrayOffsetsBuffer) const noexcept;
+      std::span<const std::byte>& arrayOffsetsBuffer) const noexcept;
 
   PropertyViewStatusType getStringOffsetsBufferSafe(
       int32_t stringOffsetsBufferView,
       PropertyComponentType stringOffsetType,
       size_t valuesBufferSize,
       size_t propertyTableCount,
-      gsl::span<const std::byte>& stringOffsetsBuffer) const noexcept;
+      std::span<const std::byte>& stringOffsetsBuffer) const noexcept;
 
   const Model* _pModel;
   const PropertyTable* _pPropertyTable;

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -84,7 +84,7 @@ public:
 };
 
 template <typename ElementType>
-ElementType assembleScalarValue(const gsl::span<uint8_t> bytes) noexcept {
+ElementType assembleScalarValue(const std::span<uint8_t> bytes) noexcept {
   if constexpr (std::is_same_v<ElementType, float>) {
     CESIUM_ASSERT(
         bytes.size() == sizeof(float) &&
@@ -111,7 +111,7 @@ ElementType assembleScalarValue(const gsl::span<uint8_t> bytes) noexcept {
 }
 
 template <typename ElementType>
-ElementType assembleVecNValue(const gsl::span<uint8_t> bytes) noexcept {
+ElementType assembleVecNValue(const std::span<uint8_t> bytes) noexcept {
   ElementType result = ElementType();
 
   const glm::length_t N =
@@ -159,7 +159,7 @@ ElementType assembleVecNValue(const gsl::span<uint8_t> bytes) noexcept {
 
 template <typename T>
 PropertyArrayCopy<T>
-assembleArrayValue(const gsl::span<uint8_t> bytes) noexcept {
+assembleArrayValue(const std::span<uint8_t> bytes) noexcept {
   std::vector<T> result(bytes.size() / sizeof(T));
 
   if constexpr (sizeof(T) == 2) {
@@ -180,7 +180,7 @@ assembleArrayValue(const gsl::span<uint8_t> bytes) noexcept {
 
 template <typename ElementType>
 PropertyValueViewToCopy<ElementType>
-assembleValueFromChannels(const gsl::span<uint8_t> bytes) noexcept {
+assembleValueFromChannels(const std::span<uint8_t> bytes) noexcept {
   CESIUM_ASSERT(
       bytes.size() > 0 && "Channel input must have at least one value.");
 
@@ -423,7 +423,7 @@ public:
         this->sampleNearestPixel(u, v, this->_channels);
 
     return assembleValueFromChannels<ElementType>(
-        gsl::span(sample.data(), this->_channels.size()));
+        std::span(sample.data(), this->_channels.size()));
   }
 
   /**
@@ -675,7 +675,7 @@ public:
         this->sampleNearestPixel(u, v, this->_channels);
 
     return assembleValueFromChannels<ElementType>(
-        gsl::span(sample.data(), this->_channels.size()));
+        std::span(sample.data(), this->_channels.size()));
   }
 
   /**

--- a/CesiumGltf/include/CesiumGltf/PropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyView.h
@@ -168,13 +168,7 @@ validateArrayPropertyType(const ClassProperty& classProperty) {
 
 template <typename T>
 static std::optional<T> getScalar(const CesiumUtility::JsonValue& jsonValue) {
-  try {
-    return jsonValue.getSafeNumber<T>();
-  } catch (const CesiumUtility::JsonValueNotRealValue& /*error*/) {
-    return std::nullopt;
-  } catch (const gsl::narrowing_error& /*error*/) {
-    return std::nullopt;
-  }
+  return jsonValue.getSafeNumber<T>();
 }
 
 template <typename VecType>
@@ -1482,7 +1476,7 @@ public:
     }
 
     return PropertyArrayView<ElementType>(
-        gsl::span<const std::byte>(_offset->data(), _offset->size()));
+        std::span<const std::byte>(_offset->data(), _offset->size()));
   }
 
   /**
@@ -1494,7 +1488,7 @@ public:
     }
 
     return PropertyArrayView<ElementType>(
-        gsl::span<const std::byte>(_scale->data(), _scale->size()));
+        std::span<const std::byte>(_scale->data(), _scale->size()));
   }
 
   /**
@@ -1506,7 +1500,7 @@ public:
     }
 
     return PropertyArrayView<ElementType>(
-        gsl::span<const std::byte>(_max->data(), _max->size()));
+        std::span<const std::byte>(_max->data(), _max->size()));
   }
 
   /**
@@ -1518,7 +1512,7 @@ public:
     }
 
     return PropertyArrayView<ElementType>(
-        gsl::span<const std::byte>(_min->data(), _min->size()));
+        std::span<const std::byte>(_min->data(), _min->size()));
   }
 
   /**
@@ -1535,7 +1529,7 @@ public:
     }
 
     return PropertyArrayView<ElementType>(
-        gsl::span<const std::byte>(_noData->data(), _noData->size()));
+        std::span<const std::byte>(_noData->data(), _noData->size()));
   }
 
   /**
@@ -1546,7 +1540,7 @@ public:
       return std::nullopt;
     }
 
-    return PropertyArrayView<ElementType>(gsl::span<const std::byte>(
+    return PropertyArrayView<ElementType>(std::span<const std::byte>(
         _defaultValue->data(),
         _defaultValue->size()));
   }
@@ -1878,7 +1872,7 @@ public:
     }
 
     return PropertyArrayView<NormalizedType>(
-        gsl::span<const std::byte>(_offset->data(), _offset->size()));
+        std::span<const std::byte>(_offset->data(), _offset->size()));
   }
 
   /**
@@ -1890,7 +1884,7 @@ public:
     }
 
     return PropertyArrayView<NormalizedType>(
-        gsl::span<const std::byte>(_scale->data(), _scale->size()));
+        std::span<const std::byte>(_scale->data(), _scale->size()));
   }
 
   /**
@@ -1902,7 +1896,7 @@ public:
     }
 
     return PropertyArrayView<NormalizedType>(
-        gsl::span<const std::byte>(_max->data(), _max->size()));
+        std::span<const std::byte>(_max->data(), _max->size()));
   }
 
   /**
@@ -1914,7 +1908,7 @@ public:
     }
 
     return PropertyArrayView<NormalizedType>(
-        gsl::span<const std::byte>(_min->data(), _min->size()));
+        std::span<const std::byte>(_min->data(), _min->size()));
   }
 
   /**
@@ -1931,7 +1925,7 @@ public:
     }
 
     return PropertyArrayView<ElementType>(
-        gsl::span<const std::byte>(_noData->data(), _noData->size()));
+        std::span<const std::byte>(_noData->data(), _noData->size()));
   }
 
   /**
@@ -1943,7 +1937,7 @@ public:
       return std::nullopt;
     }
 
-    return PropertyArrayView<NormalizedType>(gsl::span<const std::byte>(
+    return PropertyArrayView<NormalizedType>(std::span<const std::byte>(
         _defaultValue->data(),
         _defaultValue->size()));
   }
@@ -2225,7 +2219,7 @@ public:
   std::optional<PropertyArrayView<bool>> defaultValue() const noexcept {
     if (_size > 0) {
       return PropertyArrayView<bool>(
-          gsl::span<const std::byte>(
+          std::span<const std::byte>(
               _defaultValue.data(),
               _defaultValue.size()),
           /* bitOffset = */ 0,
@@ -2449,8 +2443,8 @@ public:
   std::optional<PropertyArrayView<std::string_view>> noData() const noexcept {
     if (_noData.size > 0) {
       return PropertyArrayView<std::string_view>(
-          gsl::span<const std::byte>(_noData.data.data(), _noData.data.size()),
-          gsl::span<const std::byte>(
+          std::span<const std::byte>(_noData.data.data(), _noData.data.size()),
+          std::span<const std::byte>(
               _noData.offsets.data(),
               _noData.offsets.size()),
           _noData.offsetType,
@@ -2467,10 +2461,10 @@ public:
   defaultValue() const noexcept {
     if (_defaultValue.size > 0) {
       return PropertyArrayView<std::string_view>(
-          gsl::span<const std::byte>(
+          std::span<const std::byte>(
               _defaultValue.data.data(),
               _defaultValue.data.size()),
-          gsl::span<const std::byte>(
+          std::span<const std::byte>(
               _defaultValue.offsets.data(),
               _defaultValue.offsets.size()),
           _defaultValue.offsetType,

--- a/CesiumGltf/include/CesiumGltf/getOffsetFromOffsetsBuffer.h
+++ b/CesiumGltf/include/CesiumGltf/getOffsetFromOffsetsBuffer.h
@@ -5,14 +5,13 @@
 #include <CesiumUtility/Assert.h>
 #include <CesiumUtility/SpanHelper.h>
 
-#include <gsl/span>
-
 #include <cstddef>
+#include <span>
 
 namespace CesiumGltf {
 static size_t getOffsetFromOffsetsBuffer(
     size_t index,
-    const gsl::span<const std::byte>& offsetBuffer,
+    const std::span<const std::byte>& offsetBuffer,
     PropertyComponentType offsetType) noexcept {
   switch (offsetType) {
   case PropertyComponentType::Uint8: {

--- a/CesiumGltf/src/Model.cpp
+++ b/CesiumGltf/src/Model.cpp
@@ -17,10 +17,11 @@
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtx/norm.hpp>
 #include <glm/vec3.hpp>
-#include <gsl/span>
 
 #include <algorithm>
+#include <array>
 #include <charconv>
+#include <span>
 
 using namespace CesiumUtility;
 
@@ -634,7 +635,7 @@ void Model::forEachPrimitiveInScene(
 namespace {
 template <typename TIndex>
 void addTriangleNormalToVertexNormals(
-    const gsl::span<glm::vec3>& normals,
+    const std::span<glm::vec3>& normals,
     const AccessorView<glm::vec3>& positionView,
     TIndex tIndex0,
     TIndex tIndex1,
@@ -663,7 +664,7 @@ void addTriangleNormalToVertexNormals(
 template <typename TIndex, typename GetIndex>
 bool accumulateNormals(
     int32_t meshPrimitiveMode,
-    const gsl::span<glm::vec3>& normals,
+    const std::span<glm::vec3>& normals,
     const AccessorView<glm::vec3>& positionView,
     int64_t numIndices,
     GetIndex getIndex) {
@@ -749,7 +750,7 @@ void generateSmoothNormals(
   const size_t normalBufferSize = count * normalBufferStride;
 
   std::vector<std::byte> normalByteBuffer(normalBufferSize);
-  gsl::span<glm::vec3> normals(
+  std::span<glm::vec3> normals(
       reinterpret_cast<glm::vec3*>(normalByteBuffer.data()),
       count);
 

--- a/CesiumGltf/src/PropertyTableView.cpp
+++ b/CesiumGltf/src/PropertyTableView.cpp
@@ -3,7 +3,7 @@
 namespace CesiumGltf {
 template <typename T>
 static PropertyViewStatusType checkOffsetsBuffer(
-    const gsl::span<const std::byte>& offsetBuffer,
+    const std::span<const std::byte>& offsetBuffer,
     size_t valueBufferSize,
     size_t instanceCount,
     bool checkBitSize,
@@ -20,7 +20,7 @@ static PropertyViewStatusType checkOffsetsBuffer(
         ErrorBufferViewSizeDoesNotMatchPropertyTableCount;
   }
 
-  const gsl::span<const T> offsetValues(
+  const std::span<const T> offsetValues(
       reinterpret_cast<const T*>(offsetBuffer.data()),
       size);
 
@@ -47,8 +47,8 @@ static PropertyViewStatusType checkOffsetsBuffer(
 
 template <typename T>
 static PropertyViewStatusType checkStringAndArrayOffsetsBuffers(
-    const gsl::span<const std::byte>& arrayOffsets,
-    const gsl::span<const std::byte>& stringOffsets,
+    const std::span<const std::byte>& arrayOffsets,
+    const std::span<const std::byte>& stringOffsets,
     size_t valueBufferSize,
     PropertyComponentType stringOffsetType,
     size_t propertyTableCount) noexcept {
@@ -149,7 +149,7 @@ PropertyTableView::getClassProperty(const std::string& propertyId) const {
 
 PropertyViewStatusType PropertyTableView::getBufferSafe(
     int32_t bufferViewIdx,
-    gsl::span<const std::byte>& buffer) const noexcept {
+    std::span<const std::byte>& buffer) const noexcept {
   buffer = {};
 
   const BufferView* pBufferView =
@@ -169,7 +169,7 @@ PropertyViewStatusType PropertyTableView::getBufferSafe(
     return PropertyTablePropertyViewStatus::ErrorBufferViewOutOfBounds;
   }
 
-  buffer = gsl::span<const std::byte>(
+  buffer = std::span<const std::byte>(
       pBuffer->cesium.data.data() + pBufferView->byteOffset,
       static_cast<size_t>(pBufferView->byteLength));
   return PropertyTablePropertyViewStatus::Valid;
@@ -181,7 +181,7 @@ PropertyViewStatusType PropertyTableView::getArrayOffsetsBufferSafe(
     size_t valueBufferSize,
     size_t propertyTableCount,
     bool checkBitsSize,
-    gsl::span<const std::byte>& arrayOffsetsBuffer) const noexcept {
+    std::span<const std::byte>& arrayOffsetsBuffer) const noexcept {
   const PropertyViewStatusType bufferStatus =
       getBufferSafe(arrayOffsetsBufferView, arrayOffsetsBuffer);
   if (bufferStatus != PropertyTablePropertyViewStatus::Valid) {
@@ -231,7 +231,7 @@ PropertyViewStatusType PropertyTableView::getStringOffsetsBufferSafe(
     PropertyComponentType stringOffsetType,
     size_t valueBufferSize,
     size_t propertyTableCount,
-    gsl::span<const std::byte>& stringOffsetsBuffer) const noexcept {
+    std::span<const std::byte>& stringOffsetsBuffer) const noexcept {
   const PropertyViewStatusType bufferStatus =
       getBufferSafe(stringOffsetsBufferView, stringOffsetsBuffer);
   if (bufferStatus != PropertyTablePropertyViewStatus::Valid) {
@@ -290,7 +290,7 @@ PropertyTableView::getStringPropertyValues(
         PropertyTablePropertyViewStatus::ErrorTypeMismatch);
   }
 
-  gsl::span<const std::byte> values;
+  std::span<const std::byte> values;
   auto status = getBufferSafe(propertyTableProperty.values, values);
   if (status != PropertyTablePropertyViewStatus::Valid) {
     return PropertyTablePropertyView<std::string_view>(status);
@@ -304,7 +304,7 @@ PropertyTableView::getStringPropertyValues(
         PropertyTablePropertyViewStatus::ErrorInvalidStringOffsetType);
   }
 
-  gsl::span<const std::byte> stringOffsets;
+  std::span<const std::byte> stringOffsets;
   status = getStringOffsetsBufferSafe(
       propertyTableProperty.stringOffsets,
       offsetType,
@@ -320,7 +320,7 @@ PropertyTableView::getStringPropertyValues(
       classProperty,
       _pPropertyTable->count,
       values,
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(),
       stringOffsets,
       PropertyComponentType::None,
       offsetType);
@@ -340,7 +340,7 @@ PropertyTableView::getBooleanArrayPropertyValues(
         PropertyTablePropertyViewStatus::ErrorTypeMismatch);
   }
 
-  gsl::span<const std::byte> values;
+  std::span<const std::byte> values;
   auto status = getBufferSafe(propertyTableProperty.values, values);
   if (status != PropertyTablePropertyViewStatus::Valid) {
     return PropertyTablePropertyView<PropertyArrayView<bool>>(status);
@@ -387,7 +387,7 @@ PropertyTableView::getBooleanArrayPropertyValues(
   }
 
   constexpr bool checkBitsSize = true;
-  gsl::span<const std::byte> arrayOffsets;
+  std::span<const std::byte> arrayOffsets;
   status = getArrayOffsetsBufferSafe(
       propertyTableProperty.arrayOffsets,
       arrayOffsetType,
@@ -405,7 +405,7 @@ PropertyTableView::getBooleanArrayPropertyValues(
       _pPropertyTable->count,
       values,
       arrayOffsets,
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(),
       arrayOffsetType,
       PropertyComponentType::None);
 }
@@ -424,7 +424,7 @@ PropertyTableView::getStringArrayPropertyValues(
         PropertyTablePropertyViewStatus::ErrorTypeMismatch);
   }
 
-  gsl::span<const std::byte> values;
+  std::span<const std::byte> values;
   auto status = getBufferSafe(propertyTableProperty.values, values);
   if (status != PropertyTablePropertyViewStatus::Valid) {
     return PropertyTablePropertyView<PropertyArrayView<std::string_view>>(
@@ -460,7 +460,7 @@ PropertyTableView::getStringArrayPropertyValues(
 
   // Handle fixed-length arrays
   if (fixedLengthArrayCount > 0) {
-    gsl::span<const std::byte> stringOffsets;
+    std::span<const std::byte> stringOffsets;
     status = getStringOffsetsBufferSafe(
         propertyTableProperty.stringOffsets,
         stringOffsetType,
@@ -477,7 +477,7 @@ PropertyTableView::getStringArrayPropertyValues(
         classProperty,
         _pPropertyTable->count,
         values,
-        gsl::span<const std::byte>(),
+        std::span<const std::byte>(),
         stringOffsets,
         PropertyComponentType::None,
         stringOffsetType);
@@ -498,14 +498,14 @@ PropertyTableView::getStringArrayPropertyValues(
   }
 
   // Handle variable-length arrays
-  gsl::span<const std::byte> stringOffsets;
+  std::span<const std::byte> stringOffsets;
   status = getBufferSafe(propertyTableProperty.stringOffsets, stringOffsets);
   if (status != PropertyTablePropertyViewStatus::Valid) {
     return PropertyTablePropertyView<PropertyArrayView<std::string_view>>(
         status);
   }
 
-  gsl::span<const std::byte> arrayOffsets;
+  std::span<const std::byte> arrayOffsets;
   status = getBufferSafe(propertyTableProperty.arrayOffsets, arrayOffsets);
   if (status != PropertyTablePropertyViewStatus::Valid) {
     return PropertyTablePropertyView<PropertyArrayView<std::string_view>>(

--- a/CesiumGltf/test/TestFeatureIdTextureView.cpp
+++ b/CesiumGltf/test/TestFeatureIdTextureView.cpp
@@ -5,11 +5,11 @@
 #include "CesiumUtility/Math.h"
 
 #include <catch2/catch.hpp>
-#include <gsl/span>
 
 #include <climits>
 #include <cstddef>
 #include <cstring>
+#include <span>
 #include <vector>
 
 using namespace CesiumGltf;

--- a/CesiumGltf/test/TestJsonValue.cpp
+++ b/CesiumGltf/test/TestJsonValue.cpp
@@ -39,27 +39,27 @@ TEST_CASE(
   REQUIRE(JsonValue(floatMin).getDouble() == floatMin);
 }
 
-TEST_CASE("JsonValue::getSafeNumber() throws if narrowing conversion error "
-          "would occur") {
+TEST_CASE("JsonValue::getSafeNumber() returns std::nullopt if narrowing "
+          "conversion error would occur") {
   SECTION("2^64 - 1 cannot be converted back to a double") {
     auto value = JsonValue(std::numeric_limits<std::uint64_t>::max());
-    REQUIRE_THROWS(value.getSafeNumber<double>());
+    REQUIRE(!value.getSafeNumber<double>().has_value());
   }
 
   SECTION("-2^64 cannot be converted back to a double") {
     // -9223372036854775807L cannot be represented exactly as a double
     auto value = JsonValue(std::numeric_limits<std::int64_t>::min() + 1);
-    REQUIRE_THROWS(value.getSafeNumber<double>());
+    REQUIRE(!value.getSafeNumber<double>().has_value());
   }
 
   SECTION("1024.0 cannot be converted back to a std::uint8_t") {
     auto value = JsonValue(1024.0);
-    REQUIRE_THROWS(value.getSafeNumber<std::uint8_t>());
+    REQUIRE(!value.getSafeNumber<std::uint8_t>().has_value());
   }
 
   SECTION("1.5 cannot be converted back to a std::uint16_t") {
     auto value = JsonValue(1.5);
-    REQUIRE_THROWS(value.getSafeNumber<std::uint16_t>());
+    REQUIRE(!value.getSafeNumber<std::uint16_t>().has_value());
   }
 }
 

--- a/CesiumGltf/test/TestPropertyAttributePropertyView.cpp
+++ b/CesiumGltf/test/TestPropertyAttributePropertyView.cpp
@@ -3,9 +3,9 @@
 #include <CesiumUtility/Assert.h>
 
 #include <catch2/catch.hpp>
-#include <gsl/span>
 
 #include <cstddef>
+#include <span>
 #include <vector>
 
 using namespace CesiumGltf;

--- a/CesiumGltf/test/TestPropertyAttributeView.cpp
+++ b/CesiumGltf/test/TestPropertyAttributeView.cpp
@@ -3,9 +3,9 @@
 #include <CesiumUtility/Assert.h>
 
 #include <catch2/catch.hpp>
-#include <gsl/span>
 
 #include <cstddef>
+#include <span>
 #include <vector>
 
 using namespace CesiumGltf;

--- a/CesiumGltf/test/TestPropertyTablePropertyView.cpp
+++ b/CesiumGltf/test/TestPropertyTablePropertyView.cpp
@@ -1,12 +1,12 @@
 #include "CesiumGltf/PropertyTablePropertyView.h"
 
 #include <catch2/catch.hpp>
-#include <gsl/span>
 
 #include <bitset>
 #include <climits>
 #include <cstddef>
 #include <cstring>
+#include <span>
 #include <vector>
 
 using namespace CesiumGltf;
@@ -43,7 +43,7 @@ template <typename T> static void checkNumeric(const std::vector<T>& expected) {
       propertyTableProperty,
       classProperty,
       static_cast<int64_t>(expected.size()),
-      gsl::span<const std::byte>(data.data(), data.size()));
+      std::span<const std::byte>(data.data(), data.size()));
 
   REQUIRE(property.size() == static_cast<int64_t>(expected.size()));
 
@@ -83,7 +83,7 @@ static void checkNumeric(
       propertyTableProperty,
       classProperty,
       static_cast<int64_t>(expected.size()),
-      gsl::span<const std::byte>(data.data(), data.size()));
+      std::span<const std::byte>(data.data(), data.size()));
 
   REQUIRE(property.size() == static_cast<int64_t>(expected.size()));
   REQUIRE(!property.normalized());
@@ -130,7 +130,7 @@ static void checkNormalizedNumeric(
       propertyTableProperty,
       classProperty,
       static_cast<int64_t>(expected.size()),
-      gsl::span<const std::byte>(data.data(), data.size()));
+      std::span<const std::byte>(data.data(), data.size()));
 
   REQUIRE(property.size() == static_cast<int64_t>(expected.size()));
   REQUIRE(property.normalized());
@@ -177,9 +177,9 @@ static void checkVariableLengthArray(
       propertyTableProperty,
       classProperty,
       instanceCount,
-      gsl::span<const std::byte>(buffer.data(), buffer.size()),
-      gsl::span<const std::byte>(offsetBuffer.data(), offsetBuffer.size()),
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(buffer.data(), buffer.size()),
+      std::span<const std::byte>(offsetBuffer.data(), offsetBuffer.size()),
+      std::span<const std::byte>(),
       offsetType,
       PropertyComponentType::None);
 
@@ -244,9 +244,9 @@ static void checkVariableLengthArray(
       propertyTableProperty,
       classProperty,
       instanceCount,
-      gsl::span<const std::byte>(buffer.data(), buffer.size()),
-      gsl::span<const std::byte>(offsetBuffer.data(), offsetBuffer.size()),
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(buffer.data(), buffer.size()),
+      std::span<const std::byte>(offsetBuffer.data(), offsetBuffer.size()),
+      std::span<const std::byte>(),
       offsetType,
       PropertyComponentType::None);
 
@@ -324,8 +324,8 @@ static void checkNormalizedVariableLengthArray(
       propertyTableProperty,
       classProperty,
       instanceCount,
-      gsl::span<const std::byte>(buffer.data(), buffer.size()),
-      gsl::span<const std::byte>(offsetBuffer.data(), offsetBuffer.size()),
+      std::span<const std::byte>(buffer.data(), buffer.size()),
+      std::span<const std::byte>(offsetBuffer.data(), offsetBuffer.size()),
       offsetType);
 
   REQUIRE(property.arrayCount() == 0);
@@ -389,9 +389,9 @@ static void checkFixedLengthArray(
       propertyTableProperty,
       classProperty,
       instanceCount,
-      gsl::span<const std::byte>(buffer.data(), buffer.size()),
-      gsl::span<const std::byte>(),
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(buffer.data(), buffer.size()),
+      std::span<const std::byte>(),
+      std::span<const std::byte>(),
       PropertyComponentType::None,
       PropertyComponentType::None);
 
@@ -453,9 +453,9 @@ static void checkFixedLengthArray(
       propertyTableProperty,
       classProperty,
       instanceCount,
-      gsl::span<const std::byte>(buffer.data(), buffer.size()),
-      gsl::span<const std::byte>(),
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(buffer.data(), buffer.size()),
+      std::span<const std::byte>(),
+      std::span<const std::byte>(),
       PropertyComponentType::None,
       PropertyComponentType::None);
 
@@ -528,8 +528,8 @@ static void checkNormalizedFixedLengthArray(
       propertyTableProperty,
       classProperty,
       instanceCount,
-      gsl::span<const std::byte>(buffer.data(), buffer.size()),
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(buffer.data(), buffer.size()),
+      std::span<const std::byte>(),
       PropertyComponentType::None);
 
   REQUIRE(property.arrayCount() == fixedLengthArrayCount);
@@ -656,7 +656,7 @@ TEST_CASE("Check scalar PropertyTablePropertyView") {
         propertyTableProperty,
         classProperty,
         static_cast<int64_t>(values.size()),
-        gsl::span<const std::byte>(data.data(), data.size()));
+        std::span<const std::byte>(data.data(), data.size()));
 
     REQUIRE(property.offset() == 1.0f);
     REQUIRE(property.scale() == 2.0f);
@@ -835,7 +835,7 @@ TEST_CASE("Check vecN PropertyTablePropertyView") {
         propertyTableProperty,
         classProperty,
         static_cast<int64_t>(values.size()),
-        gsl::span<const std::byte>(data.data(), data.size()));
+        std::span<const std::byte>(data.data(), data.size()));
 
     REQUIRE(property.offset() == glm::vec2(1.0f, 0.5f));
     REQUIRE(property.scale() == glm::vec2(2.0f, 1.0f));
@@ -1132,7 +1132,7 @@ TEST_CASE("Check matN PropertyTablePropertyView") {
         propertyTableProperty,
         classProperty,
         static_cast<int64_t>(values.size()),
-        gsl::span<const std::byte>(data.data(), data.size()));
+        std::span<const std::byte>(data.data(), data.size()));
 
     // clang-format off
     REQUIRE(property.offset() == glm::mat2(
@@ -1291,7 +1291,7 @@ TEST_CASE("Check boolean PropertyTablePropertyView") {
       propertyTableProperty,
       classProperty,
       static_cast<int64_t>(instanceCount),
-      gsl::span<const std::byte>(data.data(), data.size()));
+      std::span<const std::byte>(data.data(), data.size()));
 
   for (int64_t i = 0; i < property.size(); ++i) {
     REQUIRE(property.getRaw(i) == bits[static_cast<size_t>(i)]);
@@ -1345,9 +1345,9 @@ TEST_CASE("Check string PropertyTablePropertyView") {
         propertyTableProperty,
         classProperty,
         static_cast<int64_t>(strings.size()),
-        gsl::span<const std::byte>(buffer.data(), buffer.size()),
-        gsl::span<const std::byte>(),
-        gsl::span<const std::byte>(offsetBuffer.data(), offsetBuffer.size()),
+        std::span<const std::byte>(buffer.data(), buffer.size()),
+        std::span<const std::byte>(),
+        std::span<const std::byte>(offsetBuffer.data(), offsetBuffer.size()),
         PropertyComponentType::None,
         PropertyComponentType::Uint32);
 
@@ -1367,9 +1367,9 @@ TEST_CASE("Check string PropertyTablePropertyView") {
         propertyTableProperty,
         classProperty,
         static_cast<int64_t>(strings.size()),
-        gsl::span<const std::byte>(buffer.data(), buffer.size()),
-        gsl::span<const std::byte>(),
-        gsl::span<const std::byte>(offsetBuffer.data(), offsetBuffer.size()),
+        std::span<const std::byte>(buffer.data(), buffer.size()),
+        std::span<const std::byte>(),
+        std::span<const std::byte>(offsetBuffer.data(), offsetBuffer.size()),
         PropertyComponentType::None,
         PropertyComponentType::Uint32);
 
@@ -1395,9 +1395,9 @@ TEST_CASE("Check string PropertyTablePropertyView") {
         propertyTableProperty,
         classProperty,
         static_cast<int64_t>(strings.size()),
-        gsl::span<const std::byte>(buffer.data(), buffer.size()),
-        gsl::span<const std::byte>(),
-        gsl::span<const std::byte>(offsetBuffer.data(), offsetBuffer.size()),
+        std::span<const std::byte>(buffer.data(), buffer.size()),
+        std::span<const std::byte>(),
+        std::span<const std::byte>(offsetBuffer.data(), offsetBuffer.size()),
         PropertyComponentType::None,
         PropertyComponentType::Uint32);
 
@@ -1606,9 +1606,9 @@ TEST_CASE("Check fixed-length scalar array PropertyTablePropertyView") {
         propertyTableProperty,
         classProperty,
         instanceCount,
-        gsl::span<const std::byte>(buffer.data(), buffer.size()),
-        gsl::span<const std::byte>(),
-        gsl::span<const std::byte>(),
+        std::span<const std::byte>(buffer.data(), buffer.size()),
+        std::span<const std::byte>(),
+        std::span<const std::byte>(),
         PropertyComponentType::None,
         PropertyComponentType::None);
 
@@ -1820,9 +1820,9 @@ TEST_CASE("Check fixed-length vecN array PropertyTablePropertyView") {
         propertyTableProperty,
         classProperty,
         instanceCount,
-        gsl::span<const std::byte>(buffer.data(), buffer.size()),
-        gsl::span<const std::byte>(),
-        gsl::span<const std::byte>(),
+        std::span<const std::byte>(buffer.data(), buffer.size()),
+        std::span<const std::byte>(),
+        std::span<const std::byte>(),
         PropertyComponentType::None,
         PropertyComponentType::None);
 
@@ -1945,9 +1945,9 @@ TEST_CASE(
         propertyTableProperty,
         classProperty,
         instanceCount,
-        gsl::span<const std::byte>(buffer.data(), buffer.size()),
-        gsl::span<const std::byte>(),
-        gsl::span<const std::byte>(),
+        std::span<const std::byte>(buffer.data(), buffer.size()),
+        std::span<const std::byte>(),
+        std::span<const std::byte>(),
         PropertyComponentType::None,
         PropertyComponentType::None);
 
@@ -2306,9 +2306,9 @@ TEST_CASE("Check fixed-length matN array PropertyTablePropertyView") {
         propertyTableProperty,
         classProperty,
         instanceCount,
-        gsl::span<const std::byte>(buffer.data(), buffer.size()),
-        gsl::span<const std::byte>(),
-        gsl::span<const std::byte>(),
+        std::span<const std::byte>(buffer.data(), buffer.size()),
+        std::span<const std::byte>(),
+        std::span<const std::byte>(),
         PropertyComponentType::None,
         PropertyComponentType::None);
 
@@ -3221,9 +3221,9 @@ TEST_CASE("Check fixed-length array of string") {
         propertyTableProperty,
         classProperty,
         static_cast<int64_t>(stringCount / 3),
-        gsl::span<const std::byte>(buffer.data(), buffer.size()),
-        gsl::span<const std::byte>(),
-        gsl::span<const std::byte>(stringOffsets.data(), stringOffsets.size()),
+        std::span<const std::byte>(buffer.data(), buffer.size()),
+        std::span<const std::byte>(),
+        std::span<const std::byte>(stringOffsets.data(), stringOffsets.size()),
         PropertyComponentType::None,
         PropertyComponentType::Uint32);
 
@@ -3257,9 +3257,9 @@ TEST_CASE("Check fixed-length array of string") {
         propertyTableProperty,
         classProperty,
         static_cast<int64_t>(stringCount / 3),
-        gsl::span<const std::byte>(buffer.data(), buffer.size()),
-        gsl::span<const std::byte>(),
-        gsl::span<const std::byte>(stringOffsets.data(), stringOffsets.size()),
+        std::span<const std::byte>(buffer.data(), buffer.size()),
+        std::span<const std::byte>(),
+        std::span<const std::byte>(stringOffsets.data(), stringOffsets.size()),
         PropertyComponentType::None,
         PropertyComponentType::Uint32);
 
@@ -3315,9 +3315,9 @@ TEST_CASE("Check fixed-length array of string") {
         propertyTableProperty,
         classProperty,
         static_cast<int64_t>(stringCount / 3),
-        gsl::span<const std::byte>(buffer.data(), buffer.size()),
-        gsl::span<const std::byte>(),
-        gsl::span<const std::byte>(stringOffsets.data(), stringOffsets.size()),
+        std::span<const std::byte>(buffer.data(), buffer.size()),
+        std::span<const std::byte>(),
+        std::span<const std::byte>(stringOffsets.data(), stringOffsets.size()),
         PropertyComponentType::None,
         PropertyComponentType::Uint32);
 
@@ -3421,11 +3421,11 @@ TEST_CASE("Check variable-length string array PropertyTablePropertyView") {
         propertyTableProperty,
         classProperty,
         4,
-        gsl::span<const std::byte>(buffer.data(), buffer.size()),
-        gsl::span<const std::byte>(
+        std::span<const std::byte>(buffer.data(), buffer.size()),
+        std::span<const std::byte>(
             reinterpret_cast<const std::byte*>(arrayOffsets.data()),
             arrayOffsets.size() * sizeof(uint32_t)),
-        gsl::span<const std::byte>(stringOffsets.data(), stringOffsets.size()),
+        std::span<const std::byte>(stringOffsets.data(), stringOffsets.size()),
         PropertyComponentType::Uint32,
         PropertyComponentType::Uint32);
 
@@ -3458,11 +3458,11 @@ TEST_CASE("Check variable-length string array PropertyTablePropertyView") {
         propertyTableProperty,
         classProperty,
         4,
-        gsl::span<const std::byte>(buffer.data(), buffer.size()),
-        gsl::span<const std::byte>(
+        std::span<const std::byte>(buffer.data(), buffer.size()),
+        std::span<const std::byte>(
             reinterpret_cast<const std::byte*>(arrayOffsets.data()),
             arrayOffsets.size() * sizeof(uint32_t)),
-        gsl::span<const std::byte>(stringOffsets.data(), stringOffsets.size()),
+        std::span<const std::byte>(stringOffsets.data(), stringOffsets.size()),
         PropertyComponentType::Uint32,
         PropertyComponentType::Uint32);
 
@@ -3519,11 +3519,11 @@ TEST_CASE("Check variable-length string array PropertyTablePropertyView") {
         propertyTableProperty,
         classProperty,
         4,
-        gsl::span<const std::byte>(buffer.data(), buffer.size()),
-        gsl::span<const std::byte>(
+        std::span<const std::byte>(buffer.data(), buffer.size()),
+        std::span<const std::byte>(
             reinterpret_cast<const std::byte*>(arrayOffsets.data()),
             arrayOffsets.size() * sizeof(uint32_t)),
-        gsl::span<const std::byte>(stringOffsets.data(), stringOffsets.size()),
+        std::span<const std::byte>(stringOffsets.data(), stringOffsets.size()),
         PropertyComponentType::Uint32,
         PropertyComponentType::Uint32);
 
@@ -3585,9 +3585,9 @@ TEST_CASE("Check fixed-length boolean array PropertyTablePropertyView") {
       propertyTableProperty,
       classProperty,
       2,
-      gsl::span<const std::byte>(buffer.data(), buffer.size()),
-      gsl::span<const std::byte>(),
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(buffer.data(), buffer.size()),
+      std::span<const std::byte>(),
+      std::span<const std::byte>(),
       PropertyComponentType::Uint32,
       PropertyComponentType::None);
 
@@ -3652,11 +3652,11 @@ TEST_CASE("Check variable-length boolean array PropertyTablePropertyView") {
       propertyTableProperty,
       classProperty,
       3,
-      gsl::span<const std::byte>(buffer.data(), buffer.size()),
-      gsl::span<const std::byte>(
+      std::span<const std::byte>(buffer.data(), buffer.size()),
+      std::span<const std::byte>(
           reinterpret_cast<const std::byte*>(offsetBuffer.data()),
           offsetBuffer.size() * sizeof(uint32_t)),
-      gsl::span<const std::byte>(),
+      std::span<const std::byte>(),
       PropertyComponentType::Uint32,
       PropertyComponentType::None);
 

--- a/CesiumGltf/test/TestPropertyTexturePropertyView.cpp
+++ b/CesiumGltf/test/TestPropertyTexturePropertyView.cpp
@@ -3,10 +3,10 @@
 #include "CesiumUtility/Math.h"
 
 #include <catch2/catch.hpp>
-#include <gsl/span>
 
 #include <climits>
 #include <cstddef>
+#include <span>
 #include <vector>
 
 using namespace CesiumGltf;

--- a/CesiumGltf/test/TestPropertyTextureView.cpp
+++ b/CesiumGltf/test/TestPropertyTextureView.cpp
@@ -2,9 +2,9 @@
 #include "CesiumUtility/Math.h"
 
 #include <catch2/catch.hpp>
-#include <gsl/span>
 
 #include <cstddef>
+#include <span>
 #include <vector>
 
 using namespace CesiumGltf;

--- a/CesiumGltfContent/src/GltfUtilities.cpp
+++ b/CesiumGltfContent/src/GltfUtilities.cpp
@@ -24,6 +24,7 @@
 #include <glm/gtc/quaternion.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cstring>
 #include <unordered_set>
 #include <vector>

--- a/CesiumGltfContent/src/SkirtMeshMetadata.cpp
+++ b/CesiumGltfContent/src/SkirtMeshMetadata.cpp
@@ -67,26 +67,28 @@ SkirtMeshMetadata::parseFromGltfExtras(const JsonValue::Object& extras) {
       (*pMeshCenter)[1].getSafeNumberOrDefault<double>(0.0),
       (*pMeshCenter)[2].getSafeNumberOrDefault<double>(0.0));
 
-  double westHeight, southHeight, eastHeight, northHeight;
-  try {
-    westHeight = gltfSkirtMeshMetadata.getSafeNumericalValueForKey<double>(
-        "skirtWestHeight");
-    southHeight = gltfSkirtMeshMetadata.getSafeNumericalValueForKey<double>(
-        "skirtSouthHeight");
-    eastHeight = gltfSkirtMeshMetadata.getSafeNumericalValueForKey<double>(
-        "skirtEastHeight");
-    northHeight = gltfSkirtMeshMetadata.getSafeNumericalValueForKey<double>(
-        "skirtNorthHeight");
-  } catch (const JsonValueMissingKey&) {
-    return std::nullopt;
-  } catch (const JsonValueNotRealValue&) {
+  std::optional<double> maybeWestHeight =
+      gltfSkirtMeshMetadata.getSafeNumericalValueForKey<double>(
+          "skirtWestHeight");
+  std::optional<double> maybeSouthHeight =
+      gltfSkirtMeshMetadata.getSafeNumericalValueForKey<double>(
+          "skirtSouthHeight");
+  std::optional<double> maybeEastHeight =
+      gltfSkirtMeshMetadata.getSafeNumericalValueForKey<double>(
+          "skirtEastHeight");
+  std::optional<double> maybeNorthHeight =
+      gltfSkirtMeshMetadata.getSafeNumericalValueForKey<double>(
+          "skirtNorthHeight");
+
+  if (!maybeWestHeight || !maybeSouthHeight || !maybeEastHeight ||
+      !maybeNorthHeight) {
     return std::nullopt;
   }
 
-  skirtMeshMetadata.skirtWestHeight = westHeight;
-  skirtMeshMetadata.skirtSouthHeight = southHeight;
-  skirtMeshMetadata.skirtEastHeight = eastHeight;
-  skirtMeshMetadata.skirtNorthHeight = northHeight;
+  skirtMeshMetadata.skirtWestHeight = *maybeWestHeight;
+  skirtMeshMetadata.skirtSouthHeight = *maybeSouthHeight;
+  skirtMeshMetadata.skirtEastHeight = *maybeEastHeight;
+  skirtMeshMetadata.skirtNorthHeight = *maybeNorthHeight;
 
   return skirtMeshMetadata;
 }

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/AccessorReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/AccessorReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::Accessor>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Accessor from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/AccessorSparseIndicesReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/AccessorSparseIndicesReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::AccessorSparseIndices>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of AccessorSparseIndices from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/AccessorSparseReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/AccessorSparseReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::AccessorSparse>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of AccessorSparse from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/AccessorSparseValuesReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/AccessorSparseValuesReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::AccessorSparseValues>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of AccessorSparseValues from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/AnimationChannelReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/AnimationChannelReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::AnimationChannel>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of AnimationChannel from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/AnimationChannelTargetReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/AnimationChannelTargetReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::AnimationChannelTarget>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of AnimationChannelTarget from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/AnimationReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/AnimationReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::Animation>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Animation from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/AnimationSamplerReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/AnimationSamplerReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::AnimationSampler>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of AnimationSampler from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/AssetReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/AssetReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::Asset>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Asset from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/BufferReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/BufferReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::Buffer>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Buffer from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/BufferViewReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/BufferViewReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::BufferView>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of BufferView from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/CameraOrthographicReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/CameraOrthographicReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::CameraOrthographic>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of CameraOrthographic from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/CameraPerspectiveReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/CameraPerspectiveReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::CameraPerspective>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of CameraPerspective from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/CameraReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/CameraReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::Camera>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Camera from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ClassPropertyReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ClassPropertyReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::ClassProperty>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ClassProperty from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ClassReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ClassReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::Class>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Class from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/EnumReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/EnumReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::Enum>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Enum from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/EnumValueReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/EnumValueReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::EnumValue>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of EnumValue from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionBufferExtMeshoptCompressionReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionBufferExtMeshoptCompressionReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -47,7 +47,7 @@ public:
    */
   CesiumJsonReader::ReadJsonResult<
       CesiumGltf::ExtensionBufferExtMeshoptCompression>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionBufferExtMeshoptCompression from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionBufferViewExtMeshoptCompressionReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionBufferViewExtMeshoptCompressionReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -47,7 +47,7 @@ public:
    */
   CesiumJsonReader::ReadJsonResult<
       CesiumGltf::ExtensionBufferViewExtMeshoptCompression>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionBufferViewExtMeshoptCompression from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionCesiumPrimitiveOutlineReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionCesiumPrimitiveOutlineReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -46,7 +46,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionCesiumPrimitiveOutline>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionCesiumPrimitiveOutline from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionCesiumRTCReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionCesiumRTCReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionCesiumRTC>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionCesiumRTC from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionCesiumTileEdgesReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionCesiumTileEdgesReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionCesiumTileEdges>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionCesiumTileEdges from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionExtInstanceFeaturesFeatureIdReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionExtInstanceFeaturesFeatureIdReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -47,7 +47,7 @@ public:
    */
   CesiumJsonReader::ReadJsonResult<
       CesiumGltf::ExtensionExtInstanceFeaturesFeatureId>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionExtInstanceFeaturesFeatureId from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionExtInstanceFeaturesReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionExtInstanceFeaturesReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -46,7 +46,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionExtInstanceFeatures>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionExtInstanceFeatures from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionExtMeshFeaturesReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionExtMeshFeaturesReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionExtMeshFeatures>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionExtMeshFeatures from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionExtMeshGpuInstancingReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionExtMeshGpuInstancingReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -46,7 +46,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionExtMeshGpuInstancing>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionExtMeshGpuInstancing from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionKhrDracoMeshCompressionReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionKhrDracoMeshCompressionReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -46,7 +46,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionKhrDracoMeshCompression>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionKhrDracoMeshCompression from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionKhrMaterialsUnlitReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionKhrMaterialsUnlitReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionKhrMaterialsUnlit>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionKhrMaterialsUnlit from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionKhrTextureBasisuReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionKhrTextureBasisuReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionKhrTextureBasisu>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionKhrTextureBasisu from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionKhrTextureTransformReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionKhrTextureTransformReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -46,7 +46,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionKhrTextureTransform>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionKhrTextureTransform from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionMeshPrimitiveExtStructuralMetadataReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionMeshPrimitiveExtStructuralMetadataReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -47,7 +47,7 @@ public:
    */
   CesiumJsonReader::ReadJsonResult<
       CesiumGltf::ExtensionMeshPrimitiveExtStructuralMetadata>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionMeshPrimitiveExtStructuralMetadata

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionMeshPrimitiveKhrMaterialsVariantsMappingsValueReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionMeshPrimitiveKhrMaterialsVariantsMappingsValueReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -48,7 +48,7 @@ public:
    */
   CesiumJsonReader::ReadJsonResult<
       CesiumGltf::ExtensionMeshPrimitiveKhrMaterialsVariantsMappingsValue>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionMeshPrimitiveKhrMaterialsVariantsReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionMeshPrimitiveKhrMaterialsVariantsReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -47,7 +47,7 @@ public:
    */
   CesiumJsonReader::ReadJsonResult<
       CesiumGltf::ExtensionMeshPrimitiveKhrMaterialsVariants>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionMeshPrimitiveKhrMaterialsVariants from

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionModelExtStructuralMetadataReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionModelExtStructuralMetadataReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -47,7 +47,7 @@ public:
    */
   CesiumJsonReader::ReadJsonResult<
       CesiumGltf::ExtensionModelExtStructuralMetadata>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionModelExtStructuralMetadata from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionModelKhrMaterialsVariantsReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionModelKhrMaterialsVariantsReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -47,7 +47,7 @@ public:
    */
   CesiumJsonReader::ReadJsonResult<
       CesiumGltf::ExtensionModelKhrMaterialsVariants>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionModelKhrMaterialsVariants from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionModelKhrMaterialsVariantsValueReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionModelKhrMaterialsVariantsValueReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -47,7 +47,7 @@ public:
    */
   CesiumJsonReader::ReadJsonResult<
       CesiumGltf::ExtensionModelKhrMaterialsVariantsValue>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionModelKhrMaterialsVariantsValue from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionModelMaxarMeshVariantsReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionModelMaxarMeshVariantsReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -46,7 +46,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionModelMaxarMeshVariants>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionModelMaxarMeshVariants from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionModelMaxarMeshVariantsValueReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionModelMaxarMeshVariantsValueReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -47,7 +47,7 @@ public:
    */
   CesiumJsonReader::ReadJsonResult<
       CesiumGltf::ExtensionModelMaxarMeshVariantsValue>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionModelMaxarMeshVariantsValue from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionNodeMaxarMeshVariantsMappingsValueReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionNodeMaxarMeshVariantsMappingsValueReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -47,7 +47,7 @@ public:
    */
   CesiumJsonReader::ReadJsonResult<
       CesiumGltf::ExtensionNodeMaxarMeshVariantsMappingsValue>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionNodeMaxarMeshVariantsMappingsValue

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionNodeMaxarMeshVariantsReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionNodeMaxarMeshVariantsReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -46,7 +46,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionNodeMaxarMeshVariants>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionNodeMaxarMeshVariants from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionTextureWebpReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ExtensionTextureWebpReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionTextureWebp>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of ExtensionTextureWebp from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/FeatureIdReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/FeatureIdReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::FeatureId>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of FeatureId from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/FeatureIdTextureReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/FeatureIdTextureReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::FeatureIdTexture>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of FeatureIdTexture from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ImageReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ImageReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::Image>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Image from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/MaterialNormalTextureInfoReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/MaterialNormalTextureInfoReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::MaterialNormalTextureInfo>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of MaterialNormalTextureInfo from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/MaterialOcclusionTextureInfoReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/MaterialOcclusionTextureInfoReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -46,7 +46,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::MaterialOcclusionTextureInfo>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of MaterialOcclusionTextureInfo from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/MaterialPBRMetallicRoughnessReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/MaterialPBRMetallicRoughnessReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -46,7 +46,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::MaterialPBRMetallicRoughness>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of MaterialPBRMetallicRoughness from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/MaterialReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/MaterialReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::Material>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Material from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/MeshPrimitiveReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/MeshPrimitiveReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::MeshPrimitive>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of MeshPrimitive from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/MeshReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/MeshReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::Mesh>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Mesh from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/ModelReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/ModelReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::Model>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Model from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/NodeReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/NodeReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::Node>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Node from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/PropertyAttributePropertyReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/PropertyAttributePropertyReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::PropertyAttributeProperty>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of PropertyAttributeProperty from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/PropertyAttributeReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/PropertyAttributeReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::PropertyAttribute>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of PropertyAttribute from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/PropertyTablePropertyReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/PropertyTablePropertyReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::PropertyTableProperty>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of PropertyTableProperty from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/PropertyTableReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/PropertyTableReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::PropertyTable>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of PropertyTable from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/PropertyTexturePropertyReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/PropertyTexturePropertyReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::PropertyTextureProperty>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of PropertyTextureProperty from a

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/PropertyTextureReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/PropertyTextureReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::PropertyTexture>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of PropertyTexture from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/SamplerReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/SamplerReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::Sampler>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Sampler from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/SceneReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/SceneReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::Scene>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Scene from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/SchemaReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/SchemaReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::Schema>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Schema from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/SkinReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/SkinReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::Skin>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Skin from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/TextureInfoReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/TextureInfoReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::TextureInfo>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of TextureInfo from a rapidJson::Value.

--- a/CesiumGltfReader/generated/include/CesiumGltfReader/TextureReader.h
+++ b/CesiumGltfReader/generated/include/CesiumGltfReader/TextureReader.h
@@ -7,9 +7,9 @@
 #include <CesiumJsonReader/JsonReader.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumGltf {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumGltf::Texture>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Texture from a rapidJson::Value.

--- a/CesiumGltfReader/generated/src/GeneratedJsonHandlers.cpp
+++ b/CesiumGltfReader/generated/src/GeneratedJsonHandlers.cpp
@@ -73,7 +73,7 @@ ExtensionCesiumRTCReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionCesiumRTC>
 ExtensionCesiumRTCReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionCesiumRTCJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -183,7 +183,7 @@ ExtensionCesiumTileEdgesReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionCesiumTileEdges>
 ExtensionCesiumTileEdgesReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionCesiumTileEdgesJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -287,7 +287,7 @@ ExtensionExtInstanceFeaturesReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionExtInstanceFeatures>
 ExtensionExtInstanceFeaturesReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionExtInstanceFeaturesJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -390,7 +390,7 @@ ExtensionExtMeshFeaturesReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionExtMeshFeatures>
 ExtensionExtMeshFeaturesReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionExtMeshFeaturesJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -493,7 +493,7 @@ ExtensionExtMeshGpuInstancingReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionExtMeshGpuInstancing>
 ExtensionExtMeshGpuInstancingReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionExtMeshGpuInstancingJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -600,7 +600,7 @@ ExtensionBufferExtMeshoptCompressionReader::getOptions() const {
 CesiumJsonReader::ReadJsonResult<
     CesiumGltf::ExtensionBufferExtMeshoptCompression>
 ExtensionBufferExtMeshoptCompressionReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionBufferExtMeshoptCompressionJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -729,7 +729,7 @@ ExtensionBufferViewExtMeshoptCompressionReader::getOptions() const {
 CesiumJsonReader::ReadJsonResult<
     CesiumGltf::ExtensionBufferViewExtMeshoptCompression>
 ExtensionBufferViewExtMeshoptCompressionReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionBufferViewExtMeshoptCompressionJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -855,7 +855,7 @@ ExtensionModelExtStructuralMetadataReader::getOptions() const {
 CesiumJsonReader::ReadJsonResult<
     CesiumGltf::ExtensionModelExtStructuralMetadata>
 ExtensionModelExtStructuralMetadataReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionModelExtStructuralMetadataJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -975,7 +975,7 @@ ExtensionMeshPrimitiveExtStructuralMetadataReader::getOptions() const {
 CesiumJsonReader::ReadJsonResult<
     CesiumGltf::ExtensionMeshPrimitiveExtStructuralMetadata>
 ExtensionMeshPrimitiveExtStructuralMetadataReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionMeshPrimitiveExtStructuralMetadataJsonHandler handler(
       this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
@@ -1087,7 +1087,7 @@ ExtensionKhrDracoMeshCompressionReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionKhrDracoMeshCompression>
 ExtensionKhrDracoMeshCompressionReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionKhrDracoMeshCompressionJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1188,7 +1188,7 @@ ExtensionKhrMaterialsUnlitReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionKhrMaterialsUnlit>
 ExtensionKhrMaterialsUnlitReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionKhrMaterialsUnlitJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1294,7 +1294,7 @@ ExtensionModelKhrMaterialsVariantsReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionModelKhrMaterialsVariants>
 ExtensionModelKhrMaterialsVariantsReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionModelKhrMaterialsVariantsJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1404,7 +1404,7 @@ ExtensionMeshPrimitiveKhrMaterialsVariantsReader::getOptions() const {
 CesiumJsonReader::ReadJsonResult<
     CesiumGltf::ExtensionMeshPrimitiveKhrMaterialsVariants>
 ExtensionMeshPrimitiveKhrMaterialsVariantsReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionMeshPrimitiveKhrMaterialsVariantsJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1507,7 +1507,7 @@ ExtensionKhrTextureBasisuReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionKhrTextureBasisu>
 ExtensionKhrTextureBasisuReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionKhrTextureBasisuJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1614,7 +1614,7 @@ ExtensionModelMaxarMeshVariantsReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionModelMaxarMeshVariants>
 ExtensionModelMaxarMeshVariantsReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionModelMaxarMeshVariantsJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1718,7 +1718,7 @@ ExtensionNodeMaxarMeshVariantsReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionNodeMaxarMeshVariants>
 ExtensionNodeMaxarMeshVariantsReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionNodeMaxarMeshVariantsJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1831,7 +1831,7 @@ ExtensionKhrTextureTransformReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionKhrTextureTransform>
 ExtensionKhrTextureTransformReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionKhrTextureTransformJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -1930,7 +1930,7 @@ ExtensionTextureWebpReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionTextureWebp>
 ExtensionTextureWebpReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionTextureWebpJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -2031,7 +2031,7 @@ ExtensionCesiumPrimitiveOutlineReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::ExtensionCesiumPrimitiveOutline>
 ExtensionCesiumPrimitiveOutlineReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionCesiumPrimitiveOutlineJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -2131,7 +2131,7 @@ ExtensionNodeMaxarMeshVariantsMappingsValueReader::getOptions() const {
 CesiumJsonReader::ReadJsonResult<
     CesiumGltf::ExtensionNodeMaxarMeshVariantsMappingsValue>
 ExtensionNodeMaxarMeshVariantsMappingsValueReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionNodeMaxarMeshVariantsMappingsValueJsonHandler handler(
       this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
@@ -2227,7 +2227,7 @@ ExtensionModelMaxarMeshVariantsValueReader::getOptions() const {
 CesiumJsonReader::ReadJsonResult<
     CesiumGltf::ExtensionModelMaxarMeshVariantsValue>
 ExtensionModelMaxarMeshVariantsValueReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionModelMaxarMeshVariantsValueJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -2333,7 +2333,7 @@ ExtensionMeshPrimitiveKhrMaterialsVariantsMappingsValueReader::getOptions()
 CesiumJsonReader::ReadJsonResult<
     CesiumGltf::ExtensionMeshPrimitiveKhrMaterialsVariantsMappingsValue>
 ExtensionMeshPrimitiveKhrMaterialsVariantsMappingsValueReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionMeshPrimitiveKhrMaterialsVariantsMappingsValueJsonHandler handler(
       this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
@@ -2429,7 +2429,7 @@ ExtensionModelKhrMaterialsVariantsValueReader::getOptions() const {
 CesiumJsonReader::ReadJsonResult<
     CesiumGltf::ExtensionModelKhrMaterialsVariantsValue>
 ExtensionModelKhrMaterialsVariantsValueReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionModelKhrMaterialsVariantsValueJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -2524,7 +2524,7 @@ PropertyAttributeReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::PropertyAttribute>
 PropertyAttributeReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   PropertyAttributeJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -2624,7 +2624,7 @@ PropertyAttributePropertyReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::PropertyAttributeProperty>
 PropertyAttributePropertyReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   PropertyAttributePropertyJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -2718,7 +2718,7 @@ PropertyTextureReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::PropertyTexture>
 PropertyTextureReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   PropertyTextureJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -2815,7 +2815,7 @@ PropertyTexturePropertyReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::PropertyTextureProperty>
 PropertyTexturePropertyReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   PropertyTexturePropertyJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -2905,7 +2905,7 @@ TextureInfoReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::TextureInfo>
-TextureInfoReader::readFromJson(const gsl::span<const std::byte>& data) const {
+TextureInfoReader::readFromJson(const std::span<const std::byte>& data) const {
   TextureInfoJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -2998,7 +2998,7 @@ PropertyTableReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::PropertyTable>
 PropertyTableReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   PropertyTableJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -3112,7 +3112,7 @@ PropertyTablePropertyReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::PropertyTableProperty>
 PropertyTablePropertyReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   PropertyTablePropertyJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -3208,7 +3208,7 @@ const CesiumJsonReader::JsonReaderOptions& SchemaReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::Schema>
-SchemaReader::readFromJson(const gsl::span<const std::byte>& data) const {
+SchemaReader::readFromJson(const std::span<const std::byte>& data) const {
   SchemaJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -3295,7 +3295,7 @@ const CesiumJsonReader::JsonReaderOptions& EnumReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::Enum>
-EnumReader::readFromJson(const gsl::span<const std::byte>& data) const {
+EnumReader::readFromJson(const std::span<const std::byte>& data) const {
   EnumJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -3379,7 +3379,7 @@ const CesiumJsonReader::JsonReaderOptions& EnumValueReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::EnumValue>
-EnumValueReader::readFromJson(const gsl::span<const std::byte>& data) const {
+EnumValueReader::readFromJson(const std::span<const std::byte>& data) const {
   EnumValueJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -3464,7 +3464,7 @@ const CesiumJsonReader::JsonReaderOptions& ClassReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::Class>
-ClassReader::readFromJson(const gsl::span<const std::byte>& data) const {
+ClassReader::readFromJson(const std::span<const std::byte>& data) const {
   ClassJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -3592,7 +3592,7 @@ ClassPropertyReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::ClassProperty>
 ClassPropertyReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ClassPropertyJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -3686,7 +3686,7 @@ const CesiumJsonReader::JsonReaderOptions& FeatureIdReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::FeatureId>
-FeatureIdReader::readFromJson(const gsl::span<const std::byte>& data) const {
+FeatureIdReader::readFromJson(const std::span<const std::byte>& data) const {
   FeatureIdJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -3769,7 +3769,7 @@ FeatureIdTextureReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::FeatureIdTexture>
 FeatureIdTextureReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   FeatureIdTextureJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -3872,7 +3872,7 @@ ExtensionExtInstanceFeaturesFeatureIdReader::getOptions() const {
 CesiumJsonReader::ReadJsonResult<
     CesiumGltf::ExtensionExtInstanceFeaturesFeatureId>
 ExtensionExtInstanceFeaturesFeatureIdReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   ExtensionExtInstanceFeaturesFeatureIdJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -4007,7 +4007,7 @@ const CesiumJsonReader::JsonReaderOptions& ModelReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::Model>
-ModelReader::readFromJson(const gsl::span<const std::byte>& data) const {
+ModelReader::readFromJson(const std::span<const std::byte>& data) const {
   ModelJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -4088,7 +4088,7 @@ const CesiumJsonReader::JsonReaderOptions& TextureReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::Texture>
-TextureReader::readFromJson(const gsl::span<const std::byte>& data) const {
+TextureReader::readFromJson(const std::span<const std::byte>& data) const {
   TextureJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -4175,7 +4175,7 @@ const CesiumJsonReader::JsonReaderOptions& SkinReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::Skin>
-SkinReader::readFromJson(const gsl::span<const std::byte>& data) const {
+SkinReader::readFromJson(const std::span<const std::byte>& data) const {
   SkinJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -4252,7 +4252,7 @@ const CesiumJsonReader::JsonReaderOptions& SceneReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::Scene>
-SceneReader::readFromJson(const gsl::span<const std::byte>& data) const {
+SceneReader::readFromJson(const std::span<const std::byte>& data) const {
   SceneJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -4339,7 +4339,7 @@ const CesiumJsonReader::JsonReaderOptions& SamplerReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::Sampler>
-SamplerReader::readFromJson(const gsl::span<const std::byte>& data) const {
+SamplerReader::readFromJson(const std::span<const std::byte>& data) const {
   SamplerJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -4441,7 +4441,7 @@ const CesiumJsonReader::JsonReaderOptions& NodeReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::Node>
-NodeReader::readFromJson(const gsl::span<const std::byte>& data) const {
+NodeReader::readFromJson(const std::span<const std::byte>& data) const {
   NodeJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -4522,7 +4522,7 @@ const CesiumJsonReader::JsonReaderOptions& MeshReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::Mesh>
-MeshReader::readFromJson(const gsl::span<const std::byte>& data) const {
+MeshReader::readFromJson(const std::span<const std::byte>& data) const {
   MeshJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -4617,7 +4617,7 @@ MeshPrimitiveReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::MeshPrimitive>
 MeshPrimitiveReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   MeshPrimitiveJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -4726,7 +4726,7 @@ const CesiumJsonReader::JsonReaderOptions& MaterialReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::Material>
-MaterialReader::readFromJson(const gsl::span<const std::byte>& data) const {
+MaterialReader::readFromJson(const std::span<const std::byte>& data) const {
   MaterialJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -4811,7 +4811,7 @@ MaterialOcclusionTextureInfoReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::MaterialOcclusionTextureInfo>
 MaterialOcclusionTextureInfoReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   MaterialOcclusionTextureInfoJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -4900,7 +4900,7 @@ MaterialNormalTextureInfoReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::MaterialNormalTextureInfo>
 MaterialNormalTextureInfoReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   MaterialNormalTextureInfoJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -5015,7 +5015,7 @@ MaterialPBRMetallicRoughnessReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::MaterialPBRMetallicRoughness>
 MaterialPBRMetallicRoughnessReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   MaterialPBRMetallicRoughnessJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -5104,7 +5104,7 @@ const CesiumJsonReader::JsonReaderOptions& ImageReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::Image>
-ImageReader::readFromJson(const gsl::span<const std::byte>& data) const {
+ImageReader::readFromJson(const std::span<const std::byte>& data) const {
   ImageJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -5188,7 +5188,7 @@ const CesiumJsonReader::JsonReaderOptions& CameraReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::Camera>
-CameraReader::readFromJson(const gsl::span<const std::byte>& data) const {
+CameraReader::readFromJson(const std::span<const std::byte>& data) const {
   CameraJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -5280,7 +5280,7 @@ CameraPerspectiveReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::CameraPerspective>
 CameraPerspectiveReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   CameraPerspectiveJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -5375,7 +5375,7 @@ CameraOrthographicReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::CameraOrthographic>
 CameraOrthographicReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   CameraOrthographicJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -5471,7 +5471,7 @@ BufferViewReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::BufferView>
-BufferViewReader::readFromJson(const gsl::span<const std::byte>& data) const {
+BufferViewReader::readFromJson(const std::span<const std::byte>& data) const {
   BufferViewJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -5553,7 +5553,7 @@ const CesiumJsonReader::JsonReaderOptions& BufferReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::Buffer>
-BufferReader::readFromJson(const gsl::span<const std::byte>& data) const {
+BufferReader::readFromJson(const std::span<const std::byte>& data) const {
   BufferJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -5640,7 +5640,7 @@ const CesiumJsonReader::JsonReaderOptions& AssetReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::Asset>
-AssetReader::readFromJson(const gsl::span<const std::byte>& data) const {
+AssetReader::readFromJson(const std::span<const std::byte>& data) const {
   AssetJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -5721,7 +5721,7 @@ const CesiumJsonReader::JsonReaderOptions& AnimationReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::Animation>
-AnimationReader::readFromJson(const gsl::span<const std::byte>& data) const {
+AnimationReader::readFromJson(const std::span<const std::byte>& data) const {
   AnimationJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -5811,7 +5811,7 @@ AnimationSamplerReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::AnimationSampler>
 AnimationSamplerReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   AnimationSamplerJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -5899,7 +5899,7 @@ AnimationChannelReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::AnimationChannel>
 AnimationChannelReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   AnimationChannelJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -5988,7 +5988,7 @@ AnimationChannelTargetReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::AnimationChannelTarget>
 AnimationChannelTargetReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   AnimationChannelTargetJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -6095,7 +6095,7 @@ const CesiumJsonReader::JsonReaderOptions& AccessorReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::Accessor>
-AccessorReader::readFromJson(const gsl::span<const std::byte>& data) const {
+AccessorReader::readFromJson(const std::span<const std::byte>& data) const {
   AccessorJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -6184,7 +6184,7 @@ AccessorSparseReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::AccessorSparse>
 AccessorSparseReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   AccessorSparseJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -6271,7 +6271,7 @@ AccessorSparseValuesReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::AccessorSparseValues>
 AccessorSparseValuesReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   AccessorSparseValuesJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -6363,7 +6363,7 @@ AccessorSparseIndicesReader::getOptions() const {
 
 CesiumJsonReader::ReadJsonResult<CesiumGltf::AccessorSparseIndices>
 AccessorSparseIndicesReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   AccessorSparseIndicesJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }

--- a/CesiumGltfReader/include/CesiumGltfReader/GltfReader.h
+++ b/CesiumGltfReader/include/CesiumGltfReader/GltfReader.h
@@ -14,11 +14,10 @@
 #include <CesiumJsonReader/IExtensionJsonHandler.h>
 #include <CesiumJsonReader/JsonReaderOptions.h>
 
-#include <gsl/span>
-
 #include <functional>
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -146,7 +145,7 @@ public:
    * @return The result of reading the glTF.
    */
   GltfReaderResult readGltf(
-      const gsl::span<const std::byte>& data,
+      const std::span<const std::byte>& data,
       const GltfReaderOptions& options = GltfReaderOptions()) const;
 
   /**
@@ -204,7 +203,7 @@ public:
   [[deprecated(
       "Use ImageDecoder::readImage instead.")]] static ImageReaderResult
   readImage(
-      const gsl::span<const std::byte>& data,
+      const std::span<const std::byte>& data,
       const CesiumGltf::Ktx2TranscodeTargets& ktx2TranscodeTargets);
 
   /**

--- a/CesiumGltfReader/include/CesiumGltfReader/ImageDecoder.h
+++ b/CesiumGltfReader/include/CesiumGltfReader/ImageDecoder.h
@@ -5,9 +5,8 @@
 
 #include <CesiumUtility/IntrusivePointer.h>
 
-#include <gsl/span>
-
 #include <optional>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -54,7 +53,7 @@ public:
    * @return The result of reading the image.
    */
   static ImageReaderResult readImage(
-      const gsl::span<const std::byte>& data,
+      const std::span<const std::byte>& data,
       const CesiumGltf::Ktx2TranscodeTargets& ktx2TranscodeTargets);
 
   /**

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -49,7 +49,7 @@ struct ChunkHeader {
 };
 #pragma pack(pop)
 
-bool isBinaryGltf(const gsl::span<const std::byte>& data) noexcept {
+bool isBinaryGltf(const std::span<const std::byte>& data) noexcept {
   if (data.size() < sizeof(GlbHeader)) {
     return false;
   }
@@ -59,7 +59,7 @@ bool isBinaryGltf(const gsl::span<const std::byte>& data) noexcept {
 
 GltfReaderResult readJsonGltf(
     const CesiumJsonReader::JsonReaderOptions& context,
-    const gsl::span<const std::byte>& data) {
+    const std::span<const std::byte>& data) {
 
   CESIUM_TRACE("CesiumGltfReader::GltfReader::readJsonGltf");
 
@@ -95,7 +95,7 @@ std::string toMagicString(uint32_t i) {
 
 GltfReaderResult readBinaryGltf(
     const CesiumJsonReader::JsonReaderOptions& context,
-    const gsl::span<const std::byte>& data) {
+    const std::span<const std::byte>& data) {
   CESIUM_TRACE("CesiumGltfReader::GltfReader::readBinaryGltf");
 
   if (data.size() < sizeof(GlbHeader) + sizeof(ChunkHeader)) {
@@ -128,7 +128,7 @@ GltfReaderResult readBinaryGltf(
         {}};
   }
 
-  const gsl::span<const std::byte> glbData = data.subspan(0, pHeader->length);
+  const std::span<const std::byte> glbData = data.subspan(0, pHeader->length);
 
   const ChunkHeader* pJsonChunkHeader =
       reinterpret_cast<const ChunkHeader*>(glbData.data() + sizeof(GlbHeader));
@@ -152,9 +152,9 @@ GltfReaderResult readBinaryGltf(
         {}};
   }
 
-  const gsl::span<const std::byte> jsonChunk =
+  const std::span<const std::byte> jsonChunk =
       glbData.subspan(jsonStart, pJsonChunkHeader->chunkLength);
-  gsl::span<const std::byte> binaryChunk;
+  std::span<const std::byte> binaryChunk;
 
   if (jsonEnd + sizeof(ChunkHeader) <= data.size()) {
     const ChunkHeader* pBinaryChunkHeader =
@@ -278,8 +278,8 @@ void postprocess(GltfReaderResult& readGltf, const GltfReaderOptions& options) {
         continue;
       }
 
-      const gsl::span<const std::byte> bufferSpan(buffer.cesium.data);
-      const gsl::span<const std::byte> bufferViewSpan = bufferSpan.subspan(
+      const std::span<const std::byte> bufferSpan(buffer.cesium.data);
+      const std::span<const std::byte> bufferViewSpan = bufferSpan.subspan(
           static_cast<size_t>(bufferView.byteOffset),
           static_cast<size_t>(bufferView.byteLength));
       ImageReaderResult imageResult =
@@ -366,7 +366,7 @@ const CesiumJsonReader::JsonReaderOptions& GltfReader::getExtensions() const {
 }
 
 GltfReaderResult GltfReader::readGltf(
-    const gsl::span<const std::byte>& data,
+    const std::span<const std::byte>& data,
     const GltfReaderOptions& options) const {
 
   const CesiumJsonReader::JsonReaderOptions& context = this->getExtensions();
@@ -618,7 +618,7 @@ void CesiumGltfReader::GltfReader::postprocessGltf(
 }
 
 /*static*/ ImageReaderResult GltfReader::readImage(
-    const gsl::span<const std::byte>& data,
+    const std::span<const std::byte>& data,
     const Ktx2TranscodeTargets& ktx2TranscodeTargets) {
   return ImageDecoder::readImage(data, ktx2TranscodeTargets);
 }

--- a/CesiumGltfReader/src/ImageDecoder.cpp
+++ b/CesiumGltfReader/src/ImageDecoder.cpp
@@ -18,11 +18,12 @@
 #include <CesiumUtility/Tracing.h>
 #include <CesiumUtility/Uri.h>
 
-#include <gsl/span>
 #include <ktx.h>
 #include <rapidjson/reader.h>
 #include <turbojpeg.h>
 #include <webp/decode.h>
+
+#include <span>
 
 #define STBI_FAILURE_USERMSG
 
@@ -42,7 +43,7 @@ using namespace CesiumGltf;
 
 namespace {
 
-bool isKtx(const gsl::span<const std::byte>& data) {
+bool isKtx(const std::span<const std::byte>& data) {
   const size_t ktxMagicByteLength = 12;
   if (data.size() < ktxMagicByteLength) {
     return false;
@@ -54,7 +55,7 @@ bool isKtx(const gsl::span<const std::byte>& data) {
   return memcmp(data.data(), ktxMagic, ktxMagicByteLength) == 0;
 }
 
-bool isWebP(const gsl::span<const std::byte>& data) {
+bool isWebP(const std::span<const std::byte>& data) {
   if (data.size() < 12) {
     return false;
   }
@@ -67,7 +68,7 @@ bool isWebP(const gsl::span<const std::byte>& data) {
 
 /*static*/
 ImageReaderResult ImageDecoder::readImage(
-    const gsl::span<const std::byte>& data,
+    const std::span<const std::byte>& data,
     const Ktx2TranscodeTargets& ktx2TranscodeTargets) {
   CESIUM_TRACE("CesiumGltfReader::readImage");
 

--- a/CesiumGltfReader/src/decodeDataUrls.cpp
+++ b/CesiumGltfReader/src/decodeDataUrls.cpp
@@ -13,7 +13,7 @@ namespace CesiumGltfReader {
 
 namespace {
 
-std::vector<std::byte> decodeBase64(gsl::span<const std::byte> data) {
+std::vector<std::byte> decodeBase64(std::span<const std::byte> data) {
   CESIUM_TRACE("CesiumGltfReader::decodeBase64");
   std::vector<std::byte> result(modp_b64_decode_len(data.size()));
 
@@ -68,7 +68,7 @@ std::optional<DecodeResult> tryDecode(const std::string& uri) {
         result.mimeType.size() - base64IndicatorLength);
   }
 
-  const gsl::span<const std::byte> data(
+  const std::span<const std::byte> data(
       reinterpret_cast<const std::byte*>(uri.data()) + dataDelimeter + 1,
       uri.size() - dataDelimeter - 1);
 

--- a/CesiumGltfReader/src/decodeDraco.cpp
+++ b/CesiumGltfReader/src/decodeDraco.cpp
@@ -58,7 +58,7 @@ std::unique_ptr<draco::Mesh> decodeBufferViewToDracoMesh(
     return nullptr;
   }
 
-  const gsl::span<const std::byte> data(
+  const std::span<const std::byte> data(
       buffer.cesium.data.data() + bufferView.byteOffset,
       static_cast<uint64_t>(bufferView.byteLength));
 

--- a/CesiumGltfReader/src/decodeMeshOpt.cpp
+++ b/CesiumGltfReader/src/decodeMeshOpt.cpp
@@ -51,7 +51,7 @@ void decodeFilter(
 template <typename T>
 int decodeIndices(
     T* data,
-    const gsl::span<const std::byte>& buffer,
+    const std::span<const std::byte>& buffer,
     const ExtensionBufferViewExtMeshoptCompression& meshOpt) {
   if (meshOpt.mode ==
       ExtensionBufferViewExtMeshoptCompression::Mode::TRIANGLES) {
@@ -73,7 +73,7 @@ int decodeIndices(
 
 int decodeBufferView(
     void* data,
-    const gsl::span<const std::byte>& buffer,
+    const std::span<const std::byte>& buffer,
     const ExtensionBufferViewExtMeshoptCompression& meshOpt) {
   if (meshOpt.mode ==
       ExtensionBufferViewExtMeshoptCompression::Mode::ATTRIBUTES) {
@@ -133,7 +133,7 @@ void decodeMeshOpt(Model& model, CesiumGltfReader::GltfReaderResult& readGltf) {
       data.resize(static_cast<size_t>(byteLength));
       if (decodeBufferView(
               data.data(),
-              gsl::span<const std::byte>(
+              std::span<const std::byte>(
                   pBuffer->cesium.data.data() + pMeshOpt->byteOffset,
                   static_cast<size_t>(pMeshOpt->byteLength)),
               *pMeshOpt) != 0) {

--- a/CesiumGltfReader/test/TestExtensionModelExtStructuralMetadata.cpp
+++ b/CesiumGltfReader/test/TestExtensionModelExtStructuralMetadata.cpp
@@ -65,7 +65,7 @@ TEST_CASE(
   CesiumGltfReader::GltfReaderOptions options;
   CesiumGltfReader::GltfReader reader;
   CesiumGltfReader::GltfReaderResult readerResult = reader.readGltf(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
       options);
 
   REQUIRE(readerResult.errors.empty());

--- a/CesiumGltfReader/test/TestGltfReader.cpp
+++ b/CesiumGltfReader/test/TestGltfReader.cpp
@@ -14,12 +14,12 @@
 
 #include <catch2/catch.hpp>
 #include <glm/vec3.hpp>
-#include <gsl/span>
 #include <rapidjson/reader.h>
 
 #include <filesystem>
 #include <fstream>
 #include <limits>
+#include <span>
 #include <string>
 
 using namespace CesiumAsync;
@@ -75,7 +75,7 @@ TEST_CASE("CesiumGltfReader::GltfReader") {
 
   GltfReader reader;
   GltfReaderResult result = reader.readGltf(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()));
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()));
   CHECK(result.errors.empty());
   REQUIRE(result.model.has_value());
 
@@ -272,7 +272,7 @@ TEST_CASE("Nested extras deserializes properly") {
 
   GltfReader reader;
   GltfReaderResult result = reader.readGltf(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()));
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()));
 
   REQUIRE(result.errors.empty());
   REQUIRE(result.model.has_value());
@@ -324,7 +324,7 @@ TEST_CASE("Can deserialize KHR_draco_mesh_compression") {
 
   GltfReader reader;
   GltfReaderResult result = reader.readGltf(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
       options);
 
   REQUIRE(result.errors.empty());
@@ -352,7 +352,7 @@ TEST_CASE("Can deserialize KHR_draco_mesh_compression") {
       CesiumJsonReader::ExtensionState::JsonOnly);
 
   GltfReaderResult result2 = reader.readGltf(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
       options);
 
   REQUIRE(result2.errors.empty());
@@ -387,7 +387,7 @@ TEST_CASE("Can deserialize KHR_draco_mesh_compression") {
       CesiumJsonReader::ExtensionState::Disabled);
 
   GltfReaderResult result3 = reader.readGltf(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
       options);
 
   REQUIRE(result3.errors.empty());
@@ -424,7 +424,7 @@ TEST_CASE("Extensions deserialize to JsonVaue iff "
   GltfReaderOptions options;
   GltfReader reader;
   GltfReaderResult withCustomExtModel = reader.readGltf(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
       options);
 
   REQUIRE(withCustomExtModel.errors.empty());
@@ -455,7 +455,7 @@ TEST_CASE("Extensions deserialize to JsonVaue iff "
       CesiumJsonReader::ExtensionState::Disabled);
 
   GltfReaderResult withoutCustomExt = reader.readGltf(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
       options);
 
   auto& zeroExtensions = withoutCustomExt.model->extensions;
@@ -479,7 +479,7 @@ TEST_CASE("Unknown MIME types are handled") {
   GltfReaderOptions options;
   GltfReader reader;
   GltfReaderResult result = reader.readGltf(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
       options);
 
   // Note: The result.errors will not be empty,
@@ -502,7 +502,7 @@ TEST_CASE("Can parse doubles with no fractions as integers") {
   GltfReaderOptions options;
   GltfReader reader;
   GltfReaderResult result = reader.readGltf(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
       options);
 
   CHECK(result.warnings.empty());
@@ -522,7 +522,7 @@ TEST_CASE("Can parse doubles with no fractions as integers") {
     }
   )";
   result = reader.readGltf(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
       options);
   CHECK(!result.warnings.empty());
 }
@@ -553,7 +553,7 @@ TEST_CASE("Can apply RTC CENTER if model uses Cesium RTC extension") {
   GltfReaderOptions options;
   GltfReader reader;
   GltfReaderResult result = reader.readGltf(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
       options);
   REQUIRE(result.model.has_value());
   Model& model = result.model.value();
@@ -580,7 +580,7 @@ TEST_CASE("Can read unknown properties from a glTF") {
   reader.getOptions().setCaptureUnknownProperties(true);
 
   GltfReaderResult result = reader.readGltf(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
       options);
   REQUIRE(result.model.has_value());
 
@@ -610,7 +610,7 @@ TEST_CASE("Ignores unknown properties if requested") {
   reader.getOptions().setCaptureUnknownProperties(false);
 
   GltfReaderResult result = reader.readGltf(
-      gsl::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
+      std::span(reinterpret_cast<const std::byte*>(s.c_str()), s.size()),
       options);
   REQUIRE(result.model.has_value());
   CHECK(result.model->unknownProperties.empty());
@@ -658,7 +658,7 @@ TEST_CASE("Decode buffer with data URI whose length does match the buffer's "
       "\"byteLength\": 1");
 
   GltfReader reader;
-  GltfReaderResult result = reader.readGltf(gsl::span<const std::byte>(
+  GltfReaderResult result = reader.readGltf(std::span<const std::byte>(
       reinterpret_cast<const std::byte*>(gltfString.data()),
       gltfString.size()));
 

--- a/CesiumGltfWriter/include/CesiumGltfWriter/GltfWriter.h
+++ b/CesiumGltfWriter/include/CesiumGltfWriter/GltfWriter.h
@@ -4,7 +4,7 @@
 
 #include <CesiumJsonWriter/ExtensionWriterContext.h>
 
-#include <gsl/span>
+#include <span>
 
 // forward declarations
 namespace CesiumGltf {
@@ -102,7 +102,7 @@ public:
    */
   GltfWriterResult writeGlb(
       const CesiumGltf::Model& model,
-      const gsl::span<const std::byte>& bufferData,
+      const std::span<const std::byte>& bufferData,
       const GltfWriterOptions& options = GltfWriterOptions()) const;
 
 private:

--- a/CesiumGltfWriter/src/GltfWriter.cpp
+++ b/CesiumGltfWriter/src/GltfWriter.cpp
@@ -22,8 +22,8 @@ getPadding(size_t byteCount, size_t byteAlignment) noexcept {
 
 void writeGlbBuffer(
     GltfWriterResult& result,
-    const gsl::span<const std::byte>& jsonData,
-    const gsl::span<const std::byte>& bufferData,
+    const std::span<const std::byte>& jsonData,
+    const std::span<const std::byte>& bufferData,
     size_t binaryChunkByteAlignment) {
   CESIUM_ASSERT(
       binaryChunkByteAlignment > 0 && binaryChunkByteAlignment % 4 == 0);
@@ -152,7 +152,7 @@ GltfWriterResult GltfWriter::writeGltf(
 
 GltfWriterResult GltfWriter::writeGlb(
     const CesiumGltf::Model& model,
-    const gsl::span<const std::byte>& bufferData,
+    const std::span<const std::byte>& bufferData,
     const GltfWriterOptions& options) const {
   CESIUM_TRACE("GltfWriter::writeGlb");
 
@@ -173,7 +173,7 @@ GltfWriterResult GltfWriter::writeGlb(
 
   writeGlbBuffer(
       result,
-      gsl::span(jsonData),
+      std::span(jsonData),
       bufferData,
       options.binaryChunkByteAlignment);
 

--- a/CesiumGltfWriter/test/TestGltfWriter.cpp
+++ b/CesiumGltfWriter/test/TestGltfWriter.cpp
@@ -11,7 +11,7 @@
 namespace {
 void check(const std::string& input, const std::string& expectedOutput) {
   CesiumGltfReader::GltfReader reader;
-  CesiumGltfReader::GltfReaderResult readResult = reader.readGltf(gsl::span(
+  CesiumGltfReader::GltfReaderResult readResult = reader.readGltf(std::span(
       reinterpret_cast<const std::byte*>(input.c_str()),
       input.size()));
   REQUIRE(readResult.errors.empty());
@@ -532,7 +532,7 @@ TEST_CASE("Writes glb") {
 
   CesiumGltfWriter::GltfWriter writer;
   CesiumGltfWriter::GltfWriterResult writeResult =
-      writer.writeGlb(model, gsl::span(bufferData));
+      writer.writeGlb(model, std::span(bufferData));
   const std::vector<std::byte>& glbBytes = writeResult.gltfBytes;
 
   REQUIRE(writeResult.errors.empty());
@@ -567,7 +567,7 @@ TEST_CASE("Writes glb with binaryChunkByteAlignment of 8") {
   options.binaryChunkByteAlignment = 4; // default
 
   CesiumGltfWriter::GltfWriterResult writeResult =
-      writer.writeGlb(model, gsl::span(bufferData), options);
+      writer.writeGlb(model, std::span(bufferData), options);
   const std::vector<std::byte>& glbBytesDefaultPadding = writeResult.gltfBytes;
 
   REQUIRE(writeResult.errors.empty());
@@ -576,7 +576,7 @@ TEST_CASE("Writes glb with binaryChunkByteAlignment of 8") {
   REQUIRE(glbBytesDefaultPadding.size() == 84);
 
   options.binaryChunkByteAlignment = 8;
-  writeResult = writer.writeGlb(model, gsl::span(bufferData), options);
+  writeResult = writer.writeGlb(model, std::span(bufferData), options);
   const std::vector<std::byte>& glbBytesExtraPadding = writeResult.gltfBytes;
 
   REQUIRE(writeResult.errors.empty());

--- a/CesiumIonClient/src/Connection.cpp
+++ b/CesiumIonClient/src/Connection.cpp
@@ -898,7 +898,7 @@ CesiumAsync::Future<Response<Token>> Connection::createToken(
 
   writer.EndObject();
 
-  const gsl::span<const std::byte> tokenBytes(
+  const std::span<const std::byte> tokenBytes(
       reinterpret_cast<const std::byte*>(tokenBuffer.GetString()),
       tokenBuffer.GetSize());
   return this->_pAssetAccessor
@@ -987,7 +987,7 @@ Future<Response<NoValue>> Connection::modifyToken(
 
   writer.EndObject();
 
-  const gsl::span<const std::byte> tokenBytes(
+  const std::span<const std::byte> tokenBytes(
       reinterpret_cast<const std::byte*>(tokenBuffer.GetString()),
       tokenBuffer.GetSize());
 
@@ -1097,7 +1097,7 @@ Connection::getIdFromToken(const std::string& token) {
   writer.String(codeVerifier.c_str(), rapidjson::SizeType(codeVerifier.size()));
   writer.EndObject();
 
-  const gsl::span<const std::byte> payload(
+  const std::span<const std::byte> payload(
       reinterpret_cast<const std::byte*>(postBuffer.GetString()),
       postBuffer.GetSize());
 

--- a/CesiumIonClient/src/fillWithRandomBytes.cpp
+++ b/CesiumIonClient/src/fillWithRandomBytes.cpp
@@ -6,7 +6,7 @@
 
 namespace CesiumIonClient {
 
-void fillWithRandomBytes(const gsl::span<uint8_t>& buffer) {
+void fillWithRandomBytes(const std::span<uint8_t>& buffer) {
   if (buffer.empty()) {
     return;
   }

--- a/CesiumIonClient/src/fillWithRandomBytes.h
+++ b/CesiumIonClient/src/fillWithRandomBytes.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <gsl/span>
-
 #include <cstdint>
+#include <span>
 
 namespace CesiumIonClient {
 
-void fillWithRandomBytes(const gsl::span<uint8_t>& buffer);
+void fillWithRandomBytes(const std::span<uint8_t>& buffer);
 
 }

--- a/CesiumIonClient/test/TestFillWithRandomBytes.cpp
+++ b/CesiumIonClient/test/TestFillWithRandomBytes.cpp
@@ -11,7 +11,7 @@ TEST_CASE("fillWithRandomBytes") {
 
     // Allocate an extra byte to make sure we don't overflow the buffer
     std::vector<uint8_t> buffer(size + 1);
-    gsl::span<uint8_t> bufferSpan(buffer.data(), size);
+    std::span<uint8_t> bufferSpan(buffer.data(), size);
 
     fillWithRandomBytes(bufferSpan);
 

--- a/CesiumJsonReader/CMakeLists.txt
+++ b/CesiumJsonReader/CMakeLists.txt
@@ -39,6 +39,5 @@ target_include_directories(
 
 target_link_libraries(CesiumJsonReader
     PUBLIC
-        Microsoft.GSL::GSL
         CesiumUtility
 )

--- a/CesiumJsonReader/include/CesiumJsonReader/JsonReader.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/JsonReader.h
@@ -3,11 +3,11 @@
 #include "JsonHandler.h"
 #include "Library.h"
 
-#include <gsl/span>
 #include <rapidjson/document.h>
 
 #include <cstddef>
 #include <optional>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -57,7 +57,7 @@ public:
    */
   template <typename T>
   static ReadJsonResult<typename T::ValueType>
-  readJson(const gsl::span<const std::byte>& data, T& handler) {
+  readJson(const std::span<const std::byte>& data, T& handler) {
     ReadJsonResult<typename T::ValueType> result;
 
     result.value.emplace();
@@ -131,7 +131,7 @@ private:
   };
 
   static void internalRead(
-      const gsl::span<const std::byte>& data,
+      const std::span<const std::byte>& data,
       IJsonHandler& handler,
       FinalJsonHandler& finalHandler,
       std::vector<std::string>& errors,

--- a/CesiumJsonReader/src/JsonReader.cpp
+++ b/CesiumJsonReader/src/JsonReader.cpp
@@ -121,7 +121,7 @@ void JsonReader::FinalJsonHandler::setInputStream(
 }
 
 /*static*/ void JsonReader::internalRead(
-    const gsl::span<const std::byte>& data,
+    const std::span<const std::byte>& data,
     IJsonHandler& handler,
     FinalJsonHandler& finalHandler,
     std::vector<std::string>& errors,

--- a/CesiumNativeTests/include/CesiumNativeTests/FileAccessor.h
+++ b/CesiumNativeTests/include/CesiumNativeTests/FileAccessor.h
@@ -18,7 +18,7 @@ public:
       const std::string& verb,
       const std::string& url,
       const std::vector<THeader>& headers,
-      const gsl::span<const std::byte>&) override;
+      const std::span<const std::byte>&) override;
 
   void tick() noexcept override {}
 };

--- a/CesiumNativeTests/include/CesiumNativeTests/OwnedTempFile.h
+++ b/CesiumNativeTests/include/CesiumNativeTests/OwnedTempFile.h
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <gsl/span>
-
 #include <filesystem>
 #include <ios>
+#include <span>
 
 /**
  * Creates and holds on to a path for a temporary file on disk.
@@ -12,13 +11,13 @@
 class OwnedTempFile {
 public:
   OwnedTempFile();
-  OwnedTempFile(const gsl::span<const std::byte>& buffer);
+  OwnedTempFile(const std::span<const std::byte>& buffer);
   ~OwnedTempFile();
 
   const std::filesystem::path& getPath() const;
 
   void write(
-      const gsl::span<const std::byte>& buffer,
+      const std::span<const std::byte>& buffer,
       std::ios::openmode flags = std::ios::out | std::ios::binary |
                                  std::ios::trunc);
 

--- a/CesiumNativeTests/include/CesiumNativeTests/SimpleAssetAccessor.h
+++ b/CesiumNativeTests/include/CesiumNativeTests/SimpleAssetAccessor.h
@@ -43,7 +43,7 @@ public:
       const std::string& /* verb */,
       const std::string& url,
       const std::vector<THeader>& headers,
-      const gsl::span<const std::byte>&) override {
+      const std::span<const std::byte>&) override {
     return this->get(asyncSystem, url, headers);
   }
 

--- a/CesiumNativeTests/include/CesiumNativeTests/SimpleAssetResponse.h
+++ b/CesiumNativeTests/include/CesiumNativeTests/SimpleAssetResponse.h
@@ -28,8 +28,8 @@ public:
     return this->mockHeaders;
   }
 
-  virtual gsl::span<const std::byte> data() const override {
-    return gsl::span<const std::byte>(mockData.data(), mockData.size());
+  virtual std::span<const std::byte> data() const override {
+    return std::span<const std::byte>(mockData.data(), mockData.size());
   }
 
   uint16_t mockStatusCode;

--- a/CesiumNativeTests/src/FileAccessor.cpp
+++ b/CesiumNativeTests/src/FileAccessor.cpp
@@ -69,7 +69,7 @@ FileAccessor::request(
     const std::string& verb,
     const std::string& url,
     const std::vector<THeader>& headers,
-    const gsl::span<const std::byte>&) {
+    const std::span<const std::byte>&) {
   if (verb == "GET") {
     return get(asyncSystem, url, headers);
   }

--- a/CesiumNativeTests/src/OwnedTempFile.cpp
+++ b/CesiumNativeTests/src/OwnedTempFile.cpp
@@ -28,7 +28,7 @@ static std::string getTempFilename() {
 
 OwnedTempFile::OwnedTempFile() : _filePath(getTempFilename()) {}
 
-OwnedTempFile::OwnedTempFile(const gsl::span<const std::byte>& buffer)
+OwnedTempFile::OwnedTempFile(const std::span<const std::byte>& buffer)
     : OwnedTempFile() {
   write(buffer);
 }
@@ -40,7 +40,7 @@ const std::filesystem::path& OwnedTempFile::getPath() const {
 }
 
 void OwnedTempFile::write(
-    const gsl::span<const std::byte>& buffer,
+    const std::span<const std::byte>& buffer,
     std::ios::openmode flags) {
   std::fstream stream(_filePath.string(), flags);
   REQUIRE(stream.good());

--- a/CesiumQuantizedMeshTerrain/generated/include/CesiumQuantizedMeshTerrain/AvailabilityRectangleReader.h
+++ b/CesiumQuantizedMeshTerrain/generated/include/CesiumQuantizedMeshTerrain/AvailabilityRectangleReader.h
@@ -7,9 +7,9 @@
 #include <CesiumQuantizedMeshTerrain/AvailabilityRectangle.h>
 #include <CesiumQuantizedMeshTerrain/Library.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumQuantizedMeshTerrain {
@@ -46,7 +46,7 @@ public:
    */
   CesiumJsonReader::ReadJsonResult<
       CesiumQuantizedMeshTerrain::AvailabilityRectangle>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of AvailabilityRectangle from a rapidJson::Value.

--- a/CesiumQuantizedMeshTerrain/generated/include/CesiumQuantizedMeshTerrain/LayerReader.h
+++ b/CesiumQuantizedMeshTerrain/generated/include/CesiumQuantizedMeshTerrain/LayerReader.h
@@ -7,9 +7,9 @@
 #include <CesiumQuantizedMeshTerrain/Layer.h>
 #include <CesiumQuantizedMeshTerrain/Library.h>
 
-#include <gsl/span>
 #include <rapidjson/fwd.h>
 
+#include <span>
 #include <vector>
 
 namespace CesiumQuantizedMeshTerrain {
@@ -45,7 +45,7 @@ public:
    * @return The result of reading the instance.
    */
   CesiumJsonReader::ReadJsonResult<CesiumQuantizedMeshTerrain::Layer>
-  readFromJson(const gsl::span<const std::byte>& data) const;
+  readFromJson(const std::span<const std::byte>& data) const;
 
   /**
    * @brief Reads an instance of Layer from a rapidJson::Value.

--- a/CesiumQuantizedMeshTerrain/generated/src/GeneratedJsonHandlers.cpp
+++ b/CesiumQuantizedMeshTerrain/generated/src/GeneratedJsonHandlers.cpp
@@ -105,7 +105,7 @@ const CesiumJsonReader::JsonReaderOptions& LayerReader::getOptions() const {
 }
 
 CesiumJsonReader::ReadJsonResult<CesiumQuantizedMeshTerrain::Layer>
-LayerReader::readFromJson(const gsl::span<const std::byte>& data) const {
+LayerReader::readFromJson(const std::span<const std::byte>& data) const {
   LayerJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }
@@ -199,7 +199,7 @@ AvailabilityRectangleReader::getOptions() const {
 CesiumJsonReader::ReadJsonResult<
     CesiumQuantizedMeshTerrain::AvailabilityRectangle>
 AvailabilityRectangleReader::readFromJson(
-    const gsl::span<const std::byte>& data) const {
+    const std::span<const std::byte>& data) const {
   AvailabilityRectangleJsonHandler handler(this->_options);
   return CesiumJsonReader::JsonReader::readJson(data, handler);
 }

--- a/CesiumQuantizedMeshTerrain/include/CesiumQuantizedMeshTerrain/LayerWriter.h
+++ b/CesiumQuantizedMeshTerrain/include/CesiumQuantizedMeshTerrain/LayerWriter.h
@@ -4,7 +4,7 @@
 
 #include <CesiumJsonWriter/ExtensionWriterContext.h>
 
-#include <gsl/span>
+#include <span>
 
 // forward declarations
 namespace CesiumQuantizedMeshTerrain {

--- a/CesiumQuantizedMeshTerrain/include/CesiumQuantizedMeshTerrain/QuantizedMeshLoader.h
+++ b/CesiumQuantizedMeshTerrain/include/CesiumQuantizedMeshTerrain/QuantizedMeshLoader.h
@@ -9,12 +9,12 @@
 #include <CesiumGltf/Model.h>
 #include <CesiumUtility/ErrorList.h>
 
-#include <gsl/span>
 #include <rapidjson/document.h>
 
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <span>
 #include <vector>
 
 namespace CesiumAsync {
@@ -81,7 +81,7 @@ public:
       const CesiumGeometry::QuadtreeTileID& tileID,
       const CesiumGeospatial::BoundingRegion& tileBoundingVolume,
       const std::string& url,
-      const gsl::span<const std::byte>& data,
+      const std::span<const std::byte>& data,
       bool enableWaterMask,
       const CesiumGeospatial::Ellipsoid& ellipsoid CESIUM_DEFAULT_ELLIPSOID);
 
@@ -94,7 +94,7 @@ public:
    * @return The parsed metadata.
    */
   static QuantizedMeshMetadataResult loadMetadata(
-      const gsl::span<const std::byte>& data,
+      const std::span<const std::byte>& data,
       const CesiumGeometry::QuadtreeTileID& tileID);
 
   /**

--- a/CesiumQuantizedMeshTerrain/src/QuantizedMeshLoader.cpp
+++ b/CesiumQuantizedMeshTerrain/src/QuantizedMeshLoader.cpp
@@ -75,36 +75,36 @@ struct QuantizedMeshView {
 
   const QuantizedMeshHeader* header;
 
-  gsl::span<const uint16_t> uBuffer;
-  gsl::span<const uint16_t> vBuffer;
-  gsl::span<const uint16_t> heightBuffer;
+  std::span<const uint16_t> uBuffer;
+  std::span<const uint16_t> vBuffer;
+  std::span<const uint16_t> heightBuffer;
 
   QuantizedMeshIndexType indexType;
   uint32_t triangleCount;
-  gsl::span<const std::byte> indicesBuffer;
+  std::span<const std::byte> indicesBuffer;
 
   uint32_t westEdgeIndicesCount;
-  gsl::span<const std::byte> westEdgeIndicesBuffer;
+  std::span<const std::byte> westEdgeIndicesBuffer;
 
   uint32_t southEdgeIndicesCount;
-  gsl::span<const std::byte> southEdgeIndicesBuffer;
+  std::span<const std::byte> southEdgeIndicesBuffer;
 
   uint32_t eastEdgeIndicesCount;
-  gsl::span<const std::byte> eastEdgeIndicesBuffer;
+  std::span<const std::byte> eastEdgeIndicesBuffer;
 
   uint32_t northEdgeIndicesCount;
-  gsl::span<const std::byte> northEdgeIndicesBuffer;
+  std::span<const std::byte> northEdgeIndicesBuffer;
 
-  gsl::span<const std::byte> octEncodedNormalBuffer;
+  std::span<const std::byte> octEncodedNormalBuffer;
 
   bool onlyWater;
   bool onlyLand;
 
   // water mask will always be a 256*256 map where 0 is land and 255 is water.
-  gsl::span<const std::byte> waterMaskBuffer;
+  std::span<const std::byte> waterMaskBuffer;
 
   uint32_t metadataJsonLength;
-  gsl::span<const char> metadataJsonBuffer;
+  std::span<const char> metadataJsonBuffer;
 };
 
 // We can't use sizeof(QuantizedMeshHeader) because it may be padded.
@@ -117,8 +117,8 @@ int32_t zigZagDecode(int32_t value) noexcept {
 
 template <class E, class D>
 void decodeIndices(
-    const gsl::span<const E>& encoded,
-    const gsl::span<D>& decoded) {
+    const std::span<const E>& encoded,
+    const std::span<D>& decoded) {
   if (decoded.size() < encoded.size()) {
     throw std::runtime_error("decoded buffer is too small.");
   }
@@ -136,7 +136,7 @@ void decodeIndices(
 
 template <class T>
 static T readValue(
-    const gsl::span<const std::byte>& data,
+    const std::span<const std::byte>& data,
     size_t offset,
     T defaultValue) noexcept {
   if (offset + sizeof(T) <= data.size()) {
@@ -146,10 +146,10 @@ static T readValue(
 }
 
 static QuantizedMeshMetadataResult
-processMetadata(const QuadtreeTileID& tileID, gsl::span<const char> json);
+processMetadata(const QuadtreeTileID& tileID, std::span<const char> json);
 
 static std::optional<QuantizedMeshView> parseQuantizedMesh(
-    const gsl::span<const std::byte>& data,
+    const std::span<const std::byte>& data,
     bool enableWaterMask) {
   if (data.size() < headerLength) {
     return std::nullopt;
@@ -165,7 +165,7 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
   // parse u, v, and height buffers
   const uint32_t vertexCount = meshView.header->vertexCount;
 
-  meshView.uBuffer = gsl::span<const uint16_t>(
+  meshView.uBuffer = std::span<const uint16_t>(
       reinterpret_cast<const uint16_t*>(data.data() + readIndex),
       vertexCount);
   readIndex += meshView.uBuffer.size_bytes();
@@ -173,7 +173,7 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
     return std::nullopt;
   }
 
-  meshView.vBuffer = gsl::span<const uint16_t>(
+  meshView.vBuffer = std::span<const uint16_t>(
       reinterpret_cast<const uint16_t*>(data.data() + readIndex),
       vertexCount);
   readIndex += meshView.vBuffer.size_bytes();
@@ -181,7 +181,7 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
     return std::nullopt;
   }
 
-  meshView.heightBuffer = gsl::span<const uint16_t>(
+  meshView.heightBuffer = std::span<const uint16_t>(
       reinterpret_cast<const uint16_t*>(data.data() + readIndex),
       vertexCount);
   readIndex += meshView.heightBuffer.size_bytes();
@@ -207,7 +207,7 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
     }
 
     const uint32_t indicesCount = meshView.triangleCount * 3;
-    meshView.indicesBuffer = gsl::span<const std::byte>(
+    meshView.indicesBuffer = std::span<const std::byte>(
         data.data() + readIndex,
         indicesCount * sizeof(uint32_t));
     readIndex += meshView.indicesBuffer.size_bytes();
@@ -226,7 +226,7 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
     }
 
     const uint32_t indicesCount = meshView.triangleCount * 3;
-    meshView.indicesBuffer = gsl::span<const std::byte>(
+    meshView.indicesBuffer = std::span<const std::byte>(
         data.data() + readIndex,
         indicesCount * sizeof(uint16_t));
     readIndex += meshView.indicesBuffer.size_bytes();
@@ -250,7 +250,7 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
   }
 
   meshView.westEdgeIndicesBuffer =
-      gsl::span<const std::byte>(data.data() + readIndex, edgeByteSizes);
+      std::span<const std::byte>(data.data() + readIndex, edgeByteSizes);
   readIndex += edgeByteSizes;
 
   // read the south edge
@@ -262,7 +262,7 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
   }
 
   meshView.southEdgeIndicesBuffer =
-      gsl::span<const std::byte>(data.data() + readIndex, edgeByteSizes);
+      std::span<const std::byte>(data.data() + readIndex, edgeByteSizes);
   readIndex += edgeByteSizes;
 
   // read the east edge
@@ -274,7 +274,7 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
   }
 
   meshView.eastEdgeIndicesBuffer =
-      gsl::span<const std::byte>(data.data() + readIndex, edgeByteSizes);
+      std::span<const std::byte>(data.data() + readIndex, edgeByteSizes);
   readIndex += edgeByteSizes;
 
   // read the north edge
@@ -286,7 +286,7 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
   }
 
   meshView.northEdgeIndicesBuffer =
-      gsl::span<const std::byte>(data.data() + readIndex, edgeByteSizes);
+      std::span<const std::byte>(data.data() + readIndex, edgeByteSizes);
   readIndex += edgeByteSizes;
 
   // parse oct-encoded normal buffer and metadata
@@ -309,7 +309,7 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
       }
 
       meshView.octEncodedNormalBuffer =
-          gsl::span<const std::byte>(data.data() + readIndex, vertexCount * 2);
+          std::span<const std::byte>(data.data() + readIndex, vertexCount * 2);
     } else if (enableWaterMask && extensionID == 2) {
       // Water Mask
       if (extensionLength == 1) {
@@ -323,7 +323,7 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
         meshView.onlyWater = false;
         meshView.onlyLand = false;
         meshView.waterMaskBuffer =
-            gsl::span<const std::byte>(data.data() + readIndex, 65536);
+            std::span<const std::byte>(data.data() + readIndex, 65536);
       }
     } else if (extensionID == 4) {
       // Metadata
@@ -339,7 +339,7 @@ static std::optional<QuantizedMeshView> parseQuantizedMesh(
         break;
       }
 
-      meshView.metadataJsonBuffer = gsl::span<const char>(
+      meshView.metadataJsonBuffer = std::span<const char>(
           reinterpret_cast<const char*>(
               data.data() + sizeof(uint32_t) + readIndex),
           meshView.metadataJsonLength);
@@ -372,10 +372,10 @@ static void addSkirt(
     double longitudeOffset,
     double latitudeOffset,
     const std::vector<glm::dvec3>& uvsAndHeights,
-    const gsl::span<const E>& edgeIndices,
-    const gsl::span<float>& positions,
-    const gsl::span<float>& normals,
-    const gsl::span<I>& indices,
+    const std::span<const E>& edgeIndices,
+    const std::span<float>& positions,
+    const std::span<float>& normals,
+    const std::span<I>& indices,
     glm::dvec3& positionMinimums,
     glm::dvec3& positionMaximums) {
   const double west = rectangle.getWest();
@@ -443,13 +443,13 @@ static void addSkirts(
     double longitudeOffset,
     double latitudeOffset,
     const std::vector<glm::dvec3>& uvsAndHeights,
-    const gsl::span<const std::byte>& westEdgeIndicesBuffer,
-    const gsl::span<const std::byte>& southEdgeIndicesBuffer,
-    const gsl::span<const std::byte>& eastEdgeIndicesBuffer,
-    const gsl::span<const std::byte>& northEdgeIndicesBuffer,
-    const gsl::span<float>& outputPositions,
-    const gsl::span<float>& outputNormals,
-    const gsl::span<I>& outputIndices,
+    const std::span<const std::byte>& westEdgeIndicesBuffer,
+    const std::span<const std::byte>& southEdgeIndicesBuffer,
+    const std::span<const std::byte>& eastEdgeIndicesBuffer,
+    const std::span<const std::byte>& northEdgeIndicesBuffer,
+    const std::span<float>& outputPositions,
+    const std::span<float>& outputNormals,
+    const std::span<I>& outputIndices,
     glm::dvec3& positionMinimums,
     glm::dvec3& positionMaximums) {
   const uint32_t westVertexCount =
@@ -469,7 +469,7 @@ static void addSkirts(
   std::vector<E> sortEdgeIndices(maxEdgeVertexCount);
 
   // add skirt indices, vertices, and normals
-  gsl::span<const E> westEdgeIndices(
+  std::span<const E> westEdgeIndices(
       reinterpret_cast<const E*>(westEdgeIndicesBuffer.data()),
       westVertexCount);
   std::partial_sort_copy(
@@ -480,7 +480,7 @@ static void addSkirts(
       [&uvsAndHeights](auto lhs, auto rhs) noexcept {
         return uvsAndHeights[lhs].y < uvsAndHeights[rhs].y;
       });
-  westEdgeIndices = gsl::span(sortEdgeIndices.data(), westVertexCount);
+  westEdgeIndices = std::span(sortEdgeIndices.data(), westVertexCount);
   addSkirt(
       ellipsoid,
       center,
@@ -502,7 +502,7 @@ static void addSkirts(
 
   currentVertexCount += westVertexCount;
   currentIndicesCount += (westVertexCount - 1) * 6;
-  gsl::span<const E> southEdgeIndices(
+  std::span<const E> southEdgeIndices(
       reinterpret_cast<const E*>(southEdgeIndicesBuffer.data()),
       southVertexCount);
   std::partial_sort_copy(
@@ -513,7 +513,7 @@ static void addSkirts(
       [&uvsAndHeights](auto lhs, auto rhs) noexcept {
         return uvsAndHeights[lhs].x > uvsAndHeights[rhs].x;
       });
-  southEdgeIndices = gsl::span(sortEdgeIndices.data(), southVertexCount);
+  southEdgeIndices = std::span(sortEdgeIndices.data(), southVertexCount);
   addSkirt(
       ellipsoid,
       center,
@@ -535,7 +535,7 @@ static void addSkirts(
 
   currentVertexCount += southVertexCount;
   currentIndicesCount += (southVertexCount - 1) * 6;
-  gsl::span<const E> eastEdgeIndices(
+  std::span<const E> eastEdgeIndices(
       reinterpret_cast<const E*>(eastEdgeIndicesBuffer.data()),
       eastVertexCount);
   std::partial_sort_copy(
@@ -546,7 +546,7 @@ static void addSkirts(
       [&uvsAndHeights](auto lhs, auto rhs) noexcept {
         return uvsAndHeights[lhs].y > uvsAndHeights[rhs].y;
       });
-  eastEdgeIndices = gsl::span(sortEdgeIndices.data(), eastVertexCount);
+  eastEdgeIndices = std::span(sortEdgeIndices.data(), eastVertexCount);
   addSkirt(
       ellipsoid,
       center,
@@ -568,7 +568,7 @@ static void addSkirts(
 
   currentVertexCount += eastVertexCount;
   currentIndicesCount += (eastVertexCount - 1) * 6;
-  gsl::span<const E> northEdgeIndices(
+  std::span<const E> northEdgeIndices(
       reinterpret_cast<const E*>(northEdgeIndicesBuffer.data()),
       northVertexCount);
   std::partial_sort_copy(
@@ -579,7 +579,7 @@ static void addSkirts(
       [&uvsAndHeights](auto lhs, auto rhs) noexcept {
         return uvsAndHeights[lhs].x < uvsAndHeights[rhs].x;
       });
-  northEdgeIndices = gsl::span(sortEdgeIndices.data(), northVertexCount);
+  northEdgeIndices = std::span(sortEdgeIndices.data(), northVertexCount);
   addSkirt(
       ellipsoid,
       center,
@@ -601,8 +601,8 @@ static void addSkirts(
 }
 
 static void decodeNormals(
-    const gsl::span<const std::byte>& encoded,
-    const gsl::span<float>& decoded) {
+    const std::span<const std::byte>& encoded,
+    const std::span<float>& decoded) {
   if (decoded.size() < encoded.size()) {
     throw std::runtime_error("decoded buffer is too small.");
   }
@@ -620,11 +620,11 @@ static void decodeNormals(
 
 template <class T>
 static std::vector<std::byte> generateNormals(
-    const gsl::span<const float>& positions,
-    const gsl::span<T>& indices,
+    const std::span<const float>& positions,
+    const std::span<T>& indices,
     size_t currentNumOfIndex) {
   std::vector<std::byte> normalsBuffer(positions.size() * sizeof(float));
-  const gsl::span<float> normals(
+  const std::span<float> normals(
       reinterpret_cast<float*>(normalsBuffer.data()),
       positions.size());
   for (size_t i = 0; i < currentNumOfIndex; i += 3) {
@@ -673,7 +673,7 @@ static std::vector<std::byte> generateNormals(
     const QuadtreeTileID& tileID,
     const BoundingRegion& tileBoundingVolume,
     const std::string& url,
-    const gsl::span<const std::byte>& data,
+    const std::span<const std::byte>& data,
     bool enableWaterMask,
     const CesiumGeospatial::Ellipsoid& ellipsoid) {
 
@@ -701,7 +701,7 @@ static std::vector<std::byte> generateNormals(
   // skirt as well
   std::vector<std::byte> outputPositionsBuffer(
       (vertexCount + skirtVertexCount) * 3 * sizeof(float));
-  gsl::span<float> outputPositions(
+  std::span<float> outputPositions(
       reinterpret_cast<float*>(outputPositionsBuffer.data()),
       (vertexCount + skirtVertexCount) * 3);
   size_t positionOutputIndex = 0;
@@ -761,16 +761,16 @@ static std::vector<std::byte> generateNormals(
 
   // decode normal vertices of the tile as well as its metadata without skirt
   std::vector<std::byte> outputNormalsBuffer;
-  gsl::span<float> outputNormals;
+  std::span<float> outputNormals;
   if (!meshView->octEncodedNormalBuffer.empty()) {
     const uint32_t totalNormalFloats = (vertexCount + skirtVertexCount) * 3;
     outputNormalsBuffer.resize(totalNormalFloats * sizeof(float));
-    outputNormals = gsl::span<float>(
+    outputNormals = std::span<float>(
         reinterpret_cast<float*>(outputNormalsBuffer.data()),
         totalNormalFloats);
     decodeNormals(meshView->octEncodedNormalBuffer, outputNormals);
 
-    outputNormals = gsl::span<float>(
+    outputNormals = std::span<float>(
         reinterpret_cast<float*>(outputNormalsBuffer.data()),
         outputNormalsBuffer.size() / sizeof(float));
   }
@@ -798,10 +798,10 @@ static std::vector<std::byte> generateNormals(
     // decode the tile indices without skirt.
     const size_t outputIndicesCount = indicesCount + skirtIndicesCount;
     outputIndicesBuffer.resize(outputIndicesCount * sizeof(uint32_t));
-    const gsl::span<const uint32_t> indices(
+    const std::span<const uint32_t> indices(
         reinterpret_cast<const uint32_t*>(meshView->indicesBuffer.data()),
         indicesCount);
-    gsl::span<uint32_t> outputIndices(
+    std::span<uint32_t> outputIndices(
         reinterpret_cast<uint32_t*>(outputIndicesBuffer.data()),
         outputIndicesCount);
     decodeIndices(indices, outputIndices);
@@ -810,7 +810,7 @@ static std::vector<std::byte> generateNormals(
     if (outputNormalsBuffer.empty()) {
       outputNormalsBuffer =
           generateNormals(outputPositions, outputIndices, indicesCount);
-      outputNormals = gsl::span<float>(
+      outputNormals = std::span<float>(
           reinterpret_cast<float*>(outputNormalsBuffer.data()),
           outputNormalsBuffer.size() / sizeof(float));
     }
@@ -841,13 +841,13 @@ static std::vector<std::byte> generateNormals(
     indexSizeBytes = sizeof(uint32_t);
   } else {
     const size_t outputIndicesCount = indicesCount + skirtIndicesCount;
-    const gsl::span<const uint16_t> indices(
+    const std::span<const uint16_t> indices(
         reinterpret_cast<const uint16_t*>(meshView->indicesBuffer.data()),
         indicesCount);
     if (vertexCount + skirtVertexCount < std::numeric_limits<uint16_t>::max()) {
       // decode the tile indices without skirt.
       outputIndicesBuffer.resize(outputIndicesCount * sizeof(uint16_t));
-      gsl::span<uint16_t> outputIndices(
+      std::span<uint16_t> outputIndices(
           reinterpret_cast<uint16_t*>(outputIndicesBuffer.data()),
           outputIndicesCount);
       decodeIndices(indices, outputIndices);
@@ -856,7 +856,7 @@ static std::vector<std::byte> generateNormals(
       if (outputNormalsBuffer.empty()) {
         outputNormalsBuffer =
             generateNormals(outputPositions, outputIndices, indicesCount);
-        outputNormals = gsl::span<float>(
+        outputNormals = std::span<float>(
             reinterpret_cast<float*>(outputNormalsBuffer.data()),
             outputNormalsBuffer.size() / sizeof(float));
       }
@@ -886,7 +886,7 @@ static std::vector<std::byte> generateNormals(
       indexSizeBytes = sizeof(uint16_t);
     } else {
       outputIndicesBuffer.resize(outputIndicesCount * sizeof(uint32_t));
-      gsl::span<uint32_t> outputIndices(
+      std::span<uint32_t> outputIndices(
           reinterpret_cast<uint32_t*>(outputIndicesBuffer.data()),
           outputIndicesCount);
       decodeIndices(indices, outputIndices);
@@ -895,7 +895,7 @@ static std::vector<std::byte> generateNormals(
       if (outputNormalsBuffer.empty()) {
         outputNormalsBuffer =
             generateNormals(outputPositions, outputIndices, indicesCount);
-        outputNormals = gsl::span<float>(
+        outputNormals = std::span<float>(
             reinterpret_cast<float*>(outputNormalsBuffer.data()),
             outputNormalsBuffer.size() / sizeof(float));
       }
@@ -1192,7 +1192,7 @@ struct TileRange {
 
 static QuantizedMeshMetadataResult processMetadata(
     const QuadtreeTileID& tileID,
-    gsl::span<const char> metadataString) {
+    std::span<const char> metadataString) {
   rapidjson::Document metadata;
   metadata.Parse(
       reinterpret_cast<const char*>(metadataString.data()),
@@ -1214,7 +1214,7 @@ static QuantizedMeshMetadataResult processMetadata(
 }
 
 /*static*/ QuantizedMeshMetadataResult QuantizedMeshLoader::loadMetadata(
-    const gsl::span<const std::byte>& data,
+    const std::span<const std::byte>& data,
     const QuadtreeTileID& tileID) {
   std::optional<QuantizedMeshView> meshView = parseQuantizedMesh(data, false);
   if (!meshView) {

--- a/CesiumQuantizedMeshTerrain/test/TestQuantizedMeshContent.cpp
+++ b/CesiumQuantizedMeshTerrain/test/TestQuantizedMeshContent.cpp
@@ -779,7 +779,7 @@ TEST_CASE("Test converting quantized mesh to gltf with skirt") {
     // convert to gltf
     std::vector<std::byte> quantizedMeshBin =
         convertQuantizedMeshToBinary(quantizedMesh);
-    gsl::span<const std::byte> data(
+    std::span<const std::byte> data(
         quantizedMeshBin.data(),
         quantizedMeshBin.size());
     QuantizedMeshLoadResult loadResult =
@@ -853,7 +853,7 @@ TEST_CASE("Test converting quantized mesh to gltf with skirt") {
     // convert to gltf
     std::vector<std::byte> quantizedMeshBin =
         convertQuantizedMeshToBinary(quantizedMesh);
-    gsl::span<const std::byte> data(
+    std::span<const std::byte> data(
         quantizedMeshBin.data(),
         quantizedMeshBin.size());
     auto loadResult =
@@ -927,7 +927,7 @@ TEST_CASE("Test converting quantized mesh to gltf with skirt") {
     // convert to gltf
     std::vector<std::byte> quantizedMeshBin =
         convertQuantizedMeshToBinary(quantizedMesh);
-    gsl::span<const std::byte> data(
+    std::span<const std::byte> data(
         quantizedMeshBin.data(),
         quantizedMeshBin.size());
     auto loadResult =
@@ -1018,7 +1018,7 @@ TEST_CASE("Test converting quantized mesh to gltf with skirt") {
     // convert to gltf
     std::vector<std::byte> quantizedMeshBin =
         convertQuantizedMeshToBinary(quantizedMesh);
-    gsl::span<const std::byte> data(
+    std::span<const std::byte> data(
         quantizedMeshBin.data(),
         quantizedMeshBin.size());
     auto loadResult =
@@ -1104,7 +1104,7 @@ TEST_CASE("Test converting ill-formed quantized mesh") {
 
   SECTION("Quantized mesh with ill-formed header") {
     std::vector<std::byte> quantizedMeshBin(32);
-    gsl::span<const std::byte> data(
+    std::span<const std::byte> data(
         quantizedMeshBin.data(),
         quantizedMeshBin.size());
     auto loadResult =
@@ -1139,7 +1139,7 @@ TEST_CASE("Test converting ill-formed quantized mesh") {
         quantizedMesh.vertexData.u.data(),
         length);
 
-    gsl::span<const std::byte> data(
+    std::span<const std::byte> data(
         quantizedMeshBin.data(),
         quantizedMeshBin.size());
     auto loadResult =
@@ -1202,7 +1202,7 @@ TEST_CASE("Test converting ill-formed quantized mesh") {
     length = sizeof(triangleCount);
     std::memcpy(quantizedMeshBin.data() + offset, &triangleCount, length);
 
-    gsl::span<const std::byte> data(
+    std::span<const std::byte> data(
         quantizedMeshBin.data(),
         quantizedMeshBin.size());
     auto loadResult =
@@ -1282,7 +1282,7 @@ TEST_CASE("Test converting ill-formed quantized mesh") {
     length = sizeof(westCount);
     std::memcpy(quantizedMeshBin.data() + offset, &westCount, length);
 
-    gsl::span<const std::byte> data(
+    std::span<const std::byte> data(
         quantizedMeshBin.data(),
         quantizedMeshBin.size());
     auto loadResult =
@@ -1378,7 +1378,7 @@ TEST_CASE("Test converting ill-formed quantized mesh") {
     length = sizeof(westCount);
     std::memcpy(quantizedMeshBin.data() + offset, &southCount, length);
 
-    gsl::span<const std::byte> data(
+    std::span<const std::byte> data(
         quantizedMeshBin.data(),
         quantizedMeshBin.size());
     auto loadResult =
@@ -1490,7 +1490,7 @@ TEST_CASE("Test converting ill-formed quantized mesh") {
     length = sizeof(eastCount);
     std::memcpy(quantizedMeshBin.data() + offset, &eastCount, length);
 
-    gsl::span<const std::byte> data(
+    std::span<const std::byte> data(
         quantizedMeshBin.data(),
         quantizedMeshBin.size());
     auto loadResult =
@@ -1618,7 +1618,7 @@ TEST_CASE("Test converting ill-formed quantized mesh") {
     length = sizeof(northCount);
     std::memcpy(quantizedMeshBin.data() + offset, &northCount, length);
 
-    gsl::span<const std::byte> data(
+    std::span<const std::byte> data(
         quantizedMeshBin.data(),
         quantizedMeshBin.size());
     auto loadResult =

--- a/CesiumRasterOverlays/src/BingMapsRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/BingMapsRasterOverlay.cpp
@@ -364,7 +364,7 @@ BingMapsRasterOverlay::createTileProvider(
        baseUrl = this->_url,
        culture = this->_culture](
           const std::shared_ptr<IAssetRequest>& pRequest,
-          const gsl::span<const std::byte>& data) -> CreateTileProviderResult {
+          const std::span<const std::byte>& data) -> CreateTileProviderResult {
     rapidjson::Document response;
     response.Parse(reinterpret_cast<const char*>(data.data()), data.size());
 
@@ -447,7 +447,7 @@ BingMapsRasterOverlay::createTileProvider(
   auto cacheResultIt = sessionCache.find(metadataUrl);
   if (cacheResultIt != sessionCache.end()) {
     return asyncSystem.createResolvedFuture(
-        handleResponse(nullptr, gsl::span<std::byte>(cacheResultIt->second)));
+        handleResponse(nullptr, std::span<std::byte>(cacheResultIt->second)));
   }
 
   return pAssetAccessor->get(asyncSystem, metadataUrl)

--- a/CesiumRasterOverlays/src/DebugColorizeTilesRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/DebugColorizeTilesRasterOverlay.cpp
@@ -48,8 +48,8 @@ public:
     image.channels = 4;
     image.bytesPerChannel = 1;
     image.pixelData.resize(4);
-    gsl::span<uint32_t> pixels =
-        reintepretCastSpan<uint32_t>(gsl::span(image.pixelData));
+    std::span<uint32_t> pixels =
+        reintepretCastSpan<uint32_t>(std::span(image.pixelData));
     int red = rand() % 255;
     int green = rand() % 255;
     int blue = rand() % 255;

--- a/CesiumRasterOverlays/src/QuadtreeRasterOverlayTileProvider.cpp
+++ b/CesiumRasterOverlays/src/QuadtreeRasterOverlayTileProvider.cpp
@@ -335,7 +335,7 @@ QuadtreeRasterOverlayTileProvider::getQuadtreeTile(
 
 #if SHOW_TILE_BOUNDARIES
               // Highlight the edges in red to show tile boundaries.
-              gsl::span<uint32_t> pixels =
+              std::span<uint32_t> pixels =
                   reintepretCastSpan<uint32_t, std::byte>(
                       loaded.image->pixelData);
               for (int32_t j = 0; j < loaded.pImage->height; ++j) {
@@ -729,7 +729,7 @@ QuadtreeRasterOverlayTileProvider::combineImages(
 
   // Highlight the edges in yellow to show tile boundaries.
 #if SHOW_TILE_BOUNDARIES
-  gsl::span<uint32_t> pixels =
+  std::span<uint32_t> pixels =
       reintepretCastSpan<uint32_t, std::byte>(result.pImage->pixelData);
   for (int32_t j = 0; j < result.pImage->height; ++j) {
     for (int32_t i = 0; i < result.pImage->width; ++i) {

--- a/CesiumRasterOverlays/src/RasterOverlayTileProvider.cpp
+++ b/CesiumRasterOverlays/src/RasterOverlayTileProvider.cpp
@@ -183,7 +183,7 @@ RasterOverlayTileProvider::loadTileImageFromUrl(
                   options.moreDetailAvailable};
             }
 
-            const gsl::span<const std::byte> data = pResponse->data();
+            const std::span<const std::byte> data = pResponse->data();
 
             CesiumGltfReader::ImageReaderResult loadedImage =
                 ImageDecoder::readImage(data, Ktx2TranscodeTargets);

--- a/CesiumRasterOverlays/src/RasterOverlayUtilities.cpp
+++ b/CesiumRasterOverlays/src/RasterOverlayUtilities.cpp
@@ -931,7 +931,7 @@ bool upsamplePrimitiveForRasterOverlays(
       std::numeric_limits<uint32_t>::max());
 
   // std::vector<unsigned char> newVertexBuffer(vertexSizeFloats *
-  // sizeof(float)); gsl::span<float>
+  // sizeof(float)); std::span<float>
   // newVertexFloats(reinterpret_cast<float*>(newVertexBuffer.data()),
   // newVertexBuffer.size() / sizeof(float));
   std::vector<float> newVertexFloats;

--- a/CesiumRasterOverlays/src/TileMapServiceRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/TileMapServiceRasterOverlay.cpp
@@ -183,7 +183,7 @@ Future<GetXmlDocumentResult> getXmlDocument(
                       "No response received from Tile Map Service."}));
             }
 
-            const gsl::span<const std::byte> data = pResponse->data();
+            const std::span<const std::byte> data = pResponse->data();
 
             std::unique_ptr<tinyxml2::XMLDocument> pDoc =
                 std::make_unique<tinyxml2::XMLDocument>(

--- a/CesiumRasterOverlays/src/WebMapServiceRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/WebMapServiceRasterOverlay.cpp
@@ -296,7 +296,7 @@ WebMapServiceRasterOverlay::createTileProvider(
                   "No response received from web map service."});
             }
 
-            const gsl::span<const std::byte> data = pResponse->data();
+            const std::span<const std::byte> data = pResponse->data();
 
             tinyxml2::XMLDocument doc;
             const tinyxml2::XMLError error = doc.Parse(

--- a/CesiumUtility/CMakeLists.txt
+++ b/CesiumUtility/CMakeLists.txt
@@ -47,5 +47,4 @@ target_link_libraries(
         spdlog::spdlog
         glm::glm
         uriparser::uriparser
-        Microsoft.GSL::GSL
 )

--- a/CesiumUtility/include/CesiumUtility/Assert.h
+++ b/CesiumUtility/include/CesiumUtility/Assert.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 //
 // Define our own assertion, so that users can forcebly turn them on if needed
 //
@@ -7,7 +9,7 @@
 // Asserts are defined in cassert and normally compiled out when NDEBUG is
 // defined. Redirect to our own assertion that can't be compiled out
 namespace CesiumUtility {
-void forceAssertFailure();
+std::int32_t forceAssertFailure();
 };
 #define CESIUM_ASSERT(expression)                                              \
   ((expression) ? 0 : CesiumUtility::forceAssertFailure())

--- a/CesiumUtility/include/CesiumUtility/Gzip.h
+++ b/CesiumUtility/include/CesiumUtility/Gzip.h
@@ -1,6 +1,5 @@
 #pragma once
-#include <gsl/span>
-
+#include <span>
 #include <vector>
 
 namespace CesiumUtility {
@@ -12,7 +11,7 @@ namespace CesiumUtility {
  *
  * @returns Whether the data is gzipped
  */
-bool isGzip(const gsl::span<const std::byte>& data);
+bool isGzip(const std::span<const std::byte>& data);
 
 /**
  * @brief Gzips data.
@@ -25,7 +24,7 @@ bool isGzip(const gsl::span<const std::byte>& data);
  *
  * @returns True if successful, false otherwise.
  */
-bool gzip(const gsl::span<const std::byte>& data, std::vector<std::byte>& out);
+bool gzip(const std::span<const std::byte>& data, std::vector<std::byte>& out);
 
 /**
  * @brief Gunzips data.
@@ -39,7 +38,7 @@ bool gzip(const gsl::span<const std::byte>& data, std::vector<std::byte>& out);
  * @returns True if successful, false otherwise.
  */
 bool gunzip(
-    const gsl::span<const std::byte>& data,
+    const std::span<const std::byte>& data,
     std::vector<std::byte>& out);
 
 } // namespace CesiumUtility

--- a/CesiumUtility/include/CesiumUtility/JsonValue.h
+++ b/CesiumUtility/include/CesiumUtility/JsonValue.h
@@ -2,8 +2,6 @@
 
 #include "Library.h"
 
-#include <gsl/narrow>
-
 #include <cmath>
 #include <cstdint>
 #include <initializer_list>
@@ -33,7 +31,7 @@ constexpr std::optional<T> losslessNarrow(U u) noexcept {
   constexpr const bool is_different_signedness =
       (std::is_signed<T>::value != std::is_signed<U>::value);
 
-  const T t = gsl::narrow_cast<T>(u);
+  const T t = static_cast<T>(u);
 
   if (static_cast<U>(t) != u ||
       (is_different_signedness && ((t < T{}) != (u < U{})))) {
@@ -48,7 +46,7 @@ constexpr T losslessNarrowOrDefault(U u, T defaultValue) noexcept {
   constexpr const bool is_different_signedness =
       (std::is_signed<T>::value != std::is_signed<U>::value);
 
-  const T t = gsl::narrow_cast<T>(u);
+  const T t = static_cast<T>(u);
 
   if (static_cast<U>(t) != u ||
       (is_different_signedness && ((t < T{}) != (u < U{})))) {
@@ -263,31 +261,28 @@ public:
    * @brief Converts the numerical value corresponding to the given key
    * to the provided numerical template type.
 
-   * If this instance is not a {@link JsonValue::Object}, throws
-   * `std::bad_variant_access`. If the key does not exist in this object, throws
-   * `JsonValueMissingKey`. If the named value does not have a numerical type T,
-   *  throws `JsonValueNotRealValue`, if the named value cannot be converted
-   from
-   * `double` / `std::uint64_t` / `std::int64_t` without precision loss, throws
-   * `gsl::narrowing_error`
+   * If this instance is not a {@link JsonValue::Object}, the key does not exist
+   * in this object, the named value does not have a numerical type, or if the
+   * named value cannot be converted from `double` / `std::uint64_t` /
+   * `std::int64_t` without precision loss, returns `std::nullopt`.
    * @tparam To The expected type of the value.
    * @param key The key for which to retrieve the value from this object.
-   * @return The converted value.
-   * @throws If unable to convert the converted value for one of the
-   aforementioned reasons.
+   * @return The converted value, or std::nullopt if it cannot be converted for
+   * any of the previously-mentioned reasons.
    * @remarks Compilation will fail if type 'To' is not an integral / float /
-   double type.
+   * double type.
    */
   template <
       typename To,
       typename std::enable_if<
           std::is_integral<To>::value ||
           std::is_floating_point<To>::value>::type* = nullptr>
-  [[nodiscard]] To getSafeNumericalValueForKey(const std::string& key) const {
+  [[nodiscard]] std::optional<To>
+  getSafeNumericalValueForKey(const std::string& key) const {
     const Object& pObject = std::get<Object>(this->value);
     const auto it = pObject.find(key);
     if (it == pObject.end()) {
-      throw JsonValueMissingKey(key);
+      return std::nullopt;
     }
     return it->second.getSafeNumber<To>();
   }
@@ -346,32 +341,31 @@ public:
    * type. This function should be used over `getDouble()` / `getUint64()` /
    * `getInt64()` if you plan on casting that type into another smaller type or
    * different type.
-   * @returns The converted type if it can be cast without precision loss.
-   * @throws If the underlying value is not a numerical type or it cannot be
-   *         converted without precision loss.
+   * @returns The converted type if it is numerical and it can be cast without
+   * precision loss; otherwise, std::nullopt.
    */
   template <
       typename To,
       typename std::enable_if<
           std::is_integral<To>::value ||
           std::is_floating_point<To>::value>::type* = nullptr>
-  [[nodiscard]] To getSafeNumber() const {
+  [[nodiscard]] std::optional<To> getSafeNumber() const {
     const std::uint64_t* uInt = std::get_if<std::uint64_t>(&this->value);
     if (uInt) {
-      return gsl::narrow<To>(*uInt);
+      return losslessNarrow<To>(*uInt);
     }
 
     const std::int64_t* sInt = std::get_if<std::int64_t>(&this->value);
     if (sInt) {
-      return gsl::narrow<To>(*sInt);
+      return losslessNarrow<To>(*sInt);
     }
 
     const double* real = std::get_if<double>(&this->value);
     if (real) {
-      return gsl::narrow<To>(*real);
+      return losslessNarrow<To>(*real);
     }
 
-    throw JsonValueNotRealValue();
+    return std::nullopt;
   }
 
   /**

--- a/CesiumUtility/include/CesiumUtility/SpanHelper.h
+++ b/CesiumUtility/include/CesiumUtility/SpanHelper.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <gsl/span>
+#include <span>
 
 namespace CesiumUtility {
 /**
@@ -10,8 +10,8 @@ namespace CesiumUtility {
  * carefully
  */
 template <typename To, typename From>
-gsl::span<To> reintepretCastSpan(const gsl::span<From>& from) noexcept {
-  return gsl::span<To>(
+std::span<To> reintepretCastSpan(const std::span<From>& from) noexcept {
+  return std::span<To>(
       reinterpret_cast<To*>(from.data()),
       from.size() * sizeof(From) / sizeof(To));
 }

--- a/CesiumUtility/src/Assert.cpp
+++ b/CesiumUtility/src/Assert.cpp
@@ -7,7 +7,10 @@
 #define NDEBUG
 
 namespace CesiumUtility {
-void forceAssertFailure() { assert(0 && "Assertion failed"); }
+std::int32_t forceAssertFailure() {
+  assert(0 && "Assertion failed");
+  return 1;
+}
 }; // namespace CesiumUtility
 
 #endif

--- a/CesiumUtility/src/Gzip.cpp
+++ b/CesiumUtility/src/Gzip.cpp
@@ -12,14 +12,14 @@ namespace {
 constexpr unsigned int ChunkSize = 65536;
 }
 
-bool isGzip(const gsl::span<const std::byte>& data) {
+bool isGzip(const std::span<const std::byte>& data) {
   if (data.size() < 3) {
     return false;
   }
   return data[0] == std::byte{31} && data[1] == std::byte{139};
 }
 
-bool gzip(const gsl::span<const std::byte>& data, std::vector<std::byte>& out) {
+bool gzip(const std::span<const std::byte>& data, std::vector<std::byte>& out) {
   int ret;
   unsigned int index = 0;
   zng_stream strm;
@@ -63,7 +63,7 @@ bool gzip(const gsl::span<const std::byte>& data, std::vector<std::byte>& out) {
 }
 
 bool gunzip(
-    const gsl::span<const std::byte>& data,
+    const std::span<const std::byte>& data,
     std::vector<std::byte>& out) {
   int ret;
   unsigned int index = 0;

--- a/CesiumUtility/test/TestSpanHelper.cpp
+++ b/CesiumUtility/test/TestSpanHelper.cpp
@@ -15,8 +15,8 @@ TEST_CASE("reintepretCastSpan") {
   value[5] = 1.0f;
   value[6] = 2.9f;
 
-  gsl::span<std::byte> byteView(data.data(), data.size());
-  gsl::span<float> floatView =
+  std::span<std::byte> byteView(data.data(), data.size());
+  std::span<float> floatView =
       CesiumUtility::reintepretCastSpan<float>(byteView);
   REQUIRE(floatView.size() == 7);
   REQUIRE(floatView[0] == 0.0f);
@@ -28,8 +28,8 @@ TEST_CASE("reintepretCastSpan") {
   REQUIRE(floatView[6] == 2.9f);
 
   std::vector<int32_t> intData{1, -1};
-  gsl::span<int32_t> intSpan = intData;
-  gsl::span<uint32_t> uintSpan =
+  std::span<int32_t> intSpan = intData;
+  std::span<uint32_t> uintSpan =
       CesiumUtility::reintepretCastSpan<uint32_t>(intSpan);
   REQUIRE(uintSpan.size() == 2);
   REQUIRE(uintSpan[0] == 1);

--- a/ThirdParty.json
+++ b/ThirdParty.json
@@ -36,12 +36,6 @@
     "license": ["MIT"]
   },
   {
-    "name": "GSL",
-    "url": "https://github.com/microsoft/GSL",
-    "version": "4.0.0",
-    "license": ["MIT"]
-  },
-  {
     "name": "KTX-Software",
     "url": "https://github.com/CesiumGS/KTX-Software",
     "version": "94764c270d43d90e4e4cedee6248753296f874b3",

--- a/tools/generate-classes/generate.js
+++ b/tools/generate-classes/generate.js
@@ -216,7 +216,7 @@ function generate(options, schema, writers) {
     #include <CesiumJsonReader/JsonReader.h>
     #include <CesiumJsonReader/JsonReaderOptions.h>
     #include <${namespace}/${name}.h>
-    #include <gsl/span>
+    #include <span>
     #include <rapidjson/fwd.h>
     #include <vector>
 
@@ -252,7 +252,7 @@ function generate(options, schema, writers) {
        * @param data The buffer from which to read the instance.
        * @return The result of reading the instance.
        */
-      CesiumJsonReader::ReadJsonResult<${namespace}::${name}> readFromJson(const gsl::span<const std::byte>& data) const;
+      CesiumJsonReader::ReadJsonResult<${namespace}::${name}> readFromJson(const std::span<const std::byte>& data) const;
 
       /**
        * @brief Reads an instance of ${name} from a rapidJson::Value.
@@ -375,7 +375,7 @@ function generate(options, schema, writers) {
           return this->_options;
         }
 
-        CesiumJsonReader::ReadJsonResult<${namespace}::${name}> ${name}Reader::readFromJson(const gsl::span<const std::byte>& data) const {
+        CesiumJsonReader::ReadJsonResult<${namespace}::${name}> ${name}Reader::readFromJson(const std::span<const std::byte>& data) const {
           ${name}JsonHandler handler(this->_options);
           return CesiumJsonReader::JsonReader::readJson(data, handler);
         }


### PR DESCRIPTION
This builds on #976, because it switches `gsl::span` to `std::span`, which was added in C++20.

This is necessary to use cesium-native in UE 5.5 (Preview) after it introduced a broken copy of GSL.