### PR TITLE
Use Mermaid dark theme for dark mode

### DIFF
--- a/doc/footer.html
+++ b/doc/footer.html
@@ -2,7 +2,13 @@
 <script type="text/javascript" src="$relpath^mingcute.json.js"></script>
 <script type="text/javascript" src="$relpath^panzoom.js"></script>
 <script type="text/javascript">
+  let theme = "default";
+  // Detect browser dark mode and use dark theme for Mermaid if enabled
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    theme = "dark";
+  }
   mermaid.initialize({
+    theme: theme,
     startOnLoad: true,
     graph: {
       useMaxWidth: true


### PR DESCRIPTION
A simple fix to use the `dark` theme for Mermaid if the user has set a preference for dark mode. Currently, dark mode makes the diagrams unreadable as they remain in the light Mermaid `default` theme. 