### PR TITLE
Don't use std::ranges

### DIFF
--- a/Cesium3DTilesContent/src/BatchTableToGltfStructuralMetadata.cpp
+++ b/Cesium3DTilesContent/src/BatchTableToGltfStructuralMetadata.cpp
@@ -75,7 +75,7 @@ struct MaskedType {
   bool isFloat64;
   bool isBool;
 
-  MaskedType() : MaskedType(true){};
+  MaskedType() : MaskedType(true) {};
 
   MaskedType(bool defaultValue)
       : isInt8(defaultValue),
@@ -131,12 +131,12 @@ struct MaskedArrayType {
   uint32_t minArrayCount;
   uint32_t maxArrayCount;
 
-  MaskedArrayType() : MaskedArrayType(true){};
+  MaskedArrayType() : MaskedArrayType(true) {};
 
   MaskedArrayType(bool defaultValue)
       : elementType(defaultValue),
         minArrayCount(std::numeric_limits<uint32_t>::max()),
-        maxArrayCount(std::numeric_limits<uint32_t>::min()){};
+        maxArrayCount(std::numeric_limits<uint32_t>::min()) {};
 
   MaskedArrayType(
       MaskedType inElementType,
@@ -205,10 +205,10 @@ private:
   bool _canUseNullStringSentinel = true;
 
 public:
-  CompatibleTypes() : _type(){};
-  CompatibleTypes(const MaskedType& maskedType) : _type(maskedType){};
+  CompatibleTypes() : _type() {};
+  CompatibleTypes(const MaskedType& maskedType) : _type(maskedType) {};
   CompatibleTypes(const MaskedArrayType& maskedArrayType)
-      : _type(maskedArrayType){};
+      : _type(maskedArrayType) {};
 
   /**
    * Whether this is exclusively compatible with array types. This indicates an
@@ -2110,7 +2110,7 @@ struct BatchIdSemantic {
   uint32_t maxBatchId() const {
     return std::visit(
         [](auto&& batchIds) {
-          auto itr = std::ranges::max_element(batchIds);
+          auto itr = std::max_element(batchIds.begin(), batchIds.end());
           return static_cast<uint32_t>(*itr);
         },
         batchSpan);

--- a/Cesium3DTilesContent/src/BatchTableToGltfStructuralMetadata.cpp
+++ b/Cesium3DTilesContent/src/BatchTableToGltfStructuralMetadata.cpp
@@ -75,7 +75,7 @@ struct MaskedType {
   bool isFloat64;
   bool isBool;
 
-  MaskedType() : MaskedType(true) {};
+  MaskedType() : MaskedType(true){};
 
   MaskedType(bool defaultValue)
       : isInt8(defaultValue),
@@ -131,12 +131,12 @@ struct MaskedArrayType {
   uint32_t minArrayCount;
   uint32_t maxArrayCount;
 
-  MaskedArrayType() : MaskedArrayType(true) {};
+  MaskedArrayType() : MaskedArrayType(true){};
 
   MaskedArrayType(bool defaultValue)
       : elementType(defaultValue),
         minArrayCount(std::numeric_limits<uint32_t>::max()),
-        maxArrayCount(std::numeric_limits<uint32_t>::min()) {};
+        maxArrayCount(std::numeric_limits<uint32_t>::min()){};
 
   MaskedArrayType(
       MaskedType inElementType,
@@ -205,10 +205,10 @@ private:
   bool _canUseNullStringSentinel = true;
 
 public:
-  CompatibleTypes() : _type() {};
-  CompatibleTypes(const MaskedType& maskedType) : _type(maskedType) {};
+  CompatibleTypes() : _type(){};
+  CompatibleTypes(const MaskedType& maskedType) : _type(maskedType){};
   CompatibleTypes(const MaskedArrayType& maskedArrayType)
-      : _type(maskedArrayType) {};
+      : _type(maskedArrayType){};
 
   /**
    * Whether this is exclusively compatible with array types. This indicates an


### PR DESCRIPTION
Because it's not supported in Android NDK r25b.

Fixes #1069 (take 2)
