### PR TITLE
Fix variable length string array handling in `EXT_structural_metadata`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@
 - `Tile` children of external tilesets will now be cleared when the external tileset is unloaded, fixing a memory leak that happened as a result of these `Tile` skeletons accumulating over time.
 - Requests headers specified in `TilesetOptions` are now included in tile content requests. Previously they were only included in the root tileset.json / layer.json request.
 - Fixed a crash when loading a `tileset.json` without a valid root tile.
+- Fixed a bug that could cause variable length string arrays in `EXT_structural_metadata` to be interpreted incorrectly.
 
 ### v0.44.3 - 2025-02-12
 

--- a/Cesium3DTilesSelection/test/data/ComplexTypes/ComplexTypes.gltf
+++ b/Cesium3DTilesSelection/test/data/ComplexTypes/ComplexTypes.gltf
@@ -1,0 +1,214 @@
+{
+  "extensions" : {
+    "EXT_structural_metadata" : {
+      "schema" : {
+        "id": "ComplexTypes",
+        "classes" : {
+          "exampleMetadataClass" : {
+            "name" : "Example metadata class",
+            "description" : "An example metadata class with complex types",
+            "properties" : {
+              "example_variable_length_ARRAY_normalized_UINT8" : {
+                "name" : "Example variable-length ARRAY normalized INT8 property",
+                "description" : "An example property, with type ARRAY, with component type UINT8, normalized, and variable length ",
+                "type" : "SCALAR",
+                "componentType" : "UINT8",
+                "array" : true,
+                "normalized" : true
+              },
+              "example_fixed_length_ARRAY_BOOLEAN" : {
+                "name" : "Example fixed-length ARRAY BOOLEAN property",
+                "description" : "An example property, with type ARRAY, with component type BOOLEAN, and fixed length ",
+                "type" : "BOOLEAN",
+                "array" : true,
+                "count" : 10
+              },
+              "example_variable_length_ARRAY_STRING" : {
+                "name" : "Example variable-length ARRAY STRING property",
+                "description" : "An example property, with type ARRAY, with component type STRING, and variable length ",
+                "type" : "STRING",
+                "array" : true
+              },
+              "example_fixed_length_ARRAY_ENUM" : {
+                "name" : "Example fixed-length ARRAY ENUM property",
+                "description" : "An example property, with type ARRAY, with component type ENUM, enum type exampleEnumType, and fixed length ",
+                "type" : "ENUM",
+                "enumType" : "exampleEnumType",
+                "array" : true,
+                "count" : 2
+              }
+            }
+          }
+        },
+        "enums" : {
+          "exampleEnumType" : {
+            "values" : [ {
+              "name" : "ExampleEnumValueA",
+              "value" : 0
+            }, {
+              "name" : "ExampleEnumValueB",
+              "value" : 1
+            }, {
+              "name" : "ExampleEnumValueC",
+              "value" : 2
+            } ]
+          }
+        }
+      },
+      "propertyTables" : [ {
+        "name" : "Example property table",
+        "class" : "exampleMetadataClass",
+        "count" : 4,
+        "properties" : {
+          "example_variable_length_ARRAY_normalized_UINT8" : {
+            "values" : 4,
+            "arrayOffsets" : 5
+          },
+          "example_fixed_length_ARRAY_BOOLEAN" : {
+            "values" : 6
+          },
+          "example_variable_length_ARRAY_STRING" : {
+            "values" : 7,
+            "arrayOffsets" : 9,
+            "stringOffsets" : 8
+          },
+          "example_fixed_length_ARRAY_ENUM" : {
+            "values" : 10
+          }
+        }
+      } ]
+    }
+  },
+  "extensionsUsed" : [ "EXT_mesh_features", "EXT_structural_metadata" ],
+  "accessors" : [ {
+    "bufferView" : 0,
+    "byteOffset" : 0,
+    "componentType" : 5123,
+    "count" : 24,
+    "type" : "SCALAR",
+    "max" : [ 15 ],
+    "min" : [ 0 ]
+  }, {
+    "bufferView" : 1,
+    "byteOffset" : 0,
+    "componentType" : 5126,
+    "count" : 16,
+    "type" : "VEC3",
+    "max" : [ 1.0, 1.0, 0.0 ],
+    "min" : [ 0.0, 0.0, 0.0 ]
+  }, {
+    "bufferView" : 2,
+    "byteOffset" : 0,
+    "componentType" : 5126,
+    "count" : 16,
+    "type" : "VEC3",
+    "max" : [ 0.0, 0.0, 1.0 ],
+    "min" : [ 0.0, 0.0, 1.0 ]
+  }, {
+    "bufferView" : 3,
+    "byteOffset" : 0,
+    "componentType" : 5121,
+    "count" : 16,
+    "type" : "SCALAR",
+    "max" : [ 3 ],
+    "min" : [ 0 ]
+  } ],
+  "asset" : {
+    "generator" : "JglTF from https://github.com/javagl/JglTF",
+    "version" : "2.0"
+  },
+  "buffers" : [ {
+    "uri" : "data:application/gltf-buffer;base64,AAABAAIAAQADAAIABAAFAAYABQAHAAYACAAJAAoACQALAAoADAANAA4ADQAPAA4AAAAAAAAAAAAAAAAAZmbmPgAAAAAAAAAAAAAAAGZm5j4AAAAAZmbmPmZm5j4AAAAAzcwMPwAAAAAAAAAAAACAPwAAAAAAAAAAzcwMP2Zm5j4AAAAAAACAP2Zm5j4AAAAAAAAAAM3MDD8AAAAAZmbmPs3MDD8AAAAAAAAAAAAAgD8AAAAAZmbmPgAAgD8AAAAAzcwMP83MDD8AAAAAAACAP83MDD8AAAAAzcwMPwAAgD8AAAAAAACAPwAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAQAAAAEAAAACAAAAAgAAAAIAAAACAAAAAwAAAAMAAAADAAAAAwAAAA==",
+    "byteLength" : 496
+  }, {
+    "uri" : "data:application/gltf-buffer;base64,AP8AgP8AVar/AECAwP8AAAAAAAACAAAABQAAAAkAAAAOAAAAVc3MjKpPbmVPbmVUd29PbmVUd29UaHJlZU9uZVR3b1RoZWVlRm91cgAAAAADAAAABgAAAAkAAAAMAAAADwAAABQAAAAXAAAAGgAAAB8AAAAjAAAAAAAAAAEAAAADAAAABgAAAAoAAAAAAAEAAQACAAIAAAABAAIA",
+    "byteLength" : 156
+  } ],
+  "bufferViews" : [ {
+    "buffer" : 0,
+    "byteOffset" : 0,
+    "byteLength" : 48,
+    "target" : 34963
+  }, {
+    "buffer" : 0,
+    "byteOffset" : 48,
+    "byteLength" : 192,
+    "target" : 34962
+  }, {
+    "buffer" : 0,
+    "byteOffset" : 240,
+    "byteLength" : 192,
+    "target" : 34962
+  }, {
+    "buffer" : 0,
+    "byteOffset" : 432,
+    "byteLength" : 64,
+    "byteStride" : 4,
+    "target" : 34962
+  }, {
+    "buffer" : 1,
+    "byteOffset" : 0,
+    "byteLength" : 14
+  }, {
+    "buffer" : 1,
+    "byteOffset" : 16,
+    "byteLength" : 20
+  }, {
+    "buffer" : 1,
+    "byteOffset" : 36,
+    "byteLength" : 5
+  }, {
+    "buffer" : 1,
+    "byteOffset" : 41,
+    "byteLength" : 35
+  }, {
+    "buffer" : 1,
+    "byteOffset" : 76,
+    "byteLength" : 44
+  }, {
+    "buffer" : 1,
+    "byteOffset" : 120,
+    "byteLength" : 20
+  }, {
+    "buffer" : 1,
+    "byteOffset" : 140,
+    "byteLength" : 16
+  } ],
+  "materials" : [ {
+    "pbrMetallicRoughness" : {
+      "baseColorFactor" : [ 0.5, 1.0, 0.5, 1.0 ],
+      "metallicFactor" : 0.0,
+      "roughnessFactor" : 1.0
+    },
+    "alphaMode" : "OPAQUE",
+    "doubleSided" : true
+  } ],
+  "meshes" : [ {
+    "primitives" : [ {
+      "extensions" : {
+        "EXT_mesh_features" : {
+          "featureIds" : [ {
+            "featureCount" : 4,
+            "attribute" : 0,
+            "propertyTable" : 0
+          } ]
+        }
+      },
+      "attributes" : {
+        "POSITION" : 1,
+        "NORMAL" : 2,
+        "_FEATURE_ID_0" : 3
+      },
+      "indices" : 0,
+      "material" : 0,
+      "mode" : 4
+    } ]
+  } ],
+  "nodes" : [ {
+    "mesh" : 0
+  } ],
+  "scene" : 0,
+  "scenes" : [ {
+    "nodes" : [ 0 ]
+  } ]
+}

