### PR TITLE
Fix AsyncSystem example

### DIFF
--- a/CesiumAsync/test/ExamplesAsyncSystem.cpp
+++ b/CesiumAsync/test/ExamplesAsyncSystem.cpp
@@ -384,7 +384,7 @@ TEST_CASE("AsyncSystem Examples") {
                       processDownloadedContent(pResponse->data());
                   std::optional<std::string> maybeUrl =
                       findReferencedImageUrl(processed);
-                  if (maybeUrl) {
+                  if (!maybeUrl) {
                     return asyncSystem.createResolvedFuture<
                         std::shared_ptr<CesiumAsync::IAssetRequest>>(nullptr);
                   } else {


### PR DESCRIPTION
Noticed a small mistake in an example: `maybeUrl` should be `!maybeUrl`

> ![image](https://github.com/user-attachments/assets/207614e2-766b-4be0-b5c6-8340cfef8f68)
