### PR TITLE
Use vcpkg cache for Doxygen CI task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,10 @@ jobs:
       - name: Install Doxygen
         run: |
           sudo apt install -y doxygen
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.9
         with:
@@ -29,10 +33,6 @@ jobs:
           restore-keys: |
             vcpkg-ubuntu-22.04-doxygen-${{ hashFiles('CMakeLists.txt') }}
             vcpkg-ubuntu-22.04-doxygen
-      - name: Check out repository code
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - name: Generate Documentation
         run: |
           npm install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,18 @@ jobs:
       - name: Install Doxygen
         run: |
           sudo apt install -y doxygen
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.9
+        with:
+          key: ccache-ubuntu-22.04-doxygen
+      - name: Cache vcpkg artifacts
+        uses: actions/cache@v4
+        with:
+          path: ~/.ezvcpkg
+          key:  vcpkg-ubuntu-22.04-doxygen-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: |
+            vcpkg-ubuntu-22.04-doxygen-${{ hashFiles('CMakeLists.txt') }}
+            vcpkg-ubuntu-22.04-doxygen
       - name: Check out repository code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Currently, the Doxygen CI task doesn't cache the vcpkg artifacts that are built when configuring the CMake project. This means it rebuilds every single one every time the task is run! We can significantly reduce the time it takes to build documentation by simply adopting the same vcpkg cache that the other CI tasks use. This brings the time it takes to run the Documentation CI task down from [12m 17s](https://github.com/CesiumGS/cesium-native/actions/runs/12005187635/job/33461379227) to [only 32s](https://github.com/CesiumGS/cesium-native/actions/runs/12019704527/job/33507514252)!

In theory, as mentioned in #983, we shouldn't need to build the vcpkg dependencies at all to generate the documentation. But this is an easy first step to reduce the time it takes to run CI without needing to mess around with our CMakeLists.