--- a/Cesium3DTilesSelection/test/data/ComplexTypes/tileset.json
+++ b/Cesium3DTilesSelection/test/data/ComplexTypes/tileset.json
@@ -1,0 +1,19 @@
+{
+  "asset" : {
+    "version" : "1.1"
+  },
+  "geometricError" : 100.0,
+  "root" : {
+    "content" : {
+      "uri" : "ComplexTypes.gltf"
+    },
+    "boundingVolume" : {
+      "box" : [ 
+        0.5, 0.0, 0.5,
+        0.5, 0.0, 0.0, 
+        0.0, 0.01, 0.0, 
+        0.0, 0.0, 0.5]
+    },
+    "geometricError" : 0.0
+  }
+}

--- a/CesiumGltf/include/CesiumGltf/PropertyTablePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTablePropertyView.h
@@ -512,18 +512,20 @@ private:
 
     // Handle variable-length arrays
     const size_t currentArrayOffset =
-        getOffsetFromOffsetsBuffer(index, _arrayOffsets, _arrayOffsetType);
+        getOffsetFromOffsetsBuffer(index, _arrayOffsets, _arrayOffsetType) *
+        _stringOffsetTypeSize;
     const size_t nextArrayOffset =
-        getOffsetFromOffsetsBuffer(index + 1, _arrayOffsets, _arrayOffsetType);
+        getOffsetFromOffsetsBuffer(index + 1, _arrayOffsets, _arrayOffsetType) *
+        _stringOffsetTypeSize;
     const size_t arraySize = nextArrayOffset - currentArrayOffset;
     const std::span<const std::byte> stringOffsetValues(
         _stringOffsets.data() + currentArrayOffset,
-        arraySize + _arrayOffsetTypeSize);
+        arraySize + _stringOffsetTypeSize);
     return PropertyArrayView<std::string_view>(
         _values,
         stringOffsetValues,
         _stringOffsetType,
-        arraySize / _arrayOffsetTypeSize);
+        arraySize / _stringOffsetTypeSize);
   }
 
   PropertyArrayView<bool> getBooleanArrayValues(int64_t index) const noexcept {

--- a/CesiumGltf/src/PropertyTableView.cpp
+++ b/CesiumGltf/src/PropertyTableView.cpp
@@ -94,7 +94,7 @@ PropertyViewStatusType checkStringAndArrayOffsetsBuffers(
     return checkOffsetsBuffer<uint8_t>(
         stringOffsets,
         valueBufferSize,
-        pValue[propertyTableCount] / sizeof(T),
+        pValue[propertyTableCount],
         false,
         PropertyTablePropertyViewStatus::ErrorStringOffsetsNotSorted,
         PropertyTablePropertyViewStatus::ErrorStringOffsetOutOfBounds);
@@ -102,7 +102,7 @@ PropertyViewStatusType checkStringAndArrayOffsetsBuffers(
     return checkOffsetsBuffer<uint16_t>(
         stringOffsets,
         valueBufferSize,
-        pValue[propertyTableCount] / sizeof(T),
+        pValue[propertyTableCount],
         false,
         PropertyTablePropertyViewStatus::ErrorStringOffsetsNotSorted,
         PropertyTablePropertyViewStatus::ErrorStringOffsetOutOfBounds);
@@ -110,7 +110,7 @@ PropertyViewStatusType checkStringAndArrayOffsetsBuffers(
     return checkOffsetsBuffer<uint32_t>(
         stringOffsets,
         valueBufferSize,
-        pValue[propertyTableCount] / sizeof(T),
+        pValue[propertyTableCount],
         false,
         PropertyTablePropertyViewStatus::ErrorStringOffsetsNotSorted,
         PropertyTablePropertyViewStatus::ErrorStringOffsetOutOfBounds);
@@ -118,7 +118,7 @@ PropertyViewStatusType checkStringAndArrayOffsetsBuffers(
     return checkOffsetsBuffer<uint64_t>(
         stringOffsets,
         valueBufferSize,
-        pValue[propertyTableCount] / sizeof(T),
+        pValue[propertyTableCount],
         false,
         PropertyTablePropertyViewStatus::ErrorStringOffsetsNotSorted,
         PropertyTablePropertyViewStatus::ErrorStringOffsetOutOfBounds);

--- a/CesiumGltf/test/TestPropertyTablePropertyView.cpp
+++ b/CesiumGltf/test/TestPropertyTablePropertyView.cpp
@@ -3400,10 +3400,10 @@ TEST_CASE("Check variable-length string array PropertyTablePropertyView") {
   // clang-format off
   std::vector<uint32_t> arrayOffsets{
     0,
-    4 * sizeof(uint32_t),
-    7 * sizeof(uint32_t),
-    8 * sizeof(uint32_t),
-    12 * sizeof(uint32_t)
+    4,
+    7,
+    8,
+    12
   };
 
   std::vector<std::string> strings{


### PR DESCRIPTION
Closes CesiumGS/cesium-unreal#1619. When testing with the [ComplexTypes](https://github.com/CesiumGS/3d-tiles-samples/tree/a8d4e1f47fe8c7ffc44e78c5f9b970532f8c8bc2/glTF/EXT_structural_metadata/ComplexTypes) sample tileset in Cesium for Unreal, @j9liu noticed that the handling of variable length string arrays doesn't currently work. It turns out this is actually a problem in Cesium Native, not Unreal, and just somehow went unnoticed until now. The root of the problem is actually fairly simple: the `arrayOffsets` buffer specifies the _indices_ into the `stringOffsets` buffer, but we were treating it as if it was specifying the _byte offsets_ into that buffer. Some tests needed changing to make this work, but it wasn't much in the end. I also added the ComplexTypes sample as a test.