### PR TITLE
Schema is a struct not a class.

### DIFF
--- a/CesiumGltfReader/include/CesiumGltfReader/GltfSharedAssetSystem.h
+++ b/CesiumGltfReader/include/CesiumGltfReader/GltfSharedAssetSystem.h
@@ -5,7 +5,7 @@
 #include <CesiumGltfReader/NetworkSchemaAssetDescriptor.h>
 
 namespace CesiumGltf {
-class Schema;
+struct Schema;
 }
 
 namespace CesiumGltfReader {


### PR DESCRIPTION
This showed up as a compiler error when building Cesium for Unreal against the latest version of cesium-native in main.