### PR TITLE
Add `TilesetContentLoader` for iModel Mesh Export Service

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetLoaderFactory.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetLoaderFactory.h
@@ -129,4 +129,48 @@ private:
   uint32_t _iTwinCesiumContentID;
   std::string _iTwinAccessToken;
 };
+
+/**
+ * @brief A factory for creating a @ref TilesetContentLoader from data from the
+ * <a
+ * href="https://developer.bentley.com/apis/mesh-export/overview/">iModel
+ * Mesh Export</a> API.
+ */
+class IModelMeshExportContentLoaderFactory : public TilesetLoaderFactory {
+public:
+  /**
+   * @brief Creates a new factory for loading content from an iModel Mesh
+   * Export.
+   *
+   * @param iModelId The ID of the iModel to load a Mesh Export of.
+   * @param exportId The ID of a specific mesh export to use, or `std::nullopt`
+   * to use the most recently modified export.
+   * @param iTwinAccessToken The access token to use to access the API.
+   */
+  IModelMeshExportContentLoaderFactory(
+      const std::string& iModelId,
+      const std::optional<std::string>& exportId,
+      const std::string& iTwinAccessToken)
+      : _iModelId(iModelId),
+        _exportId(exportId),
+        _iTwinAccessToken(iTwinAccessToken) {}
+
+  virtual CesiumAsync::Future<
+      Cesium3DTilesSelection::TilesetContentLoaderResult<
+          Cesium3DTilesSelection::TilesetContentLoader>>
+  createLoader(
+      const TilesetExternals& externals,
+      const TilesetOptions& tilesetOptions,
+      const AuthorizationHeaderChangeListener& headerChangeListener)
+      const override;
+
+  virtual bool isValid() const override {
+    return !this->_iModelId.empty() && !this->_iTwinAccessToken.empty();
+  }
+
+private:
+  std::string _iModelId;
+  std::optional<std::string> _exportId;
+  std::string _iTwinAccessToken;
+};
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/IModelMeshExportContentLoader.cpp
+++ b/Cesium3DTilesSelection/src/IModelMeshExportContentLoader.cpp
@@ -40,7 +40,7 @@ parseGetExportsResponse(const rapidjson::Document& response) {
         if (meshLink != links->value.MemberEnd() &&
             meshLink->value.IsObject()) {
           meshHref = CesiumUtility::JsonHelpers::getStringOrDefault(
-              parsedExport,
+              meshLink->value,
               "href",
               "");
         }

--- a/Cesium3DTilesSelection/src/IModelMeshExportContentLoader.cpp
+++ b/Cesium3DTilesSelection/src/IModelMeshExportContentLoader.cpp
@@ -1,0 +1,205 @@
+#include "IModelMeshExportContentLoader.h"
+
+#include "ITwinUtilities.h"
+
+#include <CesiumAsync/IAssetAccessor.h>
+#include <CesiumAsync/IAssetRequest.h>
+#include <CesiumAsync/IAssetResponse.h>
+#include <CesiumUtility/JsonHelpers.h>
+#include <CesiumUtility/Uri.h>
+
+#include <TilesetJsonLoader.h>
+
+#include <algorithm>
+
+namespace Cesium3DTilesSelection {
+
+namespace {
+struct IModelMeshExport {
+  std::string id;
+  std::string meshHref;
+};
+
+std::vector<IModelMeshExport>
+parseGetExportsResponse(const rapidjson::Document& response) {
+  std::vector<IModelMeshExport> exports;
+  const auto exportsIt = response.FindMember("exports");
+  if (exportsIt != response.MemberEnd() && exportsIt->value.IsArray()) {
+    for (const rapidjson::Value& parsedExport : exportsIt->value.GetArray()) {
+      const std::string& exportId =
+          CesiumUtility::JsonHelpers::getStringOrDefault(
+              parsedExport,
+              "id",
+              "");
+
+      // Obtain _links.mesh.href if possible
+      std::string meshHref;
+      const auto links = parsedExport.FindMember("_links");
+      if (links != parsedExport.MemberEnd() && links->value.IsObject()) {
+        const auto meshLink = links->value.FindMember("mesh");
+        if (meshLink != links->value.MemberEnd() &&
+            meshLink->value.IsObject()) {
+          meshHref = CesiumUtility::JsonHelpers::getStringOrDefault(
+              parsedExport,
+              "href",
+              "");
+        }
+      }
+
+      // We only want to return exports that have the required values
+      if (!exportId.empty() && !meshHref.empty()) {
+        exports.emplace_back(exportId, meshHref);
+      }
+    }
+  }
+
+  return exports;
+}
+
+} // namespace
+
+CesiumAsync::Future<TilesetContentLoaderResult<IModelMeshExportContentLoader>>
+IModelMeshExportContentLoader::createLoader(
+    const TilesetExternals& externals,
+    const std::string& iModelId,
+    const std::optional<std::string>& exportId,
+    const std::string& iTwinAccessToken,
+    const CesiumGeospatial::Ellipsoid& ellipsoid) {
+  CesiumUtility::Uri getExportsUri("https://api.bentley.com/mesh-export/");
+  CesiumUtility::UriQuery getExportsQueryParams("");
+  getExportsQueryParams.setValue("iModelId", iModelId);
+  getExportsQueryParams.setValue("exportType", "3DTiles");
+  getExportsQueryParams.setValue("$orderBy", "date:desc");
+  getExportsUri.setQuery(getExportsQueryParams.toQueryString());
+
+  std::vector<CesiumAsync::IAssetAccessor::THeader> headers{
+      {"Authorization", "Bearer " + iTwinAccessToken},
+      {"Prefer", "return=representation"},
+      {"Accept", "application/vnd.bentley.itwin-platform.v1+json"}};
+
+  return externals.pAssetAccessor
+      ->get(
+          externals.asyncSystem,
+          std::string(getExportsUri.toString()),
+          headers)
+      .thenImmediately([externals,
+                        iModelId,
+                        exportId,
+                        iTwinAccessToken,
+                        ellipsoid](std::shared_ptr<CesiumAsync::IAssetRequest>&&
+                                       pRequest) {
+        const CesiumAsync::IAssetResponse* pResponse = pRequest->response();
+        const std::string& requestUrl = pRequest->url();
+        if (!pResponse) {
+          TilesetContentLoaderResult<IModelMeshExportContentLoader> result;
+          result.errors.emplaceError(fmt::format(
+              "No response received for asset request {}",
+              requestUrl));
+          return externals.asyncSystem.createResolvedFuture(std::move(result));
+        }
+
+        uint16_t statusCode = pResponse->statusCode();
+        if (statusCode < 200 || statusCode >= 300) {
+          TilesetContentLoaderResult<IModelMeshExportContentLoader> result;
+          result.errors.emplaceError(fmt::format(
+              "Received status code {} for asset response {}",
+              statusCode,
+              requestUrl));
+          result.statusCode = statusCode;
+          parseITwinErrorResponseIntoErrorList(pResponse, result.errors);
+          return externals.asyncSystem.createResolvedFuture(std::move(result));
+        }
+
+        const std::span<const std::byte> data = pResponse->data();
+
+        rapidjson::Document iModelResponse;
+        iModelResponse.Parse(
+            reinterpret_cast<const char*>(data.data()),
+            data.size());
+
+        if (iModelResponse.HasParseError()) {
+          TilesetContentLoaderResult<IModelMeshExportContentLoader> result;
+          result.errors.emplaceError(fmt::format(
+              "Error when parsing iModel Mesh Export service response JSON, "
+              "error code {} at byte "
+              "offset {}",
+              iModelResponse.GetParseError(),
+              iModelResponse.GetErrorOffset()));
+          return externals.asyncSystem.createResolvedFuture(std::move(result));
+        }
+
+        std::vector<IModelMeshExport> exports =
+            parseGetExportsResponse(iModelResponse);
+        if (exports.empty()) {
+          TilesetContentLoaderResult<IModelMeshExportContentLoader> result;
+          result.errors.emplaceError(fmt::format(
+              "No 3D Tiles exports found for iModel ID {}",
+              iModelId));
+          return externals.asyncSystem.createResolvedFuture(std::move(result));
+        }
+
+        TilesetContentLoaderResult<IModelMeshExportContentLoader> result;
+        IModelMeshExport& exportToUse = exports.front();
+        // Attempt to find the specified export ID if one was set.
+        if (exportId.has_value()) {
+          const auto foundExportIt = std::find_if(
+              exports.begin(),
+              exports.end(),
+              [exportId](const IModelMeshExport& meshExport) {
+                return meshExport.id == *exportId;
+              });
+
+          if (foundExportIt != exports.end()) {
+            exportToUse = *foundExportIt;
+          } else {
+            result.errors.emplaceWarning(fmt::format(
+                "No export ID {} found on iModel {}, using most recently "
+                "modified export",
+                *exportId,
+                iModelId));
+          }
+        }
+
+        // Mesh Export service returns the root directory of the tileset - we
+        // need to manually append "/tileset.json"
+        CesiumUtility::Uri meshUri(exportToUse.meshHref);
+        std::string meshPath{meshUri.getPath()};
+        meshUri.setPath(meshPath + "/tileset.json");
+
+        std::vector<CesiumAsync::IAssetAccessor::THeader> tilesetHeaders{
+            {"Authorization", "Bearer " + iTwinAccessToken}};
+
+        return TilesetJsonLoader::createLoader(
+                   externals,
+                   std::string{meshUri.toString()},
+                   tilesetHeaders,
+                   ellipsoid)
+            .thenImmediately([tilesetHeaders](
+                                 TilesetContentLoaderResult<TilesetJsonLoader>&&
+                                     tilesetJsonResult) mutable {
+              TilesetContentLoaderResult<IModelMeshExportContentLoader> result;
+              if (!tilesetJsonResult.errors) {
+                result.pLoader =
+                    std::make_unique<IModelMeshExportContentLoader>(
+                        std::move(tilesetJsonResult.pLoader));
+                result.pRootTile = std::move(tilesetJsonResult.pRootTile);
+                result.credits = std::move(tilesetJsonResult.credits);
+                result.requestHeaders = std::move(tilesetHeaders);
+              }
+              result.errors = std::move(tilesetJsonResult.errors);
+              result.statusCode = tilesetJsonResult.statusCode;
+              return result;
+            });
+      });
+}
+CesiumAsync::Future<TileLoadResult>
+IModelMeshExportContentLoader::loadTileContent(const TileLoadInput& loadInput) {
+  return this->_pAggregatedLoader->loadTileContent(loadInput);
+}
+TileChildrenResult IModelMeshExportContentLoader::createTileChildren(
+    const Tile& tile,
+    const CesiumGeospatial::Ellipsoid& ellipsoid) {
+  auto pLoader = tile.getLoader();
+  return pLoader->createTileChildren(tile, ellipsoid);
+}
+} // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/IModelMeshExportContentLoader.cpp
+++ b/Cesium3DTilesSelection/src/IModelMeshExportContentLoader.cpp
@@ -1,16 +1,31 @@
 #include "IModelMeshExportContentLoader.h"
 
 #include "ITwinUtilities.h"
+#include "TilesetJsonLoader.h"
 
+#include <Cesium3DTilesSelection/Tile.h>
+#include <Cesium3DTilesSelection/TileLoadResult.h>
+#include <Cesium3DTilesSelection/TilesetContentLoader.h>
+#include <Cesium3DTilesSelection/TilesetContentLoaderResult.h>
+#include <Cesium3DTilesSelection/TilesetExternals.h>
 #include <CesiumAsync/IAssetAccessor.h>
 #include <CesiumAsync/IAssetRequest.h>
 #include <CesiumAsync/IAssetResponse.h>
+#include <CesiumGeospatial/Ellipsoid.h>
 #include <CesiumUtility/JsonHelpers.h>
 #include <CesiumUtility/Uri.h>
 
-#include <TilesetJsonLoader.h>
+#include <fmt/format.h>
+#include <rapidjson/rapidjson.h>
 
 #include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace Cesium3DTilesSelection {
 
@@ -48,7 +63,7 @@ parseGetExportsResponse(const rapidjson::Document& response) {
 
       // We only want to return exports that have the required values
       if (!exportId.empty() && !meshHref.empty()) {
-        exports.emplace_back(exportId, meshHref);
+        exports.emplace_back(IModelMeshExport{exportId, meshHref});
       }
     }
   }

