### PR TITLE
Allow URLs with non-ASCII characters to be parsed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed a crash in `GltfWriter` that would happen when the `EXT_structural_metadata` `schema` property was null.
+- `CesiumUtility::Uri` now fully supports non-ASCII characters.
 
 ### v0.43.0 - 2025-01-02
 

--- a/CesiumUtility/src/Uri.cpp
+++ b/CesiumUtility/src/Uri.cpp
@@ -10,8 +10,8 @@
 #include <functional>
 #include <iomanip>
 #include <ios>
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -26,12 +26,12 @@ std::string escapeNonAscii(const std::string& url) {
   output << std::hex;
   output.fill('0');
 
-  for(size_t i = 0; i < url.length(); i++) {
+  for (size_t i = 0; i < url.length(); i++) {
     unsigned char c = static_cast<unsigned char>(url[i]);
-    if(c > 0x7f) {
-      output << std::uppercase << '%' << std::setw(2) << int(c) << std::nouppercase;
-    }
-    else {
+    if (c > 0x7f) {
+      output << std::uppercase << '%' << std::setw(2) << int(c)
+             << std::nouppercase;
+    } else {
       output << c;
     }
   }
@@ -53,7 +53,8 @@ std::string Uri::resolve(
     const std::string& relative,
     bool useBaseQuery,
     bool assumeHttpsDefault) {
-  const std::string conformedBase = cesiumConformUrl(escapeNonAscii(base), assumeHttpsDefault);
+  const std::string conformedBase =
+      cesiumConformUrl(escapeNonAscii(base), assumeHttpsDefault);
   const std::string conformedRelative =
       cesiumConformUrl(escapeNonAscii(relative), assumeHttpsDefault);
   UriUriA baseUri;
@@ -355,7 +356,8 @@ std::string Uri::uriPathToNativePath(const std::string& nativePath) {
 std::string Uri::getPath(const std::string& uri) {
   const std::string escapedUri = escapeNonAscii(uri);
   UriUriA parsedUri;
-  if (uriParseSingleUriA(&parsedUri, escapedUri.c_str(), nullptr) != URI_SUCCESS) {
+  if (uriParseSingleUriA(&parsedUri, escapedUri.c_str(), nullptr) !=
+      URI_SUCCESS) {
     // Could not parse the URI, so return an empty string.
     return std::string();
   }

--- a/CesiumUtility/test/TestUri.cpp
+++ b/CesiumUtility/test/TestUri.cpp
@@ -34,7 +34,10 @@ TEST_CASE("Uri::getPath") {
     CHECK(Uri::getPath("http://example.com/🐶.bin") == "/🐶.bin");
     CHECK(Uri::getPath("http://example.com/示例测试用例") == "/示例测试用例");
     CHECK(Uri::getPath("http://example.com/Ῥόδος") == "/Ῥόδος");
-    CHECK(Uri::getPath("http://example.com/🙍‍♂️🚪🤚/🪝🚗🚪/❓📞") == "/🙍‍♂️🚪🤚/🪝🚗🚪/❓📞");
+    CHECK(
+        Uri::getPath(
+            "http://example.com/🙍‍♂️🚪🤚/🪝🚗🚪/❓📞") ==
+        "/🙍‍♂️🚪🤚/🪝🚗🚪/❓📞");
   }
 }
 
@@ -89,8 +92,12 @@ TEST_CASE("Uri::setPath") {
   }
 
   SECTION("handles unicode characters") {
-    CHECK(Uri::setPath("http://example.com/foo/", "/🐶.bin") == "http://example.com/🐶.bin");
-    CHECK(Uri::setPath("http://example.com/bar/", "/示例测试用例") == "http://example.com/示例测试用例");
+    CHECK(
+        Uri::setPath("http://example.com/foo/", "/🐶.bin") ==
+        "http://example.com/🐶.bin");
+    CHECK(
+        Uri::setPath("http://example.com/bar/", "/示例测试用例") ==
+        "http://example.com/示例测试用例");
   }
 }
 
@@ -108,8 +115,8 @@ TEST_CASE("Uri::resolve") {
           false,
           false) == "http://www.example.com/page/test");
   CHECK(
-    CesiumUtility::Uri::resolve("https://www.example.com/", "/Ῥόδος") == "https://www.example.com/Ῥόδος"
-  );
+      CesiumUtility::Uri::resolve("https://www.example.com/", "/Ῥόδος") ==
+      "https://www.example.com/Ῥόδος");
 }
 
 TEST_CASE("Uri::escape") {

--- a/CesiumUtility/test/TestUri.cpp
+++ b/CesiumUtility/test/TestUri.cpp
@@ -29,6 +29,13 @@ TEST_CASE("Uri::getPath") {
   SECTION("returns empty path for invalid uri") {
     CHECK(Uri::getPath("not a valid uri") == "");
   }
+
+  SECTION("handles unicode characters") {
+    CHECK(Uri::getPath("http://example.com/🐶.bin") == "/🐶.bin");
+    CHECK(Uri::getPath("http://example.com/示例测试用例") == "/示例测试用例");
+    CHECK(Uri::getPath("http://example.com/Ῥόδος") == "/Ῥόδος");
+    CHECK(Uri::getPath("http://example.com/🙍‍♂️🚪🤚/🪝🚗🚪/❓📞") == "/🙍‍♂️🚪🤚/🪝🚗🚪/❓📞");
+  }
 }
 
 TEST_CASE("Uri::setPath") {
@@ -80,6 +87,11 @@ TEST_CASE("Uri::setPath") {
   SECTION("returns empty path for invalid uri") {
     CHECK(Uri::setPath("not a valid uri", "/foo/") == "");
   }
+
+  SECTION("handles unicode characters") {
+    CHECK(Uri::setPath("http://example.com/foo/", "/🐶.bin") == "http://example.com/🐶.bin");
+    CHECK(Uri::setPath("http://example.com/bar/", "/示例测试用例") == "http://example.com/示例测试用例");
+  }
 }
 
 TEST_CASE("Uri::resolve") {
@@ -95,6 +107,9 @@ TEST_CASE("Uri::resolve") {
           "/page/test",
           false,
           false) == "http://www.example.com/page/test");
+  CHECK(
+    CesiumUtility::Uri::resolve("https://www.example.com/", "/Ῥόδος") == "https://www.example.com/Ῥόδος"
+  );
 }
 
 TEST_CASE("Uri::escape") {


### PR DESCRIPTION
As described in #973, glTFs that include URIs with non-ASCII characters in them don't currently work with Cesium Native. That's because the library we use for URI parsing, `uriparser`, follows the RFC 3986 standard. According to RFC 3986, only ASCII characters are allowed in URLs, and all other characters must be escaped. Unicode support came later, in RFC 3987 and now the WhatWG URL specification which seems to be the modern standard browsers aim to support. The glTF spec allows Unicode characters in URIs "as-is," meaning a strictly RFC 3986-compliant parser won't do the job. One option would be to substitute a different, WhatWG-compliant parser in its place - but as I described in [this comment](https://github.com/CesiumGS/cesium-native/issues/973#issuecomment-2593482114), this introduces more problems than it solves. 

Instead, the solution I went with was to encode all non-ASCII characters in the string before passing it to `uriparser`, then decoding them again before returning from the method. This seems to work flawlessly - `uriparser` gets the RFC 3986-compliant URLs it expects, and the user gets the WhatWG-compliant URLs they expect. Unfortunately, this solution does introduce an extra layer of string copies into URL parsing. This isn't ideal, but considering URLs are usually fairly short, I think it's a worthwhile tradeoff to gain this compliance with the glTF spec.