### PR TITLE
Fix triplet auto detected error on macos apple silicon

### DIFF
--- a/cmake/detect-vcpkg-triplet.cmake
+++ b/cmake/detect-vcpkg-triplet.cmake
@@ -24,10 +24,19 @@ elseif(APPLE)
         else()
             set(DETECTED_VCPKG_TRIPLET "${CMAKE_OSX_ARCHITECTURES}-osx")
         endif()
-    elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-        set(DETECTED_VCPKG_TRIPLET "arm64-osx")
     else()
-        set(DETECTED_VCPKG_TRIPLET "x64-osx")
+        if(NOT CMAKE_SYSTEM_PROCESSOR)
+            execute_process(
+                COMMAND uname -m
+                OUTPUT_VARIABLE CMAKE_SYSTEM_PROCESSOR
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+        endif()
+        if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+            set(DETECTED_VCPKG_TRIPLET "arm64-osx")
+        else()
+            set(DETECTED_VCPKG_TRIPLET "x64-osx")
+        endif()
     endif()
 elseif(LINUX)
     # Assuming x64 here isn't necessarily correct, but it's the only platform we officially support.


### PR DESCRIPTION
on macos apple silicon current cmake will turn DETECTED_VCPKG_TRIPLET to unexpected x64-osx. and I found both CMAKE_SYSTEM_PROCESSOR and CMAKE_OSX_ARCHITECTURES is empty. so I add a cmd to determine CMAKE_SYSTEM_PROCESSOR