--- a/Cesium3DTilesSelection/src/IModelMeshExportContentLoader.h
+++ b/Cesium3DTilesSelection/src/IModelMeshExportContentLoader.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <Cesium3DTilesSelection/TilesetContentLoader.h>
+#include <Cesium3DTilesSelection/TilesetContentLoaderResult.h>
+#include <Cesium3DTilesSelection/TilesetExternals.h>
+
+#include <spdlog/spdlog.h>
+
+#include <string>
+
+namespace Cesium3DTilesSelection {
+
+class IModelMeshExportContentLoader : public TilesetContentLoader {
+public:
+  IModelMeshExportContentLoader(
+      std::unique_ptr<TilesetContentLoader>&& pAggregatedLoader)
+      : _pAggregatedLoader(std::move(pAggregatedLoader)) {}
+
+  static CesiumAsync::Future<
+      TilesetContentLoaderResult<IModelMeshExportContentLoader>>
+  createLoader(
+      const TilesetExternals& externals,
+      const std::string& iModelId,
+      const std::optional<std::string>& exportId,
+      const std::string& iTwinAccessToken,
+      const CesiumGeospatial::Ellipsoid& ellipsoid CESIUM_DEFAULT_ELLIPSOID);
+
+  CesiumAsync::Future<TileLoadResult>
+  loadTileContent(const TileLoadInput& loadInput) override;
+
+  TileChildrenResult createTileChildren(
+      const Tile& tile,
+      const CesiumGeospatial::Ellipsoid& ellipsoid) override;
+
+private:
+  std::unique_ptr<TilesetContentLoader> _pAggregatedLoader;
+};
+} // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/ITwinUtilities.cpp
+++ b/Cesium3DTilesSelection/src/ITwinUtilities.cpp
@@ -1,0 +1,68 @@
+#include "ITwinUtilities.h"
+
+#include "CesiumUtility/JsonHelpers.h"
+
+#include <rapidjson/document.h>
+
+namespace Cesium3DTilesSelection {
+void parseITwinErrorResponseIntoErrorList(
+    const CesiumAsync::IAssetResponse* pResponse,
+    CesiumUtility::ErrorList& errors) {
+  rapidjson::Document jsonResponse;
+  const std::span<const std::byte> data = pResponse->data();
+  jsonResponse.Parse(reinterpret_cast<const char*>(data.data()), data.size());
+
+  if (jsonResponse.HasParseError()) {
+    errors.emplaceError(fmt::format(
+        "Error when parsing iTwin API error message, error code {} at byte "
+        "offset {}",
+        jsonResponse.GetParseError(),
+        jsonResponse.GetErrorOffset()));
+    return;
+  }
+
+  const auto error = jsonResponse.FindMember("error");
+  if (error == jsonResponse.MemberEnd() || !error->value.IsObject()) {
+    // No additional error information available.
+    return;
+  }
+
+  const rapidjson::Value::Object errorObj = error->value.GetObject();
+
+  const std::string errorCode =
+      CesiumUtility::JsonHelpers::getStringOrDefault(errorObj, "code", "");
+  const std::string errorMessage =
+      CesiumUtility::JsonHelpers::getStringOrDefault(errorObj, "message", "");
+
+  std::string finalMessage =
+      fmt::format("API error code '{}': {}", errorCode, errorMessage);
+
+  const auto detailsIt = errorObj.FindMember("details");
+  if (detailsIt != errorObj.MemberEnd() && detailsIt->value.IsArray()) {
+    for (const rapidjson::Value& details : detailsIt->value.GetArray()) {
+      const std::string detailsCode =
+          CesiumUtility::JsonHelpers::getStringOrDefault(details, "code", "");
+      const std::string detailsMessage =
+          CesiumUtility::JsonHelpers::getStringOrDefault(
+              details,
+              "message",
+              "");
+      const std::string detailsTarget =
+          CesiumUtility::JsonHelpers::getStringOrDefault(details, "target", "");
+      if (!detailsTarget.empty()) {
+        finalMessage += fmt::format(
+            "\n\t- '{}' in '{}': {}",
+            detailsCode,
+            detailsTarget,
+            detailsMessage);
+      } else {
+        finalMessage +=
+            fmt::format("\n\t- '{}': {}", detailsCode, detailsMessage);
+      }
+    }
+  }
+
+  errors.emplaceError(finalMessage);
+}
+
+} // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/src/ITwinUtilities.cpp
+++ b/Cesium3DTilesSelection/src/ITwinUtilities.cpp
@@ -1,8 +1,15 @@
 #include "ITwinUtilities.h"
 
