### PR TITLE
Add -ftime-trace option for clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ option(CESIUM_GLM_STRICT_ENABLED "Whether to force strict GLM compile definition
 option(CESIUM_DISABLE_DEFAULT_ELLIPSOID "Whether to disable the WGS84 default value for ellipsoid parameters across cesium-native." OFF)
 option(CESIUM_MSVC_STATIC_RUNTIME_ENABLED "Whether to enable static linking for MSVC runtimes" OFF)
 option(CESIUM_DEBUG_TILE_UNLOADING "Whether to enable tracking of tile _doNotUnloadSubtreeCount modifications for tile unloading debugging." OFF)
+option(CESIUM_CLANG_TIME_TRACE "Whether to enable the -ftime-trace compilation option when building with Clang." OFF)
 
 if (CESIUM_MSVC_STATIC_RUNTIME_ENABLED)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

--- a/cmake/macros/configure_cesium_library.cmake
+++ b/cmake/macros/configure_cesium_library.cmake
@@ -26,6 +26,10 @@ function(configure_cesium_library targetName)
         )
     endif()
 
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CESIUM_CLANG_TIME_TRACE)
+        target_compile_options(${targetName} PRIVATE -ftime-trace)
+    endif()
+
     if (CESIUM_DEBUG_TILE_UNLOADING)
         target_compile_definitions(
             ${targetName}


### PR DESCRIPTION
Closes #1066. This is a very small change that adds a `CESIUM_CLANG_TIME_TRACE` option to the CMake build process which will add the `-ftime-trace` option to the Clang command line. This option [generates JSON files compatible with the Chrome profiler](https://aras-p.info/blog/2019/01/16/time-trace-timeline-flame-chart-profiler-for-Clang/) for each object compiled. This alone is kinda neat, but it gets particularly useful when we use it in conjunction with [ClangBuildAnalyzer](https://github.com/aras-p/ClangBuildAnalyzer). This will collate all of the individual JSON files and produce a report on the whole build process.

I've [attached a report](https://github.com/user-attachments/files/19391764/report.txt) generated using the following commands:
```
cmake -B build -S . -DCESIUM_CLANG_TIME_TRACE=1
ClangBuildAnalyzer --start build
cmake --build build --config debug --target cesium-native-tests -j22
ClangBuildAnalyzer --stop build session.dat
ClangBuildAnalyzer --analyze session.dat
```
