### PR TITLE
Fix (some) warnings in generated documentation

### DIFF
--- a/Cesium3DTiles/include/Cesium3DTiles/MetadataQuery.h
+++ b/Cesium3DTiles/include/Cesium3DTiles/MetadataQuery.h
@@ -38,7 +38,7 @@ struct CESIUM3DTILES_API FoundMetadataProperty {
 
   /**
    * @brief A reference to the {@link ClassProperty} describing the found
-   * property within the {@lnik Schema}.
+   * property within the {@link Schema}.
    */
   const ClassProperty& propertyDefinition;
 

--- a/Cesium3DTilesReader/include/Cesium3DTilesReader/SubtreeFileReader.h
+++ b/Cesium3DTilesReader/include/Cesium3DTilesReader/SubtreeFileReader.h
@@ -11,7 +11,7 @@ namespace Cesium3DTilesReader {
 /**
  * @brief Reads 3D Tiles subtrees from a binary or JSON subtree file.
  *
- * While {@link SubtreeReader} can parse a {@link Subtree} from a binary buffer
+ * While {@link SubtreeReader} can parse a {@link Cesium3DTiles::Subtree} from a binary buffer
  * as well, `SubtreeFileReader` additionally supports:
  *
  * 1. Loading binary subtree files.

--- a/Cesium3DTilesReader/include/Cesium3DTilesReader/SubtreeFileReader.h
+++ b/Cesium3DTilesReader/include/Cesium3DTilesReader/SubtreeFileReader.h
@@ -11,7 +11,7 @@ namespace Cesium3DTilesReader {
 /**
  * @brief Reads 3D Tiles subtrees from a binary or JSON subtree file.
  *
- * While {@link SubtreeReader} can parse a {@link Cesium3DTiles::Subtree} from a binary buffer
+ * While {@link Cesium3DTilesReader::SubtreeReader} can parse a {@link Cesium3DTiles::Subtree} from a binary buffer
  * as well, `SubtreeFileReader` additionally supports:
  *
  * 1. Loading binary subtree files.

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/BoundingVolume.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/BoundingVolume.h
@@ -86,6 +86,7 @@ getBoundingRegionFromBoundingVolume(const BoundingVolume& boundingVolume);
  * @brief Returns an oriented bounding box that contains the given {@link BoundingVolume}.
  *
  * @param boundingVolume The bounding volume.
+ * @param ellipsoid The ellipsoid used for this {@link BoundingVolume}.
  * @return The oriented bounding box.
  */
 CESIUM3DTILESSELECTION_API CesiumGeometry::OrientedBoundingBox

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/BoundingVolume.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/BoundingVolume.h
@@ -73,7 +73,7 @@ estimateGlobeRectangle(
 
 /**
  * @brief Returns the bounding region if the bounding volume is a
- * {@link BoundingRegion} or a {@link BoundingRegionWithLooseFittingHeights}.
+ * {@link CesiumGeospatial::BoundingRegion} or a {@link CesiumGeospatial::BoundingRegionWithLooseFittingHeights}.
  *
  * @param boundingVolume The bounding volume.
  * @return A pointer to the bounding region, or nullptr is the bounding volume

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/EllipsoidTilesetLoader.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/EllipsoidTilesetLoader.h
@@ -16,7 +16,7 @@ public:
   /**
    * @brief Constructs a new instance.
    *
-   * @param ellipsoid The {@link Ellipsoid}.
+   * @param ellipsoid The {@link CesiumGeospatial::Ellipsoid}.
    */
   EllipsoidTilesetLoader(
       const CesiumGeospatial::Ellipsoid& ellipsoid CESIUM_DEFAULT_ELLIPSOID);

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ITilesetHeightSampler.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ITilesetHeightSampler.h
@@ -25,7 +25,7 @@ public:
    *
    * @param asyncSystem The async system used to do work in threads.
    * @param positions The positions at which to query heights. The height field
-   * of each {@link Cartographic} is ignored.
+   * of each {@link CesiumGeospatial::Cartographic} is ignored.
    * @return A future that will be resolved when the heights have been queried.
    */
   virtual CesiumAsync::Future<SampleHeightResult> sampleHeights(

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterMappedTo3DTile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterMappedTo3DTile.h
@@ -14,10 +14,10 @@ namespace Cesium3DTilesSelection {
 class Tile;
 
 /**
- * @brief The result of applying a {@link RasterOverlayTile} to geometry.
+ * @brief The result of applying a {@link CesiumRasterOverlays::RasterOverlayTile} to geometry.
  *
  * Instances of this class are used by a {@link Tile} in order to map
- * imagery data that is given as {@link RasterOverlayTile} instances
+ * imagery data that is given as {@link CesiumRasterOverlays::RasterOverlayTile} instances
  * to the 2D region that is covered by the tile geometry.
  */
 class RasterMappedTo3DTile final {
@@ -47,7 +47,7 @@ public:
   /**
    * @brief Creates a new instance.
    *
-   * @param pRasterTile The {@link RasterOverlayTile} that is mapped to the
+   * @param pRasterTile The {@link CesiumRasterOverlays::RasterOverlayTile} that is mapped to the
    * geometry.
    * @param textureCoordinateIndex The index of the texture coordinates to use
    * with this mapped raster overlay.
@@ -58,7 +58,7 @@ public:
       int32_t textureCoordinateIndex);
 
   /**
-   * @brief Returns a {@link RasterOverlayTile} that is currently loading.
+   * @brief Returns a {@link CesiumRasterOverlays::RasterOverlayTile} that is currently loading.
    *
    * The caller has to check the exact state of this tile, using
    * {@link Tile::getState}.
@@ -76,7 +76,7 @@ public:
   }
 
   /**
-   * @brief Returns the {@link RasterOverlayTile} that represents the imagery
+   * @brief Returns the {@link CesiumRasterOverlays::RasterOverlayTile} that represents the imagery
    * data that is ready to render.
    *
    * This will be `nullptr` when the tile data has not yet been loaded.
@@ -153,14 +153,14 @@ public:
   /**
    * @brief Update this tile during the update of its owner.
    *
-   * This is only supposed to be called by {@link Tile::update}. It
+   * This is only supposed to be called by {@link Cesium3DTilesSelection::Tile::update}. It
    * will return whether there is a more detailed version of the
    * raster data available.
    *
-   * @param prepareRendererResources The IPrepareRendererResources used to
+   * @param prepareRendererResources The {@link IPrepareRendererResources} used to
    * create render resources for raster overlay
    * @param tile The owner tile.
-   * @return The {@link MoreDetailAvailable} state.
+   * @return The {@link CesiumRasterOverlays::RasterOverlayTile::MoreDetailAvailable} state.
    */
   CesiumRasterOverlays::RasterOverlayTile::MoreDetailAvailable
   update(IPrepareRendererResources& prepareRendererResources, Tile& tile);
@@ -178,7 +178,7 @@ public:
       Tile& tile) noexcept;
 
   /**
-   * @brief Does a throttled load of the mapped {@link RasterOverlayTile}.
+   * @brief Does a throttled load of the mapped {@link CesiumRasterOverlays::RasterOverlayTile}.
    *
    * @return If the mapped tile is already in the process of loading or it has
    * already finished loading, this method does nothing and returns true. If too
@@ -189,9 +189,9 @@ public:
   bool loadThrottled() noexcept;
 
   /**
-   * @brief Creates a maping between a {@link RasterOverlay} and a {@link Tile}.
+   * @brief Creates a maping between a {@link CesiumRasterOverlays::RasterOverlay} and a {@link Tile}.
    *
-   * The returned mapping will be to a placeholder {@link RasterOverlayTile} if
+   * The returned mapping will be to a placeholder {@link CesiumRasterOverlays::RasterOverlayTile} if
    * the overlay's tile provider is not yet ready (i.e. it's still a
    * placeholder) or if the overlap between the tile and the raster overlay
    * cannot yet be determined because the projected rectangle of the tile is not

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterMappedTo3DTile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterMappedTo3DTile.h
@@ -153,7 +153,7 @@ public:
   /**
    * @brief Update this tile during the update of its owner.
    *
-   * This is only supposed to be called by {@link Cesium3DTilesSelection::Tile::update}. It
+   * This is only supposed to be called by {@link Cesium3DTilesSelection::TilesetContentManager::updateDoneState}. It
    * will return whether there is a more detailed version of the
    * raster data available.
    *
@@ -214,6 +214,7 @@ public:
    * be added to this collection if the Tile does not yet have texture
    * coordinates for the Projection and the Projection is not already in the
    * collection.
+   * @param ellipsoid The {@link CesiumGeospatial::Ellipsoid}.
    * @return A pointer the created mapping, which may be to a placeholder, or
    * nullptr if no mapping was created at all because the Tile does not overlap
    * the raster overlay.

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayCollection.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayCollection.h
@@ -36,6 +36,7 @@ public:
    * this list, so the list needs to be kept alive as long as the collection's
    * lifetime
    * @param externals A collection of loading system to load a raster overlay
+   * @param ellipsoid The {@link CesiumGeospatial::Ellipsoid}.
    */
   RasterOverlayCollection(
       Tile::LoadedLinkedList& loadedTiles,

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayCollection.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterOverlayCollection.h
@@ -17,14 +17,14 @@
 namespace Cesium3DTilesSelection {
 
 /**
- * @brief A collection of {@link RasterOverlay} instances that are associated
+ * @brief A collection of {@link CesiumRasterOverlays::RasterOverlay} instances that are associated
  * with a {@link Tileset}.
  *
  * The raster overlay instances may be added to the raster overlay collection
  * of a tileset that is returned with {@link Tileset::getOverlays}. When the
- * tileset is loaded, one {@link RasterOverlayTileProvider} will be created
+ * tileset is loaded, one {@link CesiumRasterOverlays::RasterOverlayTileProvider} will be created
  * for each raster overlay that had been added. The raster overlay tile provider
- * instances will be passed to the {@link RasterOverlayTile} instances that
+ * instances will be passed to the {@link CesiumRasterOverlays::RasterOverlayTile} instances that
  * they create when the tiles are updated.
  */
 class CESIUM3DTILESSELECTION_API RasterOverlayCollection final {
@@ -76,7 +76,7 @@ public:
   ~RasterOverlayCollection() noexcept;
 
   /**
-   * @brief Adds the given {@link RasterOverlay} to this collection.
+   * @brief Adds the given {@link CesiumRasterOverlays::RasterOverlay} to this collection.
    *
    * @param pOverlay The pointer to the overlay. This may not be `nullptr`.
    */
@@ -84,7 +84,7 @@ public:
            CesiumRasterOverlays::RasterOverlay>& pOverlay);
 
   /**
-   * @brief Remove the given {@link RasterOverlay} from this collection.
+   * @brief Remove the given {@link CesiumRasterOverlays::RasterOverlay} from this collection.
    */
   void remove(const CesiumUtility::IntrusivePointer<
               CesiumRasterOverlays::RasterOverlay>& pOverlay) noexcept;
@@ -122,7 +122,7 @@ public:
    *
    * If the overlay's real tile provider hasn't finished being
    * created yet, a placeholder will be returned. That is, its
-   * {@link RasterOverlayTileProvider::isPlaceholder} method will return true.
+   * {@link CesiumRasterOverlays::RasterOverlayTileProvider::isPlaceholder} method will return true.
    *
    * @param overlay The overlay for which to obtain the tile provider.
    * @return The tile provider, if any, corresponding to the raster overlay.
@@ -163,7 +163,7 @@ public:
       const CesiumRasterOverlays::RasterOverlay& overlay) const noexcept;
 
   /**
-   * @brief A constant iterator for {@link RasterOverlay} instances.
+   * @brief A constant iterator for {@link CesiumRasterOverlays::RasterOverlay} instances.
    */
   typedef std::vector<CesiumUtility::IntrusivePointer<
       CesiumRasterOverlays::RasterOverlay>>::const_iterator const_iterator;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsTileExcluder.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsTileExcluder.h
@@ -13,7 +13,7 @@ namespace Cesium3DTilesSelection {
 
 /**
  * @brief When provided to {@link TilesetOptions::excluders}, uses the polygons
- * owned by a {@link RasterizedPolygonsOverlay} to exclude tiles that are
+ * owned by a {@link CesiumRasterOverlays::RasterizedPolygonsOverlay} to exclude tiles that are
  * entirely inside any of the polygon from loading. This is useful when the
  * polygons will be used for clipping.
  */

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsTileExcluder.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/RasterizedPolygonsTileExcluder.h
@@ -23,7 +23,7 @@ public:
   /**
    * @brief Constructs a new instance.
    *
-   * @param overlay The overlay definining the polygons.
+   * @param pOverlay The overlay definining the polygons.
    */
   RasterizedPolygonsTileExcluder(
       const CesiumUtility::IntrusivePointer<

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
@@ -80,7 +80,7 @@ enum class TileLoadState {
  * The actual hierarchy is represented with the {@link Tile::getParent}
  * and {@link Tile::getChildren} functions.
  *
- * The renderable content is provided as a {@link TileContentLoadResult}
+ * The renderable content is provided as a {@link TileContent}
  * from the {@link Tile::getContent} function.
  * The {@link Tile::getGeometricError} function returns the geometric
  * error of the representation of the renderable content of a tile.
@@ -274,14 +274,14 @@ public:
   /**
    * @brief Gets the tile's geometric error as if by calling
    * {@link getGeometricError}, except that if the error is smaller than
-   * {@link Math::Epsilon5} the returned geometric error is instead computed as
+   * {@link CesiumUtility::Math::Epsilon5} the returned geometric error is instead computed as
    * half of the parent tile's (non-zero) geometric error.
    *
    * This is useful for determining when to refine what would ordinarily be a
    * leaf tile, for example to attach more detailed raster overlays to it.
    *
    * If this tile and all of its ancestors have a geometric error less than
-   * {@link Math::Epsilon5}, returns {@link Math::Epsilon5}.
+   * {@link CesiumUtility::Math::Epsilon5}, returns {@link CesiumUtility::Math::Epsilon5}.
    *
    * @return The non-zero geometric error.
    */
@@ -447,11 +447,11 @@ public:
   }
 
   /**
-   * @brief get the content of the tile.
+   * @brief Get the content of the tile.
    */
   const TileContent& getContent() const noexcept { return _content; }
 
-  /** @copydoc Tile::getContent() */
+  /** @copydoc Tile::getContent() const */
   TileContent& getContent() noexcept { return _content; }
 
   /**

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
@@ -111,6 +111,7 @@ public:
    * with this constructor.
    *
    * @param pLoader The {@link TilesetContentLoader} that is assiocated with this tile.
+   * @param externalContent External content that is associated with this tile.
    */
   Tile(
       TilesetContentLoader* pLoader,
@@ -122,6 +123,7 @@ public:
    * with this constructor.
    *
    * @param pLoader The {@link TilesetContentLoader} that is assiocated with this tile.
+   * @param emptyContent A content tag indicating that the tile has no content.
    */
   Tile(TilesetContentLoader* pLoader, TileEmptyContent emptyContent) noexcept;
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
@@ -98,62 +98,64 @@ public:
   void setModel(CesiumGltf::Model&& model);
 
   /**
-   * @brief Get the {@link RasterOverlayDetails} which is the result of generating raster overlay UVs for the glTF model
+   * @brief Get the {@link CesiumRasterOverlays::RasterOverlayDetails} which is the result of generating raster overlay UVs for the glTF model
    *
-   * @return The {@link RasterOverlayDetails} that is owned by this content
+   * @return The {@link CesiumRasterOverlays::RasterOverlayDetails} that is owned by this content
    */
   const CesiumRasterOverlays::RasterOverlayDetails&
   getRasterOverlayDetails() const noexcept;
 
   /**
-   * @brief Get the {@link RasterOverlayDetails} which is the result of generating raster overlay UVs for the glTF model
+   * @brief Get the {@link CesiumRasterOverlays::RasterOverlayDetails} which is the result of generating raster overlay UVs for the glTF model
    *
-   * @return The {@link RasterOverlayDetails} that is owned by this content
+   * @return The {@link CesiumRasterOverlays::RasterOverlayDetails} that is owned by this content
    */
   CesiumRasterOverlays::RasterOverlayDetails&
   getRasterOverlayDetails() noexcept;
 
   /**
-   * @brief Set the {@link RasterOverlayDetails} which is the result of generating raster overlay UVs for the glTF model
+   * @brief Set the {@link CesiumRasterOverlays::RasterOverlayDetails} which is the result of generating raster overlay UVs for the glTF model
    *
-   * @param rasterOverlayDetails The {@link RasterOverlayDetails} that will be owned by this content
+   * @param rasterOverlayDetails The {@link CesiumRasterOverlays::RasterOverlayDetails} that will be owned by this content
    */
   void setRasterOverlayDetails(
       const CesiumRasterOverlays::RasterOverlayDetails& rasterOverlayDetails);
 
   /**
-   * @brief Set the {@link RasterOverlayDetails} which is the result of generating raster overlay UVs for the glTF model
+   * @brief Set the {@link CesiumRasterOverlays::RasterOverlayDetails} which is the result of generating raster overlay UVs for the glTF model
    *
-   * @param rasterOverlayDetails The {@link RasterOverlayDetails} that will be owned by this content
+   * @param rasterOverlayDetails The {@link CesiumRasterOverlays::RasterOverlayDetails} that will be owned by this content
    */
   void setRasterOverlayDetails(
       CesiumRasterOverlays::RasterOverlayDetails&& rasterOverlayDetails);
 
   /**
-   * @brief Get the list of {@link Credit} of the content
+   * @brief Get the list of \ref CesiumUtility::Credit "Credit" of the content
    *
-   * @return The list of {@link Credit} of the content
+   * @return The list of \ref CesiumUtility::Credit "Credit" of the content
    */
   const std::vector<CesiumUtility::Credit>& getCredits() const noexcept;
 
   /**
-   * @brief Get the list of {@link Credit} of the content
+   * @brief Get the list of \ref CesiumUtility::Credit "Credit" of the content
    *
-   * @return The list of {@link Credit} of the content
+   * @return The list of \ref CesiumUtility::Credit "Credit" of the content
    */
   std::vector<CesiumUtility::Credit>& getCredits() noexcept;
 
   /**
-   * @brief Set the list of {@link Credit} for the content
+   * @brief Set the list of \ref CesiumUtility::Credit "Credit" for the content
    *
-   * @param credits The list of {@link Credit} to be owned by the content
+   * @param credits The list of \ref CesiumUtility::Credit "Credit" to be owned
+   * by the content
    */
   void setCredits(std::vector<CesiumUtility::Credit>&& credits);
 
   /**
-   * @brief Set the list of {@link Credit} for the content
+   * @brief Set the list of \ref CesiumUtility::Credit "Credit" for the content
    *
-   * @param credits The list of {@link Credit} to be owned by the content
+   * @param credits The list of \ref CesiumUtility::Credit "Credit" to be owned
+   * by the content
    */
   void setCredits(const std::vector<CesiumUtility::Credit>& credits);
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileLoadResult.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileLoadResult.h
@@ -42,8 +42,8 @@ using TileContentKind = std::variant<
     CesiumGltf::Model>;
 
 /**
- * @brief Indicate the status of {@link TilesetContentLoader::loadTileContent} and
- * {@link TilesetContentLoader::createTileChildren} operations
+ * @brief Indicate the status of {@link Cesium3DTilesSelection::TilesetContentLoader::loadTileContent} and
+ * {@link Cesium3DTilesSelection::TilesetContentLoader::createTileChildren} operations
  */
 enum class TileLoadResultState {
   /**

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetContentLoader.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetContentLoader.h
@@ -40,6 +40,7 @@ struct CESIUM3DTILESSELECTION_API TileLoadInput {
    * @param pLogger The logger that will be used
    * @param requestHeaders The request headers that will be attached to the
    * request.
+   * @param ellipsoid The {@link CesiumGeospatial::Ellipsoid}.
    */
   TileLoadInput(
       const Tile& tile,
@@ -141,6 +142,7 @@ public:
    * children.
    *
    * @param tile The tile to create children for.
+   * @param ellipsoid The {@link CesiumGeospatial::Ellipsoid}.
    * @return The {@link TileChildrenResult} that stores the tile's children
    */
   virtual TileChildrenResult createTileChildren(

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetExternals.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetExternals.h
@@ -48,7 +48,7 @@ public:
   CesiumAsync::AsyncSystem asyncSystem;
 
   /**
-   * @brief An external {@link CreditSystem} that can be used to manage credit
+   * @brief An external {@link CesiumUtility::CreditSystem} that can be used to manage credit
    * strings and track which which credits to show and remove from the screen
    * each frame.
    */

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetOptions.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetOptions.h
@@ -259,7 +259,7 @@ struct CESIUM3DTILESSELECTION_API TilesetOptions {
    * @brief Whether to keep tiles loaded during a transition period when
    * switching to a different LOD tile.
    *
-   * For each tile, TileContentLoadResult::lodTransitionFadePercentage will
+   * For each tile, {@link TileRenderContent::getLodTransitionFadePercentage} will
    * indicate to the client how faded to render the tile throughout the
    * transition. Tile fades can be used to mask LOD transitions and make them
    * appear less abrupt and jarring.
@@ -313,7 +313,7 @@ struct CESIUM3DTILESSELECTION_API TilesetOptions {
   TilesetContentOptions contentOptions;
 
   /**
-   * @brief Arbitrary data that will be passed to {@link prepareInLoadThread}.
+   * @brief Arbitrary data that will be passed to {@link IPrepareRendererResources::prepareInLoadThread}.
    *
    * This object is copied and given to tile preparation threads,
    * so it must be inexpensive to copy.

--- a/Cesium3DTilesWriter/include/Cesium3DTilesWriter/SchemaWriter.h
+++ b/Cesium3DTilesWriter/include/Cesium3DTilesWriter/SchemaWriter.h
@@ -13,7 +13,7 @@ namespace Cesium3DTilesWriter {
 
 /**
  * @brief The result of writing a schema with
- * {@link SchemaWriterWriter::writeSchema}.
+ * {@link SchemaWriter::writeSchema}.
  */
 struct CESIUM3DTILESWRITER_API SchemaWriterResult {
   /**

--- a/Cesium3DTilesWriter/include/Cesium3DTilesWriter/SubtreeWriter.h
+++ b/Cesium3DTilesWriter/include/Cesium3DTilesWriter/SubtreeWriter.h
@@ -13,7 +13,7 @@ namespace Cesium3DTilesWriter {
 
 /**
  * @brief The result of writing a subtree with
- * {@link SubtreeWriterWriter::writeSubtree}.
+ * {@link SubtreeWriter::writeSubtree}.
  */
 struct CESIUM3DTILESWRITER_API SubtreeWriterResult {
   /**

--- a/CesiumAsync/include/CesiumAsync/Future.h
+++ b/CesiumAsync/include/CesiumAsync/Future.h
@@ -137,6 +137,7 @@ public:
    * method returns.
    *
    * @tparam Func The type of the function.
+   * @param threadPool The thread pool where this function will be invoked.
    * @param f The function.
    * @return A future that resolves after the supplied function completes.
    */

--- a/CesiumAsync/include/CesiumAsync/Future.h
+++ b/CesiumAsync/include/CesiumAsync/Future.h
@@ -209,7 +209,7 @@ public:
    * values, followed by the result of the current Future.
    *
    * @tparam TPassThrough The types to pass through to the next continuation.
-   * @param value The values to pass through to the next continuation.
+   * @param values The values to pass through to the next continuation.
    * @return A new Future that resolves to a tuple with the pass-through values,
    * followed by the result of the last Future.
    */

--- a/CesiumAsync/include/CesiumAsync/SharedAssetDepot.h
+++ b/CesiumAsync/include/CesiumAsync/SharedAssetDepot.h
@@ -24,10 +24,10 @@ template <typename T> class SharedAsset;
 namespace CesiumAsync {
 
 /**
- * @brief A depot for {@link SharedAsset} instances, which are potentially shared between multiple objects.
+ * @brief A depot for {@link CesiumUtility::SharedAsset} instances, which are potentially shared between multiple objects.
  *
  * @tparam TAssetType The type of asset stored in this depot. This should
- * be derived from {@link SharedAsset}.
+ * be derived from {@link CesiumUtility::SharedAsset}.
  */
 template <typename TAssetType, typename TAssetKey>
 class CESIUMASYNC_API SharedAssetDepot

--- a/CesiumAsync/include/CesiumAsync/SharedFuture.h
+++ b/CesiumAsync/include/CesiumAsync/SharedFuture.h
@@ -195,7 +195,7 @@ public:
    * values, followed by the result of the current Future.
    *
    * @tparam TPassThrough The types to pass through to the next continuation.
-   * @param value The values to pass through to the next continuation.
+   * @param values The values to pass through to the next continuation.
    * @return A new Future that resolves to a tuple with the pass-through values,
    * followed by the result of the last Future.
    */

--- a/CesiumAsync/include/CesiumAsync/SharedFuture.h
+++ b/CesiumAsync/include/CesiumAsync/SharedFuture.h
@@ -123,6 +123,7 @@ public:
    * method returns.
    *
    * @tparam Func The type of the function.
+   * @param threadPool The thread pool where this function will be invoked.
    * @param f The function.
    * @return A future that resolves after the supplied function completes.
    */

--- a/CesiumGeometry/include/CesiumGeometry/IntersectionTests.h
+++ b/CesiumGeometry/include/CesiumGeometry/IntersectionTests.h
@@ -94,6 +94,8 @@ public:
    * @param triangleVertA The first vertex of the triangle.
    * @param triangleVertB The second vertex of the triangle.
    * @param triangleVertC The third vertex of the triangle.
+   * @param barycentricCoordinates The barycentric coordinates for the point, if
+   * the point is inside the triangle.
    * @return Whether the point is within the triangle.
    */
   static bool pointInTriangle(

--- a/CesiumGeometry/include/CesiumGeometry/OctreeTileID.h
+++ b/CesiumGeometry/include/CesiumGeometry/OctreeTileID.h
@@ -25,10 +25,10 @@ struct CESIUMGEOMETRY_API OctreeTileID {
   /**
    * @brief Creates a new instance.
    *
-   * @param level The level of the node, with 0 being the root.
-   * @param x The x-coordinate of the tile.
-   * @param y The y-coordinate of the tile.
-   * @param z The z-coordinate of the tile.
+   * @param level_ The level of the node, with 0 being the root.
+   * @param x_ The x-coordinate of the tile.
+   * @param y_ The y-coordinate of the tile.
+   * @param z_ The z-coordinate of the tile.
    */
   constexpr OctreeTileID(
       uint32_t level_,

--- a/CesiumGeometry/include/CesiumGeometry/Rectangle.h
+++ b/CesiumGeometry/include/CesiumGeometry/Rectangle.h
@@ -14,11 +14,6 @@ namespace CesiumGeometry {
 struct CESIUMGEOMETRY_API Rectangle final {
   /**
    * @brief Creates a new instance with all coordinate values set to 0.0.
-   *
-   * @param minimumX_ The minimum x-coordinate.
-   * @param minimumY_ The minimum y-coordinate.
-   * @param maximumX_ The maximum x-coordinate.
-   * @param maximumY_ The maximum y-coordinate.
    */
   constexpr Rectangle() noexcept
       : minimumX(0.0), minimumY(0.0), maximumX(0.0), maximumY(0.0) {}

--- a/CesiumGeospatial/include/CesiumGeospatial/BoundingRegion.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/BoundingRegion.h
@@ -124,6 +124,7 @@ public:
    * @brief Computes the union of this bounding region with another.
    *
    * @param other The other bounding region.
+   * @param ellipsoid The {@link CesiumGeospatial::Ellipsoid}.
    * @return The union.
    */
   BoundingRegion computeUnion(

--- a/CesiumGeospatial/include/CesiumGeospatial/CartographicPolygon.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/CartographicPolygon.h
@@ -24,7 +24,7 @@ namespace CesiumGeospatial {
 class CESIUMGEOSPATIAL_API CartographicPolygon final {
 public:
   /**
-   * @brief Constructs a 2D polygon that can be rasterized onto {@link Tileset}
+   * @brief Constructs a 2D polygon that can be rasterized onto {@link Cesium3DTilesSelection::Tileset}
    * objects.
    *
    * @param polygon An array of longitude-latitude points in radians defining

--- a/CesiumGeospatial/include/CesiumGeospatial/Ellipsoid.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/Ellipsoid.h
@@ -145,7 +145,7 @@ public:
    * surface normal so that it is on the surface of this ellipsoid.
    *
    * @param cartesian The cartesian position to scale.
-   * @retun The scaled position, or the empty optional if the cartesian is at
+   * @returns The scaled position, or the empty optional if the cartesian is at
    * the center of this ellipsoid.
    */
   std::optional<glm::dvec3>

--- a/CesiumGeospatial/include/CesiumGeospatial/GlobeAnchor.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/GlobeAnchor.h
@@ -84,6 +84,7 @@ public:
    * the globe changes. This parameter should usually be true, but it may be
    * useful to set it to false it when the caller already accounts for globe
    * curvature itself, because in that case anchor would be over-rotated.
+   * @param ellipsoid The {@link CesiumGeospatial::Ellipsoid}.
    */
   void setAnchorToFixedTransform(
       const glm::dmat4& newAnchorToFixed,
@@ -121,6 +122,7 @@ public:
    * the globe changes. This parameter should usually be true, but it may be
    * useful to set it to false it when the caller already accounts for globe
    * curvature itself, because in that case anchor would be over-rotated.
+   * @param ellipsoid The {@link CesiumGeospatial::Ellipsoid}.
    */
   void setAnchorToLocalTransform(
       const LocalHorizontalCoordinateSystem& localCoordinateSystem,

--- a/CesiumGeospatial/include/CesiumGeospatial/Projection.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/Projection.h
@@ -103,6 +103,7 @@ projectRegionSimple(const Projection& projection, const BoundingRegion& region);
  *
  * @param projection The projection.
  * @param box The box to be unprojected.
+ * @param ellipsoid The {@link CesiumGeospatial::Ellipsoid}.
  * @return The unprojected bounding region.
  */
 BoundingRegion unprojectRegionSimple(

--- a/CesiumGeospatial/include/CesiumGeospatial/Projection.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/Projection.h
@@ -87,7 +87,7 @@ GlobeRectangle unprojectRectangleSimple(
  * necessarily true for other projections.
  *
  * @param projection The projection.
- * @param boundingRegion The bounding region to be projected.
+ * @param region The bounding region to be projected.
  * @return The projected box.
  */
 CesiumGeometry::AxisAlignedBox

--- a/CesiumGeospatial/include/CesiumGeospatial/SimplePlanarEllipsoidCurve.h
+++ b/CesiumGeospatial/include/CesiumGeospatial/SimplePlanarEllipsoidCurve.h
@@ -33,7 +33,7 @@ public:
    * @returns An optional type containing a {@link SimplePlanarEllipsoidCurve}
    * object representing the generated path, if possible. If it wasn't possible
    * to scale the input coordinates to geodetic surface coordinates on a WGS84
-   * ellipsoid, this will return {@link std::nullopt} instead.
+   * ellipsoid, this will return `std::nullopt` instead.
    */
   static std::optional<SimplePlanarEllipsoidCurve>
   fromEarthCenteredEarthFixedCoordinates(
@@ -48,15 +48,15 @@ public:
    *
    * @param ellipsoid The ellipsoid that these cartographic coordinates are
    * from.
-   * @param sourceLlh The position that the path will begin at in Longitude,
+   * @param source The position that the path will begin at in Longitude,
    * Latitude, and Height.
-   * @param destinationLlh The position that the path will end at in Longitude,
+   * @param destination The position that the path will end at in Longitude,
    * Latitude, and Height.
    *
    * @returns An optional type containing a {@link SimplePlanarEllipsoidCurve}
    * object representing the generated path, if possible. If it wasn't possible
    * to scale the input coordinates to geodetic surface coordinates on a WGS84
-   * ellipsoid, this will return {@link std::nullopt} instead.
+   * ellipsoid, this will return std::nullopt instead.
    */
   static std::optional<SimplePlanarEllipsoidCurve> fromLongitudeLatitudeHeight(
       const Ellipsoid& ellipsoid,

--- a/CesiumGltf/include/CesiumGltf/AccessorView.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorView.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include "CesiumGltf/Accessor.h"
 #include "CesiumGltf/Model.h"
 
 #include <cstddef>
 #include <stdexcept>
+
 
 namespace CesiumGltf {
 

--- a/CesiumGltf/include/CesiumGltf/AccessorView.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorView.h
@@ -6,7 +6,6 @@
 #include <cstddef>
 #include <stdexcept>
 
-
 namespace CesiumGltf {
 
 /**

--- a/CesiumGltf/include/CesiumGltf/AccessorWriter.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorWriter.h
@@ -20,8 +20,8 @@ public:
   AccessorWriter(const AccessorView<T>& accessorView)
       : _accessor(accessorView) {}
 
-  /** @copydoc AccessorView::AccessorView(const
-   * std::byte*,int64_t,int64_t,int64_t) */
+  /** @copydoc AccessorView::AccessorView(const std::byte*, int64_t, int64_t,
+   * int64_t) */
   AccessorWriter(std::byte* pData, int64_t stride, int64_t offset, int64_t size)
       : _accessor(pData, stride, offset, size) {}
 

--- a/CesiumGltf/include/CesiumGltf/FeatureIdTextureView.h
+++ b/CesiumGltf/include/CesiumGltf/FeatureIdTextureView.h
@@ -97,8 +97,7 @@ public:
    *
    * @param model The glTF in which to look for the feature ID texture's data.
    * @param featureIdTexture The feature ID texture to create a view for.
-   * @param applyKhrTextureTransformExtension Whether to automatically apply the
-   * `KHR_texture_transform` extension to the feature ID texture, if it exists.
+   * @param options The set of options to use for this `FeatureIdTextureView`.
    */
   FeatureIdTextureView(
       const Model& model,

--- a/CesiumGltf/include/CesiumGltf/MetadataConversions.h
+++ b/CesiumGltf/include/CesiumGltf/MetadataConversions.h
@@ -251,7 +251,6 @@ struct MetadataConversions<
    * This returns std::nullopt if no number is parsed from the string.
    *
    * @param from The std::string to parse from.
-   * @param defaultValue The default value to be returned if conversion fails.
    */
   static std::optional<TTo> convert(const std::string& from) {
     if (from.size() == 0) {
@@ -599,7 +598,6 @@ struct MetadataConversions<
    * @brief Converts a scalar to a std::string.
    *
    * @param from The scalar to be converted.
-   * @param defaultValue The default value to be returned if conversion fails.
    */
   static std::optional<std::string> convert(TFrom from) {
     return std::to_string(from);

--- a/CesiumGltf/include/CesiumGltf/Model.h
+++ b/CesiumGltf/include/CesiumGltf/Model.h
@@ -20,7 +20,7 @@ struct CESIUMGLTF_API Model : public ModelSpec {
    * After this method returns, this `Model` contains all of the
    * elements that were originally in it _plus_ all of the elements
    * that were in `rhs`. Element indices are updated accordingly.
-   * However, element indices in {@link ExtensibleObject::extras}, if any,
+   * However, element indices in {@link CesiumUtility::ExtensibleObject::extras}, if any,
    * are _not_ updated.
    *
    * @param rhs The model to merge into this one.
@@ -62,7 +62,7 @@ struct CESIUMGLTF_API Model : public ModelSpec {
       int32_t sceneID,
       std::function<ForEachRootNodeInSceneCallback>&& callback);
 
-  /** @copydoc Gltf::forEachRootNodeInScene() */
+  /** @copydoc Model::forEachRootNodeInScene */
   void forEachRootNodeInScene(
       int32_t sceneID,
       std::function<ForEachRootNodeInSceneConstCallback>&& callback) const;
@@ -107,7 +107,7 @@ struct CESIUMGLTF_API Model : public ModelSpec {
       const Node& node,
       const glm::dmat4& transform);
 
-  /** @copydoc Gltf::forEachNodeInScene() */
+  /** @copydoc Model::forEachNodeInScene */
   void forEachNodeInScene(
       int32_t sceneID,
       std::function<ForEachNodeInSceneConstCallback>&& callback) const;
@@ -157,7 +157,7 @@ struct CESIUMGLTF_API Model : public ModelSpec {
       const MeshPrimitive& primitive,
       const glm::dmat4& transform);
 
-  /** @copydoc Gltf::forEachPrimitiveInScene() */
+  /** @copydoc Model::forEachPrimitiveInScene */
   void forEachPrimitiveInScene(
       int32_t sceneID,
       std::function<ForEachPrimitiveInSceneConstCallback>&& callback) const;

--- a/CesiumGltf/include/CesiumGltf/NamedObject.h
+++ b/CesiumGltf/include/CesiumGltf/NamedObject.h
@@ -10,7 +10,7 @@ namespace CesiumGltf {
 /**
  * @brief The base class for objects in a glTF that have a name.
  *
- * A named object is also an {@link ExtensibleObject}.
+ * A named object is also an {@link CesiumUtility::ExtensibleObject}.
  */
 struct CESIUMGLTF_API NamedObject : public CesiumUtility::ExtensibleObject {
   /**

--- a/CesiumGltf/include/CesiumGltf/PropertyArrayView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyArrayView.h
@@ -70,7 +70,7 @@ public:
   /**
    * @brief Constructs an array view from a buffer.
    *
-   * @param buffer The buffer containing the values.
+   * @param values The buffer containing the values.
    */
   PropertyArrayCopy(const std::vector<ElementType>& values) noexcept
       : _storage(), _view() {

--- a/CesiumGltf/include/CesiumGltf/PropertyAttributeView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyAttributeView.h
@@ -166,8 +166,9 @@ public:
    *
    * @param primitive The target primitive
    * @param propertyId The id of the property to retrieve data from
-   * @tparam callback A callback function that accepts a property id and a
+   * @param callback A callback function that accepts a property id and a
    * {@link PropertyAttributePropertyView<T>}
+   * @tparam Callback The type of the callback function.
    */
   template <typename Callback>
   void getPropertyView(

--- a/CesiumGltf/include/CesiumGltf/PropertyAttributeView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyAttributeView.h
@@ -110,7 +110,7 @@ public:
    *
    * If T does not match the type specified by the class property, this returns
    * an invalid PropertyAttributePropertyView. Likewise, if the value of
-   * Normalized does not match the value of {@ClassProperty::normalized} for that
+   * Normalized does not match the value of {@link ClassProperty::normalized} for that
    * class property, this returns an invalid property view. Only types with
    * integer components may be normalized.
    *
@@ -299,9 +299,10 @@ public:
    * error status will be passed to the callback. Otherwise, a valid property
    * view will be passed to the callback.
    *
-   * @param propertyId The id of the property to retrieve data from
-   * @tparam callback A callback function that accepts property id and
+   * @param primitive The id of the property to retrieve data from
+   * @param callback A callback function that accepts property id and
    * {@link PropertyAttributePropertyView<T>}
+   * @tparam Callback The type of the callback function.
    */
   template <typename Callback>
   void

--- a/CesiumGltf/include/CesiumGltf/PropertyTablePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTablePropertyView.h
@@ -238,7 +238,7 @@ public:
    * @param property The {@link PropertyTableProperty}
    * @param classProperty The {@link ClassProperty} this property conforms to.
    * @param size The number of elements in the property table specified by {@link PropertyTable::count}
-   * @param value The raw buffer specified by {@link PropertyTableProperty::values}
+   * @param values The raw buffer specified by {@link PropertyTableProperty::values}
    */
   PropertyTablePropertyView(
       const PropertyTableProperty& property,
@@ -590,7 +590,7 @@ public:
    * @param property The {@link PropertyTableProperty}
    * @param classProperty The {@link ClassProperty} this property conforms to.
    * @param size The number of elements in the property table specified by {@link PropertyTable::count}
-   * @param value The raw buffer specified by {@link PropertyTableProperty::values}
+   * @param values The raw buffer specified by {@link PropertyTableProperty::values}
    */
   PropertyTablePropertyView(
       const PropertyTableProperty& property,
@@ -614,7 +614,7 @@ public:
    * @param size The number of elements in the property table specified by {@link PropertyTable::count}
    * @param values The raw buffer specified by {@link PropertyTableProperty::values}
    * @param arrayOffsets The raw buffer specified by {@link PropertyTableProperty::arrayOffsets}
-   * @param offsetType The offset type of arrayOffsets specified by {@link PropertyTableProperty::arrayOffsetType}
+   * @param arrayOffsetType The offset type of arrayOffsets specified by {@link PropertyTableProperty::arrayOffsetType}
    */
   PropertyTablePropertyView(
       const PropertyTableProperty& property,

--- a/CesiumGltf/include/CesiumGltf/PropertyTableView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTableView.h
@@ -168,8 +168,9 @@ public:
    * view will be passed to the callback.
    *
    * @param propertyId The id of the property to retrieve data from
-   * @tparam callback A callback function that accepts a property id and a
+   * @param callback A callback function that accepts a property id and a
    * {@link PropertyTablePropertyView<T>}
+   * @tparam Callback The type of the callback function.
    */
   template <typename Callback>
   void

--- a/CesiumGltf/include/CesiumGltf/PropertyTableView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTableView.h
@@ -122,7 +122,7 @@ public:
    * If T does not match the type specified by the class property, this returns
    * an invalid PropertyTablePropertyView. Likewise, if the value of
    * Normalized
-   * does not match the value of {@ClassProperty::normalized} for that class property,
+   * does not match the value of {@link ClassProperty::normalized} for that class property,
    * this returns an invalid property view. Only types with integer components
    * may be normalized.
    *
@@ -321,9 +321,9 @@ public:
    * an error status code will be passed to the callback. Otherwise, a valid
    * property view will be passed to the callback.
    *
-   * @param propertyId The id of the property to retrieve data from
-   * @tparam callback A callback function that accepts property id and
+   * @param callback A callback function that accepts property id and
    * {@link PropertyTablePropertyView<T>}
+   * @tparam Callback The type of the callback function.
    */
   template <typename Callback> void forEachProperty(Callback&& callback) const {
     for (const auto& property : this->_pClass->properties) {

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -291,7 +291,6 @@ public:
    * @param classProperty The {@link ClassProperty} this property conforms to.
    * @param sampler The {@link Sampler} used by the property.
    * @param image The {@link ImageAsset} used by the property.
-   * @param channels The value of {@link PropertyTextureProperty::channels}.
    * @param options The options for constructing the view.
    */
   PropertyTexturePropertyView(
@@ -524,7 +523,6 @@ public:
    * @param classProperty The {@link ClassProperty} this property conforms to.
    * @param sampler The {@link Sampler} used by the property.
    * @param image The {@link ImageAsset} used by the property.
-   * @param channels The value of {@link PropertyTextureProperty::channels}.
    * @param options The options for constructing the view.
    */
   PropertyTexturePropertyView(

--- a/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
@@ -106,7 +106,7 @@ public:
    *
    * If T does not match the type specified by the class property, this returns
    * an invalid PropertyTexturePropertyView. Likewise, if the value of
-   * Normalized does not match the value of {@ClassProperty::normalized} for that
+   * Normalized does not match the value of {@link ClassProperty::normalized} for that
    * class property, this returns an invalid property view. Only types with
    * integer components may be normalized.
    *

--- a/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
@@ -155,9 +155,10 @@ public:
    * property view will be passed to the callback.
    *
    * @param propertyId The id of the property to retrieve data from
-   * @tparam callback A callback function that accepts a property id and a
+   * @param callback A callback function that accepts a property id and a
    * {@link PropertyTexturePropertyView<T>}
    * @param propertyOptions The options to apply to the property.
+   * @tparam Callback The type of the callback function.
    */
   template <typename Callback>
   void getPropertyView(
@@ -281,10 +282,11 @@ public:
    * error status will be passed to the callback. Otherwise, a valid property
    * view will be passed to the callback.
    *
-   * @tparam callback A callback function that accepts property id and
+   * @param callback A callback function that accepts property id and
    * {@link PropertyTexturePropertyView<T>}
    * @param propertyOptions The options to apply to each property in the
    * property texture.
+   * @tparam Callback The type of the callback function.
    */
 
   template <typename Callback>

--- a/CesiumGltfContent/include/CesiumGltfContent/GltfUtilities.h
+++ b/CesiumGltfContent/include/CesiumGltfContent/GltfUtilities.h
@@ -63,7 +63,7 @@ struct CESIUMGLTFCONTENT_API GltfUtilities {
    * `RTC_CENTER` in the. If the given model does not have this extension, then
    * this function will return the `rootTransform` unchanged.
    *
-   * @param model The glTF model
+   * @param gltf The glTF model
    * @param rootTransform The matrix that will be multiplied with the transform
    * @return The result of multiplying the `RTC_CENTER` with the
    * `rootTransform`.
@@ -103,7 +103,7 @@ struct CESIUMGLTFCONTENT_API GltfUtilities {
    * value than west.
    *
    * If the glTF contains no geometry, the returned region's rectangle
-   * will be {@link GlobeRectangle::EMPTY}, its minimum height will be 1.0, and
+   * will be {@link CesiumGeospatial::GlobeRectangle::EMPTY}, its minimum height will be 1.0, and
    * its maximum height will be -1.0 (the minimum will be greater than the
    * maximum).
    *
@@ -141,8 +141,8 @@ struct CESIUMGLTFCONTENT_API GltfUtilities {
   static void collapseToSingleBuffer(CesiumGltf::Model& gltf);
 
   /**
-   * @brief Copies the content of one {@link Buffer} to the end of another,
-   * updates all {@link BufferView} instances to refer to the destination
+   * @brief Copies the content of one {@link CesiumGltf::Buffer} to the end of another,
+   * updates all {@link CesiumGltf::BufferView} instances to refer to the destination
    * buffer, and clears the contents of the original buffer.
    *
    * The source buffer is not removed, but it has a `byteLength` of zero after
@@ -261,7 +261,7 @@ struct CESIUMGLTFCONTENT_API GltfUtilities {
    * @param cullBackFaces Ignore triangles that face away from ray. Front faces
    * use CCW winding order.
    * @param gltfTransform Optional matrix to apply to entire gltf model.
-   * @param return IntersectResult describing outcome
+   * @returns IntersectResult describing outcome
    */
   static IntersectResult intersectRayGltfModel(
       const CesiumGeometry::Ray& ray,

--- a/CesiumGltfContent/include/CesiumGltfContent/GltfUtilities.h
+++ b/CesiumGltfContent/include/CesiumGltfContent/GltfUtilities.h
@@ -109,6 +109,7 @@ struct CESIUMGLTFCONTENT_API GltfUtilities {
    *
    * @param gltf The model.
    * @param transform The transform from model coordinates to ECEF coordinates.
+   * @param ellipsoid The {@link CesiumGeospatial::Ellipsoid}.
    * @return The computed bounding region.
    */
   static CesiumGeospatial::BoundingRegion computeBoundingRegion(

--- a/CesiumGltfReader/include/CesiumGltfReader/GltfReader.h
+++ b/CesiumGltfReader/include/CesiumGltfReader/GltfReader.h
@@ -63,10 +63,10 @@ struct CESIUMGLTFREADER_API GltfReaderOptions {
   bool clearDecodedDataUrls = true;
 
   /**
-   * @brief Whether embedded images in {@link Model::buffers} should be
+   * @brief Whether embedded images in {@link CesiumGltf::Model::buffers} should be
    * automatically decoded as part of the load process.
    *
-   * The {@link ImageSpec::mimeType} property is ignored, and instead the
+   * The {@link CesiumGltf::ImageSpec::mimeType} property is ignored, and instead the
    * [stb_image](https://github.com/nothings/stb) library is used to decode
    * images in `JPG`, `PNG`, `TGA`, `BMP`, `PSD`, `GIF`, `HDR`, or `PIC` format.
    */

--- a/CesiumGltfReader/include/CesiumGltfReader/ImageDecoder.h
+++ b/CesiumGltfReader/include/CesiumGltfReader/ImageDecoder.h
@@ -18,7 +18,7 @@ namespace CesiumGltfReader {
 struct CESIUMGLTFREADER_API ImageReaderResult {
 
   /**
-   * @brief The {@link ImageAsset} that was read.
+   * @brief The {@link CesiumGltf::ImageAsset} that was read.
    *
    * This will be `std::nullopt` if the image could not be read.
    */
@@ -47,7 +47,7 @@ public:
    * images in `JPG`, `PNG`, `TGA`, `BMP`, `PSD`, `GIF`, `HDR`, or `PIC` format.
    *
    * @param data The buffer from which to read the image.
-   * @param ktx2TranscodeTargetFormat The compression format to transcode
+   * @param ktx2TranscodeTargets The compression format to transcode
    * KTX v2 textures into. If this is std::nullopt, KTX v2 textures will be
    * fully decompressed into raw pixels.
    * @return The result of reading the image.
@@ -71,12 +71,12 @@ public:
   /**
    * @brief Resize an image, without validating the provided pointers or ranges.
    *
-   * @param inputPixels The input image.
+   * @param pInputPixels The input image.
    * @param inputWidth The width of the input image, in pixels.
    * @param inputHeight The height of the input image, in pixels.
    * @param inputStrideBytes The stride of the input image, in bytes. Stride is
    * the number of bytes between successive rows.
-   * @param outputPixels The buffer into which to write the output image.
+   * @param pOutputPixels The buffer into which to write the output image.
    * @param outputWidth The width of the output image, in pixels.
    * @param outputHeight The height of the otuput image, in pixels.
    * @param outputStrideBytes The stride of the output image, in bytes. Stride

--- a/CesiumGltfReader/include/CesiumGltfReader/NetworkImageAssetDescriptor.h
+++ b/CesiumGltfReader/include/CesiumGltfReader/NetworkImageAssetDescriptor.h
@@ -17,7 +17,7 @@ namespace CesiumGltfReader {
 
 /**
  * @brief A description of an image asset that can be loaded from the network
- * using an {@link IAssetAccessor}. This includes a URL, any headers to be
+ * using an {@link CesiumAsync::IAssetAccessor}. This includes a URL, any headers to be
  * included in the request, and the set of supported GPU texture formats for
  * KTX2 decoding.
  */
@@ -35,7 +35,7 @@ struct NetworkImageAssetDescriptor
 
   /**
    * @brief Request this asset from the network using the provided asset
-   * accessor and return the loaded {@link ImageAsset}.
+   * accessor and return the loaded {@link CesiumGltf::ImageAsset}.
    *
    * @param asyncSystem The async system.
    * @param pAssetAccessor The asset accessor.

--- a/CesiumGltfReader/include/CesiumGltfReader/NetworkSchemaAssetDescriptor.h
+++ b/CesiumGltfReader/include/CesiumGltfReader/NetworkSchemaAssetDescriptor.h
@@ -16,7 +16,7 @@ namespace CesiumGltfReader {
 
 /**
  * @brief A description of a schema asset that can be loaded from the network
- * using an {@link IAssetAccessor}. This includes a URL and any headers to be
+ * using an {@link CesiumAsync::IAssetAccessor}. This includes a URL and any headers to be
  * included in the request.
  */
 struct NetworkSchemaAssetDescriptor
@@ -28,7 +28,7 @@ struct NetworkSchemaAssetDescriptor
 
   /**
    * @brief Request this asset from the network using the provided asset
-   * accessor and return the loaded {@link Schema}.
+   * accessor and return the loaded {@link CesiumGltf::Schema}.
    *
    * @param asyncSystem The async system.
    * @param pAssetAccessor The asset accessor.

--- a/CesiumGltfWriter/include/CesiumGltfWriter/SchemaWriter.h
+++ b/CesiumGltfWriter/include/CesiumGltfWriter/SchemaWriter.h
@@ -13,7 +13,7 @@ namespace CesiumGltfWriter {
 
 /**
  * @brief The result of writing a schema with
- * {@link SchemaWriterWriter::writeSchema}.
+ * {@link SchemaWriter::writeSchema}.
  */
 struct CESIUMGLTFWRITER_API SchemaWriterResult {
   /**

--- a/CesiumJsonReader/include/CesiumJsonReader/JsonReader.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/JsonReader.h
@@ -18,7 +18,7 @@ struct MemoryStream;
 namespace CesiumJsonReader {
 
 /**
- * @brief The result of {@link Reader::readJson}.
+ * @brief The result of {@link JsonReader::readJson}.
  */
 template <typename T> struct ReadJsonResult {
   /**
@@ -82,7 +82,7 @@ public:
   /**
    * @brief Reads JSON from a `rapidjson::Value` into a statically-typed class.
    *
-   * @param data The `rapidjson::Value` from which to read JSON.
+   * @param jsonValue The `rapidjson::Value` from which to read JSON.
    * @param handler The handler to receive the top-level JSON object. This
    * instance must:
    *   - Implement {@link IJsonHandler}.

--- a/CesiumJsonReader/include/CesiumJsonReader/JsonReaderOptions.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/JsonReaderOptions.h
@@ -49,7 +49,7 @@ class CESIUMJSONREADER_API JsonReaderOptions {
 public:
   /**
    * @brief Gets a value indicating whether the values of unknown properties are
-   * captured in the {@link ExtensibleObject::unknownProperties} field.
+   * captured in the {@link CesiumUtility::ExtensibleObject::unknownProperties} field.
    *
    * If this is false, unknown properties are completely ignored.
    */
@@ -59,7 +59,7 @@ public:
 
   /**
    * @brief Sets a value indicating whether the values of unknown properties are
-   * captured in the {@link ExtensibleObject::unknownProperties} field.
+   * captured in the {@link CesiumUtility::ExtensibleObject::unknownProperties} field.
    *
    * If this is false, unknown properties are completely ignored.
    */

--- a/CesiumQuantizedMeshTerrain/include/CesiumQuantizedMeshTerrain/QuantizedMeshLoader.h
+++ b/CesiumQuantizedMeshTerrain/include/CesiumQuantizedMeshTerrain/QuantizedMeshLoader.h
@@ -72,9 +72,12 @@ public:
    * @brief Create a {@link QuantizedMeshLoadResult} from the given data.
    *
    * @param tileID The tile ID.
-   * @param tileBoundingVoume The tile bounding volume.
+   * @param tileBoundingVolume The tile bounding volume.
    * @param url The URL from which the data was loaded.
    * @param data The actual tile data.
+   * @param enableWaterMask If true, will attempt to load a water mask from the
+   * quantized mesh data.
+   * @param ellipsoid The ellipsoid to use for this quantized mesh.
    * @return The {@link QuantizedMeshLoadResult}
    */
   static QuantizedMeshLoadResult load(

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/IPrepareRasterOverlayRendererResources.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/IPrepareRasterOverlayRendererResources.h
@@ -36,14 +36,14 @@ public:
    *
    * This is called after {@link prepareRasterInLoadThread}, and unlike that
    * method, this one is called from the same thread that called
-   * {@link Tileset::updateView}.
+   * {@link Cesium3DTilesSelection::Tileset::updateView}.
    *
    * @param rasterTile The raster tile to prepare.
    * @param pLoadThreadResult The value returned from
    * {@link prepareRasterInLoadThread}.
    * @returns Arbitrary data representing the result of the load process. Note
    * that the value returned by {@link prepareRasterInLoadThread} will _not_ be
-   * automatically preserved and passed to {@link free}. If you need to free
+   * automatically preserved and passed to {@link freeRaster}. If you need to free
    * that value, do it in this method before returning. If you need that value
    * later, add it to the object returned from this method.
    */
@@ -56,7 +56,7 @@ public:
    *
    * This method is always called from the thread that destroyed the
    * {@link RasterOverlayTile}. When raster overlays are used with tilesets,
-   * this is the thread that called {@link Tileset::updateView} or deleted the
+   * this is the thread that called {@link Cesium3DTilesSelection::Tileset::updateView} or deleted the
    * tileset.
    *
    * @param rasterTile The tile for which to free renderer resources.

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/IonRasterOverlay.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/IonRasterOverlay.h
@@ -27,6 +27,8 @@ public:
    * @param ionAssetID The asset ID.
    * @param ionAccessToken The access token.
    * @param overlayOptions The {@link RasterOverlayOptions} for this instance.
+   * @param ionAssetEndpointUrl The URL of the ion endpoint to make our requests
+   * to.
    */
   IonRasterOverlay(
       const std::string& name,

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/QuadtreeRasterOverlayTileProvider.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/QuadtreeRasterOverlayTileProvider.h
@@ -30,7 +30,7 @@ public:
    * @param asyncSystem The async system used to do work in threads.
    * @param pAssetAccessor The interface used to obtain assets (tiles, etc.) for
    * this raster overlay.
-   * @param credit The {@link Credit} for this tile provider, if it exists.
+   * @param credit The {@link CesiumUtility::Credit} for this tile provider, if it exists.
    * @param pPrepareRendererResources The interface used to prepare raster
    * images for rendering.
    * @param pLogger The logger to which to send messages about the tile provider

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/QuadtreeRasterOverlayTileProvider.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/QuadtreeRasterOverlayTileProvider.h
@@ -36,6 +36,7 @@ public:
    * @param pLogger The logger to which to send messages about the tile provider
    * and tiles.
    * @param projection The {@link CesiumGeospatial::Projection}.
+   * @param tilingScheme The tiling scheme to be used by this {@link QuadtreeRasterOverlayTileProvider}.
    * @param coverageRectangle The {@link CesiumGeometry::Rectangle}.
    * @param minimumLevel The minimum quadtree tile level.
    * @param maximumLevel The maximum quadtree tile level.

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlay.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlay.h
@@ -193,6 +193,7 @@ public:
    * @param asyncSystem The async system used to do work in threads.
    * @param pAssetAccessor The interface used to download assets like overlay
    * metadata and tiles.
+   * @param ellipsoid The {@link CesiumGeospatial::Ellipsoid}.
    * @return The placeholder.
    */
   CesiumUtility::IntrusivePointer<RasterOverlayTileProvider> createPlaceholder(

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlay.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlay.h
@@ -88,7 +88,7 @@ struct CESIUMRASTEROVERLAYS_API RasterOverlayOptions {
    * Raster overlay resources include a Cesium ion asset endpoint or any
    * resources required for raster overlay metadata.
    *
-   * This callback is invoked by the {@link RasterOverlayCollection} when an
+   * This callback is invoked by the {@link Cesium3DTilesSelection::RasterOverlayCollection} when an
    * error occurs while it is creating a tile provider for this RasterOverlay.
    * It is always invoked in the main thread.
    */
@@ -100,7 +100,7 @@ struct CESIUMRASTEROVERLAYS_API RasterOverlayOptions {
   bool showCreditsOnScreen = false;
 
   /**
-   * @brief Arbitrary data that will be passed to {@link prepareRasterInLoadThread},
+   * @brief Arbitrary data that will be passed to {@link Cesium3DTilesSelection::IPrepareRendererResources::prepareRasterInLoadThread},
    * for example, data to control the per-raster overlay client-specific texture
    * properties.
    *
@@ -117,11 +117,11 @@ struct CESIUMRASTEROVERLAYS_API RasterOverlayOptions {
 
 /**
  * @brief The base class for a rasterized image that can be draped
- * over a {@link Tileset}. The image may be very, very high resolution, so only
+ * over a {@link Cesium3DTilesSelection::Tileset}. The image may be very, very high resolution, so only
  * small pieces of it are mapped to the Tileset at a time.
  *
- * Instances of this class can be added to the {@link RasterOverlayCollection}
- * that is returned by {@link Tileset::getOverlays}.
+ * Instances of this class can be added to the {@link Cesium3DTilesSelection::RasterOverlayCollection}
+ * that is returned by {@link Cesium3DTilesSelection::Tileset::getOverlays}.
  *
  * Instances of this class must be allocated on the heap, and their lifetimes
  * must be managed with {@link CesiumUtility::IntrusivePointer}.
@@ -152,7 +152,7 @@ public:
    *
    * @param asyncSystem The AsyncSystem to use for the returned SharedFuture,
    * if required. If this method is called multiple times, all invocations
-   * must pass {@link AsyncSystem} instances that compare equal to each other.
+   * must pass {@link CesiumAsync::AsyncSystem} instances that compare equal to each other.
    */
   CesiumAsync::SharedFuture<void>&
   getAsyncDestructionCompleteEvent(const CesiumAsync::AsyncSystem& asyncSystem);
@@ -212,8 +212,8 @@ public:
    * @param asyncSystem The async system used to do work in threads.
    * @param pAssetAccessor The interface used to download assets like overlay
    * metadata and tiles.
-   * @param pCreditSystem The {@link CreditSystem} to use when creating a
-   * per-TileProvider {@link Credit}.
+   * @param pCreditSystem The {@link CesiumUtility::CreditSystem} to use when creating a
+   * per-TileProvider {@link CesiumUtility::Credit}.
    * @param pPrepareRendererResources The interface used to prepare raster
    * images for rendering.
    * @param pLogger The logger to which to send messages about the tile provider

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayDetails.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayDetails.h
@@ -10,7 +10,7 @@
 
 namespace CesiumRasterOverlays {
 /**
- * @brief Holds details of the {@link TileRenderContent} that are useful
+ * @brief Holds details of the {@link Cesium3DTilesSelection::TileRenderContent} that are useful
  * for raster overlays.
  */
 struct CESIUMRASTEROVERLAYS_API RasterOverlayDetails {

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayDetails.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayDetails.h
@@ -52,6 +52,7 @@ struct CESIUMRASTEROVERLAYS_API RasterOverlayDetails {
    *
    * @param other The other instance of RasterOverlayDetails that will be merged
    * with this.
+   * @param ellipsoid The {@link CesiumGeospatial::Ellipsoid}.
    */
   void merge(
       const RasterOverlayDetails& other,

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayLoadFailureDetails.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayLoadFailureDetails.h
@@ -14,7 +14,7 @@ namespace CesiumRasterOverlays {
 class RasterOverlay;
 
 /**
- * @brief The type of load that failed in {@link TilesetLoadFailureDetails}.
+ * @brief The type of load that failed in {@link RasterOverlayLoadFailureDetails}.
  */
 enum class RasterOverlayLoadType {
   /**

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTile.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTile.h
@@ -25,9 +25,9 @@ class RasterOverlayTileProvider;
  * an associated image, which us used as an imagery overlay
  * for tile geometry. The connection between the imagery data
  * and the actual tile geometry is established via the
- * {@link RasterMappedTo3DTile} class, which combines a
+ * {@link Cesium3DTilesSelection::RasterMappedTo3DTile} class, which combines a
  * raster overlay tile with texture coordinates, to map the
- * image on the geometry of a {@link Tile}.
+ * image on the geometry of a {@link Cesium3DTilesSelection::Tile}.
  */
 class RasterOverlayTile final
     : public CesiumUtility::ReferenceCountedNonThreadSafe<RasterOverlayTile> {
@@ -71,10 +71,10 @@ public:
    * @brief Tile availability states.
    *
    * Values of this enumeration are returned by
-   * {@link RasterOverlayTile::update}, which in turn is called by
-   * {@link Tile::update}. These values are used to determine whether a leaf
-   * tile has been reached, but the associated raster tiles are not yet the
-   * most detailed ones that are available.
+   * {@link Cesium3DTilesSelection::RasterMappedTo3DTile::update}, which in turn is called by
+   * {@link Cesium3DTilesSelection::TilesetContentManager::updateDoneState}. These values are
+   * used to determine whether a leaf tile has been reached, but the associated
+   * raster tiles are not yet the most detailed ones that are available.
    */
   enum class MoreDetailAvailable {
 
@@ -178,7 +178,8 @@ public:
   LoadState getState() const noexcept { return this->_state; }
 
   /**
-   * @brief Returns the list of {@link Credit}s needed for this tile.
+   * @brief Returns the list of \ref CesiumUtility::Credit "Credit"s needed for
+   * this tile.
    */
   const std::vector<CesiumUtility::Credit>& getCredits() const noexcept {
     return this->_tileCredits;

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
@@ -43,7 +43,7 @@ struct CESIUMRASTEROVERLAYS_API LoadedRasterOverlayImage {
   CesiumGeometry::Rectangle rectangle{};
 
   /**
-   * @brief The {@link Credit} objects that decribe the attributions that
+   * @brief The {@link CesiumUtility::Credit} objects that decribe the attributions that
    * are required when using the image.
    */
   std::vector<CesiumUtility::Credit> credits{};
@@ -167,7 +167,7 @@ public:
    * @param asyncSystem The async system used to do work in threads.
    * @param pAssetAccessor The interface used to obtain assets (tiles, etc.) for
    * this raster overlay.
-   * @param credit The {@link Credit} for this tile provider, if it exists.
+   * @param credit The {@link CesiumUtility::Credit} for this tile provider, if it exists.
    * @param pPrepareRendererResources The interface used to prepare raster
    * images for rendering.
    * @param pLogger The logger to which to send messages about the tile provider
@@ -201,8 +201,8 @@ public:
    * So until that real `RasterOverlayTileProvider` becomes available, we use
    * a placeholder. When {@link RasterOverlayTileProvider::getTile} is invoked
    * on a placeholder, it returns a {@link RasterOverlayTile} that is also
-   * a placeholder. And whenever we see a placeholder `RasterOverTile` in
-   * {@link Tile::update}, we check if the corresponding `RasterOverlay` is
+   * a placeholder. And whenever we see a placeholder `RasterOverlayTile` in
+   * {@link Cesium3DTilesSelection::RasterMappedTo3DTile::update}, we check if the corresponding `RasterOverlay` is
    * ready yet. Once it's ready, we remove the placeholder tile and replace
    * it with the real tiles.
    *
@@ -315,7 +315,7 @@ public:
   void removeTile(RasterOverlayTile* pTile) noexcept;
 
   /**
-   * @brief Get the per-TileProvider {@link Credit} if one exists.
+   * @brief Get the per-TileProvider {@link CesiumUtility::Credit} if one exists.
    */
   const std::optional<CesiumUtility::Credit>& getCredit() const noexcept {
     return _credit;

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
@@ -152,6 +152,7 @@ public:
    * @param asyncSystem The async system used to do work in threads.
    * @param pAssetAccessor The interface used to obtain assets (tiles, etc.) for
    * this raster overlay.
+   * @param ellipsoid The {@link CesiumGeospatial::Ellipsoid}.
    */
   RasterOverlayTileProvider(
       const CesiumUtility::IntrusivePointer<const RasterOverlay>& pOwner,

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayUtilities.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayUtilities.h
@@ -108,6 +108,7 @@ struct CESIUMRASTEROVERLAYS_API RasterOverlayUtilities {
    * use. For example, if `textureCoordinateAttributeBaseName` is
    * `_CESIUMOVERLAY_` and this parameter is 0 (the defaults), then the texture
    * coordinates are read from a vertex attribute named `_CESIUMOVERLAY_0`.
+   * @param ellipsoid The {@link CesiumGeospatial::Ellipsoid}.
    * @return The upsampled model.
    */
   static std::optional<CesiumGltf::Model> upsampleGltfForRasterOverlays(

--- a/CesiumUtility/include/CesiumUtility/ErrorList.h
+++ b/CesiumUtility/include/CesiumUtility/ErrorList.h
@@ -59,7 +59,7 @@ struct CESIUMUTILITY_API ErrorList {
   /**
    * @brief Add a warning message
    *
-   * @param error The warning message to be added.
+   * @param warning The warning message to be added.
    */
   template <typename WarningStr> void emplaceWarning(WarningStr&& warning) {
     warnings.emplace_back(std::forward<WarningStr>(warning));

--- a/CesiumUtility/include/CesiumUtility/JsonValue.h
+++ b/CesiumUtility/include/CesiumUtility/JsonValue.h
@@ -298,6 +298,8 @@ public:
    *
    * @tparam To The expected type of the value.
    * @param key The key for which to retrieve the value from this object.
+   * @param defaultValue The value that will be returned if a numerical value
+   * can't be obtained.
    * @return The converted value.
    * @throws If unable to convert the converted value for one of the
    * aforementioned reasons.

--- a/CesiumUtility/include/CesiumUtility/ReferenceCounted.h
+++ b/CesiumUtility/include/CesiumUtility/ReferenceCounted.h
@@ -30,7 +30,7 @@ template <> class ThreadIdHolder<true> {};
  * {@link IntrusivePointer}.
  *
  * Consider using {@link ReferenceCountedThreadSafe} or
- * {@link ReferenceCountedNoThreadSafe} instead of using this class directly.
+ * {@link ReferenceCountedNonThreadSafe} instead of using this class directly.
  *
  * @tparam T The type that is _deriving_ from this class. For example, you
  * should declare your class as

--- a/CesiumUtility/include/CesiumUtility/ScopeGuard.h
+++ b/CesiumUtility/include/CesiumUtility/ScopeGuard.h
@@ -16,7 +16,7 @@ public:
   /**
    * @brief Constructor.
    *
-   * @param ExitFunctionArg The function type to be called when the guard is out
+   * @param exitFunc The function type to be called when the guard is out
    * of scope
    */
   template <

--- a/CesiumUtility/include/CesiumUtility/Uri.h
+++ b/CesiumUtility/include/CesiumUtility/Uri.h
@@ -137,7 +137,7 @@ public:
    * the URI are left unmodified, including any path parameters.
    *
    * @param uri The URI for which to set the path.
-   * @param The new path portion of the URI.
+   * @param newPath The new path portion of the URI.
    * @returns The new URI after setting the path. If the original URI cannot be
    * parsed, it is returned unmodified.
    */

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -87,9 +87,8 @@ if(DOXYGEN_FOUND)
     # Add support for Mermaid charts using the @mermaid command.
     set(DOXYGEN_HTML_EXTRA_FILES "${CMAKE_CURRENT_LIST_DIR}/assets/mermaid.min.js ${CMAKE_CURRENT_LIST_DIR}/assets/mingcute.json.js")
     set(DOXYGEN_ALIASES mermaid{1}="\\htmlonly <div class=\\\"mermaid\\\"> ^^ \\endhtmlonly \\htmlinclude \\\"\\1.mmd\\\" \\htmlonly ^^ </div> \\endhtmlonly")
+    set(DOXYGEN_VERBATIM_VARS DOXYGEN_ALIASES DOXYGEN_HTML_EXTRA_FILES)
     list(APPEND DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_LIST_DIR}/diagrams")
-
-    set(DOXYGEN_VERBATIM_VARS DOXYGEN_ALIASES DOXYGEN_HTML_EXTRA_FILES DOXYGEN_EXCLUDE_SYMBOLS)
 
     doxygen_add_docs(
         cesium-native-docs

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -13,6 +13,7 @@ if(DOXYGEN_FOUND)
         ../CesiumGeospatial/include
         ../CesiumGltf/include
         ../CesiumGltf/generated/include
+        ../CesiumGltfContent/include
         ../CesiumGltfReader/include
         ../CesiumGltfWriter/include
         ../CesiumIonClient/include
@@ -34,6 +35,7 @@ if(DOXYGEN_FOUND)
         ../CesiumGeometry/test
         ../CesiumGeospatial/test
         ../CesiumGltf/test
+        ../CesiumGltfContent/test
         ../CesiumGltfReader/test
         ../CesiumGltfWriter/test
         ../CesiumIonClient/test
@@ -50,7 +52,26 @@ if(DOXYGEN_FOUND)
     set(DOXYGEN_ENABLE_PREPROCESSING YES)
     set(DOXYGEN_MACRO_EXPANSION YES)
     set(DOXYGEN_EXPAND_ONLY_PREDEF YES)
-    set(DOXYGEN_PREDEFINED "CESIUM3DTILESSELECTION_API" "CESIUMGEOMETRY_API" "CESIUMUTILITY_API" "CESIUMGEOSPATIAL_API")
+    set(DOXYGEN_PREDEFINED 
+        "CESIUM3DTILES_API"
+        "CESIUM3DTILESCONTENT_API"
+        "CESIUM3DTILESREADER_API"
+        "CESIUM3DTILESSELECTION_API" 
+        "CESIUM3DTILESWRITER_API"
+        "CESIUMASYNC_API"
+        "CESIUMGEOMETRY_API" 
+        "CESIUMGEOSPATIAL_API"
+        "CESIUMGLTF_API"
+        "CESIUMGLTFCONTENT_API"
+        "CESIUMGLTFREADER_API"
+        "CESIUMGLTFWRITER_API"
+        "CESIUMIONCLIENT_API"
+        "CESIUMJSONREADER_API"
+        "CESIUMJSONWRITER_API"
+        "CESIUMQUANTIZEDMESHTERRAIN_API"
+        "CESIUMRASTEROVERLAYS_API"
+        "CESIUMUTILITY_API"
+        "CESIUM_DEFAULT_ELLIPSOID=\=CesiumGeospatial::Ellipsoid::WGS84")
     set(DOXYGEN_HTML_EXTRA_STYLESHEET "${CMAKE_CURRENT_LIST_DIR}/../node_modules/doxygen-awesome-css/doxygen-awesome.css")
     set(DOXYGEN_HTML_FOOTER "${CMAKE_CURRENT_LIST_DIR}/footer.html")
     set(DOXYGEN_GENERATE_TREEVIEW YES)
@@ -66,8 +87,9 @@ if(DOXYGEN_FOUND)
     # Add support for Mermaid charts using the @mermaid command.
     set(DOXYGEN_HTML_EXTRA_FILES "${CMAKE_CURRENT_LIST_DIR}/assets/mermaid.min.js ${CMAKE_CURRENT_LIST_DIR}/assets/mingcute.json.js")
     set(DOXYGEN_ALIASES mermaid{1}="\\htmlonly <div class=\\\"mermaid\\\"> ^^ \\endhtmlonly \\htmlinclude \\\"\\1.mmd\\\" \\htmlonly ^^ </div> \\endhtmlonly")
-    set(DOXYGEN_VERBATIM_VARS DOXYGEN_ALIASES DOXYGEN_HTML_EXTRA_FILES)
     list(APPEND DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_LIST_DIR}/diagrams")
+
+    set(DOXYGEN_VERBATIM_VARS DOXYGEN_ALIASES DOXYGEN_HTML_EXTRA_FILES DOXYGEN_EXCLUDE_SYMBOLS)
 
     doxygen_add_docs(
         cesium-native-docs


### PR DESCRIPTION
When generating our documentation, Doxygen produces a whole host of warning messages. As noted in #1010, fixing these warnings will improve the usability of our documentation. Some highlights:

- All API macros are now added to the Doxygen `PREDEFINED` list, resolving issues where Doxygen wouldn't be able to parse a type because the API macro was undefined. `CESIUM_DEFAULT_ELLIPSOID` has also been properly defined, meaning the default parameter will correctly show in the documentation.
- CesiumGltfContent is now included in the documentation.
- All previously undocumented parameters are now documented.
- Almost all "unable to resolve link" warnings have been fixed. Unaddressed here, besides the PropertyTable warnings mentioned below, are four warnings: two in ApplicationData.h and RasterOverlayLoadFailureDetails.h relating to declaration order, one in RasterOverlayTile.h because Cesium3DTilesSelection isn't included by CesiumRasterOverlays, and one in RasterOverlayUtilities.h that references a `RasterOverlay::getTile` method that no longer exists, and that I'm not sure of the current equivalent.

Besides warnings about undocumented members, most of the warnings remaining are related to `PropertyView`, `PropertyArrayView`, and `PropertyTablePropertyView`. The heavy use of templates here seems to be confusing Doxygen and many of its attempts to resolve links here. Doxygen's docs recommend using the `CLANG_ASSISTED_PARSING` option to deal with heavily templated code. However, I haven't gone down this path as it would significantly slow down our documentation generation and \it would mean that the documentation can only be correctly generated when using a CMake generator that produces a compile_commands.json. 

Considering the number of remaining warnings, this doesn't resolve #1010 itself. But it's a step in the right direction.