### PR TITLE
Allow valid binary subtrees to load without requiring a binary chunk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,9 @@
 ### ? - ?
 
 ##### Fixes :wrench:
+
 - Fixed a bug in `thenPassThrough` that caused a compiler error when given a value by r-value refrence.
+- Fixed a bug in  `SubtreeFileReader::loadBinary` that prevented valid subtrees from loading if they did not contain binary data.
 
 ### v0.42.0 - 2024-12-02
 

--- a/Cesium3DTilesContent/test/TestSubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/test/TestSubtreeAvailability.cpp
@@ -15,6 +15,7 @@
 #include <rapidjson/writer.h>
 
 #include <cstddef>
+#include <optional>
 #include <vector>
 
 using namespace Cesium3DTiles;
@@ -30,11 +31,11 @@ struct SubtreeHeader {
   uint64_t binaryByteLength;
 };
 
-struct SubtreeBuffers {
+struct SubtreeContent {
   std::vector<std::byte> buffers;
-  SubtreeAvailability::SubtreeBufferViewAvailability tileAvailability;
-  SubtreeAvailability::SubtreeBufferViewAvailability subtreeAvailability;
-  SubtreeAvailability::SubtreeBufferViewAvailability contentAvailability;
+  SubtreeAvailability::AvailabilityView tileAvailability;
+  SubtreeAvailability::AvailabilityView subtreeAvailability;
+  SubtreeAvailability::AvailabilityView contentAvailability;
 };
 
 uint64_t calculateTotalNumberOfTilesForQuadtree(uint64_t subtreeLevels) {
@@ -68,7 +69,7 @@ void markSubtreeAvailableForQuadtree(
   available[byteIndex] |= std::byte(1 << bitIndex);
 }
 
-SubtreeBuffers createSubtreeBuffers(
+SubtreeContent createSubtreeContent(
     uint32_t maxSubtreeLevels,
     const std::vector<CesiumGeometry::QuadtreeTileID>& tileAvailabilities,
     const std::vector<CesiumGeometry::QuadtreeTileID>& subtreeAvailabilities) {
@@ -114,106 +115,106 @@ SubtreeBuffers createSubtreeBuffers(
 }
 
 rapidjson::Document createSubtreeJson(
-    const SubtreeBuffers& subtreeBuffers,
+    const SubtreeContent& subtreeContent,
     const std::string& bufferUrl) {
   // create subtree json
   rapidjson::Document subtreeJson;
   subtreeJson.SetObject();
 
-  // create buffers
-  rapidjson::Value bufferObj(rapidjson::kObjectType);
-  bufferObj.AddMember(
-      "byteLength",
-      uint64_t(subtreeBuffers.buffers.size()),
-      subtreeJson.GetAllocator());
+  bool hasTileAvailabilityBufferView = false;
+  bool hasContentAvailabilityBufferView = false;
+  bool hasSubtreeAvailabilityBufferView = false;
 
-  if (!bufferUrl.empty()) {
-    rapidjson::Value uriStr(rapidjson::kStringType);
-    uriStr.SetString(
-        bufferUrl.c_str(),
-        static_cast<rapidjson::SizeType>(bufferUrl.size()),
+  // create buffers and buffer views, if necessary
+  if (!subtreeContent.buffers.empty()) {
+    rapidjson::Value bufferObj(rapidjson::kObjectType);
+    bufferObj.AddMember(
+        "byteLength",
+        uint64_t(subtreeContent.buffers.size()),
         subtreeJson.GetAllocator());
-    bufferObj.AddMember("uri", std::move(uriStr), subtreeJson.GetAllocator());
+
+    if (!bufferUrl.empty()) {
+      rapidjson::Value uriStr(rapidjson::kStringType);
+      uriStr.SetString(
+          bufferUrl.c_str(),
+          static_cast<rapidjson::SizeType>(bufferUrl.size()),
+          subtreeJson.GetAllocator());
+      bufferObj.AddMember("uri", std::move(uriStr), subtreeJson.GetAllocator());
+    }
+
+    rapidjson::Value buffersArray(rapidjson::kArrayType);
+    buffersArray.GetArray().PushBack(
+        std::move(bufferObj),
+        subtreeJson.GetAllocator());
+
+    subtreeJson.AddMember(
+        "buffers",
+        std::move(buffersArray),
+        subtreeJson.GetAllocator());
+    rapidjson::Value bufferViewsArray(rapidjson::kArrayType);
+
+    auto addBufferViewIfNeeded =
+        [&subtreeJson, &bufferViewsArray](
+            const SubtreeAvailability::AvailabilityView& view,
+            const std::vector<std::byte>& data,
+            bool& result) {
+          const auto* pBufferView =
+              std::get_if<SubtreeAvailability::SubtreeBufferViewAvailability>(
+                  &view);
+          if (pBufferView) {
+            rapidjson::Value bufferView(rapidjson::kObjectType);
+            bufferView.AddMember(
+                "buffer",
+                uint64_t(0),
+                subtreeJson.GetAllocator());
+            bufferView.AddMember(
+                "byteOffset",
+                uint64_t(pBufferView->view.data() - data.data()),
+                subtreeJson.GetAllocator());
+            bufferView.AddMember(
+                "byteLength",
+                uint64_t(pBufferView->view.size()),
+                subtreeJson.GetAllocator());
+            bufferViewsArray.GetArray().PushBack(
+                std::move(bufferView),
+                subtreeJson.GetAllocator());
+          }
+          result = (pBufferView != nullptr);
+        };
+
+    addBufferViewIfNeeded(
+        subtreeContent.tileAvailability,
+        subtreeContent.buffers,
+        hasTileAvailabilityBufferView);
+    addBufferViewIfNeeded(
+        subtreeContent.contentAvailability,
+        subtreeContent.buffers,
+        hasContentAvailabilityBufferView);
+    addBufferViewIfNeeded(
+        subtreeContent.subtreeAvailability,
+        subtreeContent.buffers,
+        hasSubtreeAvailabilityBufferView);
+
+    subtreeJson.AddMember(
+        "bufferViews",
+        std::move(bufferViewsArray),
+        subtreeJson.GetAllocator());
   }
-
-  rapidjson::Value buffersArray(rapidjson::kArrayType);
-  buffersArray.GetArray().PushBack(
-      std::move(bufferObj),
-      subtreeJson.GetAllocator());
-
-  subtreeJson.AddMember(
-      "buffers",
-      std::move(buffersArray),
-      subtreeJson.GetAllocator());
-
-  // create buffer views
-  rapidjson::Value tileAvailabilityBufferView(rapidjson::kObjectType);
-  tileAvailabilityBufferView.AddMember(
-      "buffer",
-      uint64_t(0),
-      subtreeJson.GetAllocator());
-  tileAvailabilityBufferView.AddMember(
-      "byteOffset",
-      uint64_t(
-          subtreeBuffers.tileAvailability.view.data() -
-          subtreeBuffers.buffers.data()),
-      subtreeJson.GetAllocator());
-  tileAvailabilityBufferView.AddMember(
-      "byteLength",
-      uint64_t(subtreeBuffers.tileAvailability.view.size()),
-      subtreeJson.GetAllocator());
-
-  rapidjson::Value contentAvailabilityBufferView(rapidjson::kObjectType);
-  contentAvailabilityBufferView.AddMember(
-      "buffer",
-      uint64_t(0),
-      subtreeJson.GetAllocator());
-  contentAvailabilityBufferView.AddMember(
-      "byteOffset",
-      uint64_t(
-          subtreeBuffers.contentAvailability.view.data() -
-          subtreeBuffers.buffers.data()),
-      subtreeJson.GetAllocator());
-  contentAvailabilityBufferView.AddMember(
-      "byteLength",
-      uint64_t(subtreeBuffers.contentAvailability.view.size()),
-      subtreeJson.GetAllocator());
-
-  rapidjson::Value subtreeAvailabilityBufferView(rapidjson::kObjectType);
-  subtreeAvailabilityBufferView.AddMember(
-      "buffer",
-      uint64_t(0),
-      subtreeJson.GetAllocator());
-  subtreeAvailabilityBufferView.AddMember(
-      "byteOffset",
-      uint64_t(
-          subtreeBuffers.subtreeAvailability.view.data() -
-          subtreeBuffers.buffers.data()),
-      subtreeJson.GetAllocator());
-  subtreeAvailabilityBufferView.AddMember(
-      "byteLength",
-      uint64_t(subtreeBuffers.subtreeAvailability.view.size()),
-      subtreeJson.GetAllocator());
-
-  rapidjson::Value bufferViewsArray(rapidjson::kArrayType);
-  bufferViewsArray.GetArray().PushBack(
-      std::move(tileAvailabilityBufferView),
-      subtreeJson.GetAllocator());
-  bufferViewsArray.GetArray().PushBack(
-      std::move(contentAvailabilityBufferView),
-      subtreeJson.GetAllocator());
-  bufferViewsArray.GetArray().PushBack(
-      std::move(subtreeAvailabilityBufferView),
-      subtreeJson.GetAllocator());
-
-  subtreeJson.AddMember(
-      "bufferViews",
-      std::move(bufferViewsArray),
-      subtreeJson.GetAllocator());
 
   // create tileAvailability field
   rapidjson::Value tileAvailabilityObj(rapidjson::kObjectType);
-  tileAvailabilityObj.AddMember("bitstream", 0, subtreeJson.GetAllocator());
+  if (hasTileAvailabilityBufferView) {
+    tileAvailabilityObj.AddMember("bitstream", 0, subtreeJson.GetAllocator());
+  } else {
+    const auto* pTileAvailabilityConstant =
+        std::get_if<SubtreeAvailability::SubtreeConstantAvailability>(
+            &subtreeContent.tileAvailability);
+    assert(pTileAvailabilityConstant);
+    tileAvailabilityObj.AddMember(
+        "constant",
+        pTileAvailabilityConstant->constant,
+        subtreeJson.GetAllocator());
+  }
   subtreeJson.AddMember(
       "tileAvailability",
       std::move(tileAvailabilityObj),
@@ -221,7 +222,21 @@ rapidjson::Document createSubtreeJson(
 
   // create contentAvailability field
   rapidjson::Value contentAvailabilityObj(rapidjson::kObjectType);
-  contentAvailabilityObj.AddMember("bitstream", 1, subtreeJson.GetAllocator());
+  if (hasContentAvailabilityBufferView) {
+    contentAvailabilityObj.AddMember(
+        "bitstream",
+        1,
+        subtreeJson.GetAllocator());
+  } else {
+    const auto* pContentAvailabilityConstant =
+        std::get_if<SubtreeAvailability::SubtreeConstantAvailability>(
+            &subtreeContent.contentAvailability);
+    assert(pContentAvailabilityConstant);
+    contentAvailabilityObj.AddMember(
+        "constant",
+        pContentAvailabilityConstant->constant,
+        subtreeJson.GetAllocator());
+  }
 
   rapidjson::Value contentAvailabilityArray(rapidjson::kArrayType);
   contentAvailabilityArray.GetArray().PushBack(
@@ -235,7 +250,21 @@ rapidjson::Document createSubtreeJson(
 
   // create childSubtreeAvailability
   rapidjson::Value subtreeAvailabilityObj(rapidjson::kObjectType);
-  subtreeAvailabilityObj.AddMember("bitstream", 2, subtreeJson.GetAllocator());
+  if (hasSubtreeAvailabilityBufferView) {
+    subtreeAvailabilityObj.AddMember(
+        "bitstream",
+        2,
+        subtreeJson.GetAllocator());
+  } else {
+    const auto* pSubtreeAvailabilityConstant =
+        std::get_if<SubtreeAvailability::SubtreeConstantAvailability>(
+            &subtreeContent.contentAvailability);
+    assert(pSubtreeAvailabilityConstant);
+    subtreeAvailabilityObj.AddMember(
+        "constant",
+        pSubtreeAvailabilityConstant->constant,
+        subtreeJson.GetAllocator());
+  }
   subtreeJson.AddMember(
       "childSubtreeAvailability",
       std::move(subtreeAvailabilityObj),
@@ -246,7 +275,7 @@ rapidjson::Document createSubtreeJson(
 
 std::optional<SubtreeAvailability> mockLoadSubtreeJson(
     uint32_t levelsInSubtree,
-    SubtreeBuffers&& subtreeBuffers,
+    SubtreeContent&& subtreeContent,
     rapidjson::Document&& subtreeJson) {
   rapidjson::StringBuffer subtreeJsonBuffer;
   rapidjson::Writer<rapidjson::StringBuffer> writer(subtreeJsonBuffer);
@@ -273,7 +302,7 @@ std::optional<SubtreeAvailability> mockLoadSubtreeJson(
       uint16_t(200),
       "buffer",
       CesiumAsync::HttpHeaders{},
-      std::move(subtreeBuffers.buffers));
+      std::move(subtreeContent.buffers));
   auto pMockBufferRequest = std::make_unique<SimpleAssetRequest>(
       "GET",
       "buffer",
@@ -511,7 +540,7 @@ TEST_CASE("Test parsing subtree format") {
       CesiumGeometry::QuadtreeTileID{5, 21, 11},
       CesiumGeometry::QuadtreeTileID{5, 11, 12}};
 
-  auto subtreeBuffers = createSubtreeBuffers(
+  auto subtreeBuffers = createSubtreeContent(
       maxSubtreeLevels,
       availableTileIDs,
       availableSubtreeIDs);

--- a/Cesium3DTilesReader/src/SubtreeFileReader.cpp
+++ b/Cesium3DTilesReader/src/SubtreeFileReader.cpp
@@ -152,39 +152,44 @@ Future<ReadJsonResult<Subtree>> SubtreeFileReader::loadBinary(
         sizeof(SubtreeHeader) + header->jsonByteLength,
         header->binaryByteLength);
 
-    if (result.value->buffers.empty()) {
-      result.errors.emplace_back("Subtree has a binary chunk but the JSON does "
-                                 "not define any buffers.");
-      return asyncSystem.createResolvedFuture(std::move(result));
+    if (binaryChunk.size() > 0) {
+      if (result.value->buffers.empty()) {
+        result.errors.emplace_back(
+            "Subtree has a binary chunk but the JSON does "
+            "not define any buffers.");
+        return asyncSystem.createResolvedFuture(std::move(result));
+      }
+
+      Buffer& buffer = result.value->buffers[0];
+      if (buffer.uri) {
+        result.errors.emplace_back(
+            "Subtree has a binary chunk but the first buffer "
+            "in the JSON chunk also has a 'uri'.");
+        return asyncSystem.createResolvedFuture(std::move(result));
+      }
+
+      const int64_t binaryChunkSize = static_cast<int64_t>(binaryChunk.size());
+
+      // We allow - but don't require - 8-byte padding.
+      int64_t maxPaddingBytes = 0;
+      int64_t paddingRemainder = buffer.byteLength % 8;
+      if (paddingRemainder > 0) {
+        maxPaddingBytes = 8 - paddingRemainder;
+      }
+
+      if (buffer.byteLength > binaryChunkSize ||
+          buffer.byteLength + maxPaddingBytes < binaryChunkSize) {
+        result.errors.emplace_back(
+            "Subtree binary chunk size does not match the "
+            "size of the first buffer in the JSON chunk.");
+        return asyncSystem.createResolvedFuture(std::move(result));
+      }
+
+      buffer.cesium.data = std::vector<std::byte>(
+          binaryChunk.begin(),
+          binaryChunk.begin() + buffer.byteLength);
+    } else {
     }
-
-    Buffer& buffer = result.value->buffers[0];
-    if (buffer.uri) {
-      result.errors.emplace_back(
-          "Subtree has a binary chunk but the first buffer "
-          "in the JSON chunk also has a 'uri'.");
-      return asyncSystem.createResolvedFuture(std::move(result));
-    }
-
-    const int64_t binaryChunkSize = static_cast<int64_t>(binaryChunk.size());
-
-    // We allow - but don't require - 8-byte padding.
-    int64_t maxPaddingBytes = 0;
-    int64_t paddingRemainder = buffer.byteLength % 8;
-    if (paddingRemainder > 0) {
-      maxPaddingBytes = 8 - paddingRemainder;
-    }
-
-    if (buffer.byteLength > binaryChunkSize ||
-        buffer.byteLength + maxPaddingBytes < binaryChunkSize) {
-      result.errors.emplace_back("Subtree binary chunk size does not match the "
-                                 "size of the first buffer in the JSON chunk.");
-      return asyncSystem.createResolvedFuture(std::move(result));
-    }
-
-    buffer.cesium.data = std::vector<std::byte>(
-        binaryChunk.begin(),
-        binaryChunk.begin() + buffer.byteLength);
   }
 
   return postprocess(

--- a/Cesium3DTilesReader/src/SubtreeFileReader.cpp
+++ b/Cesium3DTilesReader/src/SubtreeFileReader.cpp
@@ -188,7 +188,6 @@ Future<ReadJsonResult<Subtree>> SubtreeFileReader::loadBinary(
       buffer.cesium.data = std::vector<std::byte>(
           binaryChunk.begin(),
           binaryChunk.begin() + buffer.byteLength);
-    } else {
     }
   }
 


### PR DESCRIPTION
`SubtreeFileReader` assumed the subtree would be invalid if its binary chunk was missing, which is not necessarily true. As described in the [spec](https://github.com/CesiumGS/3d-tiles/tree/main/specification/ImplicitTiling#subtree-binary-format), subtrees expressed in the binary format can exist without the binary chunk.

This PR fixes that. I also ended up refactoring how subtrees were procedurally created in `TestSubtreeAvailability`, so the diff is relatively large because of my changes there.