### PR TITLE
Incorporate v0.44.2 patch release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v0.44.2 - 2025-02-10
+
+##### Fixes :wrench:
+
+- Fixed a bug in `GltfUtilities::parseGltfCopyright` that could cause a crash when the copyright ends with a semicolon.
+
 ### v0.44.1 - 2025-02-03
 
 ##### Fixes :wrench:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ endif()
 include("cmake/defaults.cmake")
 
 project(cesium-native
-    VERSION 0.44.0
+    VERSION 0.44.2
     LANGUAGES CXX C
 )
 

--- a/CesiumAsync/test/ExamplesAsyncSystem.cpp
+++ b/CesiumAsync/test/ExamplesAsyncSystem.cpp
@@ -384,7 +384,7 @@ TEST_CASE("AsyncSystem Examples") {
                       processDownloadedContent(pResponse->data());
                   std::optional<std::string> maybeUrl =
                       findReferencedImageUrl(processed);
-                  if (maybeUrl) {
+                  if (!maybeUrl) {
                     return asyncSystem.createResolvedFuture<
                         std::shared_ptr<CesiumAsync::IAssetRequest>>(nullptr);
                   } else {

--- a/CesiumGltfContent/include/CesiumGltfContent/GltfUtilities.h
+++ b/CesiumGltfContent/include/CesiumGltfContent/GltfUtilities.h
@@ -130,6 +130,16 @@ struct CESIUMGLTFCONTENT_API GltfUtilities {
   parseGltfCopyright(const CesiumGltf::Model& gltf);
 
   /**
+   * @brief Parse a semicolon-separated string, such as the copyright field of a
+   * glTF model, and return the individual parts (credits).
+   *
+   * @param s The string to parse.
+   * @return The semicolon-delimited parts.
+   */
+  static std::vector<std::string_view>
+  parseGltfCopyright(const std::string_view& s);
+
+  /**
    * @brief Merges all of the glTF's buffers into a single buffer (the first
    * one).
    *

--- a/CesiumGltfContent/src/GltfUtilities.cpp
+++ b/CesiumGltfContent/src/GltfUtilities.cpp
@@ -293,6 +293,9 @@ GltfUtilities::parseGltfCopyright(const CesiumGltf::Model& gltf) {
       size_t rtrim;
       do {
         ltrim = copyright.find_first_not_of(" \t", start);
+        if (ltrim == std::string::npos) {
+          break;
+        }
         end = copyright.find(';', ltrim);
         rtrim = copyright.find_last_not_of(" \t", end - 1);
         result.emplace_back(copyright.substr(ltrim, rtrim - ltrim + 1));

--- a/CesiumGltfContent/src/GltfUtilities.cpp
+++ b/CesiumGltfContent/src/GltfUtilities.cpp
@@ -297,7 +297,7 @@ GltfUtilities::parseGltfCopyright(const CesiumGltf::Model& gltf) {
         rtrim = copyright.find_last_not_of(" \t", end - 1);
         result.emplace_back(copyright.substr(ltrim, rtrim - ltrim + 1));
         start = end + 1;
-      } while (end != std::string::npos);
+      } while (end < copyright.size() - 1);
     }
   }
 

--- a/CesiumGltfContent/test/TestGltfUtilities.cpp
+++ b/CesiumGltfContent/test/TestGltfUtilities.cpp
@@ -711,3 +711,41 @@ TEST_CASE("GltfUtilities::collapseToSingleBuffer") {
     CHECK(m.bufferViews[2].byteLength == 100);
   }
 }
+
+TEST_CASE("GltfUtilities::parseGltfCopyright") {
+  SUBCASE("properly parses multiple copyright entries") {
+    Model model;
+    model.asset.copyright = "Test;a;b;c";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 4);
+    CHECK(result[0] == "Test");
+    CHECK(result[1] == "a");
+    CHECK(result[2] == "b");
+    CHECK(result[3] == "c");
+  }
+
+  SUBCASE("properly parses a single copyright entry") {
+    Model model;
+    model.asset.copyright = "Test";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 1);
+    CHECK(result[0] == "Test");
+  }
+
+  SUBCASE("properly parses an entry with a trailing semicolon") {
+    Model model;
+    model.asset.copyright = "Test;a;b;c;";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 4);
+    CHECK(result[0] == "Test");
+    CHECK(result[1] == "a");
+    CHECK(result[2] == "b");
+    CHECK(result[3] == "c");
+  }
+}

--- a/CesiumGltfContent/test/TestGltfUtilities.cpp
+++ b/CesiumGltfContent/test/TestGltfUtilities.cpp
@@ -748,4 +748,17 @@ TEST_CASE("GltfUtilities::parseGltfCopyright") {
     CHECK(result[2] == "b");
     CHECK(result[3] == "c");
   }
+
+  SUBCASE("properly parses entries with whitespace") {
+    Model model;
+    model.asset.copyright = "\tTest;a\t ;\tb;\t \tc\t;\t ";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 4);
+    CHECK(result[0] == "Test");
+    CHECK(result[1] == "a");
+    CHECK(result[2] == "b");
+    CHECK(result[3] == "c");
+  }
 }

--- a/CesiumGltfContent/test/TestGltfUtilities.cpp
+++ b/CesiumGltfContent/test/TestGltfUtilities.cpp
@@ -761,4 +761,88 @@ TEST_CASE("GltfUtilities::parseGltfCopyright") {
     CHECK(result[2] == "b");
     CHECK(result[3] == "c");
   }
+
+  SUBCASE("properly parses an empty string") {
+    Model model;
+    model.asset.copyright = "";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 0);
+  }
+
+  SUBCASE("properly parses whitespace only") {
+    Model model;
+    model.asset.copyright = " \t  \t";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 0);
+  }
+
+  SUBCASE("properly parses empty parts in the middle") {
+    Model model;
+    model.asset.copyright = "a;;b";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "a");
+    CHECK(result[1] == "b");
+  }
+
+  SUBCASE("properly parses whitespace parts in the middle") {
+    Model model;
+    model.asset.copyright = "a;\t;b";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "a");
+    CHECK(result[1] == "b");
+  }
+
+  SUBCASE("properly parses empty parts at the start") {
+    Model model;
+    model.asset.copyright = ";a;b";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "a");
+    CHECK(result[1] == "b");
+  }
+
+  SUBCASE("properly parses whitespace parts at the start") {
+    Model model;
+    model.asset.copyright = "\t;a;b";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "a");
+    CHECK(result[1] == "b");
+  }
+
+  SUBCASE("properly parses empty parts at the end") {
+    Model model;
+    model.asset.copyright = "a;b;";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "a");
+    CHECK(result[1] == "b");
+  }
+
+  SUBCASE("properly parses whitespace parts at the end") {
+    Model model;
+    model.asset.copyright = "a;b;\t";
+    std::vector<std::string_view> result =
+        GltfUtilities::parseGltfCopyright(model);
+
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "a");
+    CHECK(result[1] == "b");
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium-native",
-  "version": "0.44.0",
+  "version": "0.44.2",
   "description": "Cesium 3D Geospatial for C++",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
In order to fix a critical bug, I created a v0.44.2 version of cesium-native by starting with v0.44.1 and cherry-picking these commits:

* [Fix AsyncSystem doc example](https://github.com/CesiumGS/cesium-native/commit/f5d7b0554718846e743d232eaf72a6aa91cf9ae5)
* [Fix exception when parsing copyright with trailing semicolon](https://github.com/CesiumGS/cesium-native/commit/73bef4302c4b608a6cda7a8cc0ef11421a6d32d3)
* [Fix trailing semicolon with whitespace](https://github.com/CesiumGS/cesium-native/commit/5888d0d281465ef4c9e9bfd974a662ff13da25c7)
* [More tests for copyright parsing, and make them pass.](https://github.com/CesiumGS/cesium-native/commit/3eacde8500bf167092fe6f3a673f84f755e3b0cf)

And then adding this one:

* [Bump version, update CHANGES.md.](https://github.com/CesiumGS/cesium-native/commit/d085706d1593499fe2947a89c31fbcf7c3796a71)

This PR is to merge these commits back into main.
