### PR TITLE
Make CesiumGltf headers public and fix warnings

### DIFF
--- a/CesiumGltf/CMakeLists.txt
+++ b/CesiumGltf/CMakeLists.txt
@@ -40,10 +40,11 @@ target_sources(
         ${CESIUM_GLTF_PUBLIC_HEADERS}
 )
 
-target_include_directories(
-    CesiumGltf
-    SYSTEM PUBLIC
-        ${CMAKE_CURRENT_LIST_DIR}/include/
+cesium_target_include_directories(
+    TARGET
+        CesiumGltf
+    PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}/include
         ${CMAKE_CURRENT_LIST_DIR}/generated/include
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/src

--- a/CesiumGltf/include/CesiumGltf/AccessorUtility.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorUtility.h
@@ -242,13 +242,17 @@ struct IndicesForFaceFromAccessor {
 
     if (primitiveMode == MeshPrimitive::Mode::TRIANGLE_FAN) {
       result[0] = value[0];
-      result[1] = firstIndex < value.size() ? value[firstIndex] : -1;
-      result[2] = firstIndex + 1 < value.size() ? value[firstIndex + 1] : -1;
+      result[1] = firstIndex < value.size()
+                      ? static_cast<int64_t>(value[firstIndex])
+                      : -1;
+      result[2] = firstIndex + 1 < value.size()
+                      ? static_cast<int64_t>(value[firstIndex + 1])
+                      : -1;
     } else {
       for (int64_t i = 0; i < 3; i++) {
         int64_t index = firstIndex + i;
         result[static_cast<size_t>(i)] =
-            index < value.size() ? value[index] : -1;
+            index < value.size() ? static_cast<int64_t>(value[index]) : -1;
       }
     }
 

--- a/CesiumGltf/include/CesiumGltf/AccessorUtility.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorUtility.h
@@ -201,7 +201,8 @@ struct IndicesForFaceFromAccessor {
     } else {
       for (int64_t i = 0; i < 3; i++) {
         int64_t vertexIndex = firstVertex + i;
-        result[i] = vertexIndex < vertexCount ? vertexIndex : -1;
+        result[static_cast<size_t>(i)] =
+            vertexIndex < vertexCount ? vertexIndex : -1;
       }
     }
 

--- a/CesiumGltf/include/CesiumGltf/AccessorUtility.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorUtility.h
@@ -247,7 +247,8 @@ struct IndicesForFaceFromAccessor {
     } else {
       for (int64_t i = 0; i < 3; i++) {
         int64_t index = firstIndex + i;
-        result[i] = index < value.size() ? value[index] : -1;
+        result[static_cast<size_t>(i)] =
+            index < value.size() ? value[index] : -1;
       }
     }
 

--- a/CesiumGltf/include/CesiumGltf/NamedObject.h
+++ b/CesiumGltf/include/CesiumGltf/NamedObject.h
@@ -27,10 +27,10 @@ struct CESIUMGLTF_API NamedObject : public CesiumUtility::ExtensibleObject {
    */
   int64_t getSizeBytes() const {
     int64_t accum = 0;
-    accum += sizeof(NamedObject);
+    accum += static_cast<int64_t>(sizeof(NamedObject));
     accum +=
         ExtensibleObject::getSizeBytes() - int64_t(sizeof(ExtensibleObject));
-    accum += this->name.capacity() * sizeof(char);
+    accum += static_cast<int64_t>(this->name.capacity() * sizeof(char));
     return accum;
   }
 };

--- a/CesiumGltf/include/CesiumGltf/PropertyArrayView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyArrayView.h
@@ -40,13 +40,15 @@ public:
    * @brief Accesses the element of this array at the given index.
    */
   const ElementType& operator[](int64_t index) const noexcept {
-    return this->_values[index];
+    return this->_values[static_cast<size_t>(index)];
   }
 
   /**
    * @brief The number of elements in this array.
    */
-  int64_t size() const noexcept { return this->_values.size(); }
+  int64_t size() const noexcept {
+    return static_cast<int64_t>(this->_values.size());
+  }
 
   /**
    * @brief The `begin` iterator.

--- a/CesiumGltf/include/CesiumGltf/PropertyTablePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTablePropertyView.h
@@ -478,17 +478,19 @@ private:
   }
 
   bool getBooleanValue(int64_t index) const noexcept {
-    const int64_t byteIndex = index / 8;
+    const size_t byteIndex = static_cast<size_t>(index / 8);
     const int64_t bitIndex = index % 8;
     const int bitValue = static_cast<int>(_values[byteIndex] >> bitIndex) & 1;
     return bitValue == 1;
   }
 
   std::string_view getStringValue(int64_t index) const noexcept {
-    const size_t currentOffset =
-        getOffsetFromOffsetsBuffer(index, _stringOffsets, _stringOffsetType);
+    const size_t currentOffset = getOffsetFromOffsetsBuffer(
+        static_cast<size_t>(index),
+        _stringOffsets,
+        _stringOffsetType);
     const size_t nextOffset = getOffsetFromOffsetsBuffer(
-        index + 1,
+        static_cast<size_t>(index + 1),
         _stringOffsets,
         _stringOffsetType);
     return std::string_view(
@@ -550,19 +552,23 @@ private:
     if (count > 0) {
       size_t arraySize = count * sizeof(T);
       const std::span<const std::byte> values(
-          _values.data() + index * arraySize,
+          _values.data() + static_cast<size_t>(index) * arraySize,
           arraySize);
       return PropertyArrayView<T>{values};
     }
 
     // Handle variable-length arrays. The offsets are interpreted as array
     // indices, not byte offsets, so they must be multiplied by sizeof(T)
-    const size_t currentOffset =
-        getOffsetFromOffsetsBuffer(index, _arrayOffsets, _arrayOffsetType) *
-        sizeof(T);
-    const size_t nextOffset =
-        getOffsetFromOffsetsBuffer(index + 1, _arrayOffsets, _arrayOffsetType) *
-        sizeof(T);
+    const size_t currentOffset = getOffsetFromOffsetsBuffer(
+                                     static_cast<size_t>(index),
+                                     _arrayOffsets,
+                                     _arrayOffsetType) *
+                                 sizeof(T);
+    const size_t nextOffset = getOffsetFromOffsetsBuffer(
+                                  static_cast<size_t>(index + 1),
+                                  _arrayOffsets,
+                                  _arrayOffsetType) *
+                              sizeof(T);
     const std::span<const std::byte> values(
         _values.data() + currentOffset,
         nextOffset - currentOffset);
@@ -580,7 +586,7 @@ private:
     if (count > 0) {
       size_t arraySize = count * componentSize;
       const std::span<const std::byte> values(
-          _values.data() + index * arraySize,
+          _values.data() + static_cast<size_t>(index) * arraySize,
           arraySize);
       return PropertyArrayView<PropertyEnumValue>{
           values,
@@ -590,12 +596,16 @@ private:
 
     // Handle variable-length arrays. The offsets are interpreted as array
     // indices, not byte offsets, so they must be multiplied by sizeof(T)
-    const size_t currentOffset =
-        getOffsetFromOffsetsBuffer(index, _arrayOffsets, _arrayOffsetType) *
-        componentSize;
-    const size_t nextOffset =
-        getOffsetFromOffsetsBuffer(index + 1, _arrayOffsets, _arrayOffsetType) *
-        componentSize;
+    const size_t currentOffset = getOffsetFromOffsetsBuffer(
+                                     static_cast<size_t>(index),
+                                     _arrayOffsets,
+                                     _arrayOffsetType) *
+                                 componentSize;
+    const size_t nextOffset = getOffsetFromOffsetsBuffer(
+                                  static_cast<size_t>(index + 1),
+                                  _arrayOffsets,
+                                  _arrayOffsetType) *
+                              componentSize;
     const std::span<const std::byte> values(
         _values.data() + currentOffset,
         nextOffset - currentOffset);
@@ -611,31 +621,36 @@ private:
     // Handle fixed-length arrays
     if (count > 0) {
       // Copy the corresponding string offsets to pass to the PropertyArrayView.
-      const size_t arraySize = count * _stringOffsetTypeSize;
+      const size_t arraySize =
+          count * static_cast<size_t>(_stringOffsetTypeSize);
       const std::span<const std::byte> stringOffsetValues(
-          _stringOffsets.data() + index * arraySize,
-          arraySize + _stringOffsetTypeSize);
+          _stringOffsets.data() + static_cast<size_t>(index) * arraySize,
+          arraySize + static_cast<size_t>(_stringOffsetTypeSize));
       return PropertyArrayView<std::string_view>(
           _values,
           stringOffsetValues,
           _stringOffsetType,
-          count);
+          static_cast<int64_t>(count));
     }
 
     // Handle variable-length arrays
-    const size_t currentArrayOffset =
-        getOffsetFromOffsetsBuffer(index, _arrayOffsets, _arrayOffsetType);
-    const size_t nextArrayOffset =
-        getOffsetFromOffsetsBuffer(index + 1, _arrayOffsets, _arrayOffsetType);
+    const size_t currentArrayOffset = getOffsetFromOffsetsBuffer(
+        static_cast<size_t>(index),
+        _arrayOffsets,
+        _arrayOffsetType);
+    const size_t nextArrayOffset = getOffsetFromOffsetsBuffer(
+        static_cast<size_t>(index + 1),
+        _arrayOffsets,
+        _arrayOffsetType);
     const size_t arraySize = nextArrayOffset - currentArrayOffset;
     const std::span<const std::byte> stringOffsetValues(
         _stringOffsets.data() + currentArrayOffset,
-        arraySize + _arrayOffsetTypeSize);
+        arraySize + static_cast<size_t>(_arrayOffsetTypeSize));
     return PropertyArrayView<std::string_view>(
         _values,
         stringOffsetValues,
         _stringOffsetType,
-        arraySize / _arrayOffsetTypeSize);
+        static_cast<int64_t>(arraySize) / _arrayOffsetTypeSize);
   }
 
   PropertyArrayView<bool> getBooleanArrayValues(int64_t index) const noexcept {
@@ -654,15 +669,22 @@ private:
     }
 
     // Handle variable-length arrays
-    const size_t currentOffset =
-        getOffsetFromOffsetsBuffer(index, _arrayOffsets, _arrayOffsetType);
-    const size_t nextOffset =
-        getOffsetFromOffsetsBuffer(index + 1, _arrayOffsets, _arrayOffsetType);
+    const size_t currentOffset = getOffsetFromOffsetsBuffer(
+        static_cast<size_t>(index),
+        _arrayOffsets,
+        _arrayOffsetType);
+    const size_t nextOffset = getOffsetFromOffsetsBuffer(
+        static_cast<size_t>(index + 1),
+        _arrayOffsets,
+        _arrayOffsetType);
     const size_t totalBits = nextOffset - currentOffset;
     const std::span<const std::byte> buffer(
         _values.data() + currentOffset / 8,
         (nextOffset / 8 - currentOffset / 8 + 1));
-    return PropertyArrayView<bool>(buffer, currentOffset % 8, totalBits);
+    return PropertyArrayView<bool>(
+        buffer,
+        currentOffset % 8,
+        static_cast<int64_t>(totalBits));
   }
 
   std::span<const std::byte> _values;
@@ -937,19 +959,23 @@ private:
     if (count > 0) {
       size_t arraySize = count * sizeof(T);
       const std::span<const std::byte> values(
-          _values.data() + index * arraySize,
+          _values.data() + static_cast<size_t>(index) * arraySize,
           arraySize);
       return PropertyArrayView<T>{values};
     }
 
     // Handle variable-length arrays. The offsets are interpreted as array
     // indices, not byte offsets, so they must be multiplied by sizeof(T)
-    const size_t currentOffset =
-        getOffsetFromOffsetsBuffer(index, _arrayOffsets, _arrayOffsetType) *
-        sizeof(T);
-    const size_t nextOffset =
-        getOffsetFromOffsetsBuffer(index + 1, _arrayOffsets, _arrayOffsetType) *
-        sizeof(T);
+    const size_t currentOffset = getOffsetFromOffsetsBuffer(
+                                     static_cast<size_t>(index),
+                                     _arrayOffsets,
+                                     _arrayOffsetType) *
+                                 sizeof(T);
+    const size_t nextOffset = getOffsetFromOffsetsBuffer(
+                                  static_cast<size_t>(index + 1),
+                                  _arrayOffsets,
+                                  _arrayOffsetType) *
+                              sizeof(T);
     const std::span<const std::byte> values(
         _values.data() + currentOffset,
         nextOffset - currentOffset);

--- a/CesiumGltf/include/CesiumGltf/PropertyTableView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTableView.h
@@ -1155,7 +1155,8 @@ private:
       maxRequiredBytes = static_cast<size_t>(
           glm::ceil(static_cast<double>(_pPropertyTable->count) / 8.0));
     } else {
-      maxRequiredBytes = _pPropertyTable->count * sizeof(T);
+      maxRequiredBytes =
+          static_cast<size_t>(_pPropertyTable->count) * sizeof(T);
     }
 
     if (values.size() < maxRequiredBytes) {
@@ -1299,8 +1300,9 @@ private:
 
     // Handle fixed-length arrays
     if (fixedLengthArrayCount > 0) {
-      size_t maxRequiredBytes = maxRequiredBytes = static_cast<size_t>(
-          _pPropertyTable->count * fixedLengthArrayCount * sizeof(T));
+      size_t maxRequiredBytes =
+          static_cast<size_t>(_pPropertyTable->count * fixedLengthArrayCount) *
+          sizeof(T);
 
       if (values.size() < maxRequiredBytes) {
         return PropertyTablePropertyView<PropertyArrayView<T>, Normalized>(

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -108,7 +108,12 @@ ElementType assembleScalarValue(const std::span<uint8_t> bytes) noexcept {
     }
 
     // Reinterpret the bits as a float.
-    return *reinterpret_cast<float*>(&resultAsUint);
+    // We need to memcpy to avoid a "dereferencing type-punned pointer will
+    // break strict-aliasing rules" error on GCC See
+    // https://gist.github.com/shafik/848ae25ee209f698763cffee272a58f8#how-do-we-type-pun-correctly
+    float resultAsFloat;
+    std::memcpy(&resultAsFloat, &resultAsUint, sizeof(float));
+    return resultAsFloat;
   }
 
   if constexpr (IsMetadataInteger<ElementType>::value) {

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -12,7 +12,7 @@
 #include <CesiumGltf/TextureView.h>
 #include <CesiumUtility/Assert.h>
 
-#include <array>
+#include <bit>
 #include <cmath>
 #include <cstdint>
 #include <optional>
@@ -108,12 +108,7 @@ ElementType assembleScalarValue(const std::span<uint8_t> bytes) noexcept {
     }
 
     // Reinterpret the bits as a float.
-    // We need to memcpy to avoid a "dereferencing type-punned pointer will
-    // break strict-aliasing rules" error on GCC. See:
-    // https://gist.github.com/shafik/848ae25ee209f698763cffee272a58f8#how-do-we-type-pun-correctly
-    float resultAsFloat;
-    std::memcpy(&resultAsFloat, &resultAsUint, sizeof(float));
-    return resultAsFloat;
+    return std::bit_cast<float>(resultAsUint);
   }
 
   if constexpr (IsMetadataInteger<ElementType>::value) {

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -12,7 +12,6 @@
 #include <CesiumGltf/TextureView.h>
 #include <CesiumUtility/Assert.h>
 
-#include <bit>
 #include <cmath>
 #include <cstdint>
 #include <optional>
@@ -108,7 +107,12 @@ ElementType assembleScalarValue(const std::span<uint8_t> bytes) noexcept {
     }
 
     // Reinterpret the bits as a float.
-    return std::bit_cast<float>(resultAsUint);
+    // We need to memcpy to avoid a "dereferencing type-punned pointer will
+    // break strict-aliasing rules" error on GCC. See:
+    // https://gist.github.com/shafik/848ae25ee209f698763cffee272a58f8#how-do-we-type-pun-correctly
+    float resultAsFloat;
+    std::memcpy(&resultAsFloat, &resultAsUint, sizeof(float));
+    return resultAsFloat;
   }
 
   if constexpr (IsMetadataInteger<ElementType>::value) {

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -115,7 +115,8 @@ ElementType assembleScalarValue(const std::span<uint8_t> bytes) noexcept {
     using UintType = std::make_unsigned_t<ElementType>;
     UintType resultAsUint = 0;
     for (size_t i = 0; i < bytes.size(); i++) {
-      resultAsUint |= static_cast<UintType>(bytes[i]) << i * 8;
+      resultAsUint |=
+          static_cast<UintType>(static_cast<UintType>(bytes[i]) << i * 8);
     }
 
     // Reinterpret the bits with the correct signedness.
@@ -146,7 +147,7 @@ template <typename ElementType>
 ElementType assembleVecNValue(const std::span<uint8_t> bytes) noexcept {
   ElementType result = ElementType();
 
-  const glm::length_t N =
+  [[maybe_unused]] glm::length_t N =
       getDimensionsFromPropertyType(TypeToPropertyType<ElementType>::value);
   using T = typename ElementType::value_type;
 

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -169,20 +169,22 @@ ElementType assembleVecNValue(const std::span<uint8_t> bytes) noexcept {
     CESIUM_ASSERT(
         N == 2 && "Only vec2s can contain two-byte integer components.");
     result[0] = static_cast<uint16_t>(bytes[0]) |
-                (static_cast<uint16_t>(bytes[1]) << 8);
+                static_cast<uint16_t>(static_cast<uint16_t>(bytes[1]) << 8);
     result[1] = static_cast<uint16_t>(bytes[2]) |
-                (static_cast<uint16_t>(bytes[3]) << 8);
+                static_cast<uint16_t>(static_cast<uint16_t>(bytes[3]) << 8);
   }
 
+  const int64_t numBytes = static_cast<int64_t>(bytes.size());
   if constexpr (std::is_same_v<T, int8_t>) {
-    for (size_t i = 0; i < bytes.size(); i++) {
-      result[i] = *reinterpret_cast<const int8_t*>(&bytes[i]);
+    for (int64_t i = 0; i < numBytes; i++) {
+      result[static_cast<glm::length_t>(i)] =
+          *reinterpret_cast<const int8_t*>(&bytes[static_cast<size_t>(i)]);
     }
   }
 
   if constexpr (std::is_same_v<T, uint8_t>) {
-    for (size_t i = 0; i < bytes.size(); i++) {
-      result[i] = bytes[i];
+    for (int64_t i = 0; i < numBytes; i++) {
+      result[static_cast<glm::length_t>(i)] = bytes[static_cast<size_t>(i)];
     }
   }
 
@@ -202,10 +204,11 @@ assembleArrayValue(const std::span<uint8_t> bytes) noexcept {
   std::vector<T> result(bytes.size() / sizeof(T));
 
   if constexpr (sizeof(T) == 2) {
-    for (int i = 0, b = 0; i < result.size(); i++, b += 2) {
+    for (size_t i = 0, b = 0; i < result.size(); i++, b += 2) {
       using UintType = std::make_unsigned_t<T>;
-      UintType resultAsUint = static_cast<UintType>(bytes[b]) |
-                              (static_cast<UintType>(bytes[b + 1]) << 8);
+      UintType resultAsUint =
+          static_cast<UintType>(bytes[b]) |
+          static_cast<UintType>(static_cast<UintType>(bytes[b + 1]) << 8);
       result[i] = *reinterpret_cast<T*>(&resultAsUint);
     }
   } else {

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -109,7 +109,7 @@ ElementType assembleScalarValue(const std::span<uint8_t> bytes) noexcept {
 
     // Reinterpret the bits as a float.
     // We need to memcpy to avoid a "dereferencing type-punned pointer will
-    // break strict-aliasing rules" error on GCC See
+    // break strict-aliasing rules" error on GCC. See:
     // https://gist.github.com/shafik/848ae25ee209f698763cffee272a58f8#how-do-we-type-pun-correctly
     float resultAsFloat;
     std::memcpy(&resultAsFloat, &resultAsUint, sizeof(float));

--- a/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTextureView.h
@@ -897,7 +897,7 @@ private:
             PropertyTexturePropertyViewStatus::ErrorUnsupportedProperty);
       }
 
-      if (count * sizeof(T) > 4) {
+      if (count * static_cast<int64_t>(sizeof(T)) > 4) {
         return PropertyTexturePropertyView<PropertyArrayView<T>, Normalized>(
             PropertyTexturePropertyViewStatus::ErrorUnsupportedProperty);
       }
@@ -905,7 +905,7 @@ private:
       return createPropertyViewImpl<PropertyArrayView<T>, Normalized>(
           classProperty,
           propertyTextureProperty,
-          count * sizeof(T),
+          static_cast<size_t>(count) * sizeof(T),
           propertyOptions);
     } else {
       return PropertyTexturePropertyView<PropertyArrayView<T>, Normalized>(
@@ -956,7 +956,7 @@ private:
     return PropertyTexturePropertyView<T, Normalized>(
         propertyTextureProperty,
         classProperty,
-        _pModel->samplers[samplerIndex],
+        _pModel->samplers[static_cast<size_t>(samplerIndex)],
         *pImage,
         propertyOptions);
   }

--- a/CesiumGltf/include/CesiumGltf/PropertyTransformations.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTransformations.h
@@ -129,14 +129,15 @@ PropertyArrayCopy<T> transformArray(
     const std::optional<PropertyArrayView<T>>& scale) {
   std::vector<T> result(static_cast<size_t>(value.size()));
   for (int64_t i = 0; i < value.size(); i++) {
-    result[i] = value[i];
+    const size_t ui = static_cast<size_t>(i);
+    result[ui] = value[i];
 
     if (scale) {
-      result[i] = applyScale<T>(result[i], (*scale)[i]);
+      result[ui] = applyScale<T>(result[ui], (*scale)[i]);
     }
 
     if (offset) {
-      result[i] = result[i] + (*offset)[i];
+      result[ui] = result[ui] + (*offset)[i];
     }
   }
 
@@ -164,14 +165,15 @@ PropertyArrayCopy<NormalizedType> transformNormalizedArray(
     const std::optional<PropertyArrayView<NormalizedType>>& scale) {
   std::vector<NormalizedType> result(static_cast<size_t>(value.size()));
   for (int64_t i = 0; i < value.size(); i++) {
-    result[i] = normalize<T>(value[i]);
+    const size_t ui = static_cast<size_t>(i);
+    result[ui] = normalize<T>(value[i]);
 
     if (scale) {
-      result[i] = result[i] * (*scale)[i];
+      result[ui] = result[ui] * (*scale)[i];
     }
 
     if (offset) {
-      result[i] = result[i] + (*offset)[i];
+      result[ui] = result[ui] + (*offset)[i];
     }
   }
 
@@ -196,14 +198,15 @@ PropertyArrayCopy<glm::vec<N, double>> transformNormalizedVecNArray(
     const std::optional<PropertyArrayView<glm::vec<N, double>>>& scale) {
   std::vector<glm::vec<N, double>> result(static_cast<size_t>(value.size()));
   for (int64_t i = 0; i < value.size(); i++) {
-    result[i] = normalize<N, T>(value[i]);
+    const size_t ui = static_cast<size_t>(i);
+    result[ui] = normalize<N, T>(value[i]);
 
     if (scale) {
-      result[i] = result[i] * (*scale)[i];
+      result[ui] = result[ui] * (*scale)[i];
     }
 
     if (offset) {
-      result[i] = result[i] + (*offset)[i];
+      result[ui] = result[ui] + (*offset)[i];
     }
   }
 
@@ -228,14 +231,15 @@ PropertyArrayCopy<glm::mat<N, N, double>> transformNormalizedMatNArray(
     const std::optional<PropertyArrayView<glm::mat<N, N, double>>>& scale) {
   std::vector<glm::mat<N, N, double>> result(static_cast<size_t>(value.size()));
   for (int64_t i = 0; i < value.size(); i++) {
-    result[i] = normalize<N, T>(value[i]);
+    const size_t ui = static_cast<size_t>(i);
+    result[ui] = normalize<N, T>(value[i]);
 
     if (scale) {
-      result[i] = applyScale<glm::mat<N, N, double>>(result[i], (*scale)[i]);
+      result[ui] = applyScale<glm::mat<N, N, double>>(result[ui], (*scale)[i]);
     }
 
     if (offset) {
-      result[i] = result[i] + (*offset)[i];
+      result[ui] = result[ui] + (*offset)[i];
     }
   }
 

--- a/CesiumGltf/include/CesiumGltf/PropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyView.h
@@ -1559,8 +1559,8 @@ private:
     const auto foundValue = std::find_if(
         pEnumDefinition->values.begin(),
         pEnumDefinition->values.end(),
-        [&valueStr](const CesiumGltf::EnumValue& value) {
-          return value.name == valueStr;
+        [&valueStr](const CesiumGltf::EnumValue& enumValue) {
+          return enumValue.name == valueStr;
         });
 
     if (foundValue == pEnumDefinition->values.end()) {
@@ -1613,7 +1613,7 @@ public:
         _name(classProperty.name),
         _semantic(classProperty.semantic),
         _description(classProperty.description),
-        _count(_count = classProperty.count ? *classProperty.count : 0),
+        _count(classProperty.count ? *classProperty.count : 0),
         _offset(std::nullopt),
         _scale(std::nullopt),
         _max(std::nullopt),
@@ -2010,7 +2010,7 @@ public:
         _name(classProperty.name),
         _semantic(classProperty.semantic),
         _description(classProperty.description),
-        _count(_count = classProperty.count ? *classProperty.count : 0),
+        _count(classProperty.count ? *classProperty.count : 0),
         _offset(std::nullopt),
         _scale(std::nullopt),
         _max(std::nullopt),

--- a/CesiumGltf/include/CesiumGltf/PropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyView.h
@@ -225,7 +225,7 @@ getVecN(const CesiumUtility::JsonValue& jsonValue) {
 
   VecType result;
   for (glm::length_t i = 0; i < N; i++) {
-    std::optional<T> value = getScalar<T>(array[i]);
+    std::optional<T> value = getScalar<T>(array[static_cast<size_t>(i)]);
     if (!value) {
       return std::nullopt;
     }
@@ -265,7 +265,8 @@ getMatN(const CesiumUtility::JsonValue& jsonValue) {
   for (glm::length_t i = 0; i < N; i++) {
     // Try to parse each value in the column.
     for (glm::length_t j = 0; j < N; j++) {
-      std::optional<T> value = getScalar<T>(array[i * N + j]);
+      std::optional<T> value =
+          getScalar<T>(array[static_cast<size_t>(i * N + j)]);
       if (!value) {
         return std::nullopt;
       }

--- a/cmake/macros/configure_cesium_library.cmake
+++ b/cmake/macros/configure_cesium_library.cmake
@@ -13,7 +13,8 @@ function(configure_cesium_library targetName)
 
     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
         # Disable dangling-reference warning due to amount of false positives: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109642
-        target_compile_options(${targetName} PRIVATE -Wno-dangling-reference)
+        # Also disable unknown pragmas warning so we can use #pragma region
+        target_compile_options(${targetName} PRIVATE -Wno-dangling-reference -Wno-unknown-pragmas)
     endif()
 
     if (CESIUM_GLM_STRICT_ENABLED)

--- a/cmake/macros/configure_cesium_library.cmake
+++ b/cmake/macros/configure_cesium_library.cmake
@@ -15,6 +15,8 @@ function(configure_cesium_library targetName)
         # Disable dangling-reference warning due to amount of false positives: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109642
         # Also disable unknown pragmas warning so we can use #pragma region
         target_compile_options(${targetName} PRIVATE -Wno-dangling-reference -Wno-unknown-pragmas)
+    elseif(CMAKE_CXX_COMPILE_ID STREQUAL "GCC") 
+        target_compile_options(${targetName} PRIVATE -Wno-unknown-pragmas)
     endif()
 
     if (CESIUM_GLM_STRICT_ENABLED)

--- a/cmake/macros/configure_cesium_library.cmake
+++ b/cmake/macros/configure_cesium_library.cmake
@@ -13,10 +13,12 @@ function(configure_cesium_library targetName)
 
     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
         # Disable dangling-reference warning due to amount of false positives: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109642
-        # Also disable unknown pragmas warning so we can use #pragma region
-        target_compile_options(${targetName} PRIVATE -Wno-dangling-reference -Wno-unknown-pragmas)
-    elseif(CMAKE_CXX_COMPILE_ID STREQUAL "GCC") 
-        target_compile_options(${targetName} PRIVATE -Wno-unknown-pragmas)
+        target_compile_options(${targetName} PRIVATE -Wno-dangling-reference)
+    endif()
+
+    if (CMAKE_CXX_COMPILERID STREQUAL "GNU")
+        # Disable unknown-pragmas errors because GCC doesn't recognize #pragma region
+        target_compile_options(${targetName} PRIVATE -Wno-error=unknown-pragmas -Wno-unknown-pragmas)
     endif()
 
     if (CESIUM_GLM_STRICT_ENABLED)

--- a/cmake/macros/configure_cesium_library.cmake
+++ b/cmake/macros/configure_cesium_library.cmake
@@ -2,7 +2,7 @@ function(configure_cesium_library targetName)
     if (MSVC)
         target_compile_options(${targetName} PRIVATE /W4 /WX /wd4201 /bigobj /w45038 /w44254 /w44242 /w44191 /w45220)
     else()
-        target_compile_options(${targetName} PRIVATE -Werror -Wall -Wextra -Wconversion -Wpedantic -Wshadow -Wsign-conversion)
+        target_compile_options(${targetName} PRIVATE -Werror -Wall -Wextra -Wconversion -Wpedantic -Wshadow -Wsign-conversion -Wno-unknown-pragmas)
     endif()
 
     set_target_properties(${targetName} PROPERTIES
@@ -14,11 +14,6 @@ function(configure_cesium_library targetName)
     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
         # Disable dangling-reference warning due to amount of false positives: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109642
         target_compile_options(${targetName} PRIVATE -Wno-dangling-reference)
-    endif()
-
-    if (CMAKE_CXX_COMPILERID STREQUAL "GNU")
-        # Disable unknown-pragmas errors because GCC doesn't recognize #pragma region
-        target_compile_options(${targetName} PRIVATE -Wno-error=unknown-pragmas -Wno-unknown-pragmas)
     endif()
 
     if (CESIUM_GLM_STRICT_ENABLED)


### PR DESCRIPTION
Closes #460. As part of #1004 we stopped marking most of the public headers as `SYSTEM` so that they would be analyzed by clang-tidy, but we skipped over `CesiumGltf` as the number of warnings didn't seem worth resolving at the time. I ended up fixing some of those warnings while working on #1085, so I decided to finish the job here.