### PR TITLE
Fix angle math for implicit tiling of `BoundingCylinderRegion`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Fixed missing URI query part when downloading glTF textures or buffers.
 - Fixed bugs in I3dm metadata parsing.
 - Fixed memory leak in `CesiumGltfReader`.
+- Fixed a bug in `ImplicitTilingUtilities::computeBoundingVolume` that incorrectly subdivided a `BoundingCylinderRegion` across the discontinuity line.
 
 ### v0.45.0 - 2025-03-03
 
@@ -20,6 +21,8 @@
 - Added support for the following 3D Tiles extensions to `Cesium3DTiles`, `Cesium3DTilesReader`, and `Cesium3DTilesWriter`:
   - `3DTILES_ellipsoid`
   - `3DTILES_content_voxels`
+  - `3DTILES_bounding_volume_cylinder`
+- Added `BoundingCylinderRegion` to represent `3DTILES_bounding_volume_cylinder` in the `BoundingVolume` variant.
 - Added generated classes for `EXT_primitive_voxels` and its dependencies in `CesiumGltf`, `CesiumGltfReader`, and `CesiumGltfWriter`.
 - Added `AxisAlignedBox::fromPositions`, which creates an `AxisAlignedBox` from an input vector of positions.
 - `PropertyView`, `PropertyTableView`, `PropertyTablePropertyView`, `PropertyTextureView`, and `PropertyTexturePropertyView` now support the enum metadata type in `EXT_structural_metadata`.

