### PR TITLE
Clean up raster overlay handling of ellipsoids

### DIFF
--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/BingMapsRasterOverlay.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/BingMapsRasterOverlay.h
@@ -96,8 +96,6 @@ public:
    * all cultures are supported. See
    * http://msdn.microsoft.com/en-us/library/hh441729.aspx for information on
    * the supported cultures.
-   * @param ellipsoid The ellipsoid. Default value:
-   * {@link CesiumGeospatial::Ellipsoid::WGS84}.
    * @param overlayOptions The {@link RasterOverlayOptions} for this instance.
    */
   BingMapsRasterOverlay(
@@ -106,8 +104,6 @@ public:
       const std::string& key,
       const std::string& mapStyle = BingMapsStyle::AERIAL,
       const std::string& culture = "",
-      const CesiumGeospatial::Ellipsoid& ellipsoid =
-          CesiumGeospatial::Ellipsoid::WGS84,
       const RasterOverlayOptions& overlayOptions = {});
   virtual ~BingMapsRasterOverlay() override;
 
@@ -128,7 +124,6 @@ private:
   std::string _key;
   std::string _mapStyle;
   std::string _culture;
-  CesiumGeospatial::Ellipsoid _ellipsoid;
 };
 
 } // namespace CesiumRasterOverlays

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/DebugColorizeTilesRasterOverlay.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/DebugColorizeTilesRasterOverlay.h
@@ -32,9 +32,6 @@ public:
       const std::shared_ptr<spdlog::logger>& pLogger,
       CesiumUtility::IntrusivePointer<const RasterOverlay> pOwner)
       const override;
-
-private:
-  CesiumGeospatial::Ellipsoid _ellipsoid;
 };
 
 } // namespace CesiumRasterOverlays

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlay.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlay.h
@@ -112,7 +112,7 @@ struct CESIUMRASTEROVERLAYS_API RasterOverlayOptions {
   /**
    * @brief The ellipsoid used for this raster overlay.
    */
-  std::optional<CesiumGeospatial::Ellipsoid> ellipsoid = std::nullopt;
+  CesiumGeospatial::Ellipsoid ellipsoid = CesiumGeospatial::Ellipsoid::WGS84;
 };
 
 /**

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/TileMapServiceRasterOverlay.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/TileMapServiceRasterOverlay.h
@@ -63,15 +63,6 @@ struct TileMapServiceRasterOverlayOptions {
   std::optional<CesiumGeometry::QuadtreeTilingScheme> tilingScheme;
 
   /**
-   * @brief The {@link CesiumGeospatial::Ellipsoid}.
-   *
-   * If the `tilingScheme` is specified, this parameter is ignored and
-   * the tiling scheme's ellipsoid is used instead. If neither parameter
-   * is specified, the {@link CesiumGeospatial::Ellipsoid::WGS84} is used.
-   */
-  std::optional<CesiumGeospatial::Ellipsoid> ellipsoid;
-
-  /**
    * @brief Pixel width of image tiles.
    */
   std::optional<uint32_t> tileWidth;

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/WebMapServiceRasterOverlay.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/WebMapServiceRasterOverlay.h
@@ -62,11 +62,6 @@ struct WebMapServiceRasterOverlayOptions {
    * @brief Pixel height of image tiles.
    */
   int32_t tileHeight = 256;
-
-  /**
-   * @brief The ellipsoid used for this overlay.
-   */
-  std::optional<CesiumGeospatial::Ellipsoid> ellipsoid = std::nullopt;
 };
 
 /**

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/WebMapTileServiceRasterOverlay.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/WebMapTileServiceRasterOverlay.h
@@ -96,15 +96,6 @@ struct WebMapTileServiceRasterOverlayOptions {
   std::optional<CesiumGeometry::QuadtreeTilingScheme> tilingScheme;
 
   /**
-   * @brief The {@link CesiumGeospatial::Ellipsoid}.
-   *
-   * If the `tilingScheme` is specified, this parameter is ignored and
-   * the tiling scheme's ellipsoid is used instead. If neither parameter
-   * is specified, the {@link CesiumGeospatial::Ellipsoid::WGS84} is used.
-   */
-  std::optional<CesiumGeospatial::Ellipsoid> ellipsoid;
-
-  /**
    * @brief A object containing static dimensions and their values.
    */
   std::optional<std::map<std::string, std::string>> dimensions;

--- a/CesiumRasterOverlays/src/BingMapsRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/BingMapsRasterOverlay.cpp
@@ -229,14 +229,12 @@ BingMapsRasterOverlay::BingMapsRasterOverlay(
     const std::string& key,
     const std::string& mapStyle,
     const std::string& culture,
-    const Ellipsoid& ellipsoid,
     const RasterOverlayOptions& overlayOptions)
     : RasterOverlay(name, overlayOptions),
       _url(url),
       _key(key),
       _mapStyle(mapStyle),
-      _culture(culture),
-      _ellipsoid(ellipsoid) {}
+      _culture(culture) {}
 
 BingMapsRasterOverlay::~BingMapsRasterOverlay() {}
 
