### PR TITLE
Add more getters for `AccessorView` and `AccessorWriter`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ### ? - ?
 
+##### Additions :tada:
+
+- Added `offset` getter to `AccessorView`.
+- Added `stride`, `offset`, and `data` getters to `AccessorWriter`.
+- Added `value_type` typedef to `AccessorWriter`.
+
 ##### Fixes :wrench:
 
 - Fixed a bug in `thenPassThrough` that caused a compiler error when given a value by r-value refrence.

--- a/CesiumGltf/include/CesiumGltf/AccessorView.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorView.h
@@ -215,6 +215,14 @@ public:
   int64_t stride() const noexcept { return this->_stride; }
 
   /**
+   * @brief Returns the offset of this accessor, which is the number of bytes
+   * from the start of the buffer to the first element.
+   *
+   * @returns The offset.
+   */
+  int64_t offset() const noexcept { return this->_offset; }
+
+  /**
    * @brief Returns a pointer to the first byte of this accessor view's data.
    * The elements are stored contiguously, so the next one starts {@link stride} bytes later.
    *

--- a/CesiumGltf/include/CesiumGltf/AccessorWriter.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorWriter.h
@@ -12,6 +12,11 @@ private:
   AccessorView<T> _accessor;
 
 public:
+  /**
+   * @brief The type of the elements in the accessor.
+   */
+  typedef T value_type;
+
   AccessorWriter() : _accessor() {}
 
   /**
@@ -50,6 +55,17 @@ public:
    */
   AccessorViewStatus status() const noexcept {
     return this->_accessor.status();
+  }
+
+  /** @copydoc AccessorView::stride */
+  int64_t stride() const noexcept { return this->_accessor.stride(); }
+
+  /** @copydoc AccessorView::offset */
+  int64_t offset() const noexcept { return this->_accessor.offset(); }
+
+  /** @copydoc AccessorView::data */
+  std::byte* data() noexcept {
+    return const_cast<std::byte*>(this->_accessor.data());
   }
 };
 

--- a/CesiumGltf/test/TestAccessorView.cpp
+++ b/CesiumGltf/test/TestAccessorView.cpp
@@ -5,21 +5,23 @@
 #include <catch2/catch_test_macros.hpp>
 #include <glm/vec3.hpp>
 
+using namespace CesiumGltf;
+
 TEST_CASE("AccessorView construct and read example") {
   auto anyOldFunctionToGetAModel = []() {
-    CesiumGltf::Model model;
+    Model model;
 
-    CesiumGltf::Accessor& accessor = model.accessors.emplace_back();
+    Accessor& accessor = model.accessors.emplace_back();
     accessor.bufferView = 0;
-    accessor.componentType = CesiumGltf::Accessor::ComponentType::FLOAT;
-    accessor.type = CesiumGltf::Accessor::Type::VEC3;
+    accessor.componentType = Accessor::ComponentType::FLOAT;
+    accessor.type = Accessor::Type::VEC3;
     accessor.count = 1;
 
-    CesiumGltf::BufferView& bufferView = model.bufferViews.emplace_back();
+    BufferView& bufferView = model.bufferViews.emplace_back();
     bufferView.buffer = 0;
     bufferView.byteLength = accessor.count * int64_t(sizeof(float)) * 3;
 
-    CesiumGltf::Buffer& buffer = model.buffers.emplace_back();
+    Buffer& buffer = model.buffers.emplace_back();
     buffer.byteLength = bufferView.byteLength;
     buffer.cesium.data.resize(size_t(buffer.byteLength));
 
@@ -32,17 +34,21 @@ TEST_CASE("AccessorView construct and read example") {
   };
 
   //! [createFromAccessorAndRead]
-  CesiumGltf::Model model = anyOldFunctionToGetAModel();
-  CesiumGltf::AccessorView<glm::vec3> positions(model, 0);
+  Model model = anyOldFunctionToGetAModel();
+  AccessorView<glm::vec3> positions(model, 0);
   glm::vec3 firstPosition = positions[0];
   //! [createFromAccessorAndRead]
 
   CHECK(firstPosition == glm::vec3(1.0f, 2.0f, 3.0f));
+
+  CHECK(positions.size() == 1);
+  CHECK(positions.status() == AccessorViewStatus::Valid);
+  CHECK(positions.stride() == 12);
+  CHECK(positions.offset() == 0);
+  CHECK(positions.data() == model.buffers[0].cesium.data.data());
 }
 
 TEST_CASE("Create AccessorView of unknown type with lambda") {
-  using namespace CesiumGltf;
-
   Model model;
 
   Buffer& buffer = model.buffers.emplace_back();


### PR DESCRIPTION
> - Added `offset` getter to `AccessorView`. 

This makes it possible to create an `AccessorView` from another `AccessorView` of a different type.

> - Added `stride`, `offset`, and `data` getters to `AccessorWriter`.
> - Added `value_type` typedef to `AccessorWriter`.

For convenience when working with `AccessorWriter`.