### PR TITLE
Replace RasterOverlayTileProvider cache with SharedAssetDepot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@
 - Added support for `EXT_accessor_additional_types` in `AccessorView`.
 - Added `EllipsoidTilesetLoader` that will generate a tileset by tesselating the surface of an ellipsoid, producing a simple globe tileset without any terrain features.
 
+##### Fixes :wrench:
+
+- Updated the CMake install process to install the vcpkg-built Debug binaries in Debug builds. Previously the Release binaries were installed instead.
+
 ### v0.41.0 - 2024-11-01
 
 ##### Breaking Changes :mega:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ if(CESIUM_INSTALL_STATIC_LIBS OR CESIUM_INSTALL_HEADERS)
 
         if (CESIUM_INSTALL_STATIC_LIBS AND NOT PACKAGE IN_LIST CESIUM_EXCLUDE_INSTALL_STATIC_LIBS AND EXISTS ${PACKAGE_DIR}/lib)
             install(
-                DIRECTORY ${PACKAGE_DIR}/lib/
+                DIRECTORY $<IF:$<CONFIG:Debug>,${PACKAGE_DIR}/debug/lib/,${PACKAGE_DIR}/lib/>
                 DESTINATION ${CMAKE_INSTALL_LIBDIR}
             )
         endif()
@@ -134,7 +134,7 @@ if(CESIUM_INSTALL_STATIC_LIBS)
         message(DEBUG "PACKAGE_DIR ${PACKAGE_DIR}")
         if (NOT PACKAGE IN_LIST CESIUM_EXCLUDE_INSTALL_STATIC_LIBS AND EXISTS ${PACKAGE_DIR}/lib)
             install(
-                DIRECTORY ${PACKAGE_DIR}/lib/
+                DIRECTORY $<IF:$<CONFIG:Debug>,${PACKAGE_DIR}/debug/lib/,${PACKAGE_DIR}/lib/>
                 DESTINATION ${CMAKE_INSTALL_LIBDIR}
             )
         endif()

