### PR TITLE
Fix various build problems and merge conflicts.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -124,7 +124,9 @@ Checks:
   - "modernize-use-equals-delete"
   - "modernize-use-nullptr"
   - "modernize-use-starts-ends-with"
-  - "modernize-use-std-numbers"
+  # The <numbers> header is unfortunately not available in Android NDK r25b,
+  # which is an important target for cesium-native via Unreal Engine.
+  #- "modernize-use-std-numbers"
   #- "modernize-use-using"
   - "performance-*"
   - "-performance-enum-size"

--- a/Cesium3DTilesContent/test/TestI3dmToGltfConverter.cpp
+++ b/Cesium3DTilesContent/test/TestI3dmToGltfConverter.cpp
@@ -86,7 +86,7 @@ TEST_CASE("I3dmToGltfConverter") {
     CHECK(result.errors.hasErrors());
   }
 
-  SECTION("loads an i3dm with metadata") {
+  SUBCASE("loads an i3dm with metadata") {
     std::filesystem::path testFilePath = Cesium3DTilesSelection_TEST_DATA_DIR;
     testFilePath = testFilePath / "i3dm" / "InstancedWithBatchTable" /
                    "instancedWithBatchTable.i3dm";

--- a/CesiumRasterOverlays/test/TestUrlTemplateRasterOverlay.cpp
+++ b/CesiumRasterOverlays/test/TestUrlTemplateRasterOverlay.cpp
@@ -1,14 +1,12 @@
-#include "CesiumRasterOverlays/RasterOverlay.h"
-#include "CesiumRasterOverlays/RasterOverlayTile.h"
-#include "CesiumRasterOverlays/UrlTemplateRasterOverlay.h"
-
 #include <CesiumGeospatial/WebMercatorProjection.h>
 #include <CesiumNativeTests/SimpleAssetAccessor.h>
 #include <CesiumNativeTests/SimpleTaskProcessor.h>
 #include <CesiumNativeTests/readFile.h>
+#include <CesiumRasterOverlays/RasterOverlay.h>
+#include <CesiumRasterOverlays/RasterOverlayTile.h>
+#include <CesiumRasterOverlays/UrlTemplateRasterOverlay.h>
 
-#include <catch2/catch.hpp>
-#include <catch2/catch_test_macros.hpp>
+#include <doctest/doctest.h>
 
 #include <filesystem>
 

--- a/CesiumUtility/include/CesiumUtility/Math.h
+++ b/CesiumUtility/include/CesiumUtility/Math.h
@@ -4,8 +4,6 @@
 
 #include <glm/gtc/epsilon.hpp>
 
-#include <numbers>
-
 namespace CesiumUtility {
 
 /**
@@ -79,7 +77,7 @@ public:
   /**
    * @brief Pi
    */
-  static constexpr double OnePi = std::numbers::pi;
+  static constexpr double OnePi = 3.14159265358979323846;
 
   /**
    * @brief Two times pi

--- a/CesiumUtility/src/Assert.cpp
+++ b/CesiumUtility/src/Assert.cpp
@@ -5,6 +5,8 @@
 #include <cassert>
 #define NDEBUG
 
+#include <cstdint>
+
 namespace CesiumUtility {
 std::int32_t forceAssertFailure() {
   assert(0 && "Assertion failed");


### PR DESCRIPTION
* Disable the `modernize-use-std-numbers` clang-tidy rule and go back to using our own PI constant. Fixes CesiumGS/cesium-unreal#1587
* Convert some new test code to use doctest instead of Catch2.
* Add missing `#include <cstdint>` that would only become apparent when building the debug configuration for Unreal Engine.

Once CI is happy with this, I am going to merge it, because it fixes some brokenness in main.