### PR TITLE
Fix error with `catch2` header

### DIFF
--- a/CesiumRasterOverlays/test/ExamplesRasterOverlays.cpp
+++ b/CesiumRasterOverlays/test/ExamplesRasterOverlays.cpp
@@ -1,7 +1,7 @@
 #include <CesiumRasterOverlays/RasterOverlay.h>
 #include <CesiumRasterOverlays/UrlTemplateRasterOverlay.h>
 
-#include <catch2/catch_test_macros.hpp>
+#include <doctest/doctest.h>
 
 using namespace CesiumRasterOverlays;
 


### PR DESCRIPTION
Foolishly I merged the raster overlay doc changes without checking the CI results, thinking it was just documentation so it wouldn't be an issue. Unfortunately, one of the example bits of code was using the catch2 header, which has been removed in favor of doctest! This fixes the error.