### PR TITLE
Allow specifying request headers in `RasterOverlayOptions`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - Added `requestHeaders` field to `TilesetOptions` to allow per-tileset request headers to be specified.
+- Added `requestHeaders` field to `RasterOverlayOptions` to allow per-raster-overlay request headers to be specified.
 
 ### v0.44.0 - 2025-02-03
 

--- a/CesiumAsync/include/CesiumAsync/IAssetAccessor.h
+++ b/CesiumAsync/include/CesiumAsync/IAssetAccessor.h
@@ -69,45 +69,45 @@ public:
    * dispatch requests, this method does not need to do anything.
    */
   virtual void tick() noexcept = 0;
-};
 
-/**
- * @brief Merges two vectors of HTTP headers together, with one vector of
- * headers overriding a base vector of headers if both contain headers with the
- * same name.
- *
- * @param baseHeaders The base set of HTTP headers.
- * @param overrideHeaders The override vector of HTTP headers. If any header
- * names in this vector are also included in the `baseHeaders` vector, the
- * values of the override headers will be used instead.
- *
- * @returns A new vector of headers combining headers from the two vectors
- * passed in.
- */
-static std::vector<IAssetAccessor::THeader> mergeHeaders(
-    const std::vector<IAssetAccessor::THeader>& baseHeaders,
-    const std::vector<IAssetAccessor::THeader>& overrideHeaders) {
-  std::vector<IAssetAccessor::THeader> headers;
-  headers.reserve(std::max(baseHeaders.size(), overrideHeaders.size()));
+  /**
+   * @brief Merges two vectors of HTTP headers together, with one vector of
+   * headers overriding a base vector of headers if both contain headers with
+   * the same name.
+   *
+   * @param baseHeaders The base set of HTTP headers.
+   * @param overrideHeaders The override vector of HTTP headers. If any header
+   * names in this vector are also included in the `baseHeaders` vector, the
+   * values of the override headers will be used instead.
+   *
+   * @returns A new vector of headers combining headers from the two vectors
+   * passed in.
+   */
+  static std::vector<IAssetAccessor::THeader> mergeHeaders(
+      const std::vector<IAssetAccessor::THeader>& baseHeaders,
+      const std::vector<IAssetAccessor::THeader>& overrideHeaders) {
+    std::vector<IAssetAccessor::THeader> headers;
+    headers.reserve(std::max(baseHeaders.size(), overrideHeaders.size()));
 
-  std::set<std::string> overrideHeaderNames;
-  for (auto& [name, value] : overrideHeaders) {
-    overrideHeaderNames.emplace(name);
-  }
-
-  // Add all base headers that aren't overridden
-  for (auto& [name, value] : baseHeaders) {
-    if (!overrideHeaderNames.contains(name)) {
-      headers.emplace_back(name, value);
+    std::set<std::string> overrideHeaderNames;
+    for (auto& [name, value] : overrideHeaders) {
+      overrideHeaderNames.emplace(name);
     }
-  }
 
-  // Add override headers
-  for (auto& pair : overrideHeaders) {
-    headers.emplace_back(pair);
-  }
+    // Add all base headers that aren't overridden
+    for (auto& [name, value] : baseHeaders) {
+      if (!overrideHeaderNames.contains(name)) {
+        headers.emplace_back(name, value);
+      }
+    }
 
-  return headers;
-}
+    // Add override headers
+    for (auto& pair : overrideHeaders) {
+      headers.emplace_back(pair);
+    }
+
+    return headers;
+  }
+};
 
 } // namespace CesiumAsync

--- a/CesiumAsync/include/CesiumAsync/IAssetAccessor.h
+++ b/CesiumAsync/include/CesiumAsync/IAssetAccessor.h
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <set>
 #include <span>
 #include <string>
 #include <vector>
@@ -69,5 +70,44 @@ public:
    */
   virtual void tick() noexcept = 0;
 };