-#include "CesiumUtility/JsonHelpers.h"
+#include <CesiumAsync/IAssetResponse.h>
+#include <CesiumUtility/ErrorList.h>
+#include <CesiumUtility/JsonHelpers.h>
 
+#include <fmt/format.h>
 #include <rapidjson/document.h>
+
+#include <cstddef>
+#include <span>
+#include <string>
 
 namespace Cesium3DTilesSelection {
 void parseITwinErrorResponseIntoErrorList(

--- a/Cesium3DTilesSelection/src/ITwinUtilities.h
+++ b/Cesium3DTilesSelection/src/ITwinUtilities.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <CesiumAsync/IAssetResponse.h>
+#include <CesiumUtility/ErrorList.h>
+
+namespace Cesium3DTilesSelection {
+void parseITwinErrorResponseIntoErrorList(
+    const CesiumAsync::IAssetResponse* pResponse,
+    CesiumUtility::ErrorList& errors);
+}

--- a/Cesium3DTilesSelection/src/TilesetLoaderFactory.cpp
+++ b/Cesium3DTilesSelection/src/TilesetLoaderFactory.cpp
@@ -1,4 +1,5 @@
 #include "CesiumIonTilesetLoader.h"
+#include "IModelMeshExportContentLoader.h"
 #include "ITwinCesiumCuratedContentLoader.h"
 
 #include <Cesium3DTilesSelection/TilesetContentLoader.h>
@@ -47,6 +48,24 @@ ITwinCesiumCuratedContentLoaderFactory::createLoader(
              tilesetOptions.ellipsoid)
       .thenImmediately([](Cesium3DTilesSelection::TilesetContentLoaderResult<
                            CesiumIonTilesetLoader>&& result) {
+        return TilesetContentLoaderResult<TilesetContentLoader>(
+            std::move(result));
+      });
+}
+CesiumAsync::Future<Cesium3DTilesSelection::TilesetContentLoaderResult<
+    Cesium3DTilesSelection::TilesetContentLoader>>
+IModelMeshExportContentLoaderFactory::createLoader(
+    const TilesetExternals& externals,
+    const TilesetOptions& tilesetOptions,
+    const AuthorizationHeaderChangeListener& /*headerChangeListener*/) const {
+  return IModelMeshExportContentLoader::createLoader(
+             externals,
+             this->_iModelId,
+             this->_exportId,
+             this->_iTwinAccessToken,
+             tilesetOptions.ellipsoid)
+      .thenImmediately([](Cesium3DTilesSelection::TilesetContentLoaderResult<
+                           IModelMeshExportContentLoader>&& result) {
         return TilesetContentLoaderResult<TilesetContentLoader>(
             std::move(result));
       });


### PR DESCRIPTION
This PR builds on #1121 to add a `TilesetContentLoader` for iModels using the [iModel Mesh Export API](https://developer.bentley.com/apis/mesh-export/). As before, [there is a companion cesium-unreal branch](https://github.com/CesiumGS/cesium-unreal/tree/itwin-mesh-export-loader) for testing.