### PR TITLE
Add checks for `nullptr` credit system in raster overlays

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 ##### Fixes :wrench:
 
 - Updated the CMake install process to install the vcpkg-built Debug binaries in Debug builds. Previously the Release binaries were installed instead.
+- Fixed a crash that would occur for raster overlays attempting to dereference a null `CreditSystem`.
 
 ### v0.41.0 - 2024-11-01
 

--- a/CesiumRasterOverlays/src/BingMapsRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/BingMapsRasterOverlay.cpp
@@ -266,13 +266,18 @@ namespace {
  * @param pResource The JSON value for the resource
  * @param pCreditSystem The `CreditSystem` that will create one credit for
  * each attribution
- * @return The `CreditAndCoverageAreas` objects that have been parsed
+ * @return The `CreditAndCoverageAreas` objects that have been parsed, or an
+ * empty vector if pCreditSystem is nulpltr.
  */
 std::vector<CreditAndCoverageAreas> collectCredits(
     const rapidjson::Value* pResource,
     const std::shared_ptr<CreditSystem>& pCreditSystem,
     bool showCreditsOnScreen) {
   std::vector<CreditAndCoverageAreas> credits;
+  if (!pCreditSystem) {
+    return credits;
+  }
+
   const auto attributionsIt = pResource->FindMember("imageryProviders");
   if (attributionsIt != pResource->MemberEnd() &&
       attributionsIt->value.IsArray()) {

--- a/CesiumRasterOverlays/src/BingMapsRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/BingMapsRasterOverlay.cpp
@@ -267,7 +267,7 @@ namespace {
  * @param pCreditSystem The `CreditSystem` that will create one credit for
  * each attribution
  * @return The `CreditAndCoverageAreas` objects that have been parsed, or an
- * empty vector if pCreditSystem is nulpltr.
+ * empty vector if pCreditSystem is nullptr.
  */
 std::vector<CreditAndCoverageAreas> collectCredits(
     const rapidjson::Value* pResource,

--- a/CesiumRasterOverlays/src/TileMapServiceRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/TileMapServiceRasterOverlay.cpp
@@ -280,11 +280,12 @@ TileMapServiceRasterOverlay::createTileProvider(
 
   pOwner = pOwner ? pOwner : this;
 
-  const std::optional<Credit> credit =
-      this->_options.credit ? std::make_optional(pCreditSystem->createCredit(
-                                  this->_options.credit.value(),
-                                  pOwner->getOptions().showCreditsOnScreen))
-                            : std::nullopt;
+  std::optional<Credit> credit = std::nullopt;
+  if (pCreditSystem && this->_options.credit) {
+    credit = pCreditSystem->createCredit(
+        *this->_options.credit,
+        pOwner->getOptions().showCreditsOnScreen);
+  }
 
   return getXmlDocument(asyncSystem, pAssetAccessor, xmlUrl, this->_headers)
       .thenInMainThread(

--- a/CesiumRasterOverlays/src/WebMapServiceRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/WebMapServiceRasterOverlay.cpp
@@ -270,10 +270,12 @@ WebMapServiceRasterOverlay::createTileProvider(
 
   pOwner = pOwner ? pOwner : this;
 
-  const std::optional<Credit> credit =
-      this->_options.credit ? std::make_optional(pCreditSystem->createCredit(
-                                  this->_options.credit.value()))
-                            : std::nullopt;
+  std::optional<Credit> credit = std::nullopt;
+  if (pCreditSystem && this->_options.credit) {
+    credit = pCreditSystem->createCredit(
+        *this->_options.credit,
+        pOwner->getOptions().showCreditsOnScreen);
+  }
 
   return pAssetAccessor->get(asyncSystem, xmlUrlGetcapabilities, this->_headers)
       .thenInMainThread(

--- a/CesiumRasterOverlays/src/WebMapTileServiceRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/WebMapTileServiceRasterOverlay.cpp
@@ -193,11 +193,12 @@ WebMapTileServiceRasterOverlay::createTileProvider(
 
   pOwner = pOwner ? pOwner : this;
 
-  const std::optional<Credit> credit =
-      this->_options.credit ? std::make_optional(pCreditSystem->createCredit(
-                                  this->_options.credit.value(),
-                                  pOwner->getOptions().showCreditsOnScreen))
-                            : std::nullopt;
+  std::optional<Credit> credit = std::nullopt;
+  if (pCreditSystem && this->_options.credit) {
+    credit = pCreditSystem->createCredit(
+        *this->_options.credit,
+        pOwner->getOptions().showCreditsOnScreen);
+  }
 
   bool hasError = false;
   std::string errorMessage;

--- a/CesiumRasterOverlays/test/TestTileMapServiceRasterOverlay.cpp
+++ b/CesiumRasterOverlays/test/TestTileMapServiceRasterOverlay.cpp
@@ -198,4 +198,56 @@ TEST_CASE("TileMapServiceRasterOverlay") {
 
     REQUIRE(result);
   }
+
+  SECTION("loads with credit") {
+    TileMapServiceRasterOverlayOptions options;
+    options.credit = "test credit";
+    IntrusivePointer<TileMapServiceRasterOverlay> pRasterOverlayWithCredit =
+        new TileMapServiceRasterOverlay("test", tmr, {}, options);
+
+    std::shared_ptr<CreditSystem> pCreditSystem =
+        std::make_shared<CreditSystem>();
+
+    RasterOverlay::CreateTileProviderResult result = waitForFuture(
+        asyncSystem,
+        pRasterOverlayWithCredit->createTileProvider(
+            asyncSystem,
+            pMockAssetAccessor,
+            pCreditSystem,
+            nullptr,
+            spdlog::default_logger(),
+            nullptr));
+
+    REQUIRE(result);
+
+    CesiumUtility::IntrusivePointer<RasterOverlayTileProvider> pTileProvider =
+        *result;
+    std::optional<Credit> maybeCredit = pTileProvider->getCredit();
+
+    REQUIRE(maybeCredit);
+    CHECK(pCreditSystem->getHtml(*maybeCredit) == "test credit");
+  }
+
+  SECTION("loads with credit and null credit system") {
+    TileMapServiceRasterOverlayOptions options;
+    options.credit = "test credit";
+    IntrusivePointer<TileMapServiceRasterOverlay> pRasterOverlayWithCredit =
+        new TileMapServiceRasterOverlay("test", tmr, {}, options);
+
+    RasterOverlay::CreateTileProviderResult result = waitForFuture(
+        asyncSystem,
+        pRasterOverlayWithCredit->createTileProvider(
+            asyncSystem,
+            pMockAssetAccessor,
+            nullptr,
+            nullptr,
+            spdlog::default_logger(),
+            nullptr));
+
+    REQUIRE(result);
+
+    CesiumUtility::IntrusivePointer<RasterOverlayTileProvider> pTileProvider =
+        *result;
+    CHECK(!pTileProvider->getCredit());
+  }
 }


### PR DESCRIPTION
Part of the fix for https://github.com/CesiumGS/cesium-unreal/issues/1549. This adds checks for a null `CreditSystem` to the various overlay types.

TMS is the only raster overlay type with unit tests, so that was the only one I was able to verify via test. But the change is similar for the other raster overlay types, so hopefully it's sufficient.