### PR TITLE
Fix conversion functions for KHR_mesh_quantization decompression

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 ##### Fixes :wrench:
 
 - Fixed parsing URIs that have a scheme followed by `:` instead of `://`.
+- Fixed decoding of KHR_mesh_quantization normalized values.
 
 ### v0.44.2 - 2025-02-10
 

--- a/CesiumGltfReader/src/dequantizeMeshData.cpp
+++ b/CesiumGltfReader/src/dequantizeMeshData.cpp
@@ -27,10 +27,10 @@ template <> float intToFloat(std::int8_t c) {
   return std::max(c / 127.0f, -1.0f);
 }
 
-template <> float intToFloat(std::uint8_t c) { return c / 127.0f; }
+template <> float intToFloat(std::uint8_t c) { return c / 255.0f; }
 
 template <> float intToFloat(std::int16_t c) {
-  return std::max(c / 65535.0f, -1.0f);
+  return std::max(c / 32767.0f, -1.0f);
 }
 
 template <> float intToFloat(std::uint16_t c) { return c / 65535.0f; }


### PR DESCRIPTION
This looks like a cut-and-paste error, but the result was that geometry that used unsigned byte positions would be approximately doubled in size, and geometry that used signed 16 bit integers would be half size.

Before:
![Screenshot From 2025-02-11 15-31-14](https://github.com/user-attachments/assets/b2f11cff-4712-4bd5-ba19-904822c392e0)

After:
![Screenshot From 2025-02-11 15-33-43](https://github.com/user-attachments/assets/f2850318-567a-42eb-97da-337a39e6ed87)

I tried to come up with a test based on the compressed Duck.glb files, but the compressed normals in those files seem kind of random. I had thought that normals in glb files should be already normalized, but that is not the case for the duck files that use mesh quantization.