### PR TITLE
Fix compiler error on GCC 13

### DIFF
--- a/CesiumGltf/test/TestPropertyAttributePropertyView.cpp
+++ b/CesiumGltf/test/TestPropertyAttributePropertyView.cpp
@@ -1,3 +1,6 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
 #include "CesiumGltf/PropertyAttributePropertyView.h"
 
 #include <CesiumUtility/Assert.h>
@@ -822,3 +825,5 @@ TEST_CASE("Check that PropertyAttributeProperty values override class property "
     REQUIRE(view.get(i) == expected[static_cast<size_t>(i)]);
   }
 }
+
+#pragma GCC diagnostic pop

--- a/CesiumGltf/test/TestPropertyAttributePropertyView.cpp
+++ b/CesiumGltf/test/TestPropertyAttributePropertyView.cpp
@@ -1,5 +1,7 @@
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 
 #include "CesiumGltf/PropertyAttributePropertyView.h"
 
@@ -826,4 +828,6 @@ TEST_CASE("Check that PropertyAttributeProperty values override class property "
   }
 }
 
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
+#endif

--- a/CesiumGltf/test/TestPropertyTablePropertyView.cpp
+++ b/CesiumGltf/test/TestPropertyTablePropertyView.cpp
@@ -57,10 +57,10 @@ template <typename T>
 static void checkNumeric(
     const std::vector<T>& values,
     const std::vector<std::optional<T>>& expected,
-    const std::optional<JsonValue> offset = std::nullopt,
-    const std::optional<JsonValue> scale = std::nullopt,
-    const std::optional<JsonValue> noData = std::nullopt,
-    const std::optional<JsonValue> defaultValue = std::nullopt) {
+    const std::optional<JsonValue>& offset = std::nullopt,
+    const std::optional<JsonValue>& scale = std::nullopt,
+    const std::optional<JsonValue>& noData = std::nullopt,
+    const std::optional<JsonValue>& defaultValue = std::nullopt) {
   std::vector<std::byte> data;
   data.resize(values.size() * sizeof(T));
   std::memcpy(data.data(), values.data(), data.size());
@@ -102,10 +102,10 @@ template <typename T, typename D = typename TypeToNormalizedType<T>::type>
 static void checkNormalizedNumeric(
     const std::vector<T>& values,
     const std::vector<std::optional<D>>& expected,
-    const std::optional<JsonValue> offset = std::nullopt,
-    const std::optional<JsonValue> scale = std::nullopt,
-    const std::optional<JsonValue> noData = std::nullopt,
-    const std::optional<JsonValue> defaultValue = std::nullopt) {
+    const std::optional<JsonValue>& offset = std::nullopt,
+    const std::optional<JsonValue>& scale = std::nullopt,
+    const std::optional<JsonValue>& noData = std::nullopt,
+    const std::optional<JsonValue>& defaultValue = std::nullopt) {
   std::vector<std::byte> data;
   data.resize(values.size() * sizeof(T));
   std::memcpy(data.data(), values.data(), data.size());
@@ -210,8 +210,8 @@ static void checkVariableLengthArray(
     PropertyComponentType offsetType,
     int64_t instanceCount,
     const std::vector<std::optional<std::vector<DataType>>>& expected,
-    const std::optional<JsonValue::Array> noData = std::nullopt,
-    const std::optional<JsonValue::Array> defaultValue = std::nullopt) {
+    const std::optional<JsonValue::Array>& noData = std::nullopt,
+    const std::optional<JsonValue::Array>& defaultValue = std::nullopt) {
   // copy data to buffer
   std::vector<std::byte> buffer;
   buffer.resize(data.size() * sizeof(DataType));
@@ -291,8 +291,8 @@ static void checkNormalizedVariableLengthArray(
     PropertyComponentType offsetType,
     int64_t instanceCount,
     const std::vector<std::optional<std::vector<NormalizedType>>>& expected,
-    const std::optional<JsonValue::Array> noData = std::nullopt,
-    const std::optional<JsonValue::Array> defaultValue = std::nullopt) {
+    const std::optional<JsonValue::Array>& noData = std::nullopt,
+    const std::optional<JsonValue::Array>& defaultValue = std::nullopt) {
   // copy data to buffer
   std::vector<std::byte> buffer;
   buffer.resize(data.size() * sizeof(DataType));
@@ -420,10 +420,10 @@ static void checkFixedLengthArray(
     const std::vector<T>& data,
     int64_t fixedLengthArrayCount,
     const std::vector<std::optional<std::vector<T>>>& expected,
-    const std::optional<JsonValue::Array> offset = std::nullopt,
-    const std::optional<JsonValue::Array> scale = std::nullopt,
-    const std::optional<JsonValue::Array> noData = std::nullopt,
-    const std::optional<JsonValue::Array> defaultValue = std::nullopt) {
+    const std::optional<JsonValue::Array>& offset = std::nullopt,
+    const std::optional<JsonValue::Array>& scale = std::nullopt,
+    const std::optional<JsonValue::Array>& noData = std::nullopt,
+    const std::optional<JsonValue::Array>& defaultValue = std::nullopt) {
   int64_t instanceCount =
       static_cast<int64_t>(data.size()) / fixedLengthArrayCount;
 
@@ -495,10 +495,10 @@ static void checkNormalizedFixedLengthArray(
     const std::vector<T>& data,
     int64_t fixedLengthArrayCount,
     const std::vector<std::optional<std::vector<D>>>& expected,
-    const std::optional<JsonValue::Array> offset = std::nullopt,
-    const std::optional<JsonValue::Array> scale = std::nullopt,
-    const std::optional<JsonValue::Array> noData = std::nullopt,
-    const std::optional<JsonValue::Array> defaultValue = std::nullopt) {
+    const std::optional<JsonValue::Array>& offset = std::nullopt,
+    const std::optional<JsonValue::Array>& scale = std::nullopt,
+    const std::optional<JsonValue::Array>& noData = std::nullopt,
+    const std::optional<JsonValue::Array>& defaultValue = std::nullopt) {
   int64_t instanceCount =
       static_cast<int64_t>(data.size()) / fixedLengthArrayCount;
 

--- a/CesiumGltf/test/TestPropertyTablePropertyView.cpp
+++ b/CesiumGltf/test/TestPropertyTablePropertyView.cpp
@@ -1,3 +1,6 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
 #include "CesiumGltf/PropertyTablePropertyView.h"
 
 #include <catch2/catch.hpp>
@@ -1277,7 +1280,7 @@ TEST_CASE("Check matN PropertyTablePropertyView (normalized)") {
 }
 
 TEST_CASE("Check boolean PropertyTablePropertyView") {
-  std::bitset<sizeof(unsigned long)* CHAR_BIT> bits = 0b11110101;
+  std::bitset<sizeof(unsigned long) * CHAR_BIT> bits = 0b11110101;
   unsigned long val = bits.to_ulong();
   std::vector<std::byte> data(sizeof(val));
   std::memcpy(data.data(), &val, sizeof(val));
@@ -3710,3 +3713,5 @@ TEST_CASE("Check variable-length boolean array PropertyTablePropertyView") {
     }
   }
 }
+
+#pragma GCC diagnostic pop

--- a/CesiumGltf/test/TestPropertyTablePropertyView.cpp
+++ b/CesiumGltf/test/TestPropertyTablePropertyView.cpp
@@ -1,5 +1,7 @@
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 
 #include "CesiumGltf/PropertyTablePropertyView.h"
 
@@ -3714,4 +3716,6 @@ TEST_CASE("Check variable-length boolean array PropertyTablePropertyView") {
   }
 }
 
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
+#endif

--- a/CesiumGltf/test/TestPropertyTablePropertyView.cpp
+++ b/CesiumGltf/test/TestPropertyTablePropertyView.cpp
@@ -1280,7 +1280,7 @@ TEST_CASE("Check matN PropertyTablePropertyView (normalized)") {
 }
 
 TEST_CASE("Check boolean PropertyTablePropertyView") {
-  std::bitset<sizeof(unsigned long) * CHAR_BIT> bits = 0b11110101;
+  std::bitset<sizeof(unsigned long)* CHAR_BIT> bits = 0b11110101;
   unsigned long val = bits.to_ulong();
   std::vector<std::byte> data(sizeof(val));
   std::memcpy(data.data(), &val, sizeof(val));

--- a/CesiumGltf/test/TestPropertyTexturePropertyView.cpp
+++ b/CesiumGltf/test/TestPropertyTexturePropertyView.cpp
@@ -1,3 +1,6 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
 #include "CesiumGltf/KhrTextureTransform.h"
 #include "CesiumGltf/PropertyTexturePropertyView.h"
 #include "CesiumUtility/Math.h"
@@ -2050,3 +2053,5 @@ TEST_CASE("Test normalized PropertyTextureProperty constructs with "
     REQUIRE(view.get(uv[0], uv[1]) == static_cast<double>(data[i]) / 255.0);
   }
 }
+
+#pragma GCC diagnostic pop

--- a/CesiumGltf/test/TestPropertyTexturePropertyView.cpp
+++ b/CesiumGltf/test/TestPropertyTexturePropertyView.cpp
@@ -1,5 +1,7 @@
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 
 #include "CesiumGltf/KhrTextureTransform.h"
 #include "CesiumGltf/PropertyTexturePropertyView.h"
@@ -2054,4 +2056,6 @@ TEST_CASE("Test normalized PropertyTextureProperty constructs with "
   }
 }
 
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
This fixes the std::optional / std::variant related compiler errors that @lilleyse saw on GCC 13.

I was able to reproduce it on v13.1.0 on Ubuntu 22.04 (via WSL2) in the Release configuration, and this change fixed it for me. As far as I can tell, the previous code was valid and this is a GCC bug, but the code was a little unusual before and so the change here is an improvement.

Strangely enough, I can't seem to get it to fail to compile in the same way on the GH Actions `ubuntu-24.04` runner with `CC=gcc-13` and `CXX=g++-13`. But on that runner, after it compiles successfully, one of the tests fails:

```
192: Test command: /home/runner/work/cesium-native/cesium-native/build/CesiumNativeTests/cesium-native-tests "JsonValue::getSafeNumber() returns std::nullopt if narrowing conversion error would occur"
192: Working Directory: /home/runner/work/cesium-native/cesium-native/build/CesiumNativeTests
192: Test timeout computed to be: 1500
192: Filters: "JsonValue::getSafeNumber() returns std::nullopt if narrowing conversion error would occur"
192: Randomness seeded to: 3665553823
192: 
192: ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
192: cesium-native-tests is a Catch2 v3.7.1 host application.
192: Run with -? for options
192: 
192: -------------------------------------------------------------------------------
192: JsonValue::getSafeNumber() returns std::nullopt if narrowing conversion error
192: would occur
192:   2^64 - 1 cannot be converted back to a double
192: -------------------------------------------------------------------------------
192: /home/runner/work/cesium-native/cesium-native/CesiumGltf/test/TestJsonValue.cpp:44
192: ...............................................................................
192: 
192: /home/runner/work/cesium-native/cesium-native/CesiumGltf/test/TestJsonValue.cpp:46: FAILED:
192:   REQUIRE( !value.getSafeNumber<double>().has_value() )
192: with expansion:
192:   false
192: 
192: ===============================================================================
192: test cases: 1 | 1 failed
192: assertions: 4 | 3 passed | 1 failed
192: 
192/498 Test #192: JsonValue::getSafeNumber() returns std::nullopt if narrowing conversion error would occur ..............***Failed    0.00 sec
test 193
        Start 193: JsonValue::getSafeNumberOrDefault() returns default if narrowing conversion error would occur
```

We've seen this particular test fail elsewhere before, but can't entirely explain it. 