### PR TITLE
GltfReader.cpp: call Uri::resolve() with useBaseQuery = true.

### DIFF
--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -537,7 +537,7 @@ void CesiumGltfReader::GltfReader::postprocessGltf(
     if (buffer.uri && buffer.uri->substr(0, dataPrefixLength) != dataPrefix) {
       resolvedBuffers.push_back(
           pAssetAccessor
-              ->get(asyncSystem, Uri::resolve(baseUrl, *buffer.uri), tHeaders)
+              ->get(asyncSystem, Uri::resolve(baseUrl, *buffer.uri, true), tHeaders)
               .thenInWorkerThread([pBuffer =
                                        &buffer](std::shared_ptr<IAssetRequest>&&
                                                     pRequest) {
@@ -573,7 +573,7 @@ void CesiumGltfReader::GltfReader::postprocessGltf(
   if (options.resolveExternalImages) {
     for (Image& image : pResult->model->images) {
       if (image.uri && image.uri->substr(0, dataPrefixLength) != dataPrefix) {
-        const std::string uri = Uri::resolve(baseUrl, *image.uri);
+        const std::string uri = Uri::resolve(baseUrl, *image.uri, true);
 
         auto getAsset =
             [&options](
@@ -646,7 +646,7 @@ void CesiumGltfReader::GltfReader::postprocessGltf(
       }
     };
 
-    std::string uri = Uri::resolve(baseUrl, *pStructuralMetadata->schemaUri);
+    std::string uri = Uri::resolve(baseUrl, *pStructuralMetadata->schemaUri, true);
 
     SharedFuture<ResultPointer<Schema>> future =
         getAsset(asyncSystem, pAssetAccessor, uri, tHeaders);


### PR DESCRIPTION
This is needed to fetch the textures used by tilesets coming from the Bentley mesh export service,
because the base URL contains authorization info in its parameters, which must be kept when requesting the textures.

For example, the base url looks like this:
https://xxx/tileset.json?sv=2024-05-04&spr=https&se=yyy...
The query part (everything after the question mark) contains the authorization info.
This part must be kept when building the URL for downloading textures (or buffers).

I think this is a bug, since useBaseQuery = true is already set when downloading the gltf meshes themselves.