### PR TITLE
Pass request headers to tileset.json content requests.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,6 @@
 ##### Additions :tada:
 
 - Added `convertPropertyComponentTypeToAccessorComponentType` to `PropertyType`.
-- `LayerJsonTerrainLoader` now includes the query parameters from the base URL in the requests for each `.terrain` file loaded.
 - Added support for `3DTILES_ellipsoid` in `Cesium3DTiles`, `Cesium3DTilesReader`, and `Cesium3DTilesWriter`.
 - Added support for `3DTILES_content_voxels` in `Cesium3DTiles`, `Cesium3DTilesReader`, and `Cesium3DTilesWriter`.
 - Added generated classes for `EXT_primitive_voxels` and its dependencies in `CesiumGltf`, `CesiumGltfReader`, and `CesiumGltfWriter`.
@@ -18,6 +17,8 @@
 
 - Fixed parsing URIs that have a scheme followed by `:` instead of `://`.
 - Fixed decoding of KHR_mesh_quantization normalized values.
+- Requests headers specified in `TilesetOptions` are now included in tile content requests. Previously they were only included in the root tileset.json / layer.json request.
+- Fixed a crash when loading a `tileset.json` without a valid root tile.
 
 ### v0.44.3 - 2025-02-12
 


### PR DESCRIPTION
As noted in this private support thread:
https://community.cesium.com/t/cesium-for-unreal/37135/14

When request headers are specified in TilesetOptions, they're passed to the initial request for the tileset.json / layer.json. But previously, TilesetJsonLoader was not using those request headers for tile content requests. 

Also fixed a crash that occurs if tileset.json has no valid root tile.

I tested this by using https://webhook.site. When you visit it will create a unique URL to which you can make requests. Add a slash to the end of that, and use it as the URL of Tileset. Hit the Edit button in the top-right and set `Content type` to `application/json` and `Content` to:

```
{
  "root": {
    "boundingVolume": {
      "sphere": [0.0,0.0,0.0,10.0]
    },
    "content": {
      "uri": "foo.glb"
    }
  }
}
```

Let Cesium for Unreal or whatever load the tileset, and you should see two requests appear in the webhook.site UI. The first should be the initial tileset.json request, and the second should be for the `foo.glb` content. Both should have any custom headers that you configure on the Tileset.