### PR TITLE
Assorted fixes for `BoundingCylinderRegion`

### DIFF
--- a/Cesium3DTiles/generated/include/Cesium3DTiles/ExtensionContent3dTilesContentVoxels.h
+++ b/Cesium3DTiles/generated/include/Cesium3DTiles/ExtensionContent3dTilesContentVoxels.h
@@ -27,7 +27,7 @@ struct CESIUM3DTILES_API ExtensionContent3dTilesContentVoxels final
   static constexpr const char* ExtensionName = "3DTILES_content_voxels";
 
   /**
-   * @brief Dimensions of the voxel grid. x/y/z for a box, r/z/theta for a
+   * @brief Dimensions of the voxel grid. x/y/z for a box, r/theta/z for a
    * cylinder, lon/lat/height for an ellipsoid.
    */
   std::vector<int64_t> dimensions;

--- a/CesiumGeometry/include/CesiumGeometry/BoundingCylinderRegion.h
+++ b/CesiumGeometry/include/CesiumGeometry/BoundingCylinderRegion.h
@@ -33,8 +33,8 @@ public:
    * centered at the local origin. The height aligns with the z-axis, and the
    * cylinder extends to half the height in each direction. The angular bounds
    * are in the range [-pi, pi], and are oriented such that an angle of -pi
-   * aligns with the negative y-axis, while an angle of 0 aligns with the
-   * positive y-axis. The angular range opens counter-clockwise.
+   * aligns with the negative x-axis, while an angle of 0 aligns with the
+   * positive x-axis. The angular range opens counter-clockwise.
    *
    * It is possible for the region to only occupy part of the cylinder, and if
    * that is the case, the region's center may not necessarily equal the

--- a/CesiumGeometry/src/BoundingCylinderRegion.cpp
+++ b/CesiumGeometry/src/BoundingCylinderRegion.cpp
@@ -35,26 +35,14 @@ OrientedBoundingBox computeBoxFromCylinderRegion(
   //
   // First, compute the min and max points (x, y) on the arc drawn by the given
   // angles. Recall that the angle opens counter-clockwise, such that 0 aligns
-  // with the +y axis. The -pi/pi discontinuity happens along -y.
+  // with the +x axis. The -pi/pi discontinuity happens along -x.
   //
-  // In polar coordinates, x = r * cos(a) and y = r * sin(a), but this is
-  // complicated by the angle starting along the y-axis. Here,
-  // x = r * -sin(a) and y = r * cos(a).
+  // The cartesian positions can resolved from the polar coordinates, where
+  // x = r * cos(a) and y = r * sin(a).
 
   // When the angle range is "reversed", the region sweeps over the -pi / pi
   // discontinuity line.
   bool angleReversed = angleMax < angleMin;
-  int angleMaxSign = int(glm::sign(angleMax));
-  int angleMinSign = int(glm::sign(angleMin));
-
-  bool angleCrossesZero = angleReversed ? angleMinSign == angleMaxSign
-                                        : angleMinSign != angleMaxSign;
-  angleCrossesZero |= angleMinSign == 0 || angleMaxSign == 0;
-
-  double yMin =
-      angleReversed ? -1.0 : glm::min(glm::cos(angleMin), glm::cos(angleMax));
-  double yMax =
-      angleCrossesZero ? 1.0 : glm::max(glm::cos(angleMin), glm::cos(angleMax));
 
   constexpr double piOverTwo = CesiumUtility::Math::PiOverTwo;
   bool angleCrossesNegativePiOverTwo =
@@ -64,11 +52,21 @@ OrientedBoundingBox computeBoxFromCylinderRegion(
       angleReversed ? angleMin <= piOverTwo || angleMax >= piOverTwo
                     : angleMin <= piOverTwo && piOverTwo <= angleMax;
 
-  double xMin =
-      angleCrossesPiOverTwo ? -1.0 : glm::min(-sin(angleMin), -sin(angleMax));
-  double xMax = angleCrossesNegativePiOverTwo
+  double yMin = angleCrossesNegativePiOverTwo
+                    ? -1.0
+                    : glm::min(glm::sin(angleMin), glm::sin(angleMax));
+  double yMax = angleCrossesPiOverTwo
                     ? 1.0
-                    : glm::max(-sin(angleMin), -sin(angleMax));
+                    : glm::max(glm::sin(angleMin), glm::sin(angleMax));
+
+  int angleMaxSign = int(glm::sign(angleMax));
+  int angleMinSign = int(glm::sign(angleMin));
+  bool angleCrossesZero = angleReversed ? angleMinSign == angleMaxSign
+                                        : angleMinSign != angleMaxSign;
+  angleCrossesZero |= angleMinSign == 0 || angleMaxSign == 0;
+
+  double xMin = angleReversed ? -1.0 : glm::min(cos(angleMin), cos(angleMax));
+  double xMax = angleCrossesZero ? 1.0 : glm::max(cos(angleMin), cos(angleMax));
 
   glm::dvec2 min(xMin, yMin);
   glm::dvec2 max(xMax, yMax);
@@ -87,19 +85,13 @@ OrientedBoundingBox computeBoxFromCylinderRegion(
   OrientedBoundingBox obb = OrientedBoundingBox::fromAxisAligned(aab);
   glm::dvec3 center = obb.getCenter();
 
-  // If the input transform has a rotation, then it must be applied relative to
-  // the reference cylinder's origin (instead of the region's center).
-  glm::dmat4 centerCylinder = glm::translate(glm::dmat4(1.0), -center);
-  glm::dmat4 transformCylinder =
+  glm::dmat4 transform =
       CesiumGeometry::Transforms::createTranslationRotationScaleMatrix(
           translation,
           rotation,
           glm::dvec3(1.0));
-  glm::dmat4 uncenterCylinder = glm::translate(glm::dmat4(1.0), center);
-  glm::dmat4 finalTransform =
-      uncenterCylinder * transformCylinder * centerCylinder;
 
-  return obb.transform(finalTransform);
+  return obb.transform(transform);
 }
 
 } // namespace

--- a/CesiumGeometry/test/TestBoundingCylinderRegion.cpp
+++ b/CesiumGeometry/test/TestBoundingCylinderRegion.cpp
@@ -64,7 +64,7 @@ TEST_CASE("BoundingCylinderRegion::toOrientedBoundingBox test") {
         glm::dvec2(0.0, CesiumUtility::Math::PiOverTwo));
     CesiumGeometry::OrientedBoundingBox box = region.toOrientedBoundingBox();
 
-    glm::dvec3 expectedCenter(-1.0, 1.0, 0.0);
+    glm::dvec3 expectedCenter(1.0, 1.0, 0.0);
     glm::dmat3 expectedHalfAxes(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.5);
 
     CHECK(box.getCenter() == expectedCenter);
@@ -82,8 +82,8 @@ TEST_CASE("BoundingCylinderRegion::toOrientedBoundingBox test") {
             -CesiumUtility::Math::PiOverTwo));
     CesiumGeometry::OrientedBoundingBox box = region.toOrientedBoundingBox();
 