@@ -351,7 +349,7 @@ BingMapsRasterOverlay::createTileProvider(
 
   pOwner = pOwner ? pOwner : this;
 
-  const CesiumGeospatial::Ellipsoid& ellipsoid = this->_ellipsoid;
+  const CesiumGeospatial::Ellipsoid& ellipsoid = this->getOptions().ellipsoid;
 
   auto handleResponse =
       [pOwner,

--- a/CesiumRasterOverlays/src/DebugColorizeTilesRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/DebugColorizeTilesRasterOverlay.cpp
@@ -68,8 +68,7 @@ public:
 DebugColorizeTilesRasterOverlay::DebugColorizeTilesRasterOverlay(
     const std::string& name,
     const RasterOverlayOptions& overlayOptions)
-    : RasterOverlay(name, overlayOptions),
-      _ellipsoid(overlayOptions.ellipsoid.value_or(Ellipsoid::WGS84)) {}
+    : RasterOverlay(name, overlayOptions) {}
 
 CesiumAsync::Future<RasterOverlay::CreateTileProviderResult>
 DebugColorizeTilesRasterOverlay::createTileProvider(
@@ -89,5 +88,5 @@ DebugColorizeTilesRasterOverlay::createTileProvider(
           pAssetAccessor,
           pPrepareRendererResources,
           pLogger,
-          this->_ellipsoid)));
+          this->getOptions().ellipsoid)));
 }

--- a/CesiumRasterOverlays/src/IonRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/IonRasterOverlay.cpp
@@ -48,13 +48,16 @@ IonRasterOverlay::createTileProvider(
         endpoint.url,
         endpoint.key,
         endpoint.mapStyle,
-        endpoint.culture);
+        endpoint.culture,
+        this->getOptions());
   } else {
     pOverlay = new TileMapServiceRasterOverlay(
         this->getName(),
         endpoint.url,
         std::vector<CesiumAsync::IAssetAccessor::THeader>{
-            std::make_pair("Authorization", "Bearer " + endpoint.accessToken)});
+            std::make_pair("Authorization", "Bearer " + endpoint.accessToken)},
+        TileMapServiceRasterOverlayOptions(),
+        this->getOptions());
   }
 
   if (pCreditSystem) {

--- a/CesiumRasterOverlays/src/TileMapServiceRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/TileMapServiceRasterOverlay.cpp
@@ -343,7 +343,7 @@ TileMapServiceRasterOverlay::createTileProvider(
             }
 
             const CesiumGeospatial::Ellipsoid& ellipsoid =
-                options.ellipsoid.value_or(CesiumGeospatial::Ellipsoid::WGS84);
+                pOwner->getOptions().ellipsoid;
 
             CesiumGeospatial::GlobeRectangle tilingSchemeRectangle =
                 CesiumGeospatial::GeographicProjection::MAXIMUM_GLOBE_RECTANGLE;

--- a/CesiumRasterOverlays/src/WebMapServiceRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/WebMapServiceRasterOverlay.cpp
@@ -326,8 +326,7 @@ WebMapServiceRasterOverlay::createTileProvider(
                   validationError});
             }
 
-            const Ellipsoid& ellipsoid =
-                options.ellipsoid.value_or(CesiumGeospatial::Ellipsoid::WGS84);
+            const Ellipsoid& ellipsoid = pOwner->getOptions().ellipsoid;
 
             const auto projection =
                 CesiumGeospatial::GeographicProjection(ellipsoid);

--- a/CesiumRasterOverlays/src/WebMapTileServiceRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/WebMapTileServiceRasterOverlay.cpp
@@ -222,9 +222,8 @@ WebMapTileServiceRasterOverlay::createTileProvider(
     useKVP = false;
   }
 
-  CesiumGeospatial::Projection projection =
-      _options.projection.value_or(CesiumGeospatial::WebMercatorProjection(
-          _options.ellipsoid.value_or(CesiumGeospatial::Ellipsoid::WGS84)));
+  CesiumGeospatial::Projection projection = _options.projection.value_or(
+      CesiumGeospatial::WebMercatorProjection(pOwner->getOptions().ellipsoid));
   CesiumGeospatial::GlobeRectangle tilingSchemeRectangle =
       CesiumGeospatial::WebMercatorProjection::MAXIMUM_GLOBE_RECTANGLE;
   uint32_t rootTilesX = 1;


### PR DESCRIPTION
This is a PR into #1002 so merge that first.

Fixes CesiumGS/cesium-unreal#1551

* BingMapsRasterOverlay no longer has a separate `ellipsoid` constructor parameter and field. Instead, it uses the one in `RasterOverlayOptions`.
* The `ellipsoid` field in `RasterOverlayOptions` is no longer optional. Instead, it defaults to WGS84.
* `WebMapServiceRasterOverlayOptions` and `TileMapServiceRasterOverlayOptions` no longer have an `ellipsoid` field. It's redundant with the one in `RasterOverlayOptions`.
* `DebugColorizeTilesRasterOverlay` no longer stores its ellipsoid redundantly.
* `IonRasterOverlay` now passes its `RasterOverlayOptions` through to the Bing or TMS overlay it creates.

This all helps fix CesiumGS/cesium-unreal#1551 by making sure we're using Unreal's WGS84 ellipsoid everywhere, rather than using that one in some places and the "real" WGS84 in other places. They're different by 1e-6 meters (1 micrometer) in the semi-minor axis, which shouldn't make any practical difference, but they don't compare as exactly equal.
