### PR TITLE
Remove old `CESIUM_NATIVE_` CMake variables

### DIFF
--- a/Cesium3DTiles/CMakeLists.txt
+++ b/Cesium3DTiles/CMakeLists.txt
@@ -46,7 +46,6 @@ target_include_directories(
         ${CMAKE_CURRENT_LIST_DIR}/include
         ${CMAKE_CURRENT_LIST_DIR}/generated/include
     PRIVATE
-        ${CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/src
         ${CMAKE_CURRENT_LIST_DIR}/generated/src
 )

--- a/Cesium3DTilesSelection/CMakeLists.txt
+++ b/Cesium3DTilesSelection/CMakeLists.txt
@@ -32,9 +32,6 @@ target_sources(
 target_include_directories(
     Cesium3DTilesSelection
     SYSTEM PUBLIC
-        ${CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR}
-        ${CESIUM_NATIVE_DRACO_INCLUDE_DIR}
-        ${CESIUM_NATIVE_LIBMORTON_INCUDE_DIR}
         ${CMAKE_BINARY_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/include
     PRIVATE

--- a/CesiumAsync/CMakeLists.txt
+++ b/CesiumAsync/CMakeLists.txt
@@ -31,7 +31,6 @@ target_sources(
 target_include_directories(
     CesiumAsync
     SYSTEM PUBLIC
-        ${CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/include
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/src/

--- a/CesiumGltf/CMakeLists.txt
+++ b/CesiumGltf/CMakeLists.txt
@@ -46,7 +46,6 @@ target_include_directories(
         ${CMAKE_CURRENT_LIST_DIR}/include/
         ${CMAKE_CURRENT_LIST_DIR}/generated/include
     PRIVATE
-        ${CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/src
         ${CMAKE_CURRENT_LIST_DIR}/generated/src
 )

--- a/CesiumGltfContent/CMakeLists.txt
+++ b/CesiumGltfContent/CMakeLists.txt
@@ -49,7 +49,6 @@ target_include_directories(
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/src
         ${CMAKE_CURRENT_LIST_DIR}/generated/src
-        ${CESIUM_NATIVE_STB_INCLUDE_DIR}
 )
 
 target_link_libraries(CesiumGltfContent

--- a/CesiumGltfReader/CMakeLists.txt
+++ b/CesiumGltfReader/CMakeLists.txt
@@ -44,12 +44,9 @@ target_sources(
 target_include_directories(
     CesiumGltfReader
     SYSTEM PUBLIC
-        # Necessary for `draco/draco_features.h`
-        ${CESIUM_NATIVE_DRACO_INCLUDE_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/include
         ${CMAKE_CURRENT_LIST_DIR}/generated/include
     PRIVATE
-        ${CESIUM_NATIVE_STB_INCLUDE_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/src
         ${CMAKE_CURRENT_LIST_DIR}/generated/src
 )

--- a/CesiumGltfWriter/CMakeLists.txt
+++ b/CesiumGltfWriter/CMakeLists.txt
@@ -40,19 +40,12 @@ target_sources(
         ${CESIUM_GLTF_WRITER_PUBLIC_HEADERS}
 )
 
-target_compile_definitions(
-    CesiumGltfWriter
-    PRIVATE
-        ${CESIUM_NATIVE_RAPIDJSON_DEFINES}
-)
-
 target_include_directories(
     CesiumGltfWriter
     SYSTEM PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include
         ${CMAKE_CURRENT_LIST_DIR}/generated/include
     PRIVATE
-        ${CESIUM_NATIVE_STB_INCLUDE_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/src
         ${CMAKE_CURRENT_LIST_DIR}/generated/src
 )

--- a/CesiumJsonWriter/CMakeLists.txt
+++ b/CesiumJsonWriter/CMakeLists.txt
@@ -37,16 +37,9 @@ target_sources(
         ${CESIUM_JSON_WRITER_PUBLIC_HEADERS}
 )
 
-target_compile_definitions(
-    CesiumJsonWriter
-    PRIVATE
-        ${CESIUM_NATIVE_RAPIDJSON_DEFINES}
-)
-
 target_include_directories(
     CesiumJsonWriter
     SYSTEM PUBLIC
-        ${CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/include
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/src

--- a/CesiumQuantizedMeshTerrain/CMakeLists.txt
+++ b/CesiumQuantizedMeshTerrain/CMakeLists.txt
@@ -47,7 +47,6 @@ target_include_directories(
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/generated/include>
         $<INSTALL_INTERFACE:include>
     PRIVATE
-        ${CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/src
         ${CMAKE_CURRENT_LIST_DIR}/generated/src
 )

--- a/CesiumUtility/CMakeLists.txt
+++ b/CesiumUtility/CMakeLists.txt
@@ -33,7 +33,6 @@ target_include_directories(
     CesiumUtility
     SYSTEM PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include
-        ${CESIUM_NATIVE_RAPIDJSON_INCLUDE_DIR}
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/src
         ${CMAKE_CURRENT_BINARY_DIR}/../extern/zlib


### PR DESCRIPTION
I don't think these are needed anymore after the switch to vcpkg