### PR TITLE
Eliminate variable shadowing in JsonValue

### DIFF
--- a/CesiumUtility/include/CesiumUtility/JsonValue.h
+++ b/CesiumUtility/include/CesiumUtility/JsonValue.h
@@ -625,32 +625,34 @@ public:
    */
   int64_t getSizeBytes() const noexcept {
     struct Operation {
-      int64_t operator()([[maybe_unused]] const Null& value) { return 0; }
-      int64_t operator()([[maybe_unused]] const double& value) { return 0; }
-      int64_t operator()([[maybe_unused]] const std::uint64_t& value) {
+      int64_t operator()([[maybe_unused]] const Null& /*inside*/) { return 0; }
+      int64_t operator()([[maybe_unused]] const double& /*inside*/) {
         return 0;
       }
-      int64_t operator()([[maybe_unused]] const std::int64_t& value) {
+      int64_t operator()([[maybe_unused]] const std::uint64_t& /*inside*/) {
         return 0;
       }
-      int64_t operator()([[maybe_unused]] const Bool& value) { return 0; }
-      int64_t operator()(const String& value) {
-        return value.capacity() * sizeof(char);
+      int64_t operator()([[maybe_unused]] const std::int64_t& /*inside*/) {
+        return 0;
       }
-      int64_t operator()(const Object& value) {
+      int64_t operator()([[maybe_unused]] const Bool& /*inside*/) { return 0; }
+      int64_t operator()(const String& inside) {
+        return inside.capacity() * sizeof(char);
+      }
+      int64_t operator()(const Object& inside) {
         int64_t accum = 0;
-        accum += value.size() * (sizeof(std::string) + sizeof(JsonValue));
-        for (const auto& [k, v] : value) {
+        accum += inside.size() * (sizeof(std::string) + sizeof(JsonValue));
+        for (const auto& [k, v] : inside) {
           accum += k.capacity() * sizeof(char) - sizeof(std::string);
           accum += v.getSizeBytes() - sizeof(JsonValue);
         }
 
         return accum;
       }
-      int64_t operator()(const Array& value) {
+      int64_t operator()(const Array& inside) {
         int64_t accum = 0;
-        accum += sizeof(JsonValue) * value.capacity();
-        for (const JsonValue& v : value) {
+        accum += sizeof(JsonValue) * inside.capacity();
+        for (const JsonValue& v : inside) {
           accum += v.getSizeBytes() - sizeof(JsonValue);
         }
         return accum;


### PR DESCRIPTION
Because Clang gets upset about this in the cesium-unreal build.