### PR TITLE
Credit Text: add a way to prioritize user-defined credit text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 - Added `TypeToDimensions` class in `PropertyTypeTraits` to obtain the dimension count of a glm vector or matrix.
 - Added `canRepresentPropertyType<T>` to `PropertyTypeTraits` to check if a C++ type can represent the given `PropertyType`.
 - Added `getName` method to `CesiumGltf::Enum`, allowing a scalar enum value to be resolved into its corresponding name in the enum.
+- Added `priority` member to `CesiumUtility::Credit`, allowing to prioritize user-defined credit text.
 
 ##### Fixes :wrench:
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetOptions.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetOptions.h
@@ -81,6 +81,11 @@ struct CESIUM3DTILESSELECTION_API TilesetOptions {
   std::optional<std::string> credit;
 
   /**
+   * @brief Priority to apply to the credit text, if needed.
+   */
+  std::optional<int32_t> creditPriority;
+
+  /**
    * @brief Whether or not to display tileset's credits on the screen.
    */
   bool showCreditsOnScreen = false;

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -715,7 +715,8 @@ TilesetContentManager::TilesetContentManager(
           (tilesetOptions.credit && externals.pCreditSystem)
               ? std::optional<Credit>(externals.pCreditSystem->createCredit(
                     tilesetOptions.credit.value(),
-                    tilesetOptions.showCreditsOnScreen))
+                    tilesetOptions.showCreditsOnScreen,
+                    tilesetOptions.creditPriority.value_or(-1)))
               : std::nullopt),
       _tilesetCredits{},
       _overlayCollection{std::move(overlayCollection)},
@@ -745,7 +746,8 @@ TilesetContentManager::TilesetContentManager(
           (tilesetOptions.credit && externals.pCreditSystem)
               ? std::optional<Credit>(externals.pCreditSystem->createCredit(
                     tilesetOptions.credit.value(),
-                    tilesetOptions.showCreditsOnScreen))
+                    tilesetOptions.showCreditsOnScreen,
+                    tilesetOptions.creditPriority.value_or(-1)))
               : std::nullopt),
       _tilesetCredits{},
       _overlayCollection{std::move(overlayCollection)},
@@ -897,7 +899,8 @@ TilesetContentManager::TilesetContentManager(
           (tilesetOptions.credit && externals.pCreditSystem)
               ? std::optional<Credit>(externals.pCreditSystem->createCredit(
                     tilesetOptions.credit.value(),
-                    tilesetOptions.showCreditsOnScreen))
+                    tilesetOptions.showCreditsOnScreen,
+                    tilesetOptions.creditPriority.value_or(-1)))
               : std::nullopt),
       _tilesetCredits{},
       _overlayCollection{std::move(overlayCollection)},

--- a/CesiumUtility/include/CesiumUtility/CreditSystem.h
+++ b/CesiumUtility/include/CesiumUtility/CreditSystem.h
@@ -23,6 +23,9 @@ public:
     return this->id == rhs.id;
   }
 
+  /**
+   * @brief Gets the priority of this credit.
+   */
   int32_t getPriority() const noexcept { return priority; }
 
 private:
@@ -42,8 +45,12 @@ private:
 class CESIUMUTILITY_API CreditSystem final {
 public:
   /**
-   * @brief Inserts a credit string
+   * @brief Inserts a credit string.
    *
+   * @param html The credit string to add.
+   * @param showOnScreen Whether or not the credit should be shown on screen.
+   * @param priority The priority of the credit. Higher priority credits will
+   * be leftmost.
    * @return If this string already exists, returns a Credit handle to the
    * existing entry. Otherwise returns a Credit handle to a new entry.
    */
@@ -53,10 +60,7 @@ public:
       int32_t priority = -1);
 
   /**
-   * @brief Inserts a credit string
-   *
-   * @return If this string already exists, returns a Credit handle to the
-   * existing entry. Otherwise returns a Credit handle to a new entry.
+   * @copydoc createCredit
    */
   Credit createCredit(
       const std::string& html,

--- a/CesiumUtility/include/CesiumUtility/CreditSystem.h
+++ b/CesiumUtility/include/CesiumUtility/CreditSystem.h
@@ -32,7 +32,8 @@ private:
   size_t id;
   int32_t priority = -1;
 
-  Credit(size_t id_, int32_t priority_ = -1) noexcept : id(id_), priority(priority_) {}
+  Credit(size_t id_, int32_t priority_ = -1) noexcept
+      : id(id_), priority(priority_) {}
 
   friend class CreditSystem;
 };

--- a/CesiumUtility/include/CesiumUtility/CreditSystem.h
+++ b/CesiumUtility/include/CesiumUtility/CreditSystem.h
@@ -23,10 +23,13 @@ public:
     return this->id == rhs.id;
   }
 
+  int32_t getPriority() const noexcept { return priority; }
+
 private:
   size_t id;
+  int32_t priority = -1;
 
-  Credit(size_t id_) noexcept : id(id_) {}
+  Credit(size_t id_, int32_t priority_ = -1) noexcept : id(id_), priority(priority_) {}
 
   friend class CreditSystem;
 };
@@ -44,7 +47,10 @@ public:
    * @return If this string already exists, returns a Credit handle to the
    * existing entry. Otherwise returns a Credit handle to a new entry.
    */
-  Credit createCredit(std::string&& html, bool showOnScreen = false);
+  Credit createCredit(
+      std::string&& html,
+      bool showOnScreen = false,
+      int32_t priority = -1);
 
   /**
    * @brief Inserts a credit string
@@ -52,7 +58,10 @@ public:
    * @return If this string already exists, returns a Credit handle to the
    * existing entry. Otherwise returns a Credit handle to a new entry.
    */
-  Credit createCredit(const std::string& html, bool showOnScreen = false);
+  Credit createCredit(
+      const std::string& html,
+      bool showOnScreen = false,
+      int32_t priority = -1);
 
   /**
    * @brief Gets whether or not the credit should be shown on screen.

--- a/CesiumUtility/src/CreditSystem.cpp
+++ b/CesiumUtility/src/CreditSystem.cpp
@@ -9,11 +9,17 @@
 
 namespace CesiumUtility {
 
-Credit CreditSystem::createCredit(const std::string& html, bool showOnScreen, int32_t priority) {
+Credit CreditSystem::createCredit(
+    const std::string& html,
+    bool showOnScreen,
+    int32_t priority) {
   return this->createCredit(std::string(html), showOnScreen, priority);
 }
 
-Credit CreditSystem::createCredit(std::string&& html, bool showOnScreen, int32_t priority) {
+Credit CreditSystem::createCredit(
+    std::string&& html,
+    bool showOnScreen,
+    int32_t priority) {
   // if this credit already exists, return a Credit handle to it
   for (size_t id = 0; id < _credits.size(); ++id) {
     if (_credits[id].html == html) {


### PR DESCRIPTION
Only available for the user-defined credit text for now (the one applied to the whole tileset independently from the tiles actually viewed). It can be used to display a logo on the left of all credit texts, typically.