### PR TITLE
Remove unused `TilesetOptions::maximumSimultaneousSubtreeLoads`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Breaking Changes :mega:
+
+- Removed `TilesetOptions::maximumSimultaneousSubtreeLoads` because it was unused.
+
 ### v0.44.1 - 2025-02-03
 
 ##### Fixes :wrench:

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetOptions.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetOptions.h
@@ -103,12 +103,6 @@ struct CESIUM3DTILESSELECTION_API TilesetOptions {
   uint32_t maximumSimultaneousTileLoads = 20;
 
   /**
-   * @brief The maximum number of subtrees that may simultaneously be in the
-   * process of loading.
-   */
-  uint32_t maximumSimultaneousSubtreeLoads = 20;
-
-  /**
    * @brief Indicates whether the ancestors of rendered tiles should be
    * preloaded. Setting this to true optimizes the zoom-out experience and
    * provides more detail in newly-exposed areas when panning. The down side is


### PR DESCRIPTION
This property may have done something once upon a time, but it doesn't anymore.