+
+/**
+ * @brief Merges two vectors of HTTP headers together, with one vector of
+ * headers overriding a base vector of headers if both contain headers with the
+ * same name.
+ *
+ * @param baseHeaders The base set of HTTP headers.
+ * @param overrideHeaders The override vector of HTTP headers. If any header
+ * names in this vector are also included in the `baseHeaders` vector, the
+ * values of the override headers will be used instead.
+ *
+ * @returns A new vector of headers combining headers from the two vectors
+ * passed in.
+ */
+static std::vector<IAssetAccessor::THeader> mergeHeaders(
+    const std::vector<IAssetAccessor::THeader>& baseHeaders,
+    const std::vector<IAssetAccessor::THeader>& overrideHeaders) {
+  std::vector<IAssetAccessor::THeader> headers;
+  headers.reserve(std::max(baseHeaders.size(), overrideHeaders.size()));
+
+  std::set<std::string> overrideHeaderNames;
+  for (auto& [name, value] : overrideHeaders) {
+    overrideHeaderNames.emplace(name);
+  }
+
+  // Add all base headers that aren't overridden
+  for (auto& [name, value] : baseHeaders) {
+    if (!overrideHeaderNames.contains(name)) {
+      headers.emplace_back(name, value);
+    }
+  }
+
+  // Add override headers
+  for (auto& pair : overrideHeaders) {
+    headers.emplace_back(pair);
+  }
+
+  return headers;
+}
 
 } // namespace CesiumAsync

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlay.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlay.h
@@ -113,6 +113,11 @@ struct CESIUMRASTEROVERLAYS_API RasterOverlayOptions {
    * @brief The ellipsoid used for this raster overlay.
    */
   CesiumGeospatial::Ellipsoid ellipsoid = CesiumGeospatial::Ellipsoid::WGS84;
+
+  /**
+   * @brief HTTP headers to attach to requests made for this raster overlay.
+   */
+  std::vector<CesiumAsync::IAssetAccessor::THeader> requestHeaders;
 };
 
 /**

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/TileMapServiceRasterOverlay.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/TileMapServiceRasterOverlay.h
@@ -93,7 +93,8 @@ public:
    * @param name The user-given name of this overlay layer.
    * @param url The base URL.
    * @param headers The headers. This is a list of pairs of strings of the
-   * form (Key,Value) that will be inserted as request headers internally.
+   * form (Key,Value) that will be inserted as request headers internally. These
+   * headers will override values specified in `RasterOverlayOptions`.
    * @param tmsOptions The {@link TileMapServiceRasterOverlayOptions}.
    * @param overlayOptions The {@link RasterOverlayOptions} for this instance.
    */

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/WebMapServiceRasterOverlay.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/WebMapServiceRasterOverlay.h
@@ -75,7 +75,8 @@ public:
    * @param name The user-given name of this overlay layer.
    * @param url The base URL.
    * @param headers The headers. This is a list of pairs of strings of the
-   * form (Key,Value) that will be inserted as request headers internally.
+   * form (Key,Value) that will be inserted as request headers internally. These
+   * values will override headers specified in `overlayOptions`.
    * @param wmsOptions The {@link WebMapServiceRasterOverlayOptions}.
    * @param overlayOptions The {@link RasterOverlayOptions} for this instance.
    */

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/WebMapTileServiceRasterOverlay.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/WebMapTileServiceRasterOverlay.h
@@ -127,7 +127,8 @@ public:
    * @param name The user-given name of this overlay layer.
    * @param url The base URL.
    * @param headers The headers. This is a list of pairs of strings of the
-   * form (Key,Value) that will be inserted as request headers internally.
+   * form (Key,Value) that will be inserted as request headers internally. These
+   * values will override headers specified in `overlayOptions`.
    * @param tmsOptions The {@link WebMapTileServiceRasterOverlayOptions}.
    * @param overlayOptions The {@link RasterOverlayOptions} for this instance.
    */

--- a/CesiumRasterOverlays/src/BingMapsRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/BingMapsRasterOverlay.cpp
@@ -133,7 +133,8 @@ public:
             height),
         _credits(perTileCredits),
         _urlTemplate(urlTemplate),
-        _subdomains(subdomains) {
+        _subdomains(subdomains),
+        _headers(pOwner->getOptions().requestHeaders) {
     if (this->_urlTemplate.find("n=z") == std::string::npos) {
       this->_urlTemplate =
           CesiumUtility::Uri::addQuery(this->_urlTemplate, "n", "z");
@@ -208,7 +209,7 @@ protected:
       }
     }
 
-    return this->loadTileImageFromUrl(url, {}, std::move(options));
+    return this->loadTileImageFromUrl(url, this->_headers, std::move(options));
   }
 
 private:
@@ -235,6 +236,7 @@ private:
   std::vector<CreditAndCoverageAreas> _credits;
   std::string _urlTemplate;
   std::vector<std::string> _subdomains;
+  std::vector<IAssetAccessor::THeader> _headers;
 };
 
 BingMapsRasterOverlay::BingMapsRasterOverlay(
@@ -467,7 +469,8 @@ BingMapsRasterOverlay::createTileProvider(
         handleResponse(nullptr, std::span<std::byte>(cacheResultIt->second)));
   }
 
-  return pAssetAccessor->get(asyncSystem, metadataUrl)
+  return pAssetAccessor
+      ->get(asyncSystem, metadataUrl, this->getOptions().requestHeaders)
       .thenInMainThread(
           [metadataUrl,
            handleResponse](std::shared_ptr<IAssetRequest>&& pRequest)

--- a/CesiumRasterOverlays/src/IonRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/IonRasterOverlay.cpp
@@ -123,7 +123,8 @@ IonRasterOverlay::createTileProvider(
         pOwner);
   }
 