--- a/Cesium3DTiles/CMakeLists.txt
+++ b/Cesium3DTiles/CMakeLists.txt
@@ -46,7 +46,6 @@ target_include_directories(
         ${CMAKE_CURRENT_LIST_DIR}/include
         ${CMAKE_CURRENT_LIST_DIR}/generated/include
     PRIVATE
-        ${CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/src
         ${CMAKE_CURRENT_LIST_DIR}/generated/src
 )

--- a/Cesium3DTilesSelection/CMakeLists.txt
+++ b/Cesium3DTilesSelection/CMakeLists.txt
@@ -32,9 +32,6 @@ target_sources(
 target_include_directories(
     Cesium3DTilesSelection
     SYSTEM PUBLIC
-        ${CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR}
-        ${CESIUM_NATIVE_DRACO_INCLUDE_DIR}
-        ${CESIUM_NATIVE_LIBMORTON_INCUDE_DIR}
         ${CMAKE_BINARY_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/include
     PRIVATE

--- a/CesiumAsync/CMakeLists.txt
+++ b/CesiumAsync/CMakeLists.txt
@@ -31,7 +31,6 @@ target_sources(
 target_include_directories(
     CesiumAsync
     SYSTEM PUBLIC
-        ${CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/include
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/src/

--- a/CesiumGltf/CMakeLists.txt
+++ b/CesiumGltf/CMakeLists.txt
@@ -46,7 +46,6 @@ target_include_directories(
         ${CMAKE_CURRENT_LIST_DIR}/include/
         ${CMAKE_CURRENT_LIST_DIR}/generated/include
     PRIVATE
-        ${CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/src
         ${CMAKE_CURRENT_LIST_DIR}/generated/src
 )

--- a/CesiumGltfContent/CMakeLists.txt
+++ b/CesiumGltfContent/CMakeLists.txt
@@ -49,7 +49,6 @@ target_include_directories(
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/src
         ${CMAKE_CURRENT_LIST_DIR}/generated/src
-        ${CESIUM_NATIVE_STB_INCLUDE_DIR}
 )
 
 target_link_libraries(CesiumGltfContent

--- a/CesiumGltfReader/CMakeLists.txt
+++ b/CesiumGltfReader/CMakeLists.txt
@@ -44,12 +44,9 @@ target_sources(
 target_include_directories(
     CesiumGltfReader
     SYSTEM PUBLIC
-        # Necessary for `draco/draco_features.h`
-        ${CESIUM_NATIVE_DRACO_INCLUDE_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/include
         ${CMAKE_CURRENT_LIST_DIR}/generated/include
     PRIVATE
-        ${CESIUM_NATIVE_STB_INCLUDE_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/src
         ${CMAKE_CURRENT_LIST_DIR}/generated/src
 )

--- a/CesiumGltfWriter/CMakeLists.txt
+++ b/CesiumGltfWriter/CMakeLists.txt
@@ -40,19 +40,12 @@ target_sources(
         ${CESIUM_GLTF_WRITER_PUBLIC_HEADERS}
 )
 
-target_compile_definitions(
-    CesiumGltfWriter
-    PRIVATE
-        ${CESIUM_NATIVE_RAPIDJSON_DEFINES}
-)
-
 target_include_directories(
     CesiumGltfWriter
     SYSTEM PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include
         ${CMAKE_CURRENT_LIST_DIR}/generated/include
     PRIVATE
-        ${CESIUM_NATIVE_STB_INCLUDE_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/src
         ${CMAKE_CURRENT_LIST_DIR}/generated/src
 )

--- a/CesiumJsonWriter/CMakeLists.txt
+++ b/CesiumJsonWriter/CMakeLists.txt
@@ -37,16 +37,9 @@ target_sources(
         ${CESIUM_JSON_WRITER_PUBLIC_HEADERS}
 )
 
-target_compile_definitions(
-    CesiumJsonWriter
-    PRIVATE
-        ${CESIUM_NATIVE_RAPIDJSON_DEFINES}
-)
-
 target_include_directories(
     CesiumJsonWriter
     SYSTEM PUBLIC
-        ${CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/include
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/src

--- a/CesiumQuantizedMeshTerrain/CMakeLists.txt
+++ b/CesiumQuantizedMeshTerrain/CMakeLists.txt
@@ -47,7 +47,6 @@ target_include_directories(
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/generated/include>
         $<INSTALL_INTERFACE:include>
     PRIVATE
-        ${CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/src
         ${CMAKE_CURRENT_LIST_DIR}/generated/src
 )

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
@@ -61,6 +61,19 @@ struct CESIUMRASTEROVERLAYS_API LoadedRasterOverlayImage {
    * the bounds of this image.
    */
   bool moreDetailAvailable = false;
+
+   /**
+   * @brief Returns the size of this `LoadedRasterOverlayImage` in bytes.
+   */
+  size_t getSizeBytes() const {
+    int64_t accum = 0;
+    accum += sizeof(LoadedRasterOverlayImage);
+    accum += this->credits.capacity() * sizeof(CesiumUtility::Credit);
+    if (this->pImage) {
+      accum += this->pImage->getSizeBytes();
+    }
+    return accum;
+  }
 };
 
 /**

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
@@ -62,7 +62,7 @@ struct CESIUMRASTEROVERLAYS_API LoadedRasterOverlayImage {
    */
   bool moreDetailAvailable = false;
 
-   /**
+  /**
    * @brief Returns the size of this `LoadedRasterOverlayImage` in bytes.
    */
   size_t getSizeBytes() const {

--- a/CesiumRasterOverlays/src/QuadtreeRasterOverlayTileProvider.cpp
+++ b/CesiumRasterOverlays/src/QuadtreeRasterOverlayTileProvider.cpp
@@ -52,10 +52,83 @@ QuadtreeRasterOverlayTileProvider::QuadtreeRasterOverlayTileProvider(
       _maximumLevel(maximumLevel),
       _imageWidth(imageWidth),
       _imageHeight(imageHeight),
-      _tilingScheme(tilingScheme),
-      _tilesOldToRecent(),
-      _tileLookup(),
-      _cachedBytes(0) {}
+      _tilingScheme(tilingScheme) {
+  IntrusivePointer<QuadtreeRasterOverlayTileProvider> thisPtr{this};
+  _tileDepot.emplace(std::function(
+      [thisPtr](
+          const AsyncSystem& asyncSystem,
+          [[maybe_unused]] const std::shared_ptr<IAssetAccessor>&
+              pAssetAccessor,
+          const QuadtreeTileID& key)
+          -> Future<ResultPointer<LoadedQuadtreeImage>> {
+        return thisPtr->loadQuadtreeTileImage(key)
+            .catchImmediately([](std::exception&& e) {
+              // Turn an exception into an error.
+              LoadedRasterOverlayImage result;
+              result.errorList.emplaceError(e.what());
+              return result;
+            })
+            .thenImmediately([thisPtr,
+                              key,
+                              currentLevel = key.level,
+                              minimumLevel = thisPtr->getMinimumLevel(),
+                              asyncSystem](LoadedRasterOverlayImage&& loaded) {
+              if (loaded.pImage && !loaded.errorList.hasErrors() &&
+                  loaded.pImage->width > 0 && loaded.pImage->height > 0) {
+#if SHOW_TILE_BOUNDARIES
+                // Highlight the edges in red to show tile boundaries.
+                gsl::span<uint32_t> pixels =
+                    reintepretCastSpan<uint32_t, std::byte>(
+                        loaded.image->pixelData);
+                for (int32_t j = 0; j < loaded.pImage->height; ++j) {
+                  for (int32_t i = 0; i < loaded.pImage->width; ++i) {
+                    if (i == 0 || j == 0 || i == loaded.pImage->width - 1 ||
+                        j == loaded.pImage->height - 1) {
+                      pixels[j * loaded.pImage->width + i] = 0xFF0000FF;
+                    }
+                  }
+                }
+#endif
+                IntrusivePointer<LoadedQuadtreeImage> pLoadedImage;
+                pLoadedImage.emplace(
+                    std::make_shared<LoadedRasterOverlayImage>(
+                        std::move(loaded)),
+                    std::nullopt);
+                return asyncSystem.createResolvedFuture(
+                    ResultPointer<LoadedQuadtreeImage>(pLoadedImage));
+              }
+
+              // Tile failed to load, try loading the parent tile instead.
+              // We can only initiate a new tile request from the main thread,
+              // though.
+              if (currentLevel > minimumLevel) {
+                const Rectangle rectangle =
+                    thisPtr->getTilingScheme().tileToRectangle(key);
+                const QuadtreeTileID parentID(
+                    key.level - 1,
+                    key.x >> 1,
+                    key.y >> 1);
+                return thisPtr->getQuadtreeTile(parentID).thenImmediately(
+                    [rectangle](
+                        const ResultPointer<LoadedQuadtreeImage>& loaded) {
+                      if (loaded.pValue) {
+                        loaded.pValue->subset = rectangle;
+                      }
+                      return loaded;
+                    });
+              } else {
+                // No parent available, so return the original failed result.
+                IntrusivePointer<LoadedQuadtreeImage> pLoadedImage;
+                pLoadedImage.emplace(
+                    std::make_shared<LoadedRasterOverlayImage>(
+                        std::move(loaded)),
+                    std::nullopt);
+                return asyncSystem.createResolvedFuture(
+                    ResultPointer<LoadedQuadtreeImage>(pLoadedImage));
+              }
+            });
+      }));
+}
 
 uint32_t QuadtreeRasterOverlayTileProvider::computeLevelFromTargetScreenPixels(
     const CesiumGeometry::Rectangle& rectangle,
@@ -97,11 +170,12 @@ uint32_t QuadtreeRasterOverlayTileProvider::computeLevelFromTargetScreenPixels(
 }
 
 std::vector<CesiumAsync::SharedFuture<
-    QuadtreeRasterOverlayTileProvider::LoadedQuadtreeImage>>
+    ResultPointer<QuadtreeRasterOverlayTileProvider::LoadedQuadtreeImage>>>
 QuadtreeRasterOverlayTileProvider::mapRasterTilesToGeometryTile(
     const CesiumGeometry::Rectangle& geometryRectangle,
     const glm::dvec2 targetScreenPixels) {
-  std::vector<CesiumAsync::SharedFuture<LoadedQuadtreeImage>> result;
+  std::vector<CesiumAsync::SharedFuture<ResultPointer<LoadedQuadtreeImage>>>
+      result;
 
   const QuadtreeTilingScheme& imageryTilingScheme = this->getTilingScheme();
 
@@ -271,7 +345,7 @@ QuadtreeRasterOverlayTileProvider::mapRasterTilesToGeometryTile(
         continue;
       }
 
-      CesiumAsync::SharedFuture<LoadedQuadtreeImage> pTile =
+      CesiumAsync::SharedFuture<ResultPointer<LoadedQuadtreeImage>> pTile =
           this->getQuadtreeTile(QuadtreeTileID(level, i, j));
       result.emplace_back(std::move(pTile));
     }
@@ -281,101 +355,13 @@ QuadtreeRasterOverlayTileProvider::mapRasterTilesToGeometryTile(
 }
 
 CesiumAsync::SharedFuture<
-    QuadtreeRasterOverlayTileProvider::LoadedQuadtreeImage>
+    ResultPointer<QuadtreeRasterOverlayTileProvider::LoadedQuadtreeImage>>
 QuadtreeRasterOverlayTileProvider::getQuadtreeTile(
     const CesiumGeometry::QuadtreeTileID& tileID) {
-  auto lookupIt = this->_tileLookup.find(tileID);
-  if (lookupIt != this->_tileLookup.end()) {
-    auto& cacheIt = lookupIt->second;
-
-    // Move this entry to the end, indicating it's most recently used.
-    this->_tilesOldToRecent.splice(
-        this->_tilesOldToRecent.end(),
-        this->_tilesOldToRecent,
-        cacheIt);
-
-    return cacheIt->future;
-  }
-
-  // We create this lambda here instead of where it's used below so that we
-  // don't need to pass `this` through a thenImmediately lambda, which would
-  // create the possibility of accidentally using this pointer to a
-  // non-thread-safe object from another thread and creating a (potentially very
-  // subtle) race condition.
-  auto loadParentTile = [tileID, this]() {
-    const Rectangle rectangle = this->getTilingScheme().tileToRectangle(tileID);
-    const QuadtreeTileID parentID(
-        tileID.level - 1,
-        tileID.x >> 1,
-        tileID.y >> 1);
-    return this->getQuadtreeTile(parentID).thenImmediately(
-        [rectangle](const LoadedQuadtreeImage& loaded) {
-          return LoadedQuadtreeImage{loaded.pLoaded, rectangle};
-        });
-  };
-
-  Future<LoadedQuadtreeImage> future =
-      this->loadQuadtreeTileImage(tileID)
-          .catchImmediately([](std::exception&& e) {
-            // Turn an exception into an error.
-            LoadedRasterOverlayImage result;
-            result.errorList.emplaceError(e.what());
-            return result;
-          })
-          .thenImmediately([&cachedBytes = this->_cachedBytes,
-                            currentLevel = tileID.level,
-                            minimumLevel = this->getMinimumLevel(),
-                            asyncSystem = this->getAsyncSystem(),
-                            loadParentTile = std::move(loadParentTile)](
-                               LoadedRasterOverlayImage&& loaded) {
-            if (loaded.pImage && !loaded.errorList.hasErrors() &&
-                loaded.pImage->width > 0 && loaded.pImage->height > 0) {
-              // Successfully loaded, continue.
-              cachedBytes += int64_t(loaded.pImage->pixelData.size());
-
-#if SHOW_TILE_BOUNDARIES
-              // Highlight the edges in red to show tile boundaries.
-              gsl::span<uint32_t> pixels =
-                  reintepretCastSpan<uint32_t, std::byte>(
-                      loaded.image->pixelData);
-              for (int32_t j = 0; j < loaded.pImage->height; ++j) {
-                for (int32_t i = 0; i < loaded.pImage->width; ++i) {
-                  if (i == 0 || j == 0 || i == loaded.pImage->width - 1 ||
-                      j == loaded.pImage->height - 1) {
-                    pixels[j * loaded.pImage->width + i] = 0xFF0000FF;
-                  }
-                }
-              }
-#endif
-
-              return asyncSystem.createResolvedFuture(LoadedQuadtreeImage{
-                  std::make_shared<LoadedRasterOverlayImage>(std::move(loaded)),
-                  std::nullopt});
-            }
-
-            // Tile failed to load, try loading the parent tile instead.
-            // We can only initiate a new tile request from the main thread,
-            // though.
-            if (currentLevel > minimumLevel) {
-              return asyncSystem.runInMainThread(loadParentTile);
-            } else {
-              // No parent available, so return the original failed result.
-              return asyncSystem.createResolvedFuture(LoadedQuadtreeImage{
-                  std::make_shared<LoadedRasterOverlayImage>(std::move(loaded)),
-                  std::nullopt});
-            }
-          });
-
-  auto newIt = this->_tilesOldToRecent.emplace(
-      this->_tilesOldToRecent.end(),
-      CacheEntry{tileID, std::move(future).share()});
-  this->_tileLookup[tileID] = newIt;
-
-  SharedFuture<LoadedQuadtreeImage> result = newIt->future;
-
-  this->unloadCachedTiles();
-
-  return result;
+  return this->_tileDepot->getOrCreate(
+      this->getAsyncSystem(),
+      this->getAssetAccessor(),
+      tileID);
 }
 
 namespace {
@@ -445,95 +431,60 @@ QuadtreeRasterOverlayTileProvider::loadTileImage(
     RasterOverlayTile& overlayTile) {
   // Figure out which quadtree level we need, and which tiles from that level.
   // Load each needed tile (or pull it from cache).
-  std::vector<CesiumAsync::SharedFuture<LoadedQuadtreeImage>> tiles =
-      this->mapRasterTilesToGeometryTile(
+  std::vector<CesiumAsync::SharedFuture<ResultPointer<LoadedQuadtreeImage>>>
+      tiles = this->mapRasterTilesToGeometryTile(
           overlayTile.getRectangle(),
           overlayTile.getTargetScreenPixels());
 
   return this->getAsyncSystem()
       .all(std::move(tiles))
-      .thenInWorkerThread([projection = this->getProjection(),
-                           rectangle = overlayTile.getRectangle()](
-                              std::vector<LoadedQuadtreeImage>&& images) {
-        // This set of images is only "useful" if at least one actually has
-        // image data, and that image data is _not_ from an ancestor. We can
-        // identify ancestor images because they have a `subset`.
-        const bool haveAnyUsefulImageData = std::any_of(
-            images.begin(),
-            images.end(),
-            [](const LoadedQuadtreeImage& image) {
-              return image.pLoaded->pImage && !image.subset.has_value();
-            });
+      .thenInWorkerThread(
+          [projection = this->getProjection(),
+           rectangle = overlayTile.getRectangle()](
+              std::vector<ResultPointer<LoadedQuadtreeImage>>&& images) {
+            // This set of images is only "useful" if at least one actually has
+            // image data, and that image data is _not_ from an ancestor. We can
+            // identify ancestor images because they have a `subset`.
+            const bool haveAnyUsefulImageData = std::any_of(
+                images.begin(),
+                images.end(),
+                [](const ResultPointer<LoadedQuadtreeImage>& image) {
+                  return image.pValue && image.pValue->pLoaded->pImage &&
+                         !image.pValue->subset.has_value();
+                });
 
-        if (!haveAnyUsefulImageData) {
-          // For non-useful sets of images, just return an empty image,
-          // signalling that the parent tile should be used instead.
-          // See https://github.com/CesiumGS/cesium-native/issues/316 for an
-          // edge case that is not yet handled. Be sure to pass through any
-          // errors and warnings.
-          ErrorList errors;
-          for (LoadedQuadtreeImage& image : images) {
-            if (image.pLoaded) {
-              errors.merge(image.pLoaded->errorList);
+            if (!haveAnyUsefulImageData) {
+              // For non-useful sets of images, just return an empty image,
+              // signalling that the parent tile should be used instead.
+              // See https://github.com/CesiumGS/cesium-native/issues/316 for an
+              // edge case that is not yet handled. Be sure to pass through any
+              // errors and warnings.
+              ErrorList errors;
+              for (ResultPointer<LoadedQuadtreeImage>& image : images) {
+                if (image.pValue->pLoaded) {
+                  errors.merge(image.pValue->pLoaded->errorList);
+                }
+                errors.merge(image.errors);
+              }
+              return LoadedRasterOverlayImage{
+                  new ImageAsset(),
+                  Rectangle(),
+                  {},
+                  std::move(errors),
+                  false};
             }
-          }
-          return LoadedRasterOverlayImage{
-              new ImageAsset(),
-              Rectangle(),
-              {},
-              std::move(errors),
-              false};
-        }
 
-        return QuadtreeRasterOverlayTileProvider::combineImages(
-            rectangle,
-            projection,
-            std::move(images));
-      });
-}
-
-void QuadtreeRasterOverlayTileProvider::unloadCachedTiles() {
-  CESIUM_TRACE("QuadtreeRasterOverlayTileProvider::unloadCachedTiles");
-
-  const int64_t maxCacheBytes = this->getOwner().getOptions().subTileCacheBytes;
-  if (this->_cachedBytes <= maxCacheBytes) {
-    return;
-  }
-
-  auto it = this->_tilesOldToRecent.begin();
-
-  while (it != this->_tilesOldToRecent.end() &&
-         this->_cachedBytes > maxCacheBytes) {
-    const SharedFuture<LoadedQuadtreeImage>& future = it->future;
-    if (!future.isReady()) {
-      // Don't unload tiles that are still loading.
-      ++it;
-      continue;
-    }
-
-    // Guaranteed not to block because isReady returned true.
-    const LoadedQuadtreeImage& image = future.wait();
-
-    std::shared_ptr<LoadedRasterOverlayImage> pImage = image.pLoaded;
-
-    this->_tileLookup.erase(it->tileID);
-    it = this->_tilesOldToRecent.erase(it);
-
-    // If this is the last use of this data, it will be freed when the shared
-    // pointer goes out of scope, so reduce the cachedBytes accordingly.
-    if (pImage.use_count() == 1) {
-      if (pImage->pImage) {
-        this->_cachedBytes -= int64_t(pImage->pImage->pixelData.size());
-        CESIUM_ASSERT(this->_cachedBytes >= 0);
-      }
-    }
-  }
+            return QuadtreeRasterOverlayTileProvider::combineImages(
+                rectangle,
+                projection,
+                std::move(images));
+          });
 }
 
 /*static*/ QuadtreeRasterOverlayTileProvider::CombinedImageMeasurements
 QuadtreeRasterOverlayTileProvider::measureCombinedImage(
     const Rectangle& targetRectangle,
-    const std::vector<LoadedQuadtreeImage>& images) {
+    const std::vector<ResultPointer<LoadedQuadtreeImage>>& images) {
   // Find the image with the densest pixels, and use that to select the
   // resolution of the target image.
 
@@ -547,8 +498,11 @@ QuadtreeRasterOverlayTileProvider::measureCombinedImage(
   double projectedHeightPerPixel = std::numeric_limits<double>::max();
   int32_t channels = -1;
   int32_t bytesPerChannel = -1;
-  for (const LoadedQuadtreeImage& image : images) {
-    const LoadedRasterOverlayImage& loaded = *image.pLoaded;
+  for (const ResultPointer<LoadedQuadtreeImage>& image : images) {
+    if (!image.pValue) {
+      continue;
+    }
+    const LoadedRasterOverlayImage& loaded = *image.pValue->pLoaded;
     if (!loaded.pImage || loaded.pImage->width <= 0 ||
         loaded.pImage->height <= 0) {
       continue;
@@ -567,15 +521,19 @@ QuadtreeRasterOverlayTileProvider::measureCombinedImage(
 
   std::optional<Rectangle> combinedRectangle;
 
-  for (const LoadedQuadtreeImage& image : images) {
-    const LoadedRasterOverlayImage& loaded = *image.pLoaded;
+  for (const ResultPointer<LoadedQuadtreeImage>& image : images) {
+    if (!image.pValue) {
+      continue;
+    }
+    const LoadedRasterOverlayImage& loaded = *image.pValue->pLoaded;
     if (!loaded.pImage || loaded.pImage->width <= 0 ||
         loaded.pImage->height <= 0) {
       continue;
     }
 
     // The portion of the source that we actually need to copy.
-    const Rectangle sourceSubset = image.subset.value_or(loaded.rectangle);
+    const Rectangle sourceSubset =
+        image.pValue->subset.value_or(loaded.rectangle);
 
     // Find the bounds of the combined image.
     // Intersect the loaded image's rectangle with the target rectangle.
@@ -649,12 +607,13 @@ QuadtreeRasterOverlayTileProvider::measureCombinedImage(
 QuadtreeRasterOverlayTileProvider::combineImages(
     const Rectangle& targetRectangle,
     const Projection& /* projection */,
-    std::vector<LoadedQuadtreeImage>&& images) {
+    std::vector<ResultPointer<LoadedQuadtreeImage>>&& images) {
   ErrorList errors;
-  for (LoadedQuadtreeImage& image : images) {
-    if (image.pLoaded) {
-      errors.merge(std::move(image.pLoaded->errorList));
+  for (ResultPointer<LoadedQuadtreeImage>& image : images) {
+    if (image.pValue && image.pValue->pLoaded) {
+      errors.merge(std::move(image.pValue->pLoaded->errorList));
     }
+    errors.merge(image.errors);
   }
 
   const CombinedImageMeasurements measurements =
@@ -690,7 +649,10 @@ QuadtreeRasterOverlayTileProvider::combineImages(
       target.width * target.height * target.channels * target.bytesPerChannel));
 
   for (auto it = images.begin(); it != images.end(); ++it) {
-    const LoadedRasterOverlayImage& loaded = *it->pLoaded;
+    if (!it->pValue) {
+      continue;
+    }
+    const LoadedRasterOverlayImage& loaded = *it->pValue->pLoaded;
     if (!loaded.pImage) {
       continue;
     }
@@ -702,12 +664,15 @@ QuadtreeRasterOverlayTileProvider::combineImages(
         result.rectangle,
         *loaded.pImage,
         loaded.rectangle,
-        it->subset);
+        it->pValue->subset);
   }
 
   size_t combinedCreditsCount = 0;
   for (auto it = images.begin(); it != images.end(); ++it) {
-    const LoadedRasterOverlayImage& loaded = *it->pLoaded;
+    if (!it->pValue) {
+      continue;
+    }
+    const LoadedRasterOverlayImage& loaded = *it->pValue->pLoaded;
     if (!loaded.pImage) {
       continue;
     }
@@ -717,7 +682,10 @@ QuadtreeRasterOverlayTileProvider::combineImages(
 
   result.credits.reserve(combinedCreditsCount);
   for (auto it = images.begin(); it != images.end(); ++it) {
-    const LoadedRasterOverlayImage& loaded = *it->pLoaded;
+    if (!it->pValue) {
+      continue;
+    }
+    const LoadedRasterOverlayImage& loaded = *it->pValue->pLoaded;
     if (!loaded.pImage) {
       continue;
     }

--- a/CesiumRasterOverlays/src/QuadtreeRasterOverlayTileProvider.cpp
+++ b/CesiumRasterOverlays/src/QuadtreeRasterOverlayTileProvider.cpp
@@ -53,25 +53,25 @@ QuadtreeRasterOverlayTileProvider::QuadtreeRasterOverlayTileProvider(
       _imageWidth(imageWidth),
       _imageHeight(imageHeight),
       _tilingScheme(tilingScheme) {
-  IntrusivePointer<QuadtreeRasterOverlayTileProvider> thisPtr{this};
+  IntrusivePointer<QuadtreeRasterOverlayTileProvider> pThis{this};
   _tileDepot.emplace(std::function(
-      [thisPtr](
+      [pThis](
           const AsyncSystem& asyncSystem,
           [[maybe_unused]] const std::shared_ptr<IAssetAccessor>&
               pAssetAccessor,
           const QuadtreeTileID& key)
           -> Future<ResultPointer<LoadedQuadtreeImage>> {
-        return thisPtr->loadQuadtreeTileImage(key)
+        return pThis->loadQuadtreeTileImage(key)
             .catchImmediately([](std::exception&& e) {
               // Turn an exception into an error.
               LoadedRasterOverlayImage result;
               result.errorList.emplaceError(e.what());
               return result;
             })
-            .thenImmediately([thisPtr,
+            .thenImmediately([pThis,
                               key,
                               currentLevel = key.level,
-                              minimumLevel = thisPtr->getMinimumLevel(),
+                              minimumLevel = pThis->getMinimumLevel(),
                               asyncSystem](LoadedRasterOverlayImage&& loaded) {
               if (loaded.pImage && !loaded.errorList.hasErrors() &&
                   loaded.pImage->width > 0 && loaded.pImage->height > 0) {
@@ -103,12 +103,12 @@ QuadtreeRasterOverlayTileProvider::QuadtreeRasterOverlayTileProvider(
               // though.
               if (currentLevel > minimumLevel) {
                 const Rectangle rectangle =
-                    thisPtr->getTilingScheme().tileToRectangle(key);
+                    pThis->getTilingScheme().tileToRectangle(key);
                 const QuadtreeTileID parentID(
                     key.level - 1,
                     key.x >> 1,
                     key.y >> 1);
-                return thisPtr->getQuadtreeTile(parentID).thenImmediately(
+                return pThis->getQuadtreeTile(parentID).thenImmediately(
                     [rectangle](
                         const ResultPointer<LoadedQuadtreeImage>& loaded) {
                       if (loaded.pValue) {

--- a/CesiumUtility/CMakeLists.txt
+++ b/CesiumUtility/CMakeLists.txt
@@ -33,7 +33,6 @@ target_include_directories(
     CesiumUtility
     SYSTEM PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include
-        ${CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR}
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/src
         ${CMAKE_CURRENT_BINARY_DIR}/../extern/zlib


### PR DESCRIPTION
There is currently a cache in the `QuadtreeRasterOverlayTileProvider` to hopefully prevent the same images from being downloaded multiple times when they're used by multiple different geometry tiles. There is currently a bug that will result in the overlay provider believing that the cache is full when it's not, making the cache eventually all but useless. As mentioned in #958, the issue for this bug, now that we have the `SharedAsset` system, it makes sense to just get rid of that old cache code and use a `SharedAssetDepot` instead. That's what this PR is for.

While this PR currently implements the cache on the RasterOverlayTileProvider base class itself, it will only actually be used when the `loadTileImageFromUrl` method is called, and only `QuadtreeRasterOverlayTileProvider`-derived classes seem to call this method.

While this PR is in good working order, at least from my testing, it feels like it loads raster overlays slower than it did previously. This isn't a particularly surprising issue to occur after these changes, but it does need to be fixed. I'll try to get to the bottom of this on Monday.