--- a/Cesium3DTilesContent/test/TestImplicitTilingUtilities.cpp
+++ b/Cesium3DTilesContent/test/TestImplicitTilingUtilities.cpp
@@ -585,16 +585,147 @@ TEST_CASE("ImplicitTilingUtilities::computeBoundingVolume") {
   }
 
   SUBCASE("BoundingCylinderRegion (partial)") {
-    // This also tests for angular bounds that cross over the -pi/pi
-    // discontinuity line.
     BoundingCylinderRegion root(
         glm::dvec3(-1.0, 1.0, 2.0),
         glm::dquat(1.0, 0.0, 0.0, 0.0),
         2.0,
         glm::dvec2(0.0, 1.0),
         glm::dvec2(
-            CesiumUtility::Math::PiOverTwo,
-            -CesiumUtility::Math::PiOverTwo));
+            -CesiumUtility::Math::PiOverTwo,
+            CesiumUtility::Math::PiOverTwo));
+
+    SUBCASE("quadtree") {
+      BoundingCylinderRegion l1x0y0 =
+          ImplicitTilingUtilities::computeBoundingVolume(
+              root,
+              QuadtreeTileID(1, 0, 0));
+
+      CHECK(l1x0y0.getHeight() == root.getHeight());
+      CHECK(l1x0y0.getRadialBounds() == glm::dvec2(0.0, 0.5));
+      CHECK(CesiumUtility::Math::equalsEpsilon(
+          l1x0y0.getAngularBounds(),
+          glm::dvec2(-CesiumUtility::Math::PiOverTwo, 0.0),
+          CesiumUtility::Math::Epsilon6));
+      CHECK(l1x0y0.getRotation() == root.getRotation());
+      CHECK(l1x0y0.getTranslation() == root.getTranslation());
+
+      BoundingCylinderRegion l1x1y0 =
+          ImplicitTilingUtilities::computeBoundingVolume(
+              root,
+              QuadtreeTileID(1, 1, 0));
+
+      CHECK(l1x1y0.getHeight() == root.getHeight());
+      CHECK(l1x1y0.getRadialBounds() == glm::dvec2(0.5, 1.0));
+      CHECK(CesiumUtility::Math::equalsEpsilon(
+          l1x0y0.getAngularBounds(),
+          glm::dvec2(-CesiumUtility::Math::PiOverTwo, 0.0),
+          CesiumUtility::Math::Epsilon6));
+      CHECK(l1x1y0.getRotation() == root.getRotation());
+      CHECK(l1x1y0.getTranslation() == root.getTranslation());
+
+      BoundingCylinderRegion l1x0y1 =
+          ImplicitTilingUtilities::computeBoundingVolume(
+              root,
+              QuadtreeTileID(1, 0, 1));
+      CHECK(l1x0y1.getHeight() == root.getHeight());
+      CHECK(l1x0y1.getRadialBounds() == glm::dvec2(0.0, 0.5));
+      CHECK(CesiumUtility::Math::equalsEpsilon(
+          l1x0y1.getAngularBounds(),
+          glm::dvec2(0.0, CesiumUtility::Math::PiOverTwo),
+          CesiumUtility::Math::Epsilon6));
+      CHECK(l1x0y1.getRotation() == root.getRotation());
+      CHECK(l1x0y1.getTranslation() == root.getTranslation());
+    }
+
+    SUBCASE("octree") {
+      double expectedHeight = 0.5 * root.getHeight();
+
+      BoundingCylinderRegion l1x0y0z0 =
+          ImplicitTilingUtilities::computeBoundingVolume(
+              root,
+              OctreeTileID(1, 0, 0, 0));
+      {
+        CHECK(l1x0y0z0.getHeight() == expectedHeight);
+        CHECK(l1x0y0z0.getRadialBounds() == glm::dvec2(0.0, 0.5));
+        CHECK(CesiumUtility::Math::equalsEpsilon(
+            l1x0y0z0.getAngularBounds(),
+            glm::dvec2(-CesiumUtility::Math::PiOverTwo, 0.0),
+            CesiumUtility::Math::Epsilon6));
+        CHECK(l1x0y0z0.getRotation() == root.getRotation());
+
+        glm::dvec3 expectedTranslation =
+            root.getTranslation() + glm::dvec3(0.0, 0.0, -0.5 * expectedHeight);
+        CHECK(l1x0y0z0.getTranslation() == expectedTranslation);
+      }
+
+      BoundingCylinderRegion l1x1y0z0 =
+          ImplicitTilingUtilities::computeBoundingVolume(
+              root,
+              OctreeTileID(1, 1, 0, 0));
+      {
+        CHECK(l1x1y0z0.getHeight() == expectedHeight);
+        CHECK(l1x1y0z0.getRadialBounds() == glm::dvec2(0.5, 1.0));
+        CHECK(CesiumUtility::Math::equalsEpsilon(
+            l1x1y0z0.getAngularBounds(),
+            glm::dvec2(-CesiumUtility::Math::PiOverTwo, 0.0),
+            CesiumUtility::Math::Epsilon6));
+        CHECK(l1x1y0z0.getRotation() == root.getRotation());
+
+        glm::dvec3 expectedTranslation =
+            root.getTranslation() + glm::dvec3(0.0, 0.0, -0.5 * expectedHeight);
+        CHECK(l1x1y0z0.getTranslation() == expectedTranslation);
+      }
+
+      BoundingCylinderRegion l1x0y1z0 =
+          ImplicitTilingUtilities::computeBoundingVolume(
+              root,
+              OctreeTileID(1, 0, 1, 0));
+      {
+        CHECK(l1x0y1z0.getHeight() == expectedHeight);
+        CHECK(l1x0y1z0.getRadialBounds() == glm::dvec2(0.0, 0.5));
+        CHECK(CesiumUtility::Math::equalsEpsilon(
+            l1x0y1z0.getAngularBounds(),
+            glm::dvec2(0.0, CesiumUtility::Math::PiOverTwo),
+            CesiumUtility::Math::Epsilon6));
+        CHECK(l1x0y1z0.getRotation() == root.getRotation());
+
+        glm::dvec3 expectedTranslation =
+            root.getTranslation() + glm::dvec3(0.0, 0.0, -0.5 * expectedHeight);
+        CHECK(l1x0y1z0.getTranslation() == expectedTranslation);
+      }
+
+      BoundingCylinderRegion l1x0y0z1 =
+          ImplicitTilingUtilities::computeBoundingVolume(
+              root,
+              OctreeTileID(1, 0, 0, 1));
+      {
+        CHECK(l1x0y0z1.getHeight() == expectedHeight);
+        CHECK(l1x0y0z1.getRadialBounds() == glm::dvec2(0.0, 0.5));
+        CHECK(CesiumUtility::Math::equalsEpsilon(
+            l1x0y0z1.getAngularBounds(),
+            glm::dvec2(-CesiumUtility::Math::PiOverTwo, 0.0),
+            CesiumUtility::Math::Epsilon6));
+        CHECK(l1x0y0z1.getRotation() == root.getRotation());
+
+        glm::dvec3 expectedTranslation =
+            root.getTranslation() + glm::dvec3(0.0, 0.0, 0.5 * expectedHeight);
+        CHECK(l1x0y0z1.getTranslation() == expectedTranslation);
+      }
+    }
+  }
+
+  SUBCASE("BoundingCylinderRegion (partial with discontinuity)") {
+    BoundingCylinderRegion root(
+        glm::dvec3(-1.0, 1.0, 2.0),
+        glm::dquat(1.0, 0.0, 0.0, 0.0),
+        2.0,
+        glm::dvec2(0.0, 1.0),
+        glm::dvec2(
+            CesiumUtility::Math::PiOverFour,
+            -CesiumUtility::Math::PiOverFour));
+
+    // The full angle range is 3pi / 2, and the implicit subdivision splits
+    // this range in half at the -pi / pi discontinuity line.
 
     SUBCASE("quadtree") {
       BoundingCylinderRegion l1x0y0 =
@@ -607,7 +738,7 @@ TEST_CASE("ImplicitTilingUtilities::computeBoundingVolume") {
       CHECK(CesiumUtility::Math::equalsEpsilon(
           l1x0y0.getAngularBounds(),
           glm::dvec2(
-              CesiumUtility::Math::PiOverTwo,
+              CesiumUtility::Math::PiOverFour,
               CesiumUtility::Math::OnePi),
           CesiumUtility::Math::Epsilon6));
       CHECK(l1x0y0.getRotation() == root.getRotation());
@@ -623,7 +754,7 @@ TEST_CASE("ImplicitTilingUtilities::computeBoundingVolume") {
       CHECK(CesiumUtility::Math::equalsEpsilon(
           l1x1y0.getAngularBounds(),
           glm::dvec2(
-              CesiumUtility::Math::PiOverTwo,
+              CesiumUtility::Math::PiOverFour,
               CesiumUtility::Math::OnePi),
           CesiumUtility::Math::Epsilon6));
       CHECK(l1x1y0.getRotation() == root.getRotation());
@@ -639,7 +770,7 @@ TEST_CASE("ImplicitTilingUtilities::computeBoundingVolume") {
           l1x0y1.getAngularBounds(),
           glm::dvec2(
               -CesiumUtility::Math::OnePi,
-              -CesiumUtility::Math::PiOverTwo),
+              -CesiumUtility::Math::PiOverFour),
           CesiumUtility::Math::Epsilon6));
       CHECK(l1x0y1.getRotation() == root.getRotation());
       CHECK(l1x0y1.getTranslation() == root.getTranslation());
@@ -658,7 +789,7 @@ TEST_CASE("ImplicitTilingUtilities::computeBoundingVolume") {
         CHECK(CesiumUtility::Math::equalsEpsilon(
             l1x0y0z0.getAngularBounds(),
             glm::dvec2(
-                CesiumUtility::Math::PiOverTwo,
+                CesiumUtility::Math::PiOverFour,
                 CesiumUtility::Math::OnePi),
             CesiumUtility::Math::Epsilon6));
         CHECK(l1x0y0z0.getRotation() == root.getRotation());
@@ -678,7 +809,7 @@ TEST_CASE("ImplicitTilingUtilities::computeBoundingVolume") {
         CHECK(CesiumUtility::Math::equalsEpsilon(
             l1x1y0z0.getAngularBounds(),
             glm::dvec2(
-                CesiumUtility::Math::PiOverTwo,
+                CesiumUtility::Math::PiOverFour,
                 CesiumUtility::Math::OnePi),
             CesiumUtility::Math::Epsilon6));
         CHECK(l1x1y0z0.getRotation() == root.getRotation());
@@ -699,7 +830,7 @@ TEST_CASE("ImplicitTilingUtilities::computeBoundingVolume") {
             l1x0y1z0.getAngularBounds(),
             glm::dvec2(
                 -CesiumUtility::Math::OnePi,
-                -CesiumUtility::Math::PiOverTwo),
+                -CesiumUtility::Math::PiOverFour),
             CesiumUtility::Math::Epsilon6));
         CHECK(l1x0y1z0.getRotation() == root.getRotation());
 
@@ -718,7 +849,7 @@ TEST_CASE("ImplicitTilingUtilities::computeBoundingVolume") {
         CHECK(CesiumUtility::Math::equalsEpsilon(
             l1x0y0z1.getAngularBounds(),
             glm::dvec2(
-                CesiumUtility::Math::PiOverTwo,
+                CesiumUtility::Math::PiOverFour,
                 CesiumUtility::Math::OnePi),
             CesiumUtility::Math::Epsilon6));
         CHECK(l1x0y0z1.getRotation() == root.getRotation());


### PR DESCRIPTION
This PR fixes a bug that I unfortunately didn't realize until just now. I assumed that my unit test for `[pi, -pi`] would suffice, but turns out it's a special case that hides the problem!

Previously, the angle range of the root volume was calculated to be `glm::abs(maxAngle - minAngle)`. That works when `maxAngle >= minAngle`. But it doesn't work for `minAngle < maxAngle` cases, **unless** `minAngle = pi` and `maxAngle = -pi`.

For instance, in the below case, the actual range is `3pi / 2`, but the computed range was `pi/2`. The difference between the angles is actually a slice that is taken out of the full circle:

![image](https://github.com/user-attachments/assets/0556d1e3-8bc3-4d18-8672-60cf07d800e8)

Also, I didn't put this change in the changelog... and that was intentional at first because the original implementation wasn't robust, so I thought to treat it as "experimental". Now that the implementation is more finalized, should I add this back in?