### PR TITLE
Fix exception when parsing copyright with trailing semicolon

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 ##### Fixes :wrench:
 
 - Fixed parsing URIs that have a scheme followed by `:` instead of `://`.
+- Fixed crash in `GltfUtilities::parseGltfCopyright` when the copyright string ends with a trailing semicolon.
 
 ### v0.44.1 - 2025-02-03
 

--- a/CesiumGltfContent/include/CesiumGltfContent/GltfUtilities.h
+++ b/CesiumGltfContent/include/CesiumGltfContent/GltfUtilities.h
@@ -130,6 +130,16 @@ struct CESIUMGLTFCONTENT_API GltfUtilities {
   parseGltfCopyright(const CesiumGltf::Model& gltf);
 
   /**
+   * @brief Parse a semicolon-separated string, such as the copyright field of a
+   * glTF model, and return the individual parts (credits).
+   *
+   * @param s The string to parse.
+   * @return The semicolon-delimited parts.
+   */
+  static std::vector<std::string_view>
+  parseGltfCopyright(const std::string_view& s);
+
+  /**
    * @brief Merges all of the glTF's buffers into a single buffer (the first
    * one).
    *

--- a/CesiumGltfContent/src/GltfUtilities.cpp
+++ b/CesiumGltfContent/src/GltfUtilities.cpp
@@ -293,6 +293,9 @@ GltfUtilities::parseGltfCopyright(const CesiumGltf::Model& gltf) {
       size_t rtrim;
       do {
         ltrim = copyright.find_first_not_of(" \t", start);
+        if (ltrim == std::string::npos) {
+          break;
+        }
         end = copyright.find(';', ltrim);
         rtrim = copyright.find_last_not_of(" \t", end - 1);
         result.emplace_back(copyright.substr(ltrim, rtrim - ltrim + 1));

--- a/CesiumGltfContent/src/GltfUtilities.cpp
+++ b/CesiumGltfContent/src/GltfUtilities.cpp
@@ -297,7 +297,7 @@ GltfUtilities::parseGltfCopyright(const CesiumGltf::Model& gltf) {
         rtrim = copyright.find_last_not_of(" \t", end - 1);
         result.emplace_back(copyright.substr(ltrim, rtrim - ltrim + 1));
         start = end + 1;
-      } while (end != std::string::npos);
+      } while (end < copyright.size() - 1);
     }
   }
 

--- a/CesiumGltfContent/test/TestGltfUtilities.cpp
+++ b/CesiumGltfContent/test/TestGltfUtilities.cpp
@@ -711,3 +711,41 @@ TEST_CASE("GltfUtilities::collapseToSingleBuffer") {
     CHECK(m.bufferViews[2].byteLength == 100);
   }
 }
+
+TEST_CASE("GltfUtilities::parseGltfCopyright") {
+  SUBCASE("properly parses multiple copyright entries") {
+    Model model;
+    model.asset.copyright = "Test;a;b;c";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 4);
+    CHECK(result[0] == "Test");
+    CHECK(result[1] == "a");
+    CHECK(result[2] == "b");
+    CHECK(result[3] == "c");
+  }
+
+  SUBCASE("properly parses a single copyright entry") {
+    Model model;
+    model.asset.copyright = "Test";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 1);
+    CHECK(result[0] == "Test");
+  }
+
+  SUBCASE("properly parses an entry with a trailing semicolon") {
+    Model model;
+    model.asset.copyright = "Test;a;b;c;";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 4);
+    CHECK(result[0] == "Test");
+    CHECK(result[1] == "a");
+    CHECK(result[2] == "b");
+    CHECK(result[3] == "c");
+  }
+}

--- a/CesiumGltfContent/test/TestGltfUtilities.cpp
+++ b/CesiumGltfContent/test/TestGltfUtilities.cpp
@@ -748,4 +748,17 @@ TEST_CASE("GltfUtilities::parseGltfCopyright") {
     CHECK(result[2] == "b");
     CHECK(result[3] == "c");
   }
+
+  SUBCASE("properly parses entries with whitespace") {
+    Model model;
+    model.asset.copyright = "\tTest;a\t ;\tb;\t \tc\t;\t ";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 4);
+    CHECK(result[0] == "Test");
+    CHECK(result[1] == "a");
+    CHECK(result[2] == "b");
+    CHECK(result[3] == "c");
+  }
 }

--- a/CesiumGltfContent/test/TestGltfUtilities.cpp
+++ b/CesiumGltfContent/test/TestGltfUtilities.cpp
@@ -761,4 +761,88 @@ TEST_CASE("GltfUtilities::parseGltfCopyright") {
     CHECK(result[2] == "b");
     CHECK(result[3] == "c");
   }
+
+  SUBCASE("properly parses an empty string") {
+    Model model;
+    model.asset.copyright = "";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 0);
+  }
+
+  SUBCASE("properly parses whitespace only") {
+    Model model;
+    model.asset.copyright = " \t  \t";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 0);
+  }
+
+  SUBCASE("properly parses empty parts in the middle") {
+    Model model;
+    model.asset.copyright = "a;;b";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "a");
+    CHECK(result[1] == "b");
+  }
+
+  SUBCASE("properly parses whitespace parts in the middle") {
+    Model model;
+    model.asset.copyright = "a;\t;b";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "a");
+    CHECK(result[1] == "b");
+  }
+
+  SUBCASE("properly parses empty parts at the start") {
+    Model model;
+    model.asset.copyright = ";a;b";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "a");
+    CHECK(result[1] == "b");
+  }
+
+  SUBCASE("properly parses whitespace parts at the start") {
+    Model model;
+    model.asset.copyright = "\t;a;b";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "a");
+    CHECK(result[1] == "b");
+  }
+
+  SUBCASE("properly parses empty parts at the end") {
+    Model model;
+    model.asset.copyright = "a;b;";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "a");
+    CHECK(result[1] == "b");
+  }
+
+  SUBCASE("properly parses whitespace parts at the end") {
+    Model model;
+    model.asset.copyright = "a;b;\t";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "a");
+    CHECK(result[1] == "b");
+  }
 }


### PR DESCRIPTION
By coincidence, I happened to run into the same error while working on unloading external tilesets that a user reported on our forums yesterday: https://community.cesium.com/t/crash-with-google-tiles/38444

The crash is pretty simple. Some copyright strings end with a trailing semicolon - `Google;` being the one I saw. This causes an exception in `parseGltfCopyright`. It goes through the loop correctly once, but continues to loop again, because `end` isn't `npos` - after all, there is a semicolon, implying there's a next entry to read! But when we start the second run through the loop, `start` is pointing at the end of the string, so every value becomes `npos`, or `-1`. Trying to perform a substring between `-1` and `-1 - -1 + 1` gives us an `out_of_range` exception, and we crash.

The fix is also pretty simple - we exit the loop if we're at the end of the string, even if we saw another semicolon. 