### PR TITLE
Fix bad construction of `scopes` in Cesium ion authorize URL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v0.44.1 - 2025-02-03
+
+##### Fixes :wrench:
+
+- Fixed a bug in `CesiumIonClient::Connection` that caused the `authorize` method to use an incorrect URL.
+
 ### v0.44.0 - 2025-02-03
 
 ##### Breaking Changes :mega:

--- a/CesiumIonClient/src/Connection.cpp
+++ b/CesiumIonClient/src/Connection.cpp
@@ -171,7 +171,7 @@ std::string createAuthorizationErrorHtml(
   authorizeUrl =
       Uri::addQuery(authorizeUrl, "client_id", std::to_string(clientID));
   authorizeUrl =
-      Uri::addQuery(authorizeUrl, "scope", joinToString(scopes, "%20"));
+      Uri::addQuery(authorizeUrl, "scope", joinToString(scopes, " "));
   authorizeUrl = Uri::addQuery(authorizeUrl, "redirect_uri", redirectUrl);
   authorizeUrl = Uri::addQuery(authorizeUrl, "state", state);
   authorizeUrl = Uri::addQuery(authorizeUrl, "code_challenge_method", "S256");


### PR DESCRIPTION
Fixes #1094 
