### PR TITLE
ada-url: Substitute layer.json placeholders before treating as URLs

### DIFF
--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.h
@@ -52,6 +52,7 @@ public:
         const std::string& baseUrl,
         std::string&& version,
         std::vector<std::string>&& tileTemplateUrls,
+        std::string&& extensionsToRequest,
         CesiumGeometry::QuadtreeRectangleAvailability&& contentAvailability,
         uint32_t maxZooms,
         int32_t availabilityLevels);
@@ -59,6 +60,7 @@ public:
     std::string baseUrl;
     std::string version;
     std::vector<std::string> tileTemplateUrls;
+    std::string extensionsToRequest;
     CesiumGeometry::QuadtreeRectangleAvailability contentAvailability;
     std::vector<std::unordered_set<uint64_t>> loadedSubtrees;
     int32_t availabilityLevels;

--- a/Cesium3DTilesSelection/test/TestLayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/test/TestLayerJsonTerrainLoader.cpp
@@ -261,8 +261,8 @@ TEST_CASE("Test create layer json terrain loader") {
     CHECK(layers[0].version == "1.33.0");
     CHECK(
         layers[0].tileTemplateUrls.front() ==
-        "%7Bz%7D/%7Bx%7D/"
-        "%7By%7D.terrain?v=%7Bversion%7D&extensions=octvertexnormals-metadata");
+        "{z}/{x}/{y}.terrain?v={version}");
+    CHECK(layers[0].extensionsToRequest == "octvertexnormals-metadata");
     CHECK(layers[0].loadedSubtrees.size() == 2);
     CHECK(layers[0].availabilityLevels == 10);
   }
@@ -291,8 +291,8 @@ TEST_CASE("Test create layer json terrain loader") {
     CHECK(layers[0].version == "1.0.0");
     CHECK(
         layers[0].tileTemplateUrls.front() ==
-        "%7Bz%7D/%7Bx%7D/"
-        "%7By%7D.terrain?v=%7Bversion%7D&extensions=octvertexnormals");
+        "{z}/{x}/{y}.terrain?v={version}");
+    CHECK(layers[0].extensionsToRequest == "octvertexnormals");
     CHECK(layers[0].loadedSubtrees.empty());
     CHECK(layers[0].availabilityLevels == -1);
 
@@ -411,11 +411,8 @@ TEST_CASE("Test create layer json terrain loader") {
     const auto& layers = loaderResult.pLoader->getLayers();
     CHECK(layers.size() == 1);
     CHECK(layers[0].tileTemplateUrls.size() == 1);
-    CHECK(
-        layers[0].tileTemplateUrls[0] ==
-        "%7Bz%7D/%7Bx%7D/"
-        "%7By%7D.terrain?v=%7Bversion%7D&extensions=octvertexnormals-"
-        "watermask");
+    CHECK(layers[0].tileTemplateUrls[0] == "{z}/{x}/{y}.terrain?v={version}");
+    CHECK(layers[0].extensionsToRequest == "octvertexnormals-watermask");
   }
 }
 
@@ -446,6 +443,7 @@ TEST_CASE("Test load layer json tile content") {
         "layer.json",
         "1.0.0",
         std::vector<std::string>{"{level}.{x}.{y}/{version}.terrain"},
+        "one-two",
         std::move(contentAvailability),
         maxZoom,
         10);
@@ -454,7 +452,7 @@ TEST_CASE("Test load layer json tile content") {
 
     // mock tile content request
     pMockedAssetAccessor->mockCompletedRequests.insert(
-        {"0.0.0/1.0.0.terrain",
+        {"0.0.0/1.0.0.terrain?extensions=one-two",
          createMockAssetRequest(
              testDataPath / "CesiumTerrainTileJson" /
              "tile.metadataavailability.terrain")});
@@ -496,6 +494,7 @@ TEST_CASE("Test load layer json tile content") {
         "layer.json",
         "1.0.0",
         std::vector<std::string>{"{level}.{x}.{y}/{version}.terrain"},
+        std::string(),
         std::move(contentAvailability),
         maxZoom,
         -1);
@@ -557,6 +556,7 @@ TEST_CASE("Test load layer json tile content") {
         "layer.json",
         "1.0.0",
         std::vector<std::string>{"{level}.{x}.{y}/{version}_layer0.terrain"},
+        std::string(),
         std::move(layer0ContentAvailability),
         maxZoom,
         -1);
@@ -571,6 +571,7 @@ TEST_CASE("Test load layer json tile content") {
         "layer.json",
         "1.0.0",
         std::vector<std::string>{"{level}.{x}.{y}/{version}_layer1.terrain"},
+        std::string(),
         std::move(layer1ContentAvailability),
         maxZoom,
         -1);
@@ -633,6 +634,7 @@ TEST_CASE("Test load layer json tile content") {
         "layer.json",
         "1.0.0",
         std::vector<std::string>{"{level}.{x}.{y}/{version}_layer0.terrain"},
+        std::string(),
         std::move(layer0ContentAvailability),
         maxZoom,
         10);
@@ -644,6 +646,7 @@ TEST_CASE("Test load layer json tile content") {
         "layer.json",
         "1.0.0",
         std::vector<std::string>{"{level}.{x}.{y}/{version}_layer1.terrain"},
+        std::string(),
         std::move(layer1ContentAvailability),
         maxZoom,
         10);
@@ -739,6 +742,7 @@ TEST_CASE("Test creating tile children for layer json") {
       "layer.json",
       "1.0.0",
       std::vector<std::string>{"{level}.{x}.{y}/{version}_layer0.terrain"},
+      std::string(),
       std::move(layer0ContentAvailability),
       maxZoom,
       10);
@@ -754,6 +758,7 @@ TEST_CASE("Test creating tile children for layer json") {
       "layer.json",
       "1.0.0",
       std::vector<std::string>{"{level}.{x}.{y}/{version}_layer1.terrain"},
+      std::string(),
       std::move(layer1ContentAvailability),
       maxZoom,
       10);


### PR DESCRIPTION
This is a PR into #1072.

It bothered me that the URL placeholders (like `{z}`) in the tile URL templates in layer.json were escaped, and then `substituteTemplateParameters` had to deal with this potential escaping. So this is an attempt to avoid that in a fairly simple way: substitute the values into the template URL before treating it as a URL. 

I think this is fairly reasonable. A URL with placeholders is not a valid URL, so don't try to pretend it is. If this looks reasonable to you @azrogers, then I think the changes to `substituteTemplateParameters` to allow escaped placeholders can be reverted.

The other places we were using placeholders in URLs (`UrlTemplateRasterOverlay` and `WebMapTileServiceRasterOverlay`) were already doing this, perhaps accidentally.

