### PR TITLE
Improve Cesium ion token refresh and fix some small shared asset problems

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - The `schemaUri` property in the `EXT_structural_metadata` glTF extension is now supported, allowing structural metadata schemas to be loaded from URIs rather than being embedded in the glTF itself.
 - Added `getHeightSampler` method to `TilesetContentLoader`, allowing loaders to optionally provide a custom, more efficient means of querying heights using the `ITilesetHeightSampler` interface.
 - Added equality operator for `JsonValue`.
+- `TileLoadResult` now includes a `pAssetAccessor` that was used to retrieve the tile content and that should be used to retrieve any additional resources associated with the tile, such as external images.
 
 ##### Fixes :wrench:
 
@@ -26,6 +27,10 @@
 - Tightened the tolerance of `IntersectionTests::rayTriangleParametric`, allowing it to find intersections with smaller triangles.
 - Fixed a bug that could cause `GltfUtilities::intersectRayGltfModel` to crash when the model contains a primitive whose position accessor does not have min/max values.
 - `IonRasterOverlay` now passes its `RasterOverlayOptions` to the `BingMapsRasterOverlay` or `TileMapServiceRasterOverlay` that it creates internally.
+- Fixed a bug in `CachingAssetAccessor` that caused it to return cached request headers on a cache hit, rather than the headers included in the new request.
+- External resources (such as images) referenced from 3D Tiles content will no longer fail if a Cesium ion token refresh is necessary.
+- The Cesium ion token will now only be refreshed once when it expires. Previously, multiple refresh requests could be initiated at about the same time.
+- Fixed a bug in `SharedAssetDepot` that could lead to a crash with assets that fail to load.
 
 ### v0.41.0 - 2024-11-01
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/IPrepareRendererResources.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/IPrepareRendererResources.h
@@ -45,8 +45,7 @@ struct TileLoadResultAndRenderResources {
  * data of a {@link Tile} so that it can be used for rendering.
  *
  * Instances of this class are associated with a {@link Tileset}, in the
- * {@link TilesetExternals} structure that can be obtained
- * via {@link Tileset::getExternals}.
+ * {@link TilesetExternals} structure that is passed to the constructor.
  */
 class CESIUM3DTILESSELECTION_API IPrepareRendererResources
     : public CesiumRasterOverlays::IPrepareRasterOverlayRendererResources {

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileLoadResult.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileLoadResult.h
@@ -103,6 +103,12 @@ struct CESIUM3DTILESSELECTION_API TileLoadResult {
       rasterOverlayDetails;
 
   /**
+   * @brief The asset accessor that was used to retrieve this tile, and that
+   * should be used to retrieve further resources referenced by the tile.
+   */
+  std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor;
+
+  /**
    * @brief The request that is created to download the tile content.
    */
   std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest;
@@ -136,6 +142,7 @@ struct CESIUM3DTILESSELECTION_API TileLoadResult {
    * @param pCompletedRequest The failed request
    */
   static TileLoadResult createFailedResult(
+      std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor,
       std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest);
 
   /**
@@ -144,6 +151,7 @@ struct CESIUM3DTILESSELECTION_API TileLoadResult {
    * @param pCompletedRequest The failed request
    */
   static TileLoadResult createRetryLaterResult(
+      std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor,
       std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest);
 };
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -119,6 +119,20 @@ public:
   void setShowCreditsOnScreen(bool showCreditsOnScreen) noexcept;
 
   /**
+   * @brief Gets the {@link TilesetExternals} that summarize the external
+   * interfaces used by this tileset.
+   */
+  TilesetExternals& getExternals() noexcept { return this->_externals; }
+
+  /**
+   * @brief Gets the {@link TilesetExternals} that summarize the external
+   * interfaces used by this tileset.
+   */
+  const TilesetExternals& getExternals() const noexcept {
+    return this->_externals;
+  }
+
+  /**
    * @brief Returns the {@link CesiumAsync::AsyncSystem} that is used for
    * dispatching asynchronous tasks.
    */

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -119,20 +119,6 @@ public:
   void setShowCreditsOnScreen(bool showCreditsOnScreen) noexcept;
 
   /**
-   * @brief Gets the {@link TilesetExternals} that summarize the external
-   * interfaces used by this tileset.
-   */
-  TilesetExternals& getExternals() noexcept { return this->_externals; }
-
-  /**
-   * @brief Gets the {@link TilesetExternals} that summarize the external
-   * interfaces used by this tileset.
-   */
-  const TilesetExternals& getExternals() const noexcept {
-    return this->_externals;
-  }
-
-  /**
    * @brief Returns the {@link CesiumAsync::AsyncSystem} that is used for
    * dispatching asynchronous tasks.
    */

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
@@ -95,10 +95,6 @@ public:
   void notifyLoaderIsBeingDestroyed() { this->_pTilesetLoader = nullptr; }
 
 private:
-  CesiumAsync::Future<std::shared_ptr<CesiumAsync::IAssetRequest>>
-  handleTokenRefresh(
-      CesiumAsync::Future<std::shared_ptr<CesiumAsync::IAssetRequest>>) {}
-
   CesiumIonTilesetLoader* _pTilesetLoader;
   std::shared_ptr<CesiumAsync::IAssetAccessor> _pAggregatedAccessor;
 };

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
@@ -12,6 +12,97 @@
 #include <unordered_map>
 
 namespace Cesium3DTilesSelection {
+
+class CesiumIonAssetAccessor
+    : public std::enable_shared_from_this<CesiumIonAssetAccessor>,
+      public CesiumAsync::IAssetAccessor {
+public:
+  CesiumIonAssetAccessor(
+      CesiumIonTilesetLoader& tilesetLoader,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAggregatedAccessor)
+      : _pTilesetLoader(&tilesetLoader),
+        _pAggregatedAccessor(pAggregatedAccessor) {}
+
+  CesiumAsync::Future<std::shared_ptr<CesiumAsync::IAssetRequest>>
+  get(const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::string& url,
+      const std::vector<THeader>& headers = {}) override {
+    auto refreshToken = [pThis = this->shared_from_this()](
+                            const CesiumAsync::AsyncSystem& asyncSystem,
+                            std::shared_ptr<CesiumAsync::IAssetRequest>&&
+                                pRequest) {
+      if (!pThis->_pTilesetLoader) {
+        return asyncSystem.createResolvedFuture(std::move(pRequest));
+      }
+
+      const CesiumAsync::HttpHeaders& headers = pRequest->headers();
+      auto authIt = headers.find("authorization");
+      std::string currentAuthorizationHeader =
+          authIt != headers.end() ? authIt->second : std::string();
+
+      return pThis->_pTilesetLoader
+          ->refreshTokenInMainThread(asyncSystem, currentAuthorizationHeader)
+          .thenInMainThread(
+              [pThis, asyncSystem, pRequest = std::move(pRequest)](
+                  const std::string& newAuthorizationHeader) mutable {
+                if (newAuthorizationHeader.empty()) {
+                  // Could not refresh the token.
+                  return asyncSystem.createResolvedFuture(std::move(pRequest));
+                }
+
+                CesiumAsync::HttpHeaders headers = pRequest->headers();
+                headers["Authorization"] = newAuthorizationHeader;
+                std::vector<THeader> vecHeaders(headers.begin(), headers.end());
+                return pThis->get(asyncSystem, pRequest->url(), vecHeaders);
+              });
+    };
+
+    return this->_pAggregatedAccessor->get(asyncSystem, url, headers)
+        .thenImmediately([asyncSystem, refreshToken = std::move(refreshToken)](
+                             std::shared_ptr<CesiumAsync::IAssetRequest>&&
+                                 pRequest) mutable {
+          const CesiumAsync::IAssetResponse* pResponse = pRequest->response();
+          if (!pResponse) {
+            return asyncSystem.createResolvedFuture(std::move(pRequest));
+          }
+
+          if (pResponse->statusCode() == 401) {
+            // We need to refresh the Cesium ion token.
+            return asyncSystem.runInMainThread(
+                [asyncSystem,
+                 pRequest = std::move(pRequest),
+                 refreshToken = std::move(refreshToken)]() mutable {
+                  return refreshToken(asyncSystem, std::move(pRequest));
+                });
+          }
+
+          return asyncSystem.createResolvedFuture(std::move(pRequest));
+        });
+  }
+
+  CesiumAsync::Future<std::shared_ptr<CesiumAsync::IAssetRequest>> request(
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::string& verb,
+      const std::string& url,
+      const std::vector<THeader>& headers = std::vector<THeader>(),
+      const std::span<const std::byte>& contentPayload = {}) override {
+    return this->_pAggregatedAccessor
+        ->request(asyncSystem, verb, url, headers, contentPayload);
+  }
+
+  void tick() noexcept override { this->_pAggregatedAccessor->tick(); }
+
+  void notifyLoaderIsBeingDestroyed() { this->_pTilesetLoader = nullptr; }
+
+private:
+  CesiumAsync::Future<std::shared_ptr<CesiumAsync::IAssetRequest>>
+  handleTokenRefresh(
+      CesiumAsync::Future<std::shared_ptr<CesiumAsync::IAssetRequest>>) {}
+
+  CesiumIonTilesetLoader* _pTilesetLoader;
+  std::shared_ptr<CesiumAsync::IAssetAccessor> _pAggregatedAccessor;
+};
+
 namespace {
 struct AssetEndpointAttribution {
   std::string html;
@@ -55,8 +146,8 @@ std::optional<std::string> getNewAccessToken(
   if (ionResponse.HasParseError()) {
     SPDLOG_LOGGER_ERROR(
         pLogger,
-        "Error when parsing Cesium ion response, error code {} at byte offset "
-        "{}",
+        "Error when parsing Cesium ion response while refresh token, error "
+        "code {} at byte offset {}",
         ionResponse.GetParseError(),
         ionResponse.GetErrorOffset());
     return std::nullopt;
@@ -343,6 +434,7 @@ mainThreadHandleEndpointResponse(
       fmt::format("Received unsupported asset response type: {}", type));
   return externals.asyncSystem.createResolvedFuture(std::move(result));
 }
+
 } // namespace
 
 CesiumIonTilesetLoader::CesiumIonTilesetLoader(
@@ -353,52 +445,51 @@ CesiumIonTilesetLoader::CesiumIonTilesetLoader(
     AuthorizationHeaderChangeListener&& headerChangeListener,
     const CesiumGeospatial::Ellipsoid& ellipsoid)
     : _ellipsoid{ellipsoid},
-      _refreshTokenState{TokenRefreshState::None},
       _ionAssetID{ionAssetID},
       _ionAccessToken{std::move(ionAccessToken)},
       _ionAssetEndpointUrl{std::move(ionAssetEndpointUrl)},
       _pAggregatedLoader{std::move(pAggregatedLoader)},
-      _headerChangeListener{std::move(headerChangeListener)} {}
+      _headerChangeListener{std::move(headerChangeListener)},
+      _pLogger(nullptr),
+      _pTilesetAccessor(nullptr),
+      _pIonAccessor(nullptr),
+      _tokenRefreshInProgress() {}
+
+CesiumIonTilesetLoader::~CesiumIonTilesetLoader() noexcept {
+  if (this->_pIonAccessor) {
+    this->_pIonAccessor->notifyLoaderIsBeingDestroyed();
+  }
+}
 
 CesiumAsync::Future<TileLoadResult>
 CesiumIonTilesetLoader::loadTileContent(const TileLoadInput& loadInput) {
-  if (this->_refreshTokenState == TokenRefreshState::Loading) {
-    return loadInput.asyncSystem.createResolvedFuture(
-        TileLoadResult::createRetryLaterResult(nullptr));
-  } else if (this->_refreshTokenState == TokenRefreshState::Failed) {
-    return loadInput.asyncSystem.createResolvedFuture(
-        TileLoadResult::createFailedResult(nullptr));
+  if (this->_pTilesetAccessor == nullptr) {
+    this->_pTilesetAccessor = loadInput.pAssetAccessor;
+    this->_pIonAccessor = std::make_shared<CesiumIonAssetAccessor>(
+        *this,
+        this->_pTilesetAccessor);
   }
 
-  const auto& asyncSystem = loadInput.asyncSystem;
-  const auto& pAssetAccessor = loadInput.pAssetAccessor;
-  const auto& pLogger = loadInput.pLogger;
+  if (this->_pTilesetAccessor != loadInput.pAssetAccessor) {
+    // CesiumIonTilesetLoader requires this method to be called with the same
+    // asset accessor instance every time.
+    CESIUM_ASSERT(false);
+    return loadInput.asyncSystem.createResolvedFuture(
+        TileLoadResult::createFailedResult(loadInput.pAssetAccessor, nullptr));
+  }
 
-  // TODO: the way this is structured, requests already in progress
-  // with the old key might complete after the key has been updated,
-  // and there's nothing here clever enough to avoid refreshing the
-  // key _again_ in that instance.
-  auto refreshTokenInMainThread =
-      [this, pLogger, pAssetAccessor, asyncSystem]() {
-        this->refreshTokenInMainThread(pLogger, pAssetAccessor, asyncSystem);
-      };
+  this->_pLogger = loadInput.pLogger;
 
-  return this->_pAggregatedLoader->loadTileContent(loadInput).thenImmediately(
-      [asyncSystem,
-       refreshTokenInMainThread = std::move(refreshTokenInMainThread)](
-          TileLoadResult&& result) mutable {
-        // check to see if we need to refresh token
-        if (result.pCompletedRequest) {
-          auto response = result.pCompletedRequest->response();
-          if (response->statusCode() == 401) {
-            // retry later
-            result.state = TileLoadResultState::RetryLater;
-            asyncSystem.runInMainThread(std::move(refreshTokenInMainThread));
-          }
-        }
+  TileLoadInput aggregatedInput(
+      loadInput.tile,
+      loadInput.contentOptions,
+      loadInput.asyncSystem,
+      this->_pIonAccessor,
+      this->_pLogger,
+      loadInput.requestHeaders,
+      loadInput.ellipsoid);
 
-        return std::move(result);
-      });
+  return this->_pAggregatedLoader->loadTileContent(aggregatedInput);
 }
 
 TileChildrenResult CesiumIonTilesetLoader::createTileChildren(
@@ -408,53 +499,62 @@ TileChildrenResult CesiumIonTilesetLoader::createTileChildren(
   return pLoader->createTileChildren(tile, ellipsoid);
 }
 
-void CesiumIonTilesetLoader::refreshTokenInMainThread(
-    const std::shared_ptr<spdlog::logger>& pLogger,
-    const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
-    const CesiumAsync::AsyncSystem& asyncSystem) {
-  if (this->_refreshTokenState == TokenRefreshState::Loading) {
-    return;
+CesiumAsync::SharedFuture<std::string>
+CesiumIonTilesetLoader::refreshTokenInMainThread(
+    const CesiumAsync::AsyncSystem& asyncSystem,
+    const std::string& currentAuthorizationHeader) {
+  if (this->_tokenRefreshInProgress) {
+    if (!this->_tokenRefreshInProgress->isReady() ||
+        this->_tokenRefreshInProgress->wait() != currentAuthorizationHeader) {
+      // Only use this refreshed token if it's different from the one we're
+      // currently using. Otherwise, fall through and get a new token.
+      return *this->_tokenRefreshInProgress;
+    }
   }
-
-  this->_refreshTokenState = TokenRefreshState::Loading;
 
   std::string url = createEndpointResource(
       this->_ionAssetID,
       this->_ionAccessToken,
       this->_ionAssetEndpointUrl);
-  pAssetAccessor->get(asyncSystem, url)
-      .thenInMainThread(
-          [this,
-           pLogger](std::shared_ptr<CesiumAsync::IAssetRequest>&& pIonRequest) {
-            const CesiumAsync::IAssetResponse* pIonResponse =
-                pIonRequest->response();
+  this->_tokenRefreshInProgress =
+      this->_pTilesetAccessor->get(asyncSystem, url)
+          .thenInMainThread(
+              [this](
+                  std::shared_ptr<CesiumAsync::IAssetRequest>&& pIonRequest) {
+                const CesiumAsync::IAssetResponse* pIonResponse =
+                    pIonRequest->response();
 
-            if (!pIonResponse) {
-              this->_refreshTokenState = TokenRefreshState::Failed;
-              return;
-            }
-
-            uint16_t statusCode = pIonResponse->statusCode();
-            if (statusCode >= 200 && statusCode < 300) {
-              auto accessToken = getNewAccessToken(pIonResponse, pLogger);
-              if (accessToken) {
-                this->_headerChangeListener(
-                    "Authorization",
-                    "Bearer " + *accessToken);
-
-                // update cache with new access token
-                auto cacheIt = endpointCache.find(pIonRequest->url());
-                if (cacheIt != endpointCache.end()) {
-                  cacheIt->second.accessToken = accessToken.value();
+                if (!pIonResponse) {
+                  // Token refresh failed.
+                  return std::string();
                 }
 
-                this->_refreshTokenState = TokenRefreshState::Done;
-                return;
-              }
-            }
+                uint16_t statusCode = pIonResponse->statusCode();
+                if (statusCode >= 200 && statusCode < 300) {
+                  auto accessToken =
+                      getNewAccessToken(pIonResponse, this->_pLogger);
+                  if (accessToken) {
+                    std::string authorizationHeader = "Bearer " + *accessToken;
+                    this->_headerChangeListener(
+                        "Authorization",
+                        authorizationHeader);
 
-            this->_refreshTokenState = TokenRefreshState::Failed;
-          });
+                    // update cache with new access token
+                    auto cacheIt = endpointCache.find(pIonRequest->url());
+                    if (cacheIt != endpointCache.end()) {
+                      cacheIt->second.accessToken = accessToken.value();
+                    }
+
+                    return authorizationHeader;
+                  }
+                }
+
+                // Token refresh failed.
+                return std::string();
+              })
+          .share();
+
+  return *this->_tokenRefreshInProgress;
 }
 
 CesiumAsync::Future<TilesetContentLoaderResult<CesiumIonTilesetLoader>>
@@ -597,4 +697,5 @@ CesiumIonTilesetLoader::refreshTokenIfNeeded(
   }
   return externals.asyncSystem.createResolvedFuture(std::move(result));
 }
+
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.h
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.h
@@ -13,8 +13,6 @@ namespace Cesium3DTilesSelection {
 class CesiumIonAssetAccessor;
 
 class CesiumIonTilesetLoader : public TilesetContentLoader {
-  enum class TokenRefreshState { None, Loading, Done, Failed };
-
 public:
   using AuthorizationHeaderChangeListener = std::function<
       void(const std::string& header, const std::string& headerValue)>;

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.h
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.h
@@ -9,6 +9,9 @@
 #include <string>
 
 namespace Cesium3DTilesSelection {
+
+class CesiumIonAssetAccessor;
+
 class CesiumIonTilesetLoader : public TilesetContentLoader {
   enum class TokenRefreshState { None, Loading, Done, Failed };
 
@@ -23,6 +26,8 @@ public:
       std::unique_ptr<TilesetContentLoader>&& pAggregatedLoader,
       AuthorizationHeaderChangeListener&& headerChangeListener,
       const CesiumGeospatial::Ellipsoid& ellipsoid CESIUM_DEFAULT_ELLIPSOID);
+
+  virtual ~CesiumIonTilesetLoader() noexcept;
 
   CesiumAsync::Future<TileLoadResult>
   loadTileContent(const TileLoadInput& loadInput) override;
@@ -55,17 +60,21 @@ public:
       const CesiumGeospatial::Ellipsoid& ellipsoid CESIUM_DEFAULT_ELLIPSOID);
 
 private:
-  void refreshTokenInMainThread(
-      const std::shared_ptr<spdlog::logger>& pLogger,
-      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
-      const CesiumAsync::AsyncSystem& asyncSystem);
+  CesiumAsync::SharedFuture<std::string> refreshTokenInMainThread(
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::string& currentAuthorizationHeader);
 
   CesiumGeospatial::Ellipsoid _ellipsoid;
-  TokenRefreshState _refreshTokenState;
   int64_t _ionAssetID;
   std::string _ionAccessToken;
   std::string _ionAssetEndpointUrl;
   std::unique_ptr<TilesetContentLoader> _pAggregatedLoader;
   AuthorizationHeaderChangeListener _headerChangeListener;
+  std::shared_ptr<spdlog::logger> _pLogger;
+  std::shared_ptr<CesiumAsync::IAssetAccessor> _pTilesetAccessor;
+  std::shared_ptr<CesiumIonAssetAccessor> _pIonAccessor;
+  std::optional<CesiumAsync::SharedFuture<std::string>> _tokenRefreshInProgress;
+
+  friend class CesiumIonAssetAccessor;
 };
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/EllipsoidTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/EllipsoidTilesetLoader.cpp
@@ -59,6 +59,7 @@ EllipsoidTilesetLoader::loadTileContent(const TileLoadInput& input) {
       std::nullopt,
       std::nullopt,
       nullptr,
+      nullptr,
       {},
       TileLoadResultState::Success});
 }

--- a/Cesium3DTilesSelection/src/EllipsoidTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/EllipsoidTilesetLoader.cpp
@@ -58,7 +58,7 @@ EllipsoidTilesetLoader::loadTileContent(const TileLoadInput& input) {
       std::nullopt,
       std::nullopt,
       std::nullopt,
-      nullptr,
+      input.pAssetAccessor,
       nullptr,
       {},
       TileLoadResultState::Success});

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
@@ -121,86 +121,94 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
     const glm::dmat4& tileTransform,
     const CesiumGeospatial::Ellipsoid& ellipsoid) {
   return pAssetAccessor->get(asyncSystem, tileUrl, requestHeaders)
-      .thenInWorkerThread([pLogger,
-                           ktx2TranscodeTargets,
-                           applyTextureTransform,
-                           &asyncSystem,
-                           pAssetAccessor,
-                           tileTransform,
-                           requestHeaders,
-                           ellipsoid](
-                              std::shared_ptr<CesiumAsync::IAssetRequest>&&
-                                  pCompletedRequest) mutable {
-        const CesiumAsync::IAssetResponse* pResponse =
-            pCompletedRequest->response();
-        auto fail = [&]() {
-          return asyncSystem.createResolvedFuture(
-              TileLoadResult::createFailedResult(std::move(pCompletedRequest)));
-        };
-        const std::string& tileUrl = pCompletedRequest->url();
-        if (!pResponse) {
-          SPDLOG_LOGGER_ERROR(
-              pLogger,
-              "Did not receive a valid response for tile content {}",
-              tileUrl);
-          return fail();
-        }
+      .thenInWorkerThread(
+          [pLogger,
+           ktx2TranscodeTargets,
+           applyTextureTransform,
+           &asyncSystem,
+           pAssetAccessor,
+           tileTransform,
+           requestHeaders,
+           ellipsoid](std::shared_ptr<CesiumAsync::IAssetRequest>&&
+                          pCompletedRequest) mutable {
+            const CesiumAsync::IAssetResponse* pResponse =
+                pCompletedRequest->response();
+            auto fail = [&]() {
+              return asyncSystem.createResolvedFuture(
+                  TileLoadResult::createFailedResult(
+                      pAssetAccessor,
+                      std::move(pCompletedRequest)));
+            };
+            const std::string& tileUrl = pCompletedRequest->url();
+            if (!pResponse) {
+              SPDLOG_LOGGER_ERROR(
+                  pLogger,
+                  "Did not receive a valid response for tile content {}",
+                  tileUrl);
+              return fail();
+            }
 
-        uint16_t statusCode = pResponse->statusCode();
-        if (statusCode != 0 && (statusCode < 200 || statusCode >= 300)) {
-          SPDLOG_LOGGER_ERROR(
-              pLogger,
-              "Received status code {} for tile content {}",
-              statusCode,
-              tileUrl);
-          return fail();
-        }
+            uint16_t statusCode = pResponse->statusCode();
+            if (statusCode != 0 && (statusCode < 200 || statusCode >= 300)) {
+              SPDLOG_LOGGER_ERROR(
+                  pLogger,
+                  "Received status code {} for tile content {}",
+                  statusCode,
+                  tileUrl);
+              return fail();
+            }
 
-        // find gltf converter
-        const auto& responseData = pResponse->data();
-        auto converter = GltfConverters::getConverterByMagic(responseData);
-        if (!converter) {
-          converter = GltfConverters::getConverterByFileExtension(
-              pCompletedRequest->url());
-        }
+            // find gltf converter
+            const auto& responseData = pResponse->data();
+            auto converter = GltfConverters::getConverterByMagic(responseData);
+            if (!converter) {
+              converter = GltfConverters::getConverterByFileExtension(
+                  pCompletedRequest->url());
+            }
 
-        if (converter) {
-          // Convert to gltf
-          CesiumGltfReader::GltfReaderOptions gltfOptions;
-          gltfOptions.ktx2TranscodeTargets = ktx2TranscodeTargets;
-          gltfOptions.applyTextureTransform = applyTextureTransform;
-          AssetFetcher assetFetcher{
-              asyncSystem,
-              pAssetAccessor,
-              tileUrl,
-              tileTransform,
-              requestHeaders,
-              CesiumGeometry::Axis::Y};
-          return converter(responseData, gltfOptions, assetFetcher)
-              .thenImmediately([pLogger, tileUrl, pCompletedRequest, ellipsoid](
-                                   GltfConverterResult&& result) {
-                // Report any errors if there are any
-                logTileLoadResult(pLogger, tileUrl, result.errors);
-                if (result.errors || !result.model) {
-                  return TileLoadResult::createFailedResult(
-                      std::move(pCompletedRequest));
-                }
+            if (converter) {
+              // Convert to gltf
+              CesiumGltfReader::GltfReaderOptions gltfOptions;
+              gltfOptions.ktx2TranscodeTargets = ktx2TranscodeTargets;
+              gltfOptions.applyTextureTransform = applyTextureTransform;
+              AssetFetcher assetFetcher{
+                  asyncSystem,
+                  pAssetAccessor,
+                  tileUrl,
+                  tileTransform,
+                  requestHeaders,
+                  CesiumGeometry::Axis::Y};
+              return converter(responseData, gltfOptions, assetFetcher)
+                  .thenImmediately(
+                      [pAssetAccessor,
+                       pLogger,
+                       tileUrl,
+                       pCompletedRequest,
+                       ellipsoid](GltfConverterResult&& result) mutable {
+                        // Report any errors if there are any
+                        logTileLoadResult(pLogger, tileUrl, result.errors);
+                        if (result.errors || !result.model) {
+                          return TileLoadResult::createFailedResult(
+                              std::move(pAssetAccessor),
+                              std::move(pCompletedRequest));
+                        }
 
-                return TileLoadResult{
-                    std::move(*result.model),
-                    CesiumGeometry::Axis::Y,
-                    std::nullopt,
-                    std::nullopt,
-                    std::nullopt,
-                    std::move(pCompletedRequest),
-                    {},
-                    TileLoadResultState::Success,
-                    ellipsoid};
-              });
-        }
-        // content type is not supported
-        return fail();
-      });
+                        return TileLoadResult{
+                            std::move(*result.model),
+                            CesiumGeometry::Axis::Y,
+                            std::nullopt,
+                            std::nullopt,
+                            std::nullopt,
+                            std::move(pAssetAccessor),
+                            std::move(pCompletedRequest),
+                            {},
+                            TileLoadResultState::Success,
+                            ellipsoid};
+                      });
+            }
+            // content type is not supported
+            return fail();
+          });
 }
 } // namespace
 
@@ -219,7 +227,7 @@ ImplicitOctreeLoader::loadTileContent(const TileLoadInput& loadInput) {
       std::get_if<CesiumGeometry::OctreeTileID>(&tile.getTileID());
   if (!pOctreeID) {
     return asyncSystem.createResolvedFuture(
-        TileLoadResult::createFailedResult(nullptr));
+        TileLoadResult::createFailedResult(pAssetAccessor, nullptr));
   }
 
   // find the subtree ID
@@ -230,7 +238,7 @@ ImplicitOctreeLoader::loadTileContent(const TileLoadInput& loadInput) {
   uint32_t subtreeLevelIdx = subtreeID.level / this->_subtreeLevels;
   if (subtreeLevelIdx >= _loadedSubtrees.size()) {
     return asyncSystem.createResolvedFuture<TileLoadResult>(
-        TileLoadResult::createFailedResult(nullptr));
+        TileLoadResult::createFailedResult(pAssetAccessor, nullptr));
   }
 
   uint64_t subtreeMortonIdx =
@@ -251,18 +259,21 @@ ImplicitOctreeLoader::loadTileContent(const TileLoadInput& loadInput) {
                pLogger,
                subtreeUrl,
                requestHeaders)
-        .thenInMainThread([this, subtreeID](std::optional<SubtreeAvailability>&&
-                                                subtreeAvailability) mutable {
+        .thenInMainThread([this, pAssetAccessor, subtreeID](
+                              std::optional<SubtreeAvailability>&&
+                                  subtreeAvailability) mutable {
           if (subtreeAvailability) {
             this->addSubtreeAvailability(
                 subtreeID,
                 std::move(*subtreeAvailability));
 
             // tell client to retry later
-            return TileLoadResult::createRetryLaterResult(nullptr);
+            return TileLoadResult::createRetryLaterResult(
+                pAssetAccessor,
+                nullptr);
           } else {
             // Subtree load failed, so this tile fails, too.
-            return TileLoadResult::createFailedResult(nullptr);
+            return TileLoadResult::createFailedResult(pAssetAccessor, nullptr);
           }
         });
   }
@@ -277,6 +288,7 @@ ImplicitOctreeLoader::loadTileContent(const TileLoadInput& loadInput) {
         std::nullopt,
         std::nullopt,
         std::nullopt,
+        nullptr,
         nullptr,
         {},
         TileLoadResultState::Success,

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
@@ -126,7 +126,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
            ktx2TranscodeTargets,
            applyTextureTransform,
            &asyncSystem,
-           pAssetAccessor,
+           pAssetAccessor = pAssetAccessor,
            tileTransform,
            requestHeaders,
            ellipsoid](std::shared_ptr<CesiumAsync::IAssetRequest>&&
@@ -136,7 +136,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
             auto fail = [&]() {
               return asyncSystem.createResolvedFuture(
                   TileLoadResult::createFailedResult(
-                      pAssetAccessor,
+                      std::move(pAssetAccessor),
                       std::move(pCompletedRequest)));
             };
             const std::string& tileUrl = pCompletedRequest->url();
@@ -180,7 +180,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
                   CesiumGeometry::Axis::Y};
               return converter(responseData, gltfOptions, assetFetcher)
                   .thenImmediately(
-                      [pAssetAccessor,
+                      [pAssetAccessor = std::move(pAssetAccessor),
                        pLogger,
                        tileUrl,
                        pCompletedRequest,

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -148,7 +148,7 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
         auto fail = [&]() {
           return asyncSystem.createResolvedFuture(
               TileLoadResult::createFailedResult(
-                  std::move(pAssetAccessor),
+                  pAssetAccessor,
                   std::move(pCompletedRequest)));
         };
         const std::string& tileUrl = pCompletedRequest->url();

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -147,7 +147,9 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
             pCompletedRequest->response();
         auto fail = [&]() {
           return asyncSystem.createResolvedFuture(
-              TileLoadResult::createFailedResult(std::move(pCompletedRequest)));
+              TileLoadResult::createFailedResult(
+                  std::move(pAssetAccessor),
+                  std::move(pCompletedRequest)));
         };
         const std::string& tileUrl = pCompletedRequest->url();
         if (!pResponse) {
@@ -189,26 +191,32 @@ CesiumAsync::Future<TileLoadResult> requestTileContent(
               requestHeaders,
               CesiumGeometry::Axis::Y};
           return converter(responseData, gltfOptions, assetFetcher)
-              .thenImmediately([ellipsoid, pLogger, tileUrl, pCompletedRequest](
-                                   GltfConverterResult&& result) {
-                // Report any errors if there are any
-                logTileLoadResult(pLogger, tileUrl, result.errors);
-                if (result.errors || !result.model) {
-                  return TileLoadResult::createFailedResult(
-                      std::move(pCompletedRequest));
-                }
+              .thenImmediately(
+                  [ellipsoid,
+                   pLogger,
+                   tileUrl,
+                   pAssetAccessor,
+                   pCompletedRequest](GltfConverterResult&& result) mutable {
+                    // Report any errors if there are any
+                    logTileLoadResult(pLogger, tileUrl, result.errors);
+                    if (result.errors || !result.model) {
+                      return TileLoadResult::createFailedResult(
+                          std::move(pAssetAccessor),
+                          std::move(pCompletedRequest));
+                    }
 
-                return TileLoadResult{
-                    std::move(*result.model),
-                    CesiumGeometry::Axis::Y,
-                    std::nullopt,
-                    std::nullopt,
-                    std::nullopt,
-                    std::move(pCompletedRequest),
-                    {},
-                    TileLoadResultState::Success,
-                    ellipsoid};
-              });
+                    return TileLoadResult{
+                        std::move(*result.model),
+                        CesiumGeometry::Axis::Y,
+                        std::nullopt,
+                        std::nullopt,
+                        std::nullopt,
+                        std::move(pAssetAccessor),
+                        std::move(pCompletedRequest),
+                        {},
+                        TileLoadResultState::Success,
+                        ellipsoid};
+                  });
         }
         // content type is not supported
         return fail();
@@ -249,7 +257,7 @@ ImplicitQuadtreeLoader::loadTileContent(const TileLoadInput& loadInput) {
       std::get_if<CesiumGeometry::QuadtreeTileID>(&tile.getTileID());
   if (!pQuadtreeID) {
     return asyncSystem.createResolvedFuture<TileLoadResult>(
-        TileLoadResult::createFailedResult(nullptr));
+        TileLoadResult::createFailedResult(pAssetAccessor, nullptr));
   }
 
   // find the subtree ID
@@ -260,7 +268,7 @@ ImplicitQuadtreeLoader::loadTileContent(const TileLoadInput& loadInput) {
   uint32_t subtreeLevelIdx = subtreeID.level / this->_subtreeLevels;
   if (subtreeLevelIdx >= _loadedSubtrees.size()) {
     return asyncSystem.createResolvedFuture<TileLoadResult>(
-        TileLoadResult::createFailedResult(nullptr));
+        TileLoadResult::createFailedResult(pAssetAccessor, nullptr));
   }
 
   // the below morton index hash to the subtree assumes that tileID's components
@@ -292,18 +300,23 @@ ImplicitQuadtreeLoader::loadTileContent(const TileLoadInput& loadInput) {
                pLogger,
                subtreeUrl,
                requestHeaders)
-        .thenInMainThread([this, subtreeID](std::optional<SubtreeAvailability>&&
-                                                subtreeAvailability) mutable {
+        .thenInMainThread([this, pAssetAccessor, subtreeID](
+                              std::optional<SubtreeAvailability>&&
+                                  subtreeAvailability) mutable {
           if (subtreeAvailability) {
             this->addSubtreeAvailability(
                 subtreeID,
                 std::move(*subtreeAvailability));
 
             // tell client to retry later
-            return TileLoadResult::createRetryLaterResult(nullptr);
+            return TileLoadResult::createRetryLaterResult(
+                std::move(pAssetAccessor),
+                nullptr);
           } else {
             // Subtree load failed, so this tile fails, too.
-            return TileLoadResult::createFailedResult(nullptr);
+            return TileLoadResult::createFailedResult(
+                std::move(pAssetAccessor),
+                nullptr);
           }
         });
   }
@@ -318,6 +331,7 @@ ImplicitQuadtreeLoader::loadTileContent(const TileLoadInput& loadInput) {
         std::nullopt,
         std::nullopt,
         std::nullopt,
+        pAssetAccessor,
         nullptr,
         {},
         TileLoadResultState::Success,

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -300,7 +300,7 @@ ImplicitQuadtreeLoader::loadTileContent(const TileLoadInput& loadInput) {
                pLogger,
                subtreeUrl,
                requestHeaders)
-        .thenInMainThread([this, pAssetAccessor, subtreeID](
+        .thenInMainThread([this, pAssetAccessor = pAssetAccessor, subtreeID](
                               std::optional<SubtreeAvailability>&&
                                   subtreeAvailability) mutable {
           if (subtreeAvailability) {

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -404,7 +404,7 @@ Tileset::updateView(const std::vector<ViewState>& frustums, float deltaTime) {
       static_cast<int32_t>(this->_mainThreadLoadQueue.size());
 
   const std::shared_ptr<TileOcclusionRendererProxyPool>& pOcclusionPool =
-      this->getExternals().pTileOcclusionProxyPool;
+      this->_externals.pTileOcclusionProxyPool;
   if (pOcclusionPool) {
     pOcclusionPool->pruneOcclusionProxyMappings();
   }
@@ -1171,7 +1171,7 @@ bool Tileset::_kickDescendantsAndRenderTile(
 TileOcclusionState
 Tileset::_checkOcclusion(const Tile& tile, const FrameState& frameState) {
   const std::shared_ptr<TileOcclusionRendererProxyPool>& pOcclusionPool =
-      this->getExternals().pTileOcclusionProxyPool;
+      this->_externals.pTileOcclusionProxyPool;
   if (pOcclusionPool) {
     // First check if this tile's bounding volume has occlusion info and is
     // known to be occluded.

--- a/Cesium3DTilesSelection/src/TilesetContentLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentLoader.cpp
@@ -19,6 +19,7 @@ TileLoadInput::TileLoadInput(
       ellipsoid(ellipsoid_) {}
 
 TileLoadResult TileLoadResult::createFailedResult(
+    std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor,
     std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest) {
   return TileLoadResult{
       TileUnknownContent{},
@@ -26,6 +27,7 @@ TileLoadResult TileLoadResult::createFailedResult(
       std::nullopt,
       std::nullopt,
       std::nullopt,
+      std::move(pAssetAccessor),
       std::move(pCompletedRequest),
       {},
       TileLoadResultState::Failed,
@@ -33,6 +35,7 @@ TileLoadResult TileLoadResult::createFailedResult(
 }
 
 TileLoadResult TileLoadResult::createRetryLaterResult(
+    std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor,
     std::shared_ptr<CesiumAsync::IAssetRequest> pCompletedRequest) {
   return TileLoadResult{
       TileUnknownContent{},
@@ -40,6 +43,7 @@ TileLoadResult TileLoadResult::createRetryLaterResult(
       std::nullopt,
       std::nullopt,
       std::nullopt,
+      std::move(pAssetAccessor),
       std::move(pCompletedRequest),
       {},
       TileLoadResultState::RetryLater,

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -571,7 +571,7 @@ postProcessContentInWorkerThread(
   }
 
   auto asyncSystem = tileLoadInfo.asyncSystem;
-  auto pAssetAccessor = tileLoadInfo.pAssetAccessor;
+  auto pAssetAccessor = result.pAssetAccessor;
   return CesiumGltfReader::GltfReader::resolveExternalData(
              asyncSystem,
              baseUrl,
@@ -618,7 +618,9 @@ postProcessContentInWorkerThread(
         if (!gltfResult.model) {
           return tileLoadInfo.asyncSystem.createResolvedFuture(
               TileLoadResultAndRenderResources{
-                  TileLoadResult::createFailedResult(nullptr),
+                  TileLoadResult::createFailedResult(
+                      tileLoadInfo.pAssetAccessor,
+                      nullptr),
                   nullptr});
         }
 

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -619,7 +619,7 @@ postProcessContentInWorkerThread(
           return tileLoadInfo.asyncSystem.createResolvedFuture(
               TileLoadResultAndRenderResources{
                   TileLoadResult::createFailedResult(
-                      tileLoadInfo.pAssetAccessor,
+                      result.pAssetAccessor,
                       nullptr),
                   nullptr});
         }

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -905,8 +905,8 @@ TilesetJsonLoader::loadTileContent(const TileLoadInput& loadInput) {
            ellipsoid,
            upAxis = _upAxis,
            externalContentInitializer = std::move(externalContentInitializer),
-           pAssetAccessor,
-           &asyncSystem,
+           pAssetAccessor = pAssetAccessor,
+           asyncSystem,
            requestHeaders](std::shared_ptr<CesiumAsync::IAssetRequest>&&
                                pCompletedRequest) mutable {
             auto pResponse = pCompletedRequest->response();
@@ -918,7 +918,7 @@ TilesetJsonLoader::loadTileContent(const TileLoadInput& loadInput) {
                   tileUrl);
               return asyncSystem.createResolvedFuture(
                   TileLoadResult::createFailedResult(
-                      pAssetAccessor,
+                      std::move(pAssetAccessor),
                       std::move(pCompletedRequest)));
             }
 
@@ -931,7 +931,7 @@ TilesetJsonLoader::loadTileContent(const TileLoadInput& loadInput) {
                   tileUrl);
               return asyncSystem.createResolvedFuture(
                   TileLoadResult::createFailedResult(
-                      pAssetAccessor,
+                      std::move(pAssetAccessor),
                       std::move(pCompletedRequest)));
             }
 
@@ -962,12 +962,12 @@ TilesetJsonLoader::loadTileContent(const TileLoadInput& loadInput) {
                        pLogger,
                        upAxis,
                        tileUrl,
-                       pAssetAccessor,
+                       pAssetAccessor = std::move(pAssetAccessor),
                        pCompletedRequest](GltfConverterResult&& result) {
                         logTileLoadResult(pLogger, tileUrl, result.errors);
                         if (result.errors) {
                           return TileLoadResult::createFailedResult(
-                              pAssetAccessor,
+                              std::move(pAssetAccessor),
                               std::move(pCompletedRequest));
                         }
                         return TileLoadResult{
@@ -976,7 +976,7 @@ TilesetJsonLoader::loadTileContent(const TileLoadInput& loadInput) {
                             std::nullopt,
                             std::nullopt,
                             std::nullopt,
-                            pAssetAccessor,
+                            std::move(pAssetAccessor),
                             std::move(pCompletedRequest),
                             {},
                             TileLoadResultState::Success,
@@ -990,7 +990,7 @@ TilesetJsonLoader::loadTileContent(const TileLoadInput& loadInput) {
                       upAxis,
                       tileRefine,
                       pLogger,
-                      pAssetAccessor,
+                      std::move(pAssetAccessor),
                       std::move(pCompletedRequest),
                       std::move(externalContentInitializer),
                       ellipsoid));

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -681,6 +681,7 @@ TileLoadResult parseExternalTilesetInWorkerThread(
     CesiumGeometry::Axis upAxis,
     TileRefine tileRefine,
     const std::shared_ptr<spdlog::logger>& pLogger,
+    const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
     std::shared_ptr<CesiumAsync::IAssetRequest>&& pCompletedRequest,
     ExternalContentInitializer&& externalContentInitializer,
     const CesiumGeospatial::Ellipsoid& ellipsoid) {
@@ -699,7 +700,9 @@ TileLoadResult parseExternalTilesetInWorkerThread(
         "Error when parsing tileset JSON, error code {} at byte offset {}",
         tilesetJson.GetParseError(),
         tilesetJson.GetErrorOffset());
-    return TileLoadResult::createFailedResult(std::move(pCompletedRequest));
+    return TileLoadResult::createFailedResult(
+        pAssetAccessor,
+        std::move(pCompletedRequest));
   }
 
   // Save the parsed external tileset into custom data.
@@ -726,7 +729,9 @@ TileLoadResult parseExternalTilesetInWorkerThread(
     logTileLoadResult(pLogger, tileUrl, errors);
 
     // since the json cannot be parsed, we don't know the content of this tile
-    return TileLoadResult::createFailedResult(std::move(pCompletedRequest));
+    return TileLoadResult::createFailedResult(
+        pAssetAccessor,
+        std::move(pCompletedRequest));
   }
 
   externalContentInitializer.pExternalTilesetLoaders =
@@ -740,6 +745,7 @@ TileLoadResult parseExternalTilesetInWorkerThread(
       std::nullopt,
       std::nullopt,
       std::nullopt,
+      pAssetAccessor,
       std::move(pCompletedRequest),
       std::move(externalContentInitializer),
       TileLoadResultState::Success,
@@ -874,7 +880,7 @@ TilesetJsonLoader::loadTileContent(const TileLoadInput& loadInput) {
   const std::string* url = std::get_if<std::string>(&tile.getTileID());
   if (!url) {
     return loadInput.asyncSystem.createResolvedFuture<TileLoadResult>(
-        TileLoadResult::createFailedResult(nullptr));
+        TileLoadResult::createFailedResult(loadInput.pAssetAccessor, nullptr));
   }
 
   const glm::dmat4& tileTransform = tile.getTransform();
@@ -891,95 +897,105 @@ TilesetJsonLoader::loadTileContent(const TileLoadInput& loadInput) {
   std::string resolvedUrl =
       CesiumUtility::Uri::resolve(this->_baseUrl, *url, true);
   return pAssetAccessor->get(asyncSystem, resolvedUrl, requestHeaders)
-      .thenInWorkerThread([pLogger,
-                           contentOptions,
-                           tileTransform,
-                           tileRefine,
-                           ellipsoid,
-                           upAxis = _upAxis,
-                           externalContentInitializer =
-                               std::move(externalContentInitializer),
-                           pAssetAccessor,
-                           &asyncSystem,
-                           requestHeaders](
-                              std::shared_ptr<CesiumAsync::IAssetRequest>&&
-                                  pCompletedRequest) mutable {
-        auto pResponse = pCompletedRequest->response();
-        const std::string& tileUrl = pCompletedRequest->url();
-        if (!pResponse) {
-          SPDLOG_LOGGER_ERROR(
-              pLogger,
-              "Did not receive a valid response for tile content {}",
-              tileUrl);
-          return asyncSystem.createResolvedFuture(
-              TileLoadResult::createFailedResult(std::move(pCompletedRequest)));
-        }
-
-        uint16_t statusCode = pResponse->statusCode();
-        if (statusCode != 0 && (statusCode < 200 || statusCode >= 300)) {
-          SPDLOG_LOGGER_ERROR(
-              pLogger,
-              "Received status code {} for tile content {}",
-              statusCode,
-              tileUrl);
-          return asyncSystem.createResolvedFuture(
-              TileLoadResult::createFailedResult(std::move(pCompletedRequest)));
-        }
-
-        // find gltf converter
-        const auto& responseData = pResponse->data();
-        auto converter = GltfConverters::getConverterByMagic(responseData);
-        if (!converter) {
-          converter = GltfConverters::getConverterByFileExtension(tileUrl);
-        }
-
-        if (converter) {
-          // Convert to gltf
-          AssetFetcher assetFetcher{
-              asyncSystem,
-              pAssetAccessor,
-              tileUrl,
-              tileTransform,
-              requestHeaders,
-              upAxis};
-          CesiumGltfReader::GltfReaderOptions gltfOptions;
-          gltfOptions.ktx2TranscodeTargets =
-              contentOptions.ktx2TranscodeTargets;
-          gltfOptions.applyTextureTransform =
-              contentOptions.applyTextureTransform;
-          return converter(responseData, gltfOptions, assetFetcher)
-              .thenImmediately(
-                  [ellipsoid, pLogger, upAxis, tileUrl, pCompletedRequest](
-                      GltfConverterResult&& result) {
-                    logTileLoadResult(pLogger, tileUrl, result.errors);
-                    if (result.errors) {
-                      return TileLoadResult::createFailedResult(
-                          std::move(pCompletedRequest));
-                    }
-                    return TileLoadResult{
-                        std::move(*result.model),
-                        upAxis,
-                        std::nullopt,
-                        std::nullopt,
-                        std::nullopt,
-                        std::move(pCompletedRequest),
-                        {},
-                        TileLoadResultState::Success,
-                        ellipsoid};
-                  });
-        } else {
-          // not a renderable content, then it must be external tileset
-          return asyncSystem.createResolvedFuture(
-              parseExternalTilesetInWorkerThread(
-                  tileTransform,
-                  upAxis,
-                  tileRefine,
+      .thenInWorkerThread(
+          [pLogger,
+           contentOptions,
+           tileTransform,
+           tileRefine,
+           ellipsoid,
+           upAxis = _upAxis,
+           externalContentInitializer = std::move(externalContentInitializer),
+           pAssetAccessor,
+           &asyncSystem,
+           requestHeaders](std::shared_ptr<CesiumAsync::IAssetRequest>&&
+                               pCompletedRequest) mutable {
+            auto pResponse = pCompletedRequest->response();
+            const std::string& tileUrl = pCompletedRequest->url();
+            if (!pResponse) {
+              SPDLOG_LOGGER_ERROR(
                   pLogger,
-                  std::move(pCompletedRequest),
-                  std::move(externalContentInitializer),
-                  ellipsoid));
-        }
-      });
+                  "Did not receive a valid response for tile content {}",
+                  tileUrl);
+              return asyncSystem.createResolvedFuture(
+                  TileLoadResult::createFailedResult(
+                      pAssetAccessor,
+                      std::move(pCompletedRequest)));
+            }
+
+            uint16_t statusCode = pResponse->statusCode();
+            if (statusCode != 0 && (statusCode < 200 || statusCode >= 300)) {
+              SPDLOG_LOGGER_ERROR(
+                  pLogger,
+                  "Received status code {} for tile content {}",
+                  statusCode,
+                  tileUrl);
+              return asyncSystem.createResolvedFuture(
+                  TileLoadResult::createFailedResult(
+                      pAssetAccessor,
+                      std::move(pCompletedRequest)));
+            }
+
+            // find gltf converter
+            const auto& responseData = pResponse->data();
+            auto converter = GltfConverters::getConverterByMagic(responseData);
+            if (!converter) {
+              converter = GltfConverters::getConverterByFileExtension(tileUrl);
+            }
+
+            if (converter) {
+              // Convert to gltf
+              AssetFetcher assetFetcher{
+                  asyncSystem,
+                  pAssetAccessor,
+                  tileUrl,
+                  tileTransform,
+                  requestHeaders,
+                  upAxis};
+              CesiumGltfReader::GltfReaderOptions gltfOptions;
+              gltfOptions.ktx2TranscodeTargets =
+                  contentOptions.ktx2TranscodeTargets;
+              gltfOptions.applyTextureTransform =
+                  contentOptions.applyTextureTransform;
+              return converter(responseData, gltfOptions, assetFetcher)
+                  .thenImmediately(
+                      [ellipsoid,
+                       pLogger,
+                       upAxis,
+                       tileUrl,
+                       pAssetAccessor,
+                       pCompletedRequest](GltfConverterResult&& result) {
+                        logTileLoadResult(pLogger, tileUrl, result.errors);
+                        if (result.errors) {
+                          return TileLoadResult::createFailedResult(
+                              pAssetAccessor,
+                              std::move(pCompletedRequest));
+                        }
+                        return TileLoadResult{
+                            std::move(*result.model),
+                            upAxis,
+                            std::nullopt,
+                            std::nullopt,
+                            std::nullopt,
+                            pAssetAccessor,
+                            std::move(pCompletedRequest),
+                            {},
+                            TileLoadResultState::Success,
+                            ellipsoid};
+                      });
+            } else {
+              // not a renderable content, then it must be external tileset
+              return asyncSystem.createResolvedFuture(
+                  parseExternalTilesetInWorkerThread(
+                      tileTransform,
+                      upAxis,
+                      tileRefine,
+                      pLogger,
+                      pAssetAccessor,
+                      std::move(pCompletedRequest),
+                      std::move(externalContentInitializer),
+                      ellipsoid));
+            }
+          });
 }
 
 TileChildrenResult TilesetJsonLoader::createTileChildren(

--- a/Cesium3DTilesSelection/src/TilesetSharedAssetSystem.cpp
+++ b/Cesium3DTilesSelection/src/TilesetSharedAssetSystem.cpp
@@ -14,6 +14,7 @@ CesiumUtility::IntrusivePointer<TilesetSharedAssetSystem> createDefault() {
       GltfSharedAssetSystem::getDefault();
 
   p->pImage = pGltf->pImage;
+  p->pExternalMetadataSchema = pGltf->pExternalMetadataSchema;
 
   return p;
 }

--- a/Cesium3DTilesSelection/test/TestTilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/test/TestTilesetContentManager.cpp
@@ -441,6 +441,7 @@ TEST_CASE("Test tile state machine") {
         std::nullopt,
         std::nullopt,
         nullptr,
+        nullptr,
         [&](Tile&) { initializerCall = true; },
         TileLoadResultState::Success,
         Ellipsoid::WGS84};
@@ -546,6 +547,7 @@ TEST_CASE("Test tile state machine") {
         std::nullopt,
         std::nullopt,
         nullptr,
+        nullptr,
         [&](Tile&) { initializerCall = true; },
         TileLoadResultState::RetryLater,
         Ellipsoid::WGS84};
@@ -621,6 +623,7 @@ TEST_CASE("Test tile state machine") {
         std::nullopt,
         std::nullopt,
         std::nullopt,
+        nullptr,
         nullptr,
         [&](Tile&) { initializerCall = true; },
         TileLoadResultState::Failed,
@@ -715,6 +718,7 @@ TEST_CASE("Test tile state machine") {
         std::nullopt,
         std::nullopt,
         nullptr,
+        nullptr,
         [&](Tile&) { initializerCall = true; },
         TileLoadResultState::Success,
         Ellipsoid::WGS84};
@@ -787,6 +791,7 @@ TEST_CASE("Test tile state machine") {
         std::nullopt,
         std::nullopt,
         std::nullopt,
+        nullptr,
         nullptr,
         [&](Tile&) { initializerCall = true; },
         TileLoadResultState::Success,
@@ -877,6 +882,7 @@ TEST_CASE("Test the tileset content manager's post processing for gltf") {
         std::nullopt,
         std::nullopt,
         std::nullopt,
+        pMockedAssetAccessor,
         nullptr,
         {},
         TileLoadResultState::Success,
@@ -949,6 +955,7 @@ TEST_CASE("Test the tileset content manager's post processing for gltf") {
         std::nullopt,
         std::nullopt,
         nullptr,
+        nullptr,
         {},
         TileLoadResultState::Success,
         Ellipsoid::WGS84};
@@ -1017,6 +1024,7 @@ TEST_CASE("Test the tileset content manager's post processing for gltf") {
         std::nullopt,
         std::nullopt,
         nullptr,
+        nullptr,
         {},
         TileLoadResultState::Success,
         Ellipsoid::WGS84};
@@ -1067,6 +1075,7 @@ TEST_CASE("Test the tileset content manager's post processing for gltf") {
         std::nullopt,
         std::nullopt,
         std::nullopt,
+        nullptr,
         nullptr,
         {},
         TileLoadResultState::Success,
@@ -1361,6 +1370,7 @@ TEST_CASE("Test the tileset content manager's post processing for gltf") {
         std::nullopt,
         std::nullopt,
         nullptr,
+        nullptr,
         {},
         TileLoadResultState::Success,
         Ellipsoid::WGS84};
@@ -1582,6 +1592,7 @@ TEST_CASE("Test the tileset content manager's post processing for gltf") {
         std::nullopt,
         std::nullopt,
         std::move(rasterOverlayDetails),
+        nullptr,
         nullptr,
         {},
         TileLoadResultState::Success,

--- a/Cesium3DTilesSelection/test/TestTilesetSelectionAlgorithm.cpp
+++ b/Cesium3DTilesSelection/test/TestTilesetSelectionAlgorithm.cpp
@@ -1529,7 +1529,7 @@ void runUnconditionallyRefinedTestCase(const TilesetOptions& options) {
       }
 
       return input.asyncSystem.createResolvedFuture(
-          TileLoadResult::createFailedResult(nullptr));
+          TileLoadResult::createFailedResult(input.pAssetAccessor, nullptr));
     }
 
     virtual TileChildrenResult createTileChildren(

--- a/CesiumAsync/include/CesiumAsync/SharedAssetDepot.h
+++ b/CesiumAsync/include/CesiumAsync/SharedAssetDepot.h
@@ -405,9 +405,13 @@ private:
       // mutex. So we must take care not to lock it again, which could happen if
       // the asset is currently unreferenced and we naively create an
       // IntrusivePointer for it.
-      pAsset->addReference(true);
+      if (pAsset) {
+        pAsset->addReference(true);
+      }
       CesiumUtility::IntrusivePointer<TAssetType> p = pAsset.get();
-      pAsset->releaseReference(true);
+      if (pAsset) {
+        pAsset->releaseReference(true);
+      }
       return CesiumUtility::ResultPointer<TAssetType>(p, errorsAndWarnings);
     }
   };

--- a/CesiumAsync/include/CesiumAsync/SharedAssetDepot.h
+++ b/CesiumAsync/include/CesiumAsync/SharedAssetDepot.h
@@ -405,11 +405,10 @@ private:
       // mutex. So we must take care not to lock it again, which could happen if
       // the asset is currently unreferenced and we naively create an
       // IntrusivePointer for it.
+      CesiumUtility::IntrusivePointer<TAssetType> p = nullptr;
       if (pAsset) {
         pAsset->addReference(true);
-      }
-      CesiumUtility::IntrusivePointer<TAssetType> p = pAsset.get();
-      if (pAsset) {
+        p = pAsset.get();
         pAsset->releaseReference(true);
       }
       return CesiumUtility::ResultPointer<TAssetType>(p, errorsAndWarnings);

--- a/CesiumAsync/src/CachingAssetAccessor.cpp
+++ b/CesiumAsync/src/CachingAssetAccessor.cpp
@@ -262,7 +262,9 @@ Future<std::shared_ptr<IAssetRequest>> CachingAssetAccessor::get(
             std::shared_ptr<IAssetRequest> pRequest =
                 std::make_shared<CacheAssetRequest>(
                     std::move(url),
-                    HttpHeaders(headers.begin(), headers.end()),
+                    HttpHeaders(
+                        std::make_move_iterator(headers.begin()),
+                        std::make_move_iterator(headers.end())),
                     std::move(cacheItem));
             return asyncSystem.createResolvedFuture(std::move(pRequest));
           })

--- a/CesiumAsync/src/CachingAssetAccessor.cpp
+++ b/CesiumAsync/src/CachingAssetAccessor.cpp
@@ -139,8 +139,8 @@ Future<std::shared_ptr<IAssetRequest>> CachingAssetAccessor::get(
            pAssetAccessor = this->_pAssetAccessor,
            pCacheDatabase = this->_pCacheDatabase,
            pLogger = this->_pLogger,
-           =url,
-           =headers= headers,
+           url = url,
+           headers = headers,
            threadPool]() mutable -> Future<std::shared_ptr<IAssetRequest>> {
             std::optional<CacheItem> cacheLookup =
                 pCacheDatabase->getEntry(url);

--- a/CesiumAsync/src/CachingAssetAccessor.cpp
+++ b/CesiumAsync/src/CachingAssetAccessor.cpp
@@ -16,50 +16,56 @@
 namespace CesiumAsync {
 class CacheAssetResponse : public IAssetResponse {
 public:
-  CacheAssetResponse(const CacheItem* pCacheItem) noexcept
-      : _pCacheItem{pCacheItem} {}
+  CacheAssetResponse(CacheResponse&& cacheResponse) noexcept
+      : _cacheResponse(std::move(cacheResponse)) {}
 
   virtual uint16_t statusCode() const noexcept override {
-    return this->_pCacheItem->cacheResponse.statusCode;
+    return this->_cacheResponse.statusCode;
   }
 
   virtual std::string contentType() const override {
-    auto it = this->_pCacheItem->cacheResponse.headers.find("Content-Type");
-    if (it == this->_pCacheItem->cacheResponse.headers.end()) {
+    auto it = this->_cacheResponse.headers.find("Content-Type");
+    if (it == this->_cacheResponse.headers.end()) {
       return std::string();
     }
     return it->second;
   }
 
   virtual const HttpHeaders& headers() const noexcept override {
-    return this->_pCacheItem->cacheResponse.headers;
+    return this->_cacheResponse.headers;
   }
 
   virtual std::span<const std::byte> data() const noexcept override {
     return std::span<const std::byte>(
-        this->_pCacheItem->cacheResponse.data.data(),
-        this->_pCacheItem->cacheResponse.data.size());
+        this->_cacheResponse.data.data(),
+        this->_cacheResponse.data.size());
   }
 
 private:
-  const CacheItem* _pCacheItem;
+  CacheResponse _cacheResponse;
 };
 
 class CacheAssetRequest : public IAssetRequest {
 public:
-  CacheAssetRequest(CacheItem&& cacheItem)
-      : _cacheItem(std::move(cacheItem)), _response(&this->_cacheItem) {}
+  CacheAssetRequest(
+      std::string&& url,
+      HttpHeaders&& headers,
+      CacheItem&& cacheItem)
+      : _method(std::move(cacheItem.cacheRequest.method)),
+        _url(std::move(url)),
+        _headers(std::move(headers)),
+        _response(std::move(cacheItem.cacheResponse)) {}
 
   virtual const std::string& method() const noexcept override {
-    return this->_cacheItem.cacheRequest.method;
+    return this->_method;
   }
 
   virtual const std::string& url() const noexcept override {
-    return this->_cacheItem.cacheRequest.url;
+    return this->_url;
   }
 
   virtual const HttpHeaders& headers() const noexcept override {
-    return this->_cacheItem.cacheRequest.headers;
+    return this->_headers;
   }
 
   virtual const IAssetResponse* response() const noexcept override {
@@ -67,7 +73,9 @@ public:
   }
 
 private:
-  CacheItem _cacheItem;
+  std::string _method;
+  std::string _url;
+  HttpHeaders _headers;
   CacheAssetResponse _response;
 };
 
@@ -131,9 +139,9 @@ Future<std::shared_ptr<IAssetRequest>> CachingAssetAccessor::get(
            pAssetAccessor = this->_pAssetAccessor,
            pCacheDatabase = this->_pCacheDatabase,
            pLogger = this->_pLogger,
-           url,
-           headers,
-           threadPool]() -> Future<std::shared_ptr<IAssetRequest>> {
+           =url,
+           =headers= headers,
+           threadPool]() mutable -> Future<std::shared_ptr<IAssetRequest>> {
             std::optional<CacheItem> cacheLookup =
                 pCacheDatabase->getEntry(url);
             if (!cacheLookup) {
@@ -244,7 +252,10 @@ Future<std::shared_ptr<IAssetRequest>> CachingAssetAccessor::get(
             // Good cache item that doesn't need to be revalidated, just return
             // it.
             std::shared_ptr<IAssetRequest> pRequest =
-                std::make_shared<CacheAssetRequest>(std::move(cacheItem));
+                std::make_shared<CacheAssetRequest>(
+                    std::move(url),
+                    HttpHeaders(headers.begin(), headers.end()),
+                    std::move(cacheItem));
             return asyncSystem.createResolvedFuture(std::move(pRequest));
           })
       .thenImmediately([](std::shared_ptr<IAssetRequest>&& pRequest) noexcept {
@@ -410,7 +421,10 @@ updateCacheItem(CacheItem&& cacheItem, const IAssetRequest& request) {
     }
   }
 
-  return std::make_unique<CacheAssetRequest>(std::move(cacheItem));
+  return std::make_unique<CacheAssetRequest>(
+      std::string(request.url()),
+      HttpHeaders(request.headers()),
+      std::move(cacheItem));
 }
 
 std::time_t convertHttpDateToTime(const std::string& httpDate) {

--- a/CesiumAsync/test/TestCacheAssetAccessor.cpp
+++ b/CesiumAsync/test/TestCacheAssetAccessor.cpp
@@ -692,15 +692,22 @@ TEST_CASE("Test serving cache item") {
     // test that the response is from the cache
     AsyncSystem asyncSystem(mockTaskProcessor);
     cacheAssetAccessor
-        ->get(asyncSystem, "test.com", std::vector<IAssetAccessor::THeader>{})
+        ->get(
+            asyncSystem,
+            "test.com",
+            std::vector<IAssetAccessor::THeader>{
+                {"Some-Request-Header", "The Value"}})
         .thenImmediately(
             [](const std::shared_ptr<IAssetRequest>& completedRequest) {
               REQUIRE(completedRequest != nullptr);
-              REQUIRE(completedRequest->url() == "cache.com");
+              REQUIRE(completedRequest->method() == "GET");
+
+              // URL and Headers should match the original request, even if
+              // that's different from what's in the cache.
+              REQUIRE(completedRequest->url() == "test.com");
               REQUIRE(
                   completedRequest->headers() ==
-                  HttpHeaders{{"Cache-Request-Header", "Cache-Request-Value"}});
-              REQUIRE(completedRequest->method() == "GET");
+                  HttpHeaders{{"Some-Request-Header", "The Value"}});
 
               const IAssetResponse* response = completedRequest->response();
               REQUIRE(response != nullptr);
@@ -783,15 +790,22 @@ TEST_CASE("Test serving cache item") {
     // and cache control coming from the validation response
     AsyncSystem asyncSystem(mockTaskProcessor);
     cacheAssetAccessor
-        ->get(asyncSystem, "test.com", std::vector<IAssetAccessor::THeader>{})
+        ->get(
+            asyncSystem,
+            "test.com",
+            std::vector<IAssetAccessor::THeader>{
+                {"Some-Request-Header", "The Value"}})
         .thenImmediately(
             [](const std::shared_ptr<IAssetRequest>& completedRequest) {
               REQUIRE(completedRequest != nullptr);
-              REQUIRE(completedRequest->url() == "cache.com");
+              REQUIRE(completedRequest->method() == "GET");
+
+              // URL and Headers should match the original request, even if
+              // that's different from what's in the cache.
+              REQUIRE(completedRequest->url() == "test.com");
               REQUIRE(
                   completedRequest->headers() ==
-                  HttpHeaders{{"Cache-Request-Header", "Cache-Request-Value"}});
-              REQUIRE(completedRequest->method() == "GET");
+                  HttpHeaders{{"Some-Request-Header", "The Value"}});
 
               // check response header is updated
               const IAssetResponse* response = completedRequest->response();

--- a/CesiumGltfReader/include/CesiumGltfReader/GltfReader.h
+++ b/CesiumGltfReader/include/CesiumGltfReader/GltfReader.h
@@ -195,10 +195,10 @@ public:
    * @param result The result of the synchronous readGltf invocation.
    */
   static CesiumAsync::Future<GltfReaderResult> resolveExternalData(
-      CesiumAsync::AsyncSystem asyncSystem,
+      const CesiumAsync::AsyncSystem& asyncSystem,
       const std::string& baseUrl,
       const CesiumAsync::HttpHeaders& headers,
-      std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
       const GltfReaderOptions& options,
       GltfReaderResult&& result);
 

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -445,10 +445,10 @@ void CesiumGltfReader::GltfReader::postprocessGltf(
 }
 
 /*static*/ Future<GltfReaderResult> GltfReader::resolveExternalData(
-    AsyncSystem asyncSystem,
+    const AsyncSystem& asyncSystem,
     const std::string& baseUrl,
     const HttpHeaders& headers,
-    std::shared_ptr<IAssetAccessor> pAssetAccessor,
+    const std::shared_ptr<IAssetAccessor>& pAssetAccessor,
     const GltfReaderOptions& options,
     GltfReaderResult&& result) {
 

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -514,7 +514,7 @@ void CesiumGltfReader::GltfReader::postprocessGltf(
               .thenInWorkerThread([pBuffer =
                                        &buffer](std::shared_ptr<IAssetRequest>&&
                                                     pRequest) {
-                std::string bufferUri = *pBuffer->uri;
+                std::string bufferUri = pRequest->url();
 
                 const IAssetResponse* pResponse = pRequest->response();
                 if (!pResponse) {
@@ -576,22 +576,16 @@ void CesiumGltfReader::GltfReader::postprocessGltf(
             getAsset(asyncSystem, pAssetAccessor, uri, tHeaders);
 
         resolvedBuffers.push_back(future.thenInWorkerThread(
-            [pImage = &image](const ResultPointer<ImageAsset>& loadedImage) {
-              std::string imageUri = *pImage->uri;
+            [pImage = &image,
+             uri](const ResultPointer<ImageAsset>& loadedImage) {
               pImage->uri = std::nullopt;
 
               if (loadedImage.pValue) {
                 pImage->pAsset = loadedImage.pValue;
-                return ExternalBufferLoadResult{
-                    true,
-                    imageUri,
-                    loadedImage.errors};
+                return ExternalBufferLoadResult{true, uri, loadedImage.errors};
               }
 
-              return ExternalBufferLoadResult{
-                  false,
-                  imageUri,
-                  loadedImage.errors};
+              return ExternalBufferLoadResult{false, uri, loadedImage.errors};
             }));
       }
     }
@@ -612,7 +606,7 @@ void CesiumGltfReader::GltfReader::postprocessGltf(
       NetworkSchemaAssetDescriptor assetKey{{uri, headers}};
 
       if (options.pSharedAssetSystem == nullptr ||
-          options.pSharedAssetSystem->pImage == nullptr) {
+          options.pSharedAssetSystem->pExternalMetadataSchema == nullptr) {
         // We don't have a depot, so fetch this asset directly.
         return assetKey.load(asyncSystem, pAssetAccessor).share();
       } else {
@@ -624,30 +618,22 @@ void CesiumGltfReader::GltfReader::postprocessGltf(
       }
     };
 
-    SharedFuture<ResultPointer<Schema>> future = getAsset(
-        asyncSystem,
-        pAssetAccessor,
-        *pStructuralMetadata->schemaUri,
-        tHeaders);
+    std::string uri = Uri::resolve(baseUrl, *pStructuralMetadata->schemaUri);
+
+    SharedFuture<ResultPointer<Schema>> future =
+        getAsset(asyncSystem, pAssetAccessor, uri, tHeaders);
 
     resolvedBuffers.push_back(future.thenInWorkerThread(
-        [pStructuralMetadata = pStructuralMetadata](
-            const ResultPointer<CesiumGltf::Schema>& loadedSchema) {
-          std::string schemaUri = *pStructuralMetadata->schemaUri;
+        [pStructuralMetadata = pStructuralMetadata,
+         uri](const ResultPointer<CesiumGltf::Schema>& loadedSchema) {
           pStructuralMetadata->schemaUri = std::nullopt;
 
           if (loadedSchema.pValue) {
             pStructuralMetadata->schema = loadedSchema.pValue;
-            return ExternalBufferLoadResult{
-                true,
-                schemaUri,
-                loadedSchema.errors};
+            return ExternalBufferLoadResult{true, uri, loadedSchema.errors};
           }
 
-          return ExternalBufferLoadResult{
-              false,
-              schemaUri,
-              loadedSchema.errors};
+          return ExternalBufferLoadResult{false, uri, loadedSchema.errors};
         }));
   }
 

--- a/CesiumQuantizedMeshTerrain/include/CesiumQuantizedMeshTerrain/QuantizedMeshLoader.h
+++ b/CesiumQuantizedMeshTerrain/include/CesiumQuantizedMeshTerrain/QuantizedMeshLoader.h
@@ -18,9 +18,8 @@
 #include <vector>
 
 namespace CesiumAsync {
-class IAssetAccessor;
 class IAssetRequest;
-} // namespace CesiumAsync
+}
 
 namespace CesiumQuantizedMeshTerrain {
 

--- a/CesiumQuantizedMeshTerrain/include/CesiumQuantizedMeshTerrain/QuantizedMeshLoader.h
+++ b/CesiumQuantizedMeshTerrain/include/CesiumQuantizedMeshTerrain/QuantizedMeshLoader.h
@@ -50,13 +50,6 @@ struct QuantizedMeshLoadResult {
       availableTileRectangles{};
 
   /**
-   * @brief The asset accessor that was used to retrieve this quantized mesh
-   * tile, and that should be used to retrieve further resources referenced by
-   * the tile.
-   */
-  std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor;
-
-  /**
    * @brief The request that was used to download the tile content, if any.
    *
    * This field is only populated when there are request-related errors.

--- a/CesiumQuantizedMeshTerrain/include/CesiumQuantizedMeshTerrain/QuantizedMeshLoader.h
+++ b/CesiumQuantizedMeshTerrain/include/CesiumQuantizedMeshTerrain/QuantizedMeshLoader.h
@@ -18,8 +18,9 @@
 #include <vector>
 
 namespace CesiumAsync {
+class IAssetAccessor;
 class IAssetRequest;
-}
+} // namespace CesiumAsync
 
 namespace CesiumQuantizedMeshTerrain {
 
@@ -47,6 +48,13 @@ struct QuantizedMeshLoadResult {
    */
   std::vector<CesiumGeometry::QuadtreeTileRectangularRange>
       availableTileRectangles{};
+
+  /**
+   * @brief The asset accessor that was used to retrieve this quantized mesh
+   * tile, and that should be used to retrieve further resources referenced by
+   * the tile.
+   */
+  std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor;
 
   /**
    * @brief The request that was used to download the tile content, if any.


### PR DESCRIPTION
In addition to what's in the changelog:

- Fixed nullptr pExternalMetadataSchema in default TilesetSharedAssetSystem.
- Fixed a missing check for pExternalMetadataSchema in TilesetSharedAssetSystem (it was accidentally checking for pImage instead)
- Fixed a bug where schema URI relative paths were not resolved to absolute ones before starting the request.

These aren't mentioned in the changelog because they're fixes for a feature that hasn't shipped yet.

The bulk of these changes rework how Cesium ion tokens get refreshed when the expire. Previously, CesiumIonTilesetLoader would manually look for tile content requests returning a 401 error, and would refresh the token and retry the request. But that didn't work well when the tile content referenced external resources, like images and schemas. These could fail with an expired token, too, and nothing would retry them. This was especially common because of some weird behavior in CachingAssetAccessor where a cache hit would return a request object with URL and headers from the cache, rather than the actually-requested URL and headers. The cached request could and often did hold an expired Cesium ion token, while the actual request would have a new token. When we later used the headers from the (successful despite the expired token because it came from cache) tile content request to request the linked resources, these non-cached requests would fail. This exacerbating problem has also been fixed in this PR.

In this PR, CesiumIonTilesetLoader installs an IAssetAccessor decorator that watches for 401 errors and does the token refresh. That means the token refresh will work with any request that uses the acessor, including linked resources. The decorator is wrapped around the asset accessor `TileLoadInput` passed to `loadTileContent`. The returned `TileLoadResult` now also includes that an `IAssetAccessor` so that it can be used for further requests (linked resources) related to the `Tile`.