-    glm::dvec3 expectedCenter(0.0, -1.0, 0.0);
-    glm::dmat3 expectedHalfAxes(2.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.5);
+    glm::dvec3 expectedCenter(-1.0, 0.0, 0.0);
+    glm::dmat3 expectedHalfAxes(1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 1.5);
 
     CHECK(CesiumUtility::Math::equalsEpsilon(
         box.getCenter(),
@@ -175,7 +175,7 @@ TEST_CASE("BoundingCylinderRegion::transform test") {
     CesiumGeometry::OrientedBoundingBox box =
         transformedRegion.toOrientedBoundingBox();
 
-    glm::dvec3 expectedCenter(0.0, 3.0, 3.0);
+    glm::dvec3 expectedCenter(2.0, 2.0, 2.0);
     glm::dmat3 expectedHalfAxes(1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1.5, 0.0);
 
     CHECK(box.getCenter() == expectedCenter);
@@ -203,7 +203,7 @@ TEST_CASE("BoundingCylinderRegion::transform test") {
     // Verify construction before the additional transform.
     {
       CesiumGeometry::OrientedBoundingBox box = region.toOrientedBoundingBox();
-      glm::dvec3 expectedCenter(-2.0, 1.0, 1.0);
+      glm::dvec3 expectedCenter(-1.0, 1.0, 0.0);
       glm::dmat3 expectedHalfAxes(0.0, 0.0, 1.0, 0.0, 1.0, 0.0, -1.5, 0.0, 0);
 
       CHECK(CesiumUtility::Math::equalsEpsilon(
@@ -245,8 +245,10 @@ TEST_CASE("BoundingCylinderRegion::transform test") {
 
     {
       CesiumGeometry::OrientedBoundingBox box = region.toOrientedBoundingBox();
+      //glm::dvec3 expectedCenter(-1.0, 1.0, 0.0);
+
       glm::dvec3 expectedCenter(-2.0, 1.0, 1.0);
-      glm::dmat3 expectedHalfAxes(0.0, 0.0, 1.0, 0.0, 1.0, 0.0, -1.5, 0.0, 0.0);
+      glm::dmat3 expectedHalfAxes(0.0, 0.0, 1.0, 0.0, 1.5, 0.0, 1.0, 0.0, 0.0);
 
       CHECK(CesiumUtility::Math::equalsEpsilon(
           box.getCenter(),

--- a/CesiumGeometry/test/TestBoundingCylinderRegion.cpp
+++ b/CesiumGeometry/test/TestBoundingCylinderRegion.cpp
@@ -203,7 +203,7 @@ TEST_CASE("BoundingCylinderRegion::transform test") {
     // Verify construction before the additional transform.
     {
       CesiumGeometry::OrientedBoundingBox box = region.toOrientedBoundingBox();
-      glm::dvec3 expectedCenter(-1.0, 1.0, 0.0);
+      glm::dvec3 expectedCenter(-1.0, 1.0, 2.0);
       glm::dmat3 expectedHalfAxes(0.0, 0.0, 1.0, 0.0, 1.0, 0.0, -1.5, 0.0, 0);
 
       CHECK(CesiumUtility::Math::equalsEpsilon(
@@ -221,34 +221,33 @@ TEST_CASE("BoundingCylinderRegion::transform test") {
     }
 
     BoundingCylinderRegion transformedRegion = region.transform(transform);
-    glm::dmat4 finalTransform =
-        transform * glm::translate(glm::dmat4(1.0), translation) *
-        glm::dmat4(CesiumGeometry::Transforms::X_UP_TO_Z_UP);
-
-    glm::dvec3 expectedTranslation(0.0);
-    glm::dquat expectedRotation(1.0, 0.0, 0.0, 0.0);
-
-    CesiumGeometry::Transforms::computeTranslationRotationScaleFromMatrix(
-        finalTransform,
-        &expectedTranslation,
-        &expectedRotation,
-        nullptr);
-
-    CHECK(transformedRegion.getTranslation() == expectedTranslation);
-    glm::dquat transformedRotation = transformedRegion.getRotation();
-    for (glm::length_t i = 0; i < 3; i++) {
-      CHECK(CesiumUtility::Math::equalsEpsilon(
-          transformedRotation[i],
-          expectedRotation[i],
-          CesiumUtility::Math::Epsilon6));
-    }
 
     {
-      CesiumGeometry::OrientedBoundingBox box = region.toOrientedBoundingBox();
-      //glm::dvec3 expectedCenter(-1.0, 1.0, 0.0);
+      glm::dmat4 finalTransform =
+          transform * glm::translate(glm::dmat4(1.0), translation) *
+          glm::dmat4(CesiumGeometry::Transforms::X_UP_TO_Z_UP);
 
-      glm::dvec3 expectedCenter(-2.0, 1.0, 1.0);
-      glm::dmat3 expectedHalfAxes(0.0, 0.0, 1.0, 0.0, 1.5, 0.0, 1.0, 0.0, 0.0);
+      glm::dvec3 expectedTranslation(0.0);
+      glm::dquat expectedRotation(1.0, 0.0, 0.0, 0.0);
+
+      CesiumGeometry::Transforms::computeTranslationRotationScaleFromMatrix(
+          finalTransform,
+          &expectedTranslation,
+          &expectedRotation,
+          nullptr);
+
+      CHECK(transformedRegion.getTranslation() == expectedTranslation);
+      glm::dquat transformedRotation = transformedRegion.getRotation();
+      for (glm::length_t i = 0; i < 3; i++) {
+        CHECK(CesiumUtility::Math::equalsEpsilon(
+            transformedRotation[i],
+            expectedRotation[i],
+            CesiumUtility::Math::Epsilon6));
+      }
+      CesiumGeometry::OrientedBoundingBox box =
+          transformedRegion.toOrientedBoundingBox();
+      glm::dvec3 expectedCenter(0.0, 4.0, 2.0);
+      glm::dmat3 expectedHalfAxes(0.0, 1.0, 0.0, 0.0, 0.0, -1.0, -1.5, 0.0, 0.0);
 
       CHECK(CesiumUtility::Math::equalsEpsilon(
           box.getCenter(),


### PR DESCRIPTION
- Updates for the axis change in https://github.com/CesiumGS/3d-tiles/tree/voxels/extensions/3DTILES_bounding_volume_cylinder, where `angle = 0` now happens at the `+x` axis.
- Fixed incorrect transform math. (For some reason, I did the opposite of what I intended -- transforming at the region's center instead of the reference cylinder's center. Not sure how that got flipped in my head!)
- Fixed the math for computing the new cylinder angles in implicit tiling.