-  return pAssetAccessor->get(asyncSystem, ionUrl)
+  return pAssetAccessor
+      ->get(asyncSystem, ionUrl, this->getOptions().requestHeaders)
       .thenImmediately(
           [](std::shared_ptr<IAssetRequest>&& pRequest)
               -> nonstd::expected<

--- a/CesiumRasterOverlays/src/TileMapServiceRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/TileMapServiceRasterOverlay.cpp
@@ -176,7 +176,7 @@ TileMapServiceRasterOverlay::TileMapServiceRasterOverlay(
     : RasterOverlay(name, overlayOptions),
       _url(url),
       _headers(
-          CesiumAsync::mergeHeaders(overlayOptions.requestHeaders, headers)),
+          IAssetAccessor::mergeHeaders(overlayOptions.requestHeaders, headers)),
       _options(tmsOptions) {}
 
 TileMapServiceRasterOverlay::~TileMapServiceRasterOverlay() = default;

--- a/CesiumRasterOverlays/src/TileMapServiceRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/TileMapServiceRasterOverlay.cpp
@@ -175,7 +175,8 @@ TileMapServiceRasterOverlay::TileMapServiceRasterOverlay(
     const RasterOverlayOptions& overlayOptions)
     : RasterOverlay(name, overlayOptions),
       _url(url),
-      _headers(headers),
+      _headers(
+          CesiumAsync::mergeHeaders(overlayOptions.requestHeaders, headers)),
       _options(tmsOptions) {}
 
 TileMapServiceRasterOverlay::~TileMapServiceRasterOverlay() = default;

--- a/CesiumRasterOverlays/src/WebMapServiceRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/WebMapServiceRasterOverlay.cpp
@@ -260,7 +260,7 @@ WebMapServiceRasterOverlay::WebMapServiceRasterOverlay(
     : RasterOverlay(name, overlayOptions),
       _baseUrl(url),
       _headers(
-          CesiumAsync::mergeHeaders(overlayOptions.requestHeaders, headers)),
+          IAssetAccessor::mergeHeaders(overlayOptions.requestHeaders, headers)),
       _options(wmsOptions) {}
 
 WebMapServiceRasterOverlay::~WebMapServiceRasterOverlay() = default;

--- a/CesiumRasterOverlays/src/WebMapServiceRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/WebMapServiceRasterOverlay.cpp
@@ -259,7 +259,8 @@ WebMapServiceRasterOverlay::WebMapServiceRasterOverlay(
     const RasterOverlayOptions& overlayOptions)
     : RasterOverlay(name, overlayOptions),
       _baseUrl(url),
-      _headers(headers),
+      _headers(
+          CesiumAsync::mergeHeaders(overlayOptions.requestHeaders, headers)),
       _options(wmsOptions) {}
 
 WebMapServiceRasterOverlay::~WebMapServiceRasterOverlay() = default;

--- a/CesiumRasterOverlays/src/WebMapTileServiceRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/WebMapTileServiceRasterOverlay.cpp
@@ -196,7 +196,7 @@ WebMapTileServiceRasterOverlay::WebMapTileServiceRasterOverlay(
     : RasterOverlay(name, overlayOptions),
       _url(url),
       _headers(
-          CesiumAsync::mergeHeaders(overlayOptions.requestHeaders, headers)),
+          IAssetAccessor::mergeHeaders(overlayOptions.requestHeaders, headers)),
       _options(wmtsOptions) {}
 
 WebMapTileServiceRasterOverlay::~WebMapTileServiceRasterOverlay() = default;

--- a/CesiumRasterOverlays/src/WebMapTileServiceRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/WebMapTileServiceRasterOverlay.cpp
@@ -195,7 +195,8 @@ WebMapTileServiceRasterOverlay::WebMapTileServiceRasterOverlay(
     const RasterOverlayOptions& overlayOptions)
     : RasterOverlay(name, overlayOptions),
       _url(url),
-      _headers(headers),
+      _headers(
+          CesiumAsync::mergeHeaders(overlayOptions.requestHeaders, headers)),
       _options(wmtsOptions) {}
 
 WebMapTileServiceRasterOverlay::~WebMapTileServiceRasterOverlay() = default;


### PR DESCRIPTION
Fixes #1067. This is a companion to #1057, applying a similar change to raster overlays. One wrinkle in the implementation is that some raster overlays already accept headers in their constructor. Not only would it be best to avoid changing the public API, but `IonRasterOverlay` in particular relies on this functionality being present so it can pass the `Authorization` header to the underlying `TileMapServiceRasterOverlay`. To support this, I've added a `mergeHeaders` method that allows the headers specified in the constructor to override any headers with the same name specified in the `RasterOverlayOptions`. 