### PR TITLE
Add `default` constructor to `ImageAsset`

### DIFF
--- a/CesiumGltf/include/CesiumGltf/ImageAsset.h
+++ b/CesiumGltf/include/CesiumGltf/ImageAsset.h
@@ -114,8 +114,8 @@ struct CESIUMGLTF_API ImageAsset final
   int64_t sizeBytes = -1;
 
   /**
-  * @brief Constructs an empty image asset.
-  */
+   * @brief Constructs an empty image asset.
+   */
   ImageAsset() = default;
 
   /**

--- a/CesiumGltf/include/CesiumGltf/ImageAsset.h
+++ b/CesiumGltf/include/CesiumGltf/ImageAsset.h
@@ -114,6 +114,11 @@ struct CESIUMGLTF_API ImageAsset final
   int64_t sizeBytes = -1;
 
   /**
+  * @brief Constructs an empty image asset.
+  */
+  ImageAsset() = default;
+
+  /**
    * @brief Gets the size of this asset, in bytes.
    *
    * If {@link sizeBytes} is greater than or equal to zero, it is returned.


### PR DESCRIPTION
This is a small change to make the changes from #926 compatible with C++ 20. I previously got errors while trying to instantiate an empty `ImageAsset`, because its underlying `SharedAsset` constructor is `protected`. I'm not sure why this wasn't flagged in C++17,  but oh well :shrug: