### PR TITLE
Multiple Views: Improve performance of selection state tracking

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/DebugTileStateDatabase.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/DebugTileStateDatabase.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Cesium3DTilesSelection/TileSelectionState.h>
+#include <CesiumUtility/IntrusivePointer.h>
 
 #include <memory>
 #include <string>
@@ -31,7 +32,9 @@ public:
    * @brief Records the state of all tiles that are currently loaded by the
    * given tileset.
    *
-   * The state is obtained from the view group's "previous" results.
+   * The state is obtained from the view group's
+   * {@link TilesetViewGroup::getTraversalState} by calling
+   * {@link TreeTraversalState::slowlyGetPreviousStates}.
    *
    * @param frameNumber The current frame number.
    * @param tileset The tileset.
@@ -45,7 +48,9 @@ public:
   /**
    * @brief Records the state of a given tile.
    *
-   * The state is obtained from the view group's "previous" results.
+   * The state is obtained from the view group's
+   * {@link TilesetViewGroup::getTraversalState} by calling
+   * {@link TreeTraversalState::slowlyGetPreviousStates}.
    *
    * @param frameNumber The current frame number.
    * @param viewGroup The view group.
@@ -68,8 +73,9 @@ public:
   void recordTileState(
       int32_t frameNumber,
       const Tile& tile,
-      const std::unordered_map<const Tile*, TileSelectionState::Result>&
-          states);
+      const std::unordered_map<
+          CesiumUtility::IntrusivePointer<const Tile>,
+          TileSelectionState>& states);
 
 private:
   struct Impl;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/DebugTileStateDatabase.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/DebugTileStateDatabase.h
@@ -34,7 +34,7 @@ public:
    *
    * The state is obtained from the view group's
    * {@link TilesetViewGroup::getTraversalState} by calling
-   * {@link TreeTraversalState::slowlyGetPreviousStates}.
+   * {@link CesiumUtility::TreeTraversalState::slowlyGetPreviousStates}.
    *
    * @param frameNumber The current frame number.
    * @param tileset The tileset.
@@ -50,7 +50,7 @@ public:
    *
    * The state is obtained from the view group's
    * {@link TilesetViewGroup::getTraversalState} by calling
-   * {@link TreeTraversalState::slowlyGetPreviousStates}.
+   * {@link CesiumUtility::TreeTraversalState::slowlyGetPreviousStates}.
    *
    * @param frameNumber The current frame number.
    * @param viewGroup The view group.

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/DebugTileStateDatabase.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/DebugTileStateDatabase.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <Cesium3DTilesSelection/TileSelectionState.h>
+
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace Cesium3DTilesSelection {
 
@@ -28,8 +31,7 @@ public:
    * @brief Records the state of all tiles that are currently loaded by the
    * given tileset.
    *
-   * The state is obtained from
-   * {@link TilesetViewGroup::getPreviousSelectionState}.
+   * The state is obtained from the view group's "previous" results.
    *
    * @param frameNumber The current frame number.
    * @param tileset The tileset.
@@ -43,8 +45,7 @@ public:
   /**
    * @brief Records the state of a given tile.
    *
-   * The state is obtained from
-   * {@link TilesetViewGroup::getPreviousSelectionState}.
+   * The state is obtained from the view group's "previous" results.
    *
    * @param frameNumber The current frame number.
    * @param viewGroup The view group.
@@ -54,6 +55,21 @@ public:
       int32_t frameNumber,
       const TilesetViewGroup& viewGroup,
       const Tile& tile);
+
+  /**
+   * @brief Records the state of a given tile.
+   *
+   * The state is obtained from the provided map.
+   *
+   * @param frameNumber The current frame number.
+   * @param tile The tile.
+   * @param states The lookup table for tile states.
+   */
+  void recordTileState(
+      int32_t frameNumber,
+      const Tile& tile,
+      const std::unordered_map<const Tile*, TileSelectionState::Result>&
+          states);
 
 private:
   struct Impl;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -595,8 +595,7 @@ private:
 
   static TraversalDetails createTraversalDetailsForSingleTile(
       const FrameState& frameState,
-      const Tile& tile,
-      const TileSelectionState& lastFrameSelectionState);
+      const Tile& tile);
 };
 
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetViewGroup.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetViewGroup.h
@@ -5,6 +5,7 @@
 #include <Cesium3DTilesSelection/TileSelectionState.h>
 #include <Cesium3DTilesSelection/ViewUpdateResult.h>
 #include <CesiumUtility/IntrusivePointer.h>
+#include <CesiumUtility/TreeTraversalState.h>
 
 #include <cstddef>
 #include <unordered_map>
@@ -23,6 +24,10 @@ class TilesetContentManager;
 class CESIUM3DTILESSELECTION_API TilesetViewGroup final
     : public TileLoadRequester {
 public:
+  using TraversalState = CesiumUtility::TreeTraversalState<
+      CesiumUtility::IntrusivePointer<const Tile>,
+      TileSelectionState>;
+
   /**
    * @brief Constructs a new instance.
    */
@@ -59,40 +64,47 @@ public:
   /** @copydoc getViewUpdateResult */
   ViewUpdateResult& getViewUpdateResult();
 
-  /**
-   * @brief Returns the previous {@link TileSelectionState} of this tile last
-   * time this view group was updated.
-   *
-   * @param tile The tile for which to get the selection state.
-   * @return The previous selection state
-   */
-  TileSelectionState getPreviousSelectionState(const Tile& tile) const noexcept;
+  TraversalState& getTraversalState() noexcept { return this->_traversalState; }
+  const TraversalState& getTraversalState() const noexcept {
+    return this->_traversalState;
+  }
 
-  /**
-   * @brief Returns the current {@link TileSelectionState} of this tile during
-   * the current update of this view group.
-   *
-   * @param tile The tile for which to get the selection state.
-   * @return The current selection state
-   */
-  TileSelectionState getCurrentSelectionState(const Tile& tile) const noexcept;
+  // /**
+  //  * @brief Returns the previous {@link TileSelectionState} of this tile last
+  //  * time this view group was updated.
+  //  *
+  //  * @param tile The tile for which to get the selection state.
+  //  * @return The previous selection state
+  //  */
+  // TileSelectionState getPreviousSelectionState(const Tile& tile) const
+  // noexcept;
 
-  /**
-   * @brief Sets the {@link TileSelectionState} of this tile.
-   *
-   * @param tile The tile for which to set the selection state.
-   * @param newState The new state
-   */
-  void setCurrentSelectionState(
-      const Tile& tile,
-      const TileSelectionState& newState) noexcept;
+  // /**
+  //  * @brief Returns the current {@link TileSelectionState} of this tile during
+  //  * the current update of this view group.
+  //  *
+  //  * @param tile The tile for which to get the selection state.
+  //  * @return The current selection state
+  //  */
+  // TileSelectionState getCurrentSelectionState(const Tile& tile) const
+  // noexcept;
 
-  /**
-   * @brief Marks a tile as "kicked".
-   *
-   * @param tile The tile to "kick".
-   */
-  void kick(const Tile& tile) noexcept;
+  // /**
+  //  * @brief Sets the {@link TileSelectionState} of this tile.
+  //  *
+  //  * @param tile The tile for which to set the selection state.
+  //  * @param newState The new state
+  //  */
+  // void setCurrentSelectionState(
+  //     const Tile& tile,
+  //     const TileSelectionState& newState) noexcept;
+
+  // /**
+  //  * @brief Marks a tile as "kicked".
+  //  *
+  //  * @param tile The tile to "kick".
+  //  */
+  // void kick(const Tile& tile) noexcept;
 
   /**
    * @brief Adds a tile load task to this view group's load queue.
@@ -213,6 +225,8 @@ private:
   std::vector<TileLoadTask> _workerThreadLoadQueue;
 
   ViewUpdateResult _updateResult;
+
+  TraversalState _traversalState;
 };
 
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetViewGroup.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetViewGroup.h
@@ -25,8 +25,8 @@ class CESIUM3DTILESSELECTION_API TilesetViewGroup final
     : public TileLoadRequester {
 public:
   /**
-   * @brief The type of the {@link TreeTraversalState} used to track tile
-   * selection states for this view group.
+   * @brief The type of the {@link CesiumUtility::TreeTraversalState}
+   * used to track tile selection states for this view group.
    */
   using TraversalState = CesiumUtility::TreeTraversalState<
       CesiumUtility::IntrusivePointer<const Tile>,

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetViewGroup.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetViewGroup.h
@@ -24,6 +24,10 @@ class TilesetContentManager;
 class CESIUM3DTILESSELECTION_API TilesetViewGroup final
     : public TileLoadRequester {
 public:
+  /**
+   * @brief The type of the {@link TreeTraversalState} used to track tile
+   * selection states for this view group.
+   */
   using TraversalState = CesiumUtility::TreeTraversalState<
       CesiumUtility::IntrusivePointer<const Tile>,
       TileSelectionState>;
@@ -64,47 +68,16 @@ public:
   /** @copydoc getViewUpdateResult */
   ViewUpdateResult& getViewUpdateResult();
 
+  /**
+   * @brief Gets an object used to track the selection state of tiles as they
+   * are traversed for this view group.
+   */
   TraversalState& getTraversalState() noexcept { return this->_traversalState; }
+
+  /** @copydoc getTraversalState */
   const TraversalState& getTraversalState() const noexcept {
     return this->_traversalState;
   }
-
-  // /**
-  //  * @brief Returns the previous {@link TileSelectionState} of this tile last
-  //  * time this view group was updated.
-  //  *
-  //  * @param tile The tile for which to get the selection state.
-  //  * @return The previous selection state
-  //  */
-  // TileSelectionState getPreviousSelectionState(const Tile& tile) const
-  // noexcept;
-
-  // /**
-  //  * @brief Returns the current {@link TileSelectionState} of this tile during
-  //  * the current update of this view group.
-  //  *
-  //  * @param tile The tile for which to get the selection state.
-  //  * @return The current selection state
-  //  */
-  // TileSelectionState getCurrentSelectionState(const Tile& tile) const
-  // noexcept;
-
-  // /**
-  //  * @brief Sets the {@link TileSelectionState} of this tile.
-  //  *
-  //  * @param tile The tile for which to set the selection state.
-  //  * @param newState The new state
-  //  */
-  // void setCurrentSelectionState(
-  //     const Tile& tile,
-  //     const TileSelectionState& newState) noexcept;
-
-  // /**
-  //  * @brief Marks a tile as "kicked".
-  //  *
-  //  * @param tile The tile to "kick".
-  //  */
-  // void kick(const Tile& tile) noexcept;
 
   /**
    * @brief Adds a tile load task to this view group's load queue.

--- a/Cesium3DTilesSelection/src/DebugTileStateDatabase.cpp
+++ b/Cesium3DTilesSelection/src/DebugTileStateDatabase.cpp
@@ -1,3 +1,4 @@
+#if false
 #include <Cesium3DTilesSelection/DebugTileStateDatabase.h>
 #include <Cesium3DTilesSelection/TileID.h>
 #include <Cesium3DTilesSelection/TileSelectionState.h>
@@ -267,3 +268,4 @@ void DebugTileStateDatabase::recordTileState(
 }
 
 } // namespace Cesium3DTilesSelection
+#endif

--- a/Cesium3DTilesSelection/src/DebugTileStateDatabase.cpp
+++ b/Cesium3DTilesSelection/src/DebugTileStateDatabase.cpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -29,6 +29,7 @@
 #include <CesiumRasterOverlays/RasterOverlayTile.h>
 #include <CesiumUtility/Assert.h>
 #include <CesiumUtility/CreditSystem.h>
+#include <CesiumUtility/IntrusivePointer.h>
 #include <CesiumUtility/Math.h>
 #include <CesiumUtility/Tracing.h>
 

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -690,8 +690,9 @@ const TilesetViewGroup& Tileset::getDefaultViewGroup() const {
 
 namespace {
 
-TileSelectionState
-getPreviousState(const TilesetViewGroup& viewGroup, [[maybe_unused]] const Tile& tile) {
+TileSelectionState getPreviousState(
+    const TilesetViewGroup& viewGroup,
+    [[maybe_unused]] const Tile& tile) {
   const TilesetViewGroup::TraversalState& traversalState =
       viewGroup.getTraversalState();
   CESIUM_ASSERT(traversalState.getCurrentNode() == &tile);

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -229,74 +229,77 @@ double computeFogDensity(
 } // namespace
 
 void Tileset::_updateLodTransitions(
-    const FrameState& frameState,
-    float deltaTime,
+    const FrameState& /* frameState */,
+    float /* deltaTime */,
     ViewUpdateResult& result) const noexcept {
   if (_options.enableLodTransitionPeriod) {
-    // We always fade tiles from 0.0 --> 1.0. Whether the tile is fading in or
-    // out is determined by whether the tile is in the tilesToRenderThisFrame
-    // or tilesFadingOut list.
-    float deltaTransitionPercentage =
-        deltaTime / this->_options.lodTransitionLength;
+    // TODO
+    // // We always fade tiles from 0.0 --> 1.0. Whether the tile is fading in
+    // or
+    // // out is determined by whether the tile is in the tilesToRenderThisFrame
+    // // or tilesFadingOut list.
+    // float deltaTransitionPercentage =
+    //     deltaTime / this->_options.lodTransitionLength;
 
-    // Update fade out
-    for (auto tileIt = result.tilesFadingOut.begin();
-         tileIt != result.tilesFadingOut.end();) {
-      TileRenderContent* pRenderContent =
-          (*tileIt)->getContent().getRenderContent();
+    // // Update fade out
+    // for (auto tileIt = result.tilesFadingOut.begin();
+    //      tileIt != result.tilesFadingOut.end();) {
+    //   TileRenderContent* pRenderContent =
+    //       (*tileIt)->getContent().getRenderContent();
 
-      if (!pRenderContent) {
-        // This tile is done fading out and was immediately kicked from the
-        // cache.
-        (*tileIt)->decrementDoNotUnloadSubtreeCount(
-            "Tileset::_updateLodTransitions done fading out");
-        tileIt = result.tilesFadingOut.erase(tileIt);
-        continue;
-      }
+    //   if (!pRenderContent) {
+    //     // This tile is done fading out and was immediately kicked from the
+    //     // cache.
+    //     (*tileIt)->decrementDoNotUnloadSubtreeCount(
+    //         "Tileset::_updateLodTransitions done fading out");
+    //     tileIt = result.tilesFadingOut.erase(tileIt);
+    //     continue;
+    //   }
 
-      // Remove tile from fade-out list if it is back on the render list.
-      TileSelectionState::Result selectionResult =
-          frameState.viewGroup.getCurrentSelectionState(**tileIt).getResult();
-      if (selectionResult == TileSelectionState::Result::Rendered) {
-        // This tile will already be on the render list.
-        pRenderContent->setLodTransitionFadePercentage(0.0f);
-        (*tileIt)->decrementDoNotUnloadSubtreeCount(
-            "Tileset::_updateLodTransitions in render list");
-        tileIt = result.tilesFadingOut.erase(tileIt);
-        continue;
-      }
+    //   // Remove tile from fade-out list if it is back on the render list.
+    //   TileSelectionState::Result selectionResult =
+    //       frameState.viewGroup.getCurrentSelectionState(**tileIt).getResult();
+    //   if (selectionResult == TileSelectionState::Result::Rendered) {
+    //     // This tile will already be on the render list.
+    //     pRenderContent->setLodTransitionFadePercentage(0.0f);
+    //     (*tileIt)->decrementDoNotUnloadSubtreeCount(
+    //         "Tileset::_updateLodTransitions in render list");
+    //     tileIt = result.tilesFadingOut.erase(tileIt);
+    //     continue;
+    //   }
 
-      float currentPercentage =
-          pRenderContent->getLodTransitionFadePercentage();
-      if (currentPercentage >= 1.0f) {
-        // Remove this tile from the fading out list if it is already done.
-        // The client will already have had a chance to stop rendering the tile
-        // last frame.
-        pRenderContent->setLodTransitionFadePercentage(0.0f);
-        (*tileIt)->decrementDoNotUnloadSubtreeCount(
-            "Tileset::_updateLodTransitions done fading out");
-        tileIt = result.tilesFadingOut.erase(tileIt);
-        continue;
-      }
+    //   float currentPercentage =
+    //       pRenderContent->getLodTransitionFadePercentage();
+    //   if (currentPercentage >= 1.0f) {
+    //     // Remove this tile from the fading out list if it is already done.
+    //     // The client will already have had a chance to stop rendering the
+    //     tile
+    //     // last frame.
+    //     pRenderContent->setLodTransitionFadePercentage(0.0f);
+    //     (*tileIt)->decrementDoNotUnloadSubtreeCount(
+    //         "Tileset::_updateLodTransitions done fading out");
+    //     tileIt = result.tilesFadingOut.erase(tileIt);
+    //     continue;
+    //   }
 
-      float newPercentage =
-          glm::min(currentPercentage + deltaTransitionPercentage, 1.0f);
-      pRenderContent->setLodTransitionFadePercentage(newPercentage);
-      ++tileIt;
-    }
+    //   float newPercentage =
+    //       glm::min(currentPercentage + deltaTransitionPercentage, 1.0f);
+    //   pRenderContent->setLodTransitionFadePercentage(newPercentage);
+    //   ++tileIt;
+    // }
 
-    // Update fade in
-    for (Tile* pTile : result.tilesToRenderThisFrame) {
-      TileRenderContent* pRenderContent =
-          pTile->getContent().getRenderContent();
-      if (pRenderContent) {
-        float transitionPercentage =
-            pRenderContent->getLodTransitionFadePercentage();
-        float newTransitionPercentage =
-            glm::min(transitionPercentage + deltaTransitionPercentage, 1.0f);
-        pRenderContent->setLodTransitionFadePercentage(newTransitionPercentage);
-      }
-    }
+    // // Update fade in
+    // for (Tile* pTile : result.tilesToRenderThisFrame) {
+    //   TileRenderContent* pRenderContent =
+    //       pTile->getContent().getRenderContent();
+    //   if (pRenderContent) {
+    //     float transitionPercentage =
+    //         pRenderContent->getLodTransitionFadePercentage();
+    //     float newTransitionPercentage =
+    //         glm::min(transitionPercentage + deltaTransitionPercentage, 1.0f);
+    //     pRenderContent->setLodTransitionFadePercentage(newTransitionPercentage);
+    //   }
+    // }
   } else {
     // If there are any tiles still fading in, set them to fully visible right
     // away.
@@ -429,6 +432,7 @@ const ViewUpdateResult& Tileset::updateViewGroup(
       currentFrameNumber};
 
   if (!frustums.empty()) {
+    viewGroup.getTraversalState().beginTraversal();
     this->_visitTileIfNeeded(frameState, 0, false, *pRootTile, result);
   } else {
     result = ViewUpdateResult();
@@ -715,8 +719,12 @@ void markTileNonRendered(
     TilesetViewGroup& viewGroup,
     Tile& tile,
     ViewUpdateResult& result) {
-  const TileSelectionState::Result lastResult =
-      viewGroup.getPreviousSelectionState(tile).getResult();
+  const TileSelectionState* pPreviousState =
+      viewGroup.getTraversalState().previousState();
+  TileSelectionState::Result lastResult =
+      pPreviousState ? pPreviousState->getResult()
+                     : TileSelectionState::Result::None;
+
   markTileNonRendered(lastResult, tile, result);
 }
 
@@ -726,11 +734,17 @@ void markChildrenNonRendered(
     Tile& tile,
     ViewUpdateResult& result) {
   if (lastResult == TileSelectionState::Result::Refined) {
+    TilesetViewGroup::TraversalState& traversal = viewGroup.getTraversalState();
     for (Tile& child : tile.getChildren()) {
-      const TileSelectionState::Result childLastResult =
-          viewGroup.getPreviousSelectionState(child).getResult();
+      // TODO: is this safe?
+      traversal.beginNode(&child);
+      const TileSelectionState* pChildLastResult = traversal.previousState();
+      TileSelectionState::Result childLastResult =
+          pChildLastResult ? pChildLastResult->getResult()
+                           : TileSelectionState::Result::None;
       markTileNonRendered(childLastResult, child, result);
       markChildrenNonRendered(viewGroup, childLastResult, child, result);
+      traversal.finishNode(&child);
     }
   }
 }
@@ -739,8 +753,10 @@ void markChildrenNonRendered(
     TilesetViewGroup& viewGroup,
     Tile& tile,
     ViewUpdateResult& result) {
-  const TileSelectionState::Result lastResult =
-      viewGroup.getPreviousSelectionState(tile).getResult();
+  const TileSelectionState* pLastResult =
+      viewGroup.getTraversalState().previousState();
+  TileSelectionState::Result lastResult =
+      pLastResult ? pLastResult->getResult() : TileSelectionState::Result::None;
   markChildrenNonRendered(viewGroup, lastResult, tile, result);
 }
 
@@ -748,8 +764,10 @@ void markTileAndChildrenNonRendered(
     TilesetViewGroup& viewGroup,
     Tile& tile,
     ViewUpdateResult& result) {
-  const TileSelectionState::Result lastResult =
-      viewGroup.getPreviousSelectionState(tile).getResult();
+  const TileSelectionState* pLastResult =
+      viewGroup.getTraversalState().previousState();
+  TileSelectionState::Result lastResult =
+      pLastResult ? pLastResult->getResult() : TileSelectionState::Result::None;
   markTileNonRendered(lastResult, tile, result);
   markChildrenNonRendered(viewGroup, lastResult, tile, result);
 }
@@ -997,6 +1015,10 @@ Tileset::TraversalDetails Tileset::_visitTileIfNeeded(
     bool ancestorMeetsSse,
     Tile& tile,
     ViewUpdateResult& result) {
+  TilesetViewGroup::TraversalState& traversalState =
+      frameState.viewGroup.getTraversalState();
+
+  traversalState.beginNode(&tile);
 
   std::vector<double>& distances = this->_distances;
   computeDistances(tile, frameState.frustums, distances);
@@ -1045,13 +1067,10 @@ Tileset::TraversalDetails Tileset::_visitTileIfNeeded(
   }
 
   if (!cullResult.shouldVisit) {
-    const TileSelectionState lastFrameSelectionState =
-        frameState.viewGroup.getPreviousSelectionState(tile);
-
     markTileAndChildrenNonRendered(frameState.viewGroup, tile, result);
-    frameState.viewGroup.setCurrentSelectionState(
-        tile,
-        TileSelectionState(TileSelectionState::Result::Culled));
+
+    frameState.viewGroup.getTraversalState().currentState() =
+        TileSelectionState(TileSelectionState::Result::Culled);
 
     ++result.tilesCulled;
 
@@ -1067,10 +1086,8 @@ Tileset::TraversalDetails Tileset::_visitTileIfNeeded(
           TileLoadPriorityGroup::Normal,
           tilePriority);
 
-      traversalDetails = Tileset::createTraversalDetailsForSingleTile(
-          frameState,
-          tile,
-          lastFrameSelectionState);
+      traversalDetails =
+          Tileset::createTraversalDetailsForSingleTile(frameState, tile);
     } else if (this->_options.preloadSiblings) {
       // Preload this culled sibling as requested.
       addTileToLoadQueue(
@@ -1079,6 +1096,8 @@ Tileset::TraversalDetails Tileset::_visitTileIfNeeded(
           TileLoadPriorityGroup::Preload,
           tilePriority);
     }
+
+    traversalState.finishNode(&tile);
 
     return traversalDetails;
   }
@@ -1090,7 +1109,7 @@ Tileset::TraversalDetails Tileset::_visitTileIfNeeded(
   bool meetsSse =
       this->_meetsSse(frameState.frustums, tile, distances, cullResult.culled);
 
-  return this->_visitTile(
+  TraversalDetails details = this->_visitTile(
       frameState,
       depth,
       meetsSse,
@@ -1098,6 +1117,10 @@ Tileset::TraversalDetails Tileset::_visitTileIfNeeded(
       tile,
       tilePriority,
       result);
+
+  traversalState.finishNode(&tile);
+
+  return details;
 }
 
 namespace {
@@ -1109,13 +1132,8 @@ Tileset::TraversalDetails Tileset::_renderLeaf(
     Tile& tile,
     double tilePriority,
     ViewUpdateResult& result) {
-
-  const TileSelectionState lastFrameSelectionState =
-      frameState.viewGroup.getPreviousSelectionState(tile);
-
-  frameState.viewGroup.setCurrentSelectionState(
-      tile,
-      TileSelectionState(TileSelectionState::Result::Rendered));
+  frameState.viewGroup.getTraversalState().currentState() =
+      TileSelectionState(TileSelectionState::Result::Rendered);
   result.tilesToRenderThisFrame.push_back(&tile);
 
   addTileToLoadQueue(
@@ -1124,10 +1142,7 @@ Tileset::TraversalDetails Tileset::_renderLeaf(
       TileLoadPriorityGroup::Normal,
       tilePriority);
 
-  return Tileset::createTraversalDetailsForSingleTile(
-      frameState,
-      tile,
-      lastFrameSelectionState);
+  return Tileset::createTraversalDetailsForSingleTile(frameState, tile);
 }
 
 namespace {
@@ -1165,19 +1180,12 @@ Tileset::TraversalDetails Tileset::_renderInnerTile(
     Tile& tile,
     ViewUpdateResult& result) {
 
-  const TileSelectionState lastFrameSelectionState =
-      frameState.viewGroup.getPreviousSelectionState(tile);
-
   markChildrenNonRendered(frameState.viewGroup, tile, result);
-  frameState.viewGroup.setCurrentSelectionState(
-      tile,
-      TileSelectionState(TileSelectionState::Result::Rendered));
+  frameState.viewGroup.getTraversalState().currentState() =
+      TileSelectionState(TileSelectionState::Result::Rendered);
   result.tilesToRenderThisFrame.push_back(&tile);
 
-  return Tileset::createTraversalDetailsForSingleTile(
-      frameState,
-      tile,
-      lastFrameSelectionState);
+  return Tileset::createTraversalDetailsForSingleTile(frameState, tile);
 }
 
 bool Tileset::_loadAndRenderAdditiveRefinedTile(
@@ -1213,25 +1221,15 @@ bool Tileset::_kickDescendantsAndRenderTile(
     const TilesetViewGroup::LoadQueueCheckpoint& loadQueueBeforeChildren,
     bool queuedForLoad,
     double tilePriority) {
-  const TileSelectionState lastFrameSelectionState =
-      frameState.viewGroup.getPreviousSelectionState(tile);
-
-  std::vector<Tile*>& renderList = result.tilesToRenderThisFrame;
-
-  // Mark the rendered descendants and their ancestors - up to this tile - as
-  // kicked.
-  for (size_t i = firstRenderedDescendantIndex; i < renderList.size(); ++i) {
-    Tile* pWorkTile = renderList[i];
-    while (pWorkTile != nullptr &&
-           !frameState.viewGroup.getCurrentSelectionState(*pWorkTile)
-                .wasKicked() &&
-           pWorkTile != &tile) {
-      frameState.viewGroup.kick(*pWorkTile);
-      pWorkTile = pWorkTile->getParent();
-    }
-  }
+  // Mark all visited descendants of this tile as kicked.
+  TilesetViewGroup::TraversalState& traversalState =
+      frameState.viewGroup.getTraversalState();
+  traversalState.forEachCurrentDescendant(
+      [](const IntrusivePointer<const Tile>& /*pTile*/,
+         TileSelectionState& selectionState) { selectionState.kick(); });
 
   // Remove all descendants from the render list and add this tile.
+  std::vector<Tile*>& renderList = result.tilesToRenderThisFrame;
   renderList.erase(
       renderList.begin() +
           static_cast<std::vector<Tile*>::iterator::difference_type>(
@@ -1242,9 +1240,8 @@ bool Tileset::_kickDescendantsAndRenderTile(
     renderList.push_back(&tile);
   }
 
-  frameState.viewGroup.setCurrentSelectionState(
-      tile,
-      TileSelectionState(TileSelectionState::Result::Rendered));
+  traversalState.currentState() =
+      TileSelectionState(TileSelectionState::Result::Rendered);
 
   // If we're waiting on heaps of descendants, the above will take too long. So
   // in that case, load this tile INSTEAD of loading any of the descendants, and
@@ -1252,8 +1249,13 @@ bool Tileset::_kickDescendantsAndRenderTile(
   // actually manage to render this tile.
   // Make sure we don't end up waiting on a tile that will _never_ be
   // renderable.
-  const bool wasRenderedLastFrame = lastFrameSelectionState.getResult() ==
-                                    TileSelectionState::Result::Rendered;
+  const TileSelectionState* pLastFrameSelectionState =
+      traversalState.previousState();
+  TileSelectionState::Result lastFrameSelectionState =
+      pLastFrameSelectionState ? pLastFrameSelectionState->getResult()
+                               : TileSelectionState::Result::None;
+  const bool wasRenderedLastFrame =
+      lastFrameSelectionState == TileSelectionState::Result::Rendered;
   const bool wasReallyRenderedLastFrame =
       wasRenderedLastFrame && tile.isRenderable();
 
@@ -1400,12 +1402,15 @@ Tileset::TraversalDetails Tileset::_visitTile(
     Tile& tile,
     double tilePriority,
     ViewUpdateResult& result) {
+  TilesetViewGroup::TraversalState& traversalState =
+      frameState.viewGroup.getTraversalState();
+
   ++result.tilesVisited;
   result.maxDepthVisited = glm::max(result.maxDepthVisited, depth);
 
   // If this is a leaf tile, just render it (it's already been deemed visible).
   if (isLeaf(tile)) {
-    return _renderLeaf(frameState, tile, tilePriority, result);
+    return this->_renderLeaf(frameState, tile, tilePriority, result);
   }
 
   const bool unconditionallyRefine = tile.getUnconditionallyRefine();
@@ -1420,9 +1425,12 @@ Tileset::TraversalDetails Tileset::_visitTile(
   else
     action = VisitTileAction::Render;
 
-  const TileSelectionState lastFrameSelectionState =
-      frameState.viewGroup.getPreviousSelectionState(tile);
-  const TileSelectionState::Result lastFrameSelectionResult =
+  const TileSelectionState* pLastFrameSelectionState =
+      traversalState.previousState();
+  TileSelectionState lastFrameSelectionState =
+      pLastFrameSelectionState ? *pLastFrameSelectionState
+                               : TileSelectionState::Result::None;
+  TileSelectionState::Result lastFrameSelectionResult =
       lastFrameSelectionState.getResult();
 
   // If occlusion culling is enabled, we may not want to refine for two
@@ -1435,14 +1443,15 @@ Tileset::TraversalDetails Tileset::_visitTile(
   //   kicking off descendant loads that we later find to be unnecessary.
   bool tileLastRefined =
       lastFrameSelectionResult == TileSelectionState::Result::Refined;
+
   bool childLastRefined = false;
-  for (const Tile& child : tile.getChildren()) {
-    if (frameState.viewGroup.getPreviousSelectionState(child).getResult() ==
-        TileSelectionState::Result::Refined) {
-      childLastRefined = true;
-      break;
-    }
-  }
+  traversalState.forEachPreviousChild(
+      [&](const IntrusivePointer<const Tile>& /*pTile*/,
+          const TileSelectionState& state) {
+        if (state.getResult() == TileSelectionState::Result::Refined) {
+          childLastRefined = true;
+        }
+      });
 
   // If this tile and a child were both refined last frame, this tile does not
   // need occlusion results.
@@ -1460,8 +1469,8 @@ Tileset::TraversalDetails Tileset::_visitTile(
     } else if (
         occlusion == TileOcclusionState::OcclusionUnavailable &&
         this->_options.delayRefinementForOcclusion &&
-        frameState.viewGroup.getPreviousSelectionState(tile)
-                .getOriginalResult() != TileSelectionState::Result::Refined) {
+        lastFrameSelectionState.getOriginalResult() !=
+            TileSelectionState::Result::Refined) {
       ++result.tilesWaitingForOcclusionResults;
       action = VisitTileAction::Render;
       meetsSse = true;
@@ -1508,7 +1517,8 @@ Tileset::TraversalDetails Tileset::_visitTile(
             TileLoadPriorityGroup::Normal,
             tilePriority);
       }
-      return _renderInnerTile(frameState, tile, result);
+
+      return this->_renderInnerTile(frameState, tile, result);
     }
   }
 
@@ -1578,9 +1588,8 @@ Tileset::TraversalDetails Tileset::_visitTile(
       markTileNonRendered(frameState.viewGroup, tile, result);
     }
 
-    frameState.viewGroup.setCurrentSelectionState(
-        tile,
-        TileSelectionState(TileSelectionState::Result::Refined));
+    traversalState.currentState() =
+        TileSelectionState(TileSelectionState::Result::Refined);
   }
 
   if (this->_options.preloadAncestors && !queuedForLoad) {
@@ -1633,10 +1642,14 @@ void Tileset::addTileToLoadQueue(
 
 Tileset::TraversalDetails Tileset::createTraversalDetailsForSingleTile(
     const FrameState& frameState,
-    const Tile& tile,
-    const TileSelectionState& lastFrameSelectionState) {
+    const Tile& tile) {
+  TilesetViewGroup::TraversalState& traversalState =
+      frameState.viewGroup.getTraversalState();
+  const TileSelectionState* pLastFrameResult = traversalState.previousState();
   TileSelectionState::Result lastFrameResult =
-      lastFrameSelectionState.getResult();
+      pLastFrameResult ? pLastFrameResult->getResult()
+                       : TileSelectionState::Result::None;
+
   bool isRenderable = tile.isRenderable();
 
   bool wasRenderedLastFrame =
@@ -1654,11 +1667,12 @@ Tileset::TraversalDetails Tileset::createTraversalDetailsForSingleTile(
       // kicked just because _it_ wasn't rendered last frame (which could cause
       // a new hole to appear).
       for (const Tile& child : tile.getChildren()) {
-        TraversalDetails childDetails = createTraversalDetailsForSingleTile(
-            frameState,
-            child,
-            frameState.viewGroup.getPreviousSelectionState(child));
+        // TODO: this traversal of children might be redundant.
+        traversalState.beginNode(&child);
+        TraversalDetails childDetails =
+            createTraversalDetailsForSingleTile(frameState, child);
         wasRenderedLastFrame |= childDetails.anyWereRenderedLastFrame;
+        traversalState.finishNode(&child);
       }
     }
   }

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -287,9 +287,10 @@ void Tileset::_updateLodTransitions(
       }
 
       // Remove a tile from fade-out list if it is back on the render list.
-      pTile->decrementDoNotUnloadSubtreeCount(
-          "Tileset::_updateLodTransitions in render list");
-      result.tilesFadingOut.erase(pTile);
+      if (result.tilesFadingOut.erase(pTile) > 0) {
+        pTile->decrementDoNotUnloadSubtreeCount(
+            "Tileset::_updateLodTransitions in render list");
+      }
     }
   } else {
     // If there are any tiles still fading in, set them to fully visible right

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -691,7 +691,7 @@ const TilesetViewGroup& Tileset::getDefaultViewGroup() const {
 namespace {
 
 TileSelectionState
-getPreviousState(const TilesetViewGroup& viewGroup, const Tile& tile) {
+getPreviousState(const TilesetViewGroup& viewGroup, [[maybe_unused]] const Tile& tile) {
   const TilesetViewGroup::TraversalState& traversalState =
       viewGroup.getTraversalState();
   CESIUM_ASSERT(traversalState.getCurrentNode() == &tile);

--- a/Cesium3DTilesSelection/src/TilesetViewGroup.cpp
+++ b/Cesium3DTilesSelection/src/TilesetViewGroup.cpp
@@ -28,45 +28,6 @@ ViewUpdateResult& TilesetViewGroup::getViewUpdateResult() {
   return this->_updateResult;
 }
 
-// TileSelectionState
-// TilesetViewGroup::getPreviousSelectionState(const Tile& tile) const noexcept
-// {
-//   auto it = this->_previousSelectionStates.find(&tile);
-//   if (it == this->_previousSelectionStates.end()) {
-//     return TileSelectionState();
-//   } else {
-//     return it->second;
-//   }
-// }
-
-// TileSelectionState
-// TilesetViewGroup::getCurrentSelectionState(const Tile& tile) const noexcept {
-//   auto it = this->_currentSelectionStates.find(&tile);
-//   if (it == this->_currentSelectionStates.end()) {
-//     return TileSelectionState();
-//   } else {
-//     return it->second;
-//   }
-// }
-
-// void TilesetViewGroup::setCurrentSelectionState(
-//     const Tile& tile,
-//     const TileSelectionState& newState) noexcept {
-//   this->_currentSelectionStates[&tile] = newState;
-// }
-
-// void TilesetViewGroup::kick(const Tile& tile) noexcept {
-//   auto it = this->_currentSelectionStates.find(&tile);
-//   if (it == this->_currentSelectionStates.end()) {
-//     // There should already be a selection result for this tile prior to
-//     // kicking.
-//     CESIUM_ASSERT(false);
-//     return;
-//   } else {
-//     it->second.kick();
-//   }
-// }
-
 void TilesetViewGroup::addToLoadQueue(const TileLoadTask& task) {
   Tile* pTile = task.pTile;
   CESIUM_ASSERT(pTile != nullptr);

--- a/Cesium3DTilesSelection/src/TilesetViewGroup.cpp
+++ b/Cesium3DTilesSelection/src/TilesetViewGroup.cpp
@@ -1,5 +1,4 @@
 #include <Cesium3DTilesSelection/TileLoadTask.h>
-#include <Cesium3DTilesSelection/TileSelectionState.h>
 #include <Cesium3DTilesSelection/Tileset.h>
 #include <Cesium3DTilesSelection/TilesetViewGroup.h>
 #include <Cesium3DTilesSelection/ViewUpdateResult.h>

--- a/Cesium3DTilesSelection/src/TilesetViewGroup.cpp
+++ b/Cesium3DTilesSelection/src/TilesetViewGroup.cpp
@@ -28,43 +28,44 @@ ViewUpdateResult& TilesetViewGroup::getViewUpdateResult() {
   return this->_updateResult;
 }
 
-TileSelectionState
-TilesetViewGroup::getPreviousSelectionState(const Tile& tile) const noexcept {
-  auto it = this->_previousSelectionStates.find(&tile);
-  if (it == this->_previousSelectionStates.end()) {
-    return TileSelectionState();
-  } else {
-    return it->second;
-  }
-}
+// TileSelectionState
+// TilesetViewGroup::getPreviousSelectionState(const Tile& tile) const noexcept
+// {
+//   auto it = this->_previousSelectionStates.find(&tile);
+//   if (it == this->_previousSelectionStates.end()) {
+//     return TileSelectionState();
+//   } else {
+//     return it->second;
+//   }
+// }
 
-TileSelectionState
-TilesetViewGroup::getCurrentSelectionState(const Tile& tile) const noexcept {
-  auto it = this->_currentSelectionStates.find(&tile);
-  if (it == this->_currentSelectionStates.end()) {
-    return TileSelectionState();
-  } else {
-    return it->second;
-  }
-}
+// TileSelectionState
+// TilesetViewGroup::getCurrentSelectionState(const Tile& tile) const noexcept {
+//   auto it = this->_currentSelectionStates.find(&tile);
+//   if (it == this->_currentSelectionStates.end()) {
+//     return TileSelectionState();
+//   } else {
+//     return it->second;
+//   }
+// }
 
-void TilesetViewGroup::setCurrentSelectionState(
-    const Tile& tile,
-    const TileSelectionState& newState) noexcept {
-  this->_currentSelectionStates[&tile] = newState;
-}
+// void TilesetViewGroup::setCurrentSelectionState(
+//     const Tile& tile,
+//     const TileSelectionState& newState) noexcept {
+//   this->_currentSelectionStates[&tile] = newState;
+// }
 
-void TilesetViewGroup::kick(const Tile& tile) noexcept {
-  auto it = this->_currentSelectionStates.find(&tile);
-  if (it == this->_currentSelectionStates.end()) {
-    // There should already be a selection result for this tile prior to
-    // kicking.
-    CESIUM_ASSERT(false);
-    return;
-  } else {
-    it->second.kick();
-  }
-}
+// void TilesetViewGroup::kick(const Tile& tile) noexcept {
+//   auto it = this->_currentSelectionStates.find(&tile);
+//   if (it == this->_currentSelectionStates.end()) {
+//     // There should already be a selection result for this tile prior to
+//     // kicking.
+//     CESIUM_ASSERT(false);
+//     return;
+//   } else {
+//     it->second.kick();
+//   }
+// }
 
 void TilesetViewGroup::addToLoadQueue(const TileLoadTask& task) {
   Tile* pTile = task.pTile;
@@ -113,7 +114,7 @@ size_t TilesetViewGroup::restoreTileLoadQueueCheckpoint(
   size_t after =
       this->_workerThreadLoadQueue.size() + this->_mainThreadLoadQueue.size();
 
-  return after - before;
+  return before - after;
 }
 
 size_t TilesetViewGroup::getWorkerThreadLoadQueueLength() const {

--- a/Cesium3DTilesSelection/test/TestTilesetSelectionAlgorithm.cpp
+++ b/Cesium3DTilesSelection/test/TestTilesetSelectionAlgorithm.cpp
@@ -1,3 +1,4 @@
+#if false
 #include "SimplePrepareRendererResource.h"
 
 #include <Cesium3DTiles/GroupMetadata.h>
@@ -1715,3 +1716,4 @@ TEST_CASE("Additive-refined tiles are added to the tilesFadingOut array") {
   CHECK(updateResult.tilesToRenderThisFrame.size() == 2);
   CHECK(updateResult.tilesFadingOut.size() == 2);
 }
+#endif

--- a/Cesium3DTilesSelection/test/TestTilesetSelectionAlgorithm.cpp
+++ b/Cesium3DTilesSelection/test/TestTilesetSelectionAlgorithm.cpp
@@ -1,4 +1,3 @@
-#if false
 #include "SimplePrepareRendererResource.h"
 
 #include <Cesium3DTiles/GroupMetadata.h>
@@ -1594,15 +1593,15 @@ void runUnconditionallyRefinedTestCase(const TilesetOptions& options) {
   initializeTileset(tileset);
   const Tile& child = tileset.getRootTile()->getChildren()[0];
   const Tile& grandchild = child.getChildren()[0];
+
+  auto states = viewGroup.getTraversalState().slowlyGetCurrentStates();
+
   CHECK(
-      viewGroup.getPreviousSelectionState(*tileset.getRootTile()).getResult() ==
+      states[tileset.getRootTile()].getResult() ==
       TileSelectionState::Result::Refined);
+  CHECK(states[&child].getResult() == TileSelectionState::Result::Refined);
   CHECK(
-      viewGroup.getPreviousSelectionState(child).getResult() ==
-      TileSelectionState::Result::Refined);
-  CHECK(
-      viewGroup.getPreviousSelectionState(grandchild).getResult() ==
-      TileSelectionState::Result::Rendered);
+      states[&grandchild].getResult() == TileSelectionState::Result::Rendered);
 
   // After the third update, the root and child tiles have been loaded, while
   // the grandchild has not. But the child is unconditionally refined, so we
@@ -1610,15 +1609,15 @@ void runUnconditionallyRefinedTestCase(const TilesetOptions& options) {
   // the child and grandchild are kicked.
   initializeTileset(tileset);
   initializeTileset(tileset);
+
+  states = viewGroup.getTraversalState().slowlyGetCurrentStates();
+
   CHECK(
-      viewGroup.getPreviousSelectionState(*tileset.getRootTile()).getResult() ==
+      states[tileset.getRootTile()].getResult() ==
       TileSelectionState::Result::Rendered);
+  CHECK(states[&child].getResult() != TileSelectionState::Result::Rendered);
   CHECK(
-      viewGroup.getPreviousSelectionState(child).getResult() !=
-      TileSelectionState::Result::Rendered);
-  CHECK(
-      viewGroup.getPreviousSelectionState(grandchild).getResult() !=
-      TileSelectionState::Result::Rendered);
+      states[&grandchild].getResult() != TileSelectionState::Result::Rendered);
 
   REQUIRE(pRawLoader->_grandchildPromise);
 
@@ -1629,9 +1628,10 @@ void runUnconditionallyRefinedTestCase(const TilesetOptions& options) {
 
   initializeTileset(tileset);
 
+  states = viewGroup.getTraversalState().slowlyGetCurrentStates();
+
   CHECK(
-      viewGroup.getPreviousSelectionState(grandchild).getResult() ==
-      TileSelectionState::Result::Rendered);
+      states[&grandchild].getResult() == TileSelectionState::Result::Rendered);
 }
 
 } // namespace
@@ -1716,4 +1716,3 @@ TEST_CASE("Additive-refined tiles are added to the tilesFadingOut array") {
   CHECK(updateResult.tilesToRenderThisFrame.size() == 2);
   CHECK(updateResult.tilesFadingOut.size() == 2);
 }
-#endif

--- a/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
+++ b/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
@@ -151,9 +151,9 @@ public:
    * {@link finishNode}.
    *
    * After `finishNode`, this node's parent node becomes the "current" node.
-   * {@link previousState} and {@link nextState} will return
-   * previous the states of this node's parent. A call to {@link beginNode}
-   * will delineate a new child of that same parent.
+   * {@link previousState} and {@link currentState} will return
+   * the states of this node's parent. A call to {@link beginNode} will
+   * delineate a new child of that same parent.
    *
    * @param pNode The node that is done being traversed.
    */

--- a/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
+++ b/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
@@ -55,14 +55,14 @@ public:
    *
    * @param pNode The node traversed.
    */
-  void beginNode(TNodePointer pNode) {
+  void beginNode(const TNodePointer& pNode) {
     int64_t currentTraversalIndex = this->_currentTraversal.size();
     int64_t previousTraversalIndex = this->_previousTraversalNextNodeIndex;
 
     if (previousTraversalIndex >= 0 &&
-        previousTraversalIndex < int64_t(this->_previousTraversal.size())) {
+        size_t(previousTraversalIndex) < this->_previousTraversal.size()) {
       const TraversalData& previousData =
-          this->_previousTraversal[previousTraversalIndex];
+          this->_previousTraversal[size_t(previousTraversalIndex)];
       if (previousData.pNode == pNode) {
         ++this->_previousTraversalNextNodeIndex;
       } else {
@@ -157,7 +157,7 @@ public:
    *
    * @param pNode The node that is done being traversed.
    */
-  void finishNode([[maybe_unused]] TNodePointer pNode) {
+  void finishNode([[maybe_unused]] const TNodePointer& pNode) {
     // An assertion failure here indicates mismatched calls to beginNode /
     // finishNode.
     CESIUM_ASSERT(!this->_currentTraversal.empty());
@@ -200,7 +200,7 @@ public:
     const TraversalData& parentPreviousData =
         this->_previousTraversal[parentPreviousIndex];
 
-    for (size_t i = parentPreviousIndex + 1;
+    for (size_t i = size_t(parentPreviousIndex + 1);
          i < size_t(parentPreviousData.nextSiblingIndex);) {
       CESIUM_ASSERT(i < this->_previousTraversal.size());
       const TraversalData& data = this->_previousTraversal[i];
@@ -233,7 +233,7 @@ public:
     const TraversalData& parentPreviousData =
         this->_previousTraversal[parentPreviousIndex];
 
-    for (size_t i = parentPreviousIndex + 1;
+    for (size_t i = size_t(parentPreviousIndex + 1);
          i < size_t(parentPreviousData.nextSiblingIndex);
          ++i) {
       CESIUM_ASSERT(i < this->_previousTraversal.size());
@@ -347,7 +347,8 @@ private:
 
   TraversalData& currentData() {
     int64_t currentIndex = this->currentDataIndex();
-    return this->_currentTraversal[currentIndex];
+    CESIUM_ASSERT(currentIndex >= 0);
+    return this->_currentTraversal[size_t(currentIndex)];
   }
 
   const TraversalData& currentData() const {

--- a/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
+++ b/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
@@ -56,7 +56,7 @@ public:
    * @param pNode The node traversed.
    */
   void beginNode(const TNodePointer& pNode) {
-    int64_t currentTraversalIndex = this->_currentTraversal.size();
+    int64_t currentTraversalIndex = int64_t(this->_currentTraversal.size());
     int64_t previousTraversalIndex = this->_previousTraversalNextNodeIndex;
 
     if (previousTraversalIndex >= 0 &&
@@ -198,7 +198,7 @@ public:
     }
 
     const TraversalData& parentPreviousData =
-        this->_previousTraversal[parentPreviousIndex];
+        this->_previousTraversal[size_t(parentPreviousIndex)];
 
     for (size_t i = size_t(parentPreviousIndex + 1);
          i < size_t(parentPreviousData.nextSiblingIndex);) {
@@ -263,7 +263,7 @@ public:
         this->_currentTraversal[size_t(parentCurrentIndex)];
 
     size_t endIndex = parentCurrentData.nextSiblingIndex >= 0
-                          ? parentCurrentData.nextSiblingIndex
+                          ? size_t(parentCurrentData.nextSiblingIndex)
                           : this->_currentTraversal.size();
 
     for (size_t i = size_t(parentCurrentIndex + 1); i < endIndex; ++i) {

--- a/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
+++ b/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
@@ -231,7 +231,7 @@ public:
     }
 
     const TraversalData& parentPreviousData =
-        this->_previousTraversal[parentPreviousIndex];
+        this->_previousTraversal[size_t(parentPreviousIndex)];
 
     for (size_t i = size_t(parentPreviousIndex + 1);
          i < size_t(parentPreviousData.nextSiblingIndex);
@@ -260,7 +260,7 @@ public:
     CESIUM_ASSERT(parentCurrentIndex >= 0);
 
     const TraversalData& parentCurrentData =
-        this->_currentTraversal[parentCurrentIndex];
+        this->_currentTraversal[size_t(parentCurrentIndex)];
 
     size_t endIndex = parentCurrentData.nextSiblingIndex >= 0
                           ? parentCurrentData.nextSiblingIndex
@@ -353,7 +353,8 @@ private:
 
   const TraversalData& currentData() const {
     int64_t currentIndex = this->currentDataIndex();
-    return this->_currentTraversal[currentIndex];
+    CESIUM_ASSERT(currentIndex >= 0);
+    return this->_currentTraversal[size_t(currentIndex)];
   }
 
   std::unordered_map<TNodePointer, TState>

--- a/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
+++ b/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
@@ -80,6 +80,33 @@ public:
   }
 
   /**
+   * @brief Gets the current node in the traversal.beginNode
+   *
+   * When {@link beginNode} is called, the node passed to it becomes the
+   * current one. When {@link finishNode} is called, the parent node of the
+   * one passed to it becomes the current one.
+   *
+   * @return The current node, or nullptr if no traversal is in progress.
+   */
+  TNodePointer getCurrentNode() const noexcept {
+    if (this->_parentIndices.empty())
+      return nullptr;
+
+    return this->currentData().pNode;
+  }
+
+  /**
+   * @brief Determines if the current node was visited in the previous
+   * traversal.
+   *
+   * @return true if the current node was visited in the previous traversal;
+   * otherwise, false.
+   */
+  bool wasCurrentNodePreviouslyTraversed() const noexcept {
+    return this->previousState() != nullptr;
+  }
+
+  /**
    * @brief Gets the state of the current node on the previous traversal. The
    * current node is the one for which {@link beginNode} was most recently
    * called.
@@ -87,7 +114,7 @@ public:
    * @return The state on the previous traversal, or `nullptr` if the current
    * node was not traversed during the previous traversal.
    */
-  const TState* previousState() {
+  const TState* previousState() const {
     const TraversalData* pData = this->previousData();
     return pData ? &pData->state : nullptr;
   }

--- a/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
+++ b/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
@@ -1,0 +1,198 @@
+#pragma once
+
+#include <CesiumUtility/Assert.h>
+
+namespace CesiumUtility {
+
+/**
+ * @brief Associates state (arbitrary data) with each node during partial,
+ * depth-first traversal of a tree. Then, during a later traversal of a
+ * potentially different subset of the same tree, the state previously
+ * associated with each node can be looked up.
+ *
+ * In order to operate efficiently, this class makes some assumptions. Violation
+ * of these assumptions can lead to undefined behavior.
+ *
+ * 1. Nodes are identified by pointer. It is _not_ required that all nodes
+ * previously traversed remain valid in a later traversal. However, if a new
+ * node instance is created at the same memory address as a previous one, it
+ * will be considered the same node.
+ * 2. The entire tree is not necessarily traversed each time. However, if any
+ * children of a tile are traversed, then _all_ children of the tile must be
+ * traversed.
+ * 3. The order of traversal of children must be the same every time.
+ * 4. A node that previously had no children may gain them. A node that
+ * previously had children may lose all of them. However, partial updates of the
+ * children of a node are not allowed.
+ *
+ * @tparam TNodePointer The type of each node in the tree.
+ * @tparam TState The state to associate with each node.
+ */
+template <typename TNodePointer, typename TState> class TreeTraversalState {
+public:
+  void beginTraversal() {
+    std::swap(this->_previousTraversal, this->_currentTraversal);
+    this->_currentTraversal.clear();
+    this->_previousTraversalIndex = -1;
+    this->_currentTraversalIndex = -1;
+  }
+
+  void beginNode(TNodePointer pNode) {
+    this->_currentTraversalIndex = this->_currentTraversal.size();
+
+    this->_parentIndices.emplace_back(this->_currentTraversal.size());
+    this->_currentTraversal.emplace_back(TraversalData{pNode, -1, TState()});
+
+    int64_t oldPreviousTraversalIndex = this->_previousTraversalIndex;
+    ++this->_previousTraversalIndex;
+
+    CESIUM_ASSERT(this->_previousTraversalIndex >= 0);
+
+    // Find this node in the previous traversal, if it exists.
+    if (size_t(this->_previousTraversalIndex) <
+        this->_previousTraversal.size()) {
+      TraversalData& previousData =
+          this->_previousTraversal[this->_previousTraversalIndex];
+      if (previousData.pNode != pNode) {
+        // The node we're currently visiting does not match the one that was
+        // visited here in the previous traversal. There are two possibilities:
+        //
+        // 1. We're visiting the first child of the previous node, and in the
+        // previous traversal the previous node either didn't have any children
+        // or they weren't visited.
+        // 2. We're visiting the next sibling of the previous node, because the
+        // previous node either doesn't have any children or they're not being
+        // visited. In the previous traversal, the previous node had children
+        // and we visited them.
+        //
+        // We can distinguish these cases by looking at the previous entry's
+        // `nextSiblingIndex`. In case (1), the `nextSiblingIndex` will equal
+        // the current `previousTraversalIndex`. In case (2), it will tell us
+        // how many nodes in the previous traversal to skip.
+        if (oldPreviousTraversalIndex >= 0) {
+          TraversalData& oldData =
+              this->_previousTraversal[oldPreviousTraversalIndex];
+          if (oldData.nextSiblingIndex == this->_previousTraversalIndex) {
+            // Case 1 - visiting a child that was previous unvisited.
+            // Hold the position in the previous traversal.
+            this->_previousTraversalIndex = oldPreviousTraversalIndex;
+          } else {
+            // Case 2 - skipping children that were previously visited.
+            this->_previousTraversalIndex = oldData.nextSiblingIndex;
+            CESIUM_ASSERT(
+                this->_previousTraversalIndex >= 0 &&
+                size_t(this->_previousTraversalIndex) <
+                    this->_previousTraversal.size() &&
+                this->_previousTraversal[this->_previousTraversalIndex].pNode ==
+                    pNode);
+          }
+        }
+      }
+    }
+  }
+
+  const TState* previousState() {
+    const TraversalData* pData = this->previousData();
+    return pData ? &pData->state : nullptr;
+  }
+
+  TState& currentState() {
+    TraversalData& data = this->currentData();
+    return data.state;
+  }
+
+  void finishNode(TNodePointer pNode) {
+    CESIUM_ASSERT(!this->_currentTraversal.empty());
+    CESIUM_ASSERT(!this->_parentIndices.empty());
+    CESIUM_ASSERT(
+        int64_t(this->_parentIndices.back()) == this->_currentTraversalIndex);
+    CESIUM_ASSERT(
+        this->_currentTraversalIndex >= 0 &&
+        size_t(this->_currentTraversalIndex) < this->_currentTraversal.size());
+
+    this->_parentIndices.pop_back();
+    this->_currentTraversal[this->_currentTraversalIndex].nextSiblingIndex =
+        int64_t(this->_currentTraversal.size());
+    this->_currentTraversalIndex =
+        this->_parentIndices.empty() ? -1 : this->_parentIndices.back();
+  }
+
+  template <typename Func> void forEachPreviousChild(Func&& callback) {
+    const TraversalData* pPrevious = this->previousData();
+    if (!pPrevious)
+      return;
+
+    for (size_t i = size_t(this->_previousTraversalIndex + 1);
+         i < size_t(pPrevious->nextSiblingIndex);) {
+      TraversalData& data = this->_previousTraversal[i];
+      callback(data.pNode, data.state);
+      CESIUM_ASSERT(
+          data.nextSiblingIndex >= 0 && size_t(data.nextSiblingIndex) > i);
+      i = size_t(data.nextSiblingIndex);
+    }
+  }
+
+  template <typename Func> void forEachPreviousDescendant(Func&& callback) {
+    const TraversalData* pPrevious = this->previousData();
+    if (!pPrevious)
+      return;
+
+    for (size_t i = size_t(this->_previousTraversalIndex + 1);
+         i < size_t(pPrevious->nextSiblingIndex);
+         ++i) {
+      TraversalData& data = this->_previousTraversal[i];
+      callback(data.pNode, data.state);
+    }
+  }
+
+  template <typename Func> void forEachCurrentDescendant(Func&& callback) {
+    for (size_t i = size_t(this->_currentTraversalIndex + 1);
+         i < this->_currentTraversal.size();
+         ++i) {
+      TraversalData& data = this->_currentTraversal[i];
+      callback(data.pNode, data.state);
+    }
+  }
+
+private:
+  struct TraversalData {
+    TNodePointer pNode;
+    int64_t nextSiblingIndex;
+    TState state;
+  };
+
+  const TraversalData* previousData() {
+    if (this->_previousTraversalIndex >= 0 &&
+        size_t(this->_previousTraversalIndex) <
+            this->_previousTraversal.size()) {
+      CESIUM_ASSERT(
+          this->_currentTraversalIndex >= 0 &&
+          size_t(this->_currentTraversalIndex) <
+              this->_currentTraversal.size());
+      TNodePointer pCurrentNode =
+          this->_currentTraversal[this->_currentTraversalIndex].pNode;
+      const TraversalData& previousData =
+          this->_previousTraversal[this->_previousTraversalIndex];
+      if (previousData.pNode == pCurrentNode) {
+        return &previousData;
+      }
+    }
+
+    return nullptr;
+  }
+
+  TraversalData& currentData() {
+    CESIUM_ASSERT(
+        this->_currentTraversalIndex >= 0 &&
+        size_t(this->_currentTraversalIndex) < this->_currentTraversal.size());
+    return this->_currentTraversal[this->_currentTraversalIndex];
+  }
+
+  std::vector<TraversalData> _previousTraversal;
+  std::vector<TraversalData> _currentTraversal;
+  std::vector<size_t> _parentIndices;
+  int64_t _previousTraversalIndex;
+  int64_t _currentTraversalIndex;
+};
+
+} // namespace CesiumUtility

--- a/CesiumUtility/test/TestTreeTraversalState.cpp
+++ b/CesiumUtility/test/TestTreeTraversalState.cpp
@@ -1,0 +1,314 @@
+#include <CesiumUtility/TreeTraversalState.h>
+
+#include <doctest/doctest.h>
+
+#include <string>
+
+using namespace CesiumUtility;
+
+namespace {
+
+struct Node {
+  std::string name;
+};
+
+} // namespace
+
+TEST_CASE("TreeTraversalState") {
+  SUBCASE("Three Levels") {
+    Node a{"a"}, b{"b"}, c{"c"}, d{"d"}, e{"e"}, f{"f"};
+    TreeTraversalState<Node*, int> traversalState;
+
+    //           a
+    //         / | \
+    //        b  c  d
+    //          / \
+    //         e   f
+    // clang-format off
+    traversalState.beginNode(&a);
+      traversalState.currentState() = 1;
+
+      traversalState.beginNode(&b);
+        traversalState.currentState() = 2;
+      traversalState.finishNode(&b);
+
+      traversalState.beginNode(&c);
+        traversalState.currentState() = 3;
+
+        traversalState.beginNode(&e);
+          traversalState.currentState() = 5;
+        traversalState.finishNode(&e);
+
+        traversalState.beginNode(&f);
+          traversalState.currentState() = 6;
+        traversalState.finishNode(&f);
+
+      traversalState.finishNode(&c);
+
+      traversalState.beginNode(&d);
+        traversalState.currentState() = 4;
+      traversalState.finishNode(&d);
+
+    traversalState.finishNode(&a);
+    // clang-format on
+
+    SUBCASE("First traversal captures current states") {
+      auto map = traversalState.slowlyGetCurrentStates();
+      CHECK(map[&a] == 1);
+      CHECK(map[&b] == 2);
+      CHECK(map[&c] == 3);
+      CHECK(map[&d] == 4);
+      CHECK(map[&e] == 5);
+      CHECK(map[&f] == 6);
+    }
+
+    SUBCASE("First traversal does not populate previous") {
+      CHECK(traversalState.slowlyGetPreviousStates().empty());
+    }
+
+    SUBCASE("beginTraversal moves current to previous") {
+      traversalState.beginTraversal();
+      CHECK(!traversalState.slowlyGetPreviousStates().empty());
+      CHECK(traversalState.slowlyGetCurrentStates().empty());
+    }
+
+    SUBCASE("Second identical traversal can access previous states") {
+      traversalState.beginTraversal();
+
+      // clang-format off
+      traversalState.beginNode(&a);
+        REQUIRE(traversalState.previousState() != nullptr);
+        CHECK(*traversalState.previousState() == 1);
+
+        traversalState.beginNode(&b);
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 2);
+        traversalState.finishNode(&b);
+
+        traversalState.beginNode(&c);
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 3);
+
+          traversalState.beginNode(&e);
+            REQUIRE(traversalState.previousState() != nullptr);
+            CHECK(*traversalState.previousState() == 5);
+          traversalState.finishNode(&e);
+
+          traversalState.beginNode(&f);
+            REQUIRE(traversalState.previousState() != nullptr);
+            CHECK(*traversalState.previousState() == 6);
+          traversalState.finishNode(&f);
+
+        traversalState.finishNode(&c);
+
+        traversalState.beginNode(&d);
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 4);
+        traversalState.finishNode(&d);
+
+      traversalState.finishNode(&a);
+      // clang-format on
+    }
+
+    SUBCASE("Second traversal can skip children") {
+      traversalState.beginTraversal();
+
+      // clang-format off
+      traversalState.beginNode(&a);
+        REQUIRE(traversalState.previousState() != nullptr);
+        CHECK(*traversalState.previousState() == 1);
+
+        traversalState.beginNode(&b);
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 2);
+        traversalState.finishNode(&b);
+
+        traversalState.beginNode(&c);
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 3);
+        traversalState.finishNode(&c);
+
+        traversalState.beginNode(&d);
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 4);
+        traversalState.finishNode(&d);
+
+      traversalState.finishNode(&a);
+      // clang-format on
+    }
+
+    SUBCASE("Second traversal can visit new children") {
+      Node g{"g"};
+
+      traversalState.beginTraversal();
+
+      // clang-format off
+      traversalState.beginNode(&a);
+        REQUIRE(traversalState.previousState() != nullptr);
+        CHECK(*traversalState.previousState() == 1);
+
+        traversalState.beginNode(&b);
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 2);
+        traversalState.finishNode(&b);
+
+        traversalState.beginNode(&c);
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 3);
+
+          traversalState.beginNode(&e);
+            REQUIRE(traversalState.previousState() != nullptr);
+            CHECK(*traversalState.previousState() == 5);
+
+            traversalState.beginNode(&g);
+              CHECK(traversalState.previousState() == nullptr);
+              traversalState.currentState() = 7;
+            traversalState.finishNode(&g);
+
+          traversalState.finishNode(&e);
+
+          traversalState.beginNode(&f);
+            REQUIRE(traversalState.previousState() != nullptr);
+            CHECK(*traversalState.previousState() == 6);
+          traversalState.finishNode(&f);
+
+        traversalState.finishNode(&c);
+
+        traversalState.beginNode(&d);
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 4);
+        traversalState.finishNode(&d);
+
+      traversalState.finishNode(&a);
+      // clang-format on
+    }
+
+    SUBCASE("Second traversal can add two new levels") {
+      Node g{"g"}, h{"h"};
+
+      traversalState.beginTraversal();
+
+      // clang-format off
+      traversalState.beginNode(&a);
+        REQUIRE(traversalState.previousState() != nullptr);
+        CHECK(*traversalState.previousState() == 1);
+
+        traversalState.beginNode(&b);
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 2);
+        traversalState.finishNode(&b);
+
+        traversalState.beginNode(&c);
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 3);
+
+          traversalState.beginNode(&e);
+            REQUIRE(traversalState.previousState() != nullptr);
+            CHECK(*traversalState.previousState() == 5);
+
+            traversalState.beginNode(&g);
+              CHECK(traversalState.previousState() == nullptr);
+              traversalState.currentState() = 7;
+
+              traversalState.beginNode(&h);
+                CHECK(traversalState.previousState() == nullptr);
+                traversalState.currentState() = 8;
+              traversalState.finishNode(&h);
+            traversalState.finishNode(&g);
+
+          traversalState.finishNode(&e);
+
+          traversalState.beginNode(&f);
+            REQUIRE(traversalState.previousState() != nullptr);
+            CHECK(*traversalState.previousState() == 6);
+          traversalState.finishNode(&f);
+
+        traversalState.finishNode(&c);
+
+        traversalState.beginNode(&d);
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 4);
+        traversalState.finishNode(&d);
+
+      traversalState.finishNode(&a);
+      // clang-format on
+    }
+  }
+
+  SUBCASE("Four Levels") {
+    Node a{"a"}, b{"b"}, c{"c"}, d{"d"}, e{"e"}, f{"f"}, g{"g"}, h{"h"};
+    TreeTraversalState<Node*, int> traversalState;
+
+    //           a
+    //         / | \
+    //        b  c  d
+    //          / \
+    //         e   f
+    //        / \
+    //       g   h
+    // clang-format off
+    traversalState.beginNode(&a);
+      traversalState.currentState() = 1;
+
+      traversalState.beginNode(&b);
+        traversalState.currentState() = 2;
+      traversalState.finishNode(&b);
+
+      traversalState.beginNode(&c);
+        traversalState.currentState() = 3;
+
+        traversalState.beginNode(&e);
+          traversalState.currentState() = 5;
+
+          traversalState.beginNode(&g);
+            CHECK(traversalState.previousState() == nullptr);
+            traversalState.currentState() = 7;
+          traversalState.finishNode(&g);
+
+          traversalState.beginNode(&h);
+            CHECK(traversalState.previousState() == nullptr);
+            traversalState.currentState() = 8;
+          traversalState.finishNode(&h);
+        traversalState.finishNode(&e);
+
+        traversalState.beginNode(&f);
+          traversalState.currentState() = 6;
+        traversalState.finishNode(&f);
+
+      traversalState.finishNode(&c);
+
+      traversalState.beginNode(&d);
+        traversalState.currentState() = 4;
+      traversalState.finishNode(&d);
+
+    traversalState.finishNode(&a);
+    // clang-format on
+
+    SUBCASE("Second traversal can skip two levels") {
+      traversalState.beginTraversal();
+
+      // clang-format off
+      traversalState.beginNode(&a);
+        REQUIRE(traversalState.previousState() != nullptr);
+        CHECK(*traversalState.previousState() == 1);
+
+        traversalState.beginNode(&b);
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 2);
+        traversalState.finishNode(&b);
+
+        traversalState.beginNode(&c);
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 3);
+        traversalState.finishNode(&c);
+
+        traversalState.beginNode(&d);
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 4);
+        traversalState.finishNode(&d);
+
+      traversalState.finishNode(&a);
+      // clang-format on
+    }
+  }
+}

--- a/CesiumUtility/test/TestTreeTraversalState.cpp
+++ b/CesiumUtility/test/TestTreeTraversalState.cpp
@@ -233,6 +233,71 @@ TEST_CASE("TreeTraversalState") {
       traversalState.finishNode(&a);
       // clang-format on
     }
+
+    SUBCASE(
+        "Can access both current and previous states after child finishNode") {
+      traversalState.beginTraversal();
+
+      // clang-format off
+      traversalState.beginNode(&a);
+        traversalState.currentState() = 1;
+
+        traversalState.beginNode(&b);
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 2);
+        traversalState.finishNode(&b);
+
+        REQUIRE(traversalState.previousState() != nullptr);
+        CHECK(*traversalState.previousState() == 1);
+        CHECK(traversalState.currentState() == 1);
+        traversalState.currentState() = 100;
+        CHECK(traversalState.currentState() == 100);
+
+        traversalState.beginNode(&c);
+          traversalState.currentState() = 3;
+
+          traversalState.beginNode(&e);
+            REQUIRE(traversalState.previousState() != nullptr);
+            CHECK(*traversalState.previousState() == 5);
+          traversalState.finishNode(&e);
+
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 3);
+          CHECK(traversalState.currentState() == 3);
+          traversalState.currentState() = 300;
+          CHECK(traversalState.currentState() == 300);
+
+          traversalState.beginNode(&f);
+            REQUIRE(traversalState.previousState() != nullptr);
+            CHECK(*traversalState.previousState() == 6);
+          traversalState.finishNode(&f);
+
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 3);
+          CHECK(traversalState.currentState() == 300);
+          traversalState.currentState() = 350;
+          CHECK(traversalState.currentState() == 350);
+        traversalState.finishNode(&c);
+
+        REQUIRE(traversalState.previousState() != nullptr);
+        CHECK(*traversalState.previousState() == 1);
+        CHECK(traversalState.currentState() == 100);
+        traversalState.currentState() = 150;
+        CHECK(traversalState.currentState() == 150);
+
+        traversalState.beginNode(&d);
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 4);
+        traversalState.finishNode(&d);
+
+        REQUIRE(traversalState.previousState() != nullptr);
+        CHECK(*traversalState.previousState() == 1);
+        CHECK(traversalState.currentState() == 150);
+        traversalState.currentState() = 175;
+        CHECK(traversalState.currentState() == 175);
+      traversalState.finishNode(&a);
+      // clang-format on
+    }
   }
 
   SUBCASE("Four Levels") {
@@ -310,5 +375,99 @@ TEST_CASE("TreeTraversalState") {
       traversalState.finishNode(&a);
       // clang-format on
     }
+  }
+
+  SUBCASE("Node with children after a node where they're added") {
+    Node a{"a"}, b{"b"}, c{"c"}, d{"d"}, e{"e"}, f{"f"}, g{"g"};
+    TreeTraversalState<Node*, int> traversalState;
+
+    // First traversal:
+    //           a
+    //         /  \
+    //        b    c
+    //            / \
+    //           d   e
+
+    // Second traversal:
+    //           a
+    //         /  \
+    //        b    c
+    //       /    / \
+    //      f    d   e
+    //     /
+    //    g
+
+    traversalState.beginTraversal();
+
+    // clang-format off
+    traversalState.beginNode(&a);
+      traversalState.currentState() = 1;
+
+      traversalState.beginNode(&b);
+        traversalState.currentState() = 2;
+      traversalState.finishNode(&b);
+
+      traversalState.beginNode(&c);
+        traversalState.currentState() = 3;
+
+        traversalState.beginNode(&d);
+          traversalState.currentState() = 4;
+        traversalState.finishNode(&d);
+
+        traversalState.beginNode(&e);
+          traversalState.currentState() = 5;
+        traversalState.finishNode(&e);
+
+      traversalState.finishNode(&c);
+
+    traversalState.finishNode(&a);
+    // clang-format on
+
+    traversalState.beginTraversal();
+
+    // clang-format off
+    traversalState.beginNode(&a);
+      traversalState.currentState() = 1;
+      REQUIRE(traversalState.previousState() != nullptr);
+      CHECK(*traversalState.previousState() == 1);
+
+      traversalState.beginNode(&b);
+        traversalState.currentState() = 2;
+        REQUIRE(traversalState.previousState() != nullptr);
+        CHECK(*traversalState.previousState() == 2);
+
+        traversalState.beginNode(&f);
+          traversalState.currentState() = 6;
+          REQUIRE(traversalState.previousState() == nullptr);
+
+          traversalState.beginNode(&g);
+            traversalState.currentState() = 7;
+            REQUIRE(traversalState.previousState() == nullptr);
+          traversalState.finishNode(&g);
+        traversalState.finishNode(&f);
+
+      traversalState.finishNode(&b);
+
+      traversalState.beginNode(&c);
+        traversalState.currentState() = 3;
+        REQUIRE(traversalState.previousState() != nullptr);
+        CHECK(*traversalState.previousState() == 3);
+
+        traversalState.beginNode(&d);
+          traversalState.currentState() = 4;
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 4);
+        traversalState.finishNode(&d);
+
+        traversalState.beginNode(&e);
+          traversalState.currentState() = 5;
+          REQUIRE(traversalState.previousState() != nullptr);
+          CHECK(*traversalState.previousState() == 5);
+        traversalState.finishNode(&e);
+
+      traversalState.finishNode(&c);
+
+    traversalState.finishNode(&a);
+    // clang-format on
   }
 }

--- a/CesiumUtility/test/TestTreeTraversalState.cpp
+++ b/CesiumUtility/test/TestTreeTraversalState.cpp
@@ -19,11 +19,13 @@ TEST_CASE("TreeTraversalState") {
     Node a{"a"}, b{"b"}, c{"c"}, d{"d"}, e{"e"}, f{"f"};
     TreeTraversalState<Node*, int> traversalState;
 
-    //           a
-    //         / | \
-    //        b  c  d
-    //          / \
-    //         e   f
+    /*
+     *       a
+     *     / | \
+     *    b  c  d
+     *      / \
+     *     e   f
+     */
     // clang-format off
     traversalState.beginNode(&a);
       traversalState.currentState() = 1;
@@ -304,13 +306,15 @@ TEST_CASE("TreeTraversalState") {
     Node a{"a"}, b{"b"}, c{"c"}, d{"d"}, e{"e"}, f{"f"}, g{"g"}, h{"h"};
     TreeTraversalState<Node*, int> traversalState;
 
-    //           a
-    //         / | \
-    //        b  c  d
-    //          / \
-    //         e   f
-    //        / \
-    //       g   h
+    /*
+     *       a
+     *     / | \
+     *    b  c  d
+     *      / \
+     *     e   f
+     *    / \
+     *   g   h
+     */
     // clang-format off
     traversalState.beginNode(&a);
       traversalState.currentState() = 1;
@@ -381,21 +385,25 @@ TEST_CASE("TreeTraversalState") {
     Node a{"a"}, b{"b"}, c{"c"}, d{"d"}, e{"e"}, f{"f"}, g{"g"};
     TreeTraversalState<Node*, int> traversalState;
 
-    // First traversal:
-    //           a
-    //         /  \
-    //        b    c
-    //            / \
-    //           d   e
+    /*
+     * First traversal:
+     *      a
+     *    /  \
+     *   b    c
+     *       / \
+     *      d   e
+     */
 
-    // Second traversal:
-    //           a
-    //         /  \
-    //        b    c
-    //       /    / \
-    //      f    d   e
-    //     /
-    //    g
+    /*
+     * Second traversal:
+     *         a
+     *       /  \
+     *      b    c
+     *     /    / \
+     *    f    d   e
+     *   /
+     *  g
+     */
 
     traversalState.beginTraversal();
 


### PR DESCRIPTION
This is a PR into #1125. I'm going to merge it myself, this PR is just for visibility.

Prior to #1125, the "last selection state" of each tile was stored in a field on the tile. With #1125, this is no longer viable, because a separate selection state is needed per view group. So, in that PR, I did the obvious thing of storing the selection state in a hash table indexed by `Tile` pointer. That worked fine, but it noticeably slowed down the `updateView` process (by about 20% in my quick tests) because we look up a _lot_ of tile selection states.

This PR replaces the hashtable with a different scheme that requires more careful bookkeeping, but is drastically faster. Selection states are kept in a new class called `TreeTraversalState`, which is a template and not specific to `Tile`. This class maintains per-node/tile states in an array that is parallel to the `Tile` tree in its depth-first traversal order. The trick is that different tiles may be visited from one traversal to the next (because of tile load/unloads, culling changes, or refinement changes), so some careful accounting is needed to ensure that the state from the last traversal may still be accessed during the current, potentially different, traversal.

`TreeTraversalState` achieves this with a few rules about how the traversal may change (documented in the doxygen for that class), plus a `nextSiblingIndex` stored with each visited tile that points to the next tile in the traversal array that is not a child/descendant of the current one. The `nextSiblingIndex` allows us to skip descendants from the last traversal that are not visited this traversal, and it allows us to identify new children/descendants visited this traversal that weren't visited in the previous one.

The biggest downside to this (aside from the complexity, which I've tried to ameliorate with tests and lots of assertions) is that it's no longer possible to quickly look up the previous selection state of an arbitrary tile. Looking up the previous selection state of the _current_ tile during a traversal is simple and fast, but lookups outside the normal flow are going to be very slow at best. This wasn't really a problem outside of test and debug code, though.

In this PR, I'm no longer able to measure a performance impact from tile selection state tracking.
