### PR TITLE
Add <algorithm> to Cesium3DTiles/test/TestTileset.cpp

### DIFF
--- a/Cesium3DTiles/test/TestTileset.cpp
+++ b/Cesium3DTiles/test/TestTileset.cpp
@@ -2,6 +2,7 @@
 
 #include <doctest/doctest.h>
 
+#include <algorithm>
 #include <cstring>
 
 using namespace Cesium3DTiles;


### PR DESCRIPTION
The new use of std::find in TestTileset.cpp  was failing on Fedora 41.