### PR TITLE
Fix scheme detection in CesiumUtility::Uri

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,10 +6,14 @@
 
 - Removed `TilesetOptions::maximumSimultaneousSubtreeLoads` because it was unused.
 
-### Additions :tada:
+##### Additions :tada:
 
 - Added `convertPropertyComponentTypeToAccessorComponentType` to `PropertyType`.
 - Added support for `3DTILES_ellipsoid` in `Cesium3DTiles`, `Cesium3DTilesReader`, and `Cesium3DTilesWriter`.
+
+##### Fixes :wrench:
+
+- Fixed parsing URIs that have a scheme followed by `:` instead of `://`.
 
 ### v0.44.1 - 2025-02-03
 

--- a/CesiumUtility/src/Uri.cpp
+++ b/CesiumUtility/src/Uri.cpp
@@ -28,19 +28,24 @@ using UrlResult = ada::result<ada::url_aggregator>;
 bool isAsciiAlpha(unsigned char c) {
   return c >= 0x41 && c <= 0x7a && (c <= 0x5a || c >= 0x61);
 }
-bool isAscii(unsigned char c) { return c <= 0x7f; }
+bool isAsciiAlphanumeric(unsigned char c) {
+  return isAsciiAlpha(c) || (c >= '0' && c <= '9');
+}
 
 /**
  * A URI has a valid scheme if it starts with an ASCII alpha character and has a
- * sequence of ASCII characters followed by a ":"
+ * sequence of ASCII characters followed by a "://"
  */
 bool urlHasScheme(const std::string& uri) {
   for (size_t i = 0; i < uri.length(); i++) {
     unsigned char c = static_cast<unsigned char>(uri[i]);
     if (c == ':') {
       return true;
-    } else if ((i == 0 && !isAsciiAlpha(c)) || !isAscii(c)) {
-      // Scheme must start with an ASCII alpha character and be an ASCII string
+    } else if (
+        (i == 0 && !isAsciiAlpha(c)) ||
+        (!isAsciiAlphanumeric(c) && c != '+' && c != '-' && c != '.')) {
+      // Scheme must start with an ASCII alpha character and be a string
+      // containing only alphanumeric ASCII or the characters '+', '-', and '.'.
       return false;
     }
   }

--- a/CesiumUtility/src/Uri.cpp
+++ b/CesiumUtility/src/Uri.cpp
@@ -32,13 +32,13 @@ bool isAscii(unsigned char c) { return c <= 0x7f; }
 
 /**
  * A URI has a valid scheme if it starts with an ASCII alpha character and has a
- * sequence of ASCII characters followed by a "://"
+ * sequence of ASCII characters followed by a ":"
  */
 bool urlHasScheme(const std::string& uri) {
   for (size_t i = 0; i < uri.length(); i++) {
     unsigned char c = static_cast<unsigned char>(uri[i]);
     if (c == ':') {
-      return uri.length() > i + 2 && uri[i + 1] == '/' && uri[i + 2] == '/';
+      return true;
     } else if ((i == 0 && !isAsciiAlpha(c)) || !isAscii(c)) {
       // Scheme must start with an ASCII alpha character and be an ASCII string
       return false;

--- a/CesiumUtility/test/TestUri.cpp
+++ b/CesiumUtility/test/TestUri.cpp
@@ -22,6 +22,9 @@ TEST_CASE("Uri::getPath") {
     CHECK(
         Uri::getPath("https://example.com/foo/bar/?some=parameter") ==
         "/foo/bar/");
+    CHECK(
+        Uri::getPath("geopackage:/home/courtyard_imagery.gpkg") ==
+        "/home/courtyard_imagery.gpkg");
   }
 
   SUBCASE("returns / path for nonexistent paths") {


### PR DESCRIPTION
`urlHasScheme` checks if a scheme is followed by `://` but just `:` should be allowed too.

![URI_syntax_diagram svg](https://github.com/user-attachments/assets/7d353f1c-22e9-42db-ac5a-775d2ed6555c)

For example, `"geopackage:/home/courtyard_imagery.gpkg"` wasn't being parsed correctly. This seems to be a regression from https://github.com/CesiumGS/cesium-native/pull/1072.