### PR TITLE
Fix placeholder handling in BingMapsRasterOverlay.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 - Added `UrlTemplateRasterOverlay` for requesting raster tiles from services using a templated URL.
 - `upsampleGltfForRasterOverlays` is now compatible with meshes using TRIANGLE_STRIP, TRIANGLE_FAN, or non-indexed TRIANGLES primitives.
 - Added `requestHeaders` field to `TilesetOptions` to allow per-tileset request headers to be specified.
+- Fixed a bug that prevented the `culture` parameter of the `BingMapsRasterOverlay` from having an effect.
 
 ##### Fixes :wrench:
 

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
@@ -698,7 +698,7 @@ std::string resolveTileUrl(
     uri.setQuery(params.toQueryString());
   }
 
-  return uri.toString();
+  return std::string(uri.toString());
 }
 
 Future<QuantizedMeshLoadResult> requestTileContent(

--- a/CesiumUtility/include/CesiumUtility/Uri.h
+++ b/CesiumUtility/include/CesiumUtility/Uri.h
@@ -45,7 +45,7 @@ public:
    * @brief Returns a string representation of the entire URI including path and
    * query parameters.
    */
-  std::string toString() const;
+  std::string_view toString() const;
 
   /**
    * @brief Returns true if this URI has been successfully parsed.

--- a/CesiumUtility/src/Uri.cpp
+++ b/CesiumUtility/src/Uri.cpp
@@ -97,14 +97,13 @@ Uri::Uri(const Uri& base, const std::string& relative, bool useBaseQuery) {
   }
 }
 
-std::string Uri::toString() const {
+std::string_view Uri::toString() const {
   if (!this->_url) {
-    return "";
+    return std::string_view();
   }
 
   const std::string_view result = this->_url->get_href();
-  return this->_hasScheme ? std::string(result)
-                          : std::string(result.substr(FILE_PREFIX.length()));
+  return this->_hasScheme ? result : result.substr(FILE_PREFIX.length());
 }
 
 bool Uri::isValid() const { return this->_url.has_value(); }
@@ -155,7 +154,7 @@ std::string Uri::resolve(
     const std::string& relative,
     bool useBaseQuery,
     [[maybe_unused]] bool assumeHttpsDefault) {
-  return Uri(Uri(base), relative, useBaseQuery).toString();
+  return std::string(Uri(Uri(base), relative, useBaseQuery).toString());
 }
 
 std::string Uri::addQuery(
@@ -170,7 +169,7 @@ std::string Uri::addQuery(
   UriQuery params(parsedUri);
   params.setValue(key, value);
   parsedUri.setQuery(params.toQueryString());
-  return parsedUri.toString();
+  return std::string(parsedUri.toString());
 }
 
 std::string Uri::getQueryValue(const std::string& uri, const std::string& key) {
@@ -311,7 +310,7 @@ std::string Uri::getPath(const std::string& uri) {
 std::string Uri::setPath(const std::string& uri, const std::string& newPath) {
   Uri parsedUri(uri);
   parsedUri.setPath(newPath);
-  return parsedUri.toString();
+  return std::string(parsedUri.toString());
 }
 
 } // namespace CesiumUtility

--- a/CesiumUtility/test/TestUri.cpp
+++ b/CesiumUtility/test/TestUri.cpp
@@ -236,3 +236,20 @@ TEST_CASE("Uri::substituteTemplateParameters") {
           "https://example.com/a}",
           substitutionCallback) == "https://example.com/a}");
 }
+
+TEST_CASE("UriQuery") {
+  SUBCASE("preserves placeholders") {
+    Uri uri("https://example.com?query={whatever}&{this}={that}");
+    UriQuery query(uri);
+
+    CHECK(query.getValue("query") == "{whatever}");
+    CHECK(query.getValue("{this}") == "{that}");
+
+    query.setValue("query", "foo");
+    query.setValue("{this}", "{another}");
+    CHECK(query.getValue("query") == "foo");
+    CHECK(query.getValue("{this}") == "{another}");
+
+    CHECK(query.toQueryString() == "query=foo&%7Bthis%7D=%7Banother%7D");
+  }
+}


### PR DESCRIPTION
This was causing the Bing Maps overlay to fail to work in Cesium for Unreal, so the first sample level just showed a textureless white terrain and lots of errors.

Also fixed a problem where the `culture` parameter was not actually used correctly, so specifying a Bing culture wouldn't have worked.

And I changed `Uri::toString` to return a `std::string_view` to match most of the other methods, and because it can. This required explicitly turning it into a `std::string` in a few places.

I'm going to merge this for today's release once CI is happy.