### PR TITLE
Fix crash when writing `EXT_structural_metadata` with null schema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v0.44.0 - 2025-02-03
+
+##### Fixes :wrench:
+
+- Fixed a crash in `GltfWriter` that would happen when the `EXT_structural_metadata` `schema` property was null.
+
 ### v0.43.0 - 2025-01-02
 
 ##### Breaking Changes :mega:

--- a/CesiumGltfWriter/generated/src/ModelJsonWriter.cpp
+++ b/CesiumGltfWriter/generated/src/ModelJsonWriter.cpp
@@ -761,8 +761,10 @@ void writeJson(
     const CesiumJsonWriter::ExtensionWriterContext& context) {
   jsonWriter.StartObject();
 
-  jsonWriter.Key("schema");
-  writeJson(obj.schema, jsonWriter, context);
+  if (obj.schema) {
+    jsonWriter.Key("schema");
+    writeJson(obj.schema, jsonWriter, context);
+  }
 
   if (obj.schemaUri) {
     jsonWriter.Key("schemaUri");

--- a/tools/generate-classes/generate.js
+++ b/tools/generate-classes/generate.js
@@ -621,17 +621,20 @@ function formatWriterPropertyImpl(property) {
   const isVector = type.startsWith("std::vector");
   const isMap = type.startsWith("std::unordered_map");
   const isOptional = type.startsWith("std::optional");
+  const isPointer = type.startsWith("CesiumUtility::IntrusivePointer");
 
   const hasDefaultValueGuard =
     !isId && !isRequiredEnum && defaultValue !== undefined;
   const hasDefaultVectorGuard = hasDefaultValueGuard && isVector;
   const hasEmptyGuard = isVector || isMap;
   const hasOptionalGuard = isOptional;
+  const hasPointerGuard = isPointer;
   const hasNegativeIndexGuard = isId;
   const hasGuard =
     hasDefaultValueGuard ||
     hasEmptyGuard ||
     hasOptionalGuard ||
+    hasPointerGuard ||
     hasNegativeIndexGuard;
 
   if (hasDefaultVectorGuard) {
@@ -653,7 +656,7 @@ function formatWriterPropertyImpl(property) {
     result += `if (!obj.${property.cppSafeName}.empty()) {\n`;
   } else if (hasNegativeIndexGuard) {
     result += `if (obj.${property.cppSafeName} > -1) {\n`;
-  } else if (hasOptionalGuard) {
+  } else if (hasOptionalGuard || hasPointerGuard) {
     result += `if (obj.${property.cppSafeName}) {\n`;
   }
 


### PR DESCRIPTION
Fixes a small regression from https://github.com/CesiumGS/cesium-native/pull/969. The glTF writer code now checks if `schema` is null before writing it.