### PR TITLE
Specify CESIUM_PRODUCTION_DOCS cmake variable correctly.

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Mark documentation official
         if: ${{ github.ref_name == 'cesium.com' }}
         run: |
-          echo "EXTRA_CONFIGURE_ARGS=-DCESIUM_PRODUCTION_DOCS" >> "$GITHUB_ENV"
+          echo "EXTRA_CONFIGURE_ARGS=-DCESIUM_PRODUCTION_DOCS=TRUE" >> "$GITHUB_ENV"
       - name: Generate Documentation
         run: |
           npm install


### PR DESCRIPTION
To fix a failure when publishing production reference docs:
https://github.com/CesiumGS/cesium-native/actions/runs/12576935529/job/35053725492

I've already merged this to the `cesium.com` to confirm it works, so I'm going to merge it to main right away after opening.