### PR TITLE
Fix memory leak in GltfReader::postprocessGltf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed missing URI query part when downloading glTF textures or buffers.
+- Fixed memory leak in `CesiumGltfReader`.
 
 ### v0.45.0 - 2025-03-03
 

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -699,7 +699,7 @@ void CesiumGltfReader::GltfReader::postprocessGltf(
               }
             }
 
-            return std::move(*pResult.release());
+            return std::move(*pResult);
           });
 }
 

--- a/CesiumGltfReader/src/GltfReader.cpp
+++ b/CesiumGltfReader/src/GltfReader.cpp
@@ -672,7 +672,7 @@ void CesiumGltfReader::GltfReader::postprocessGltf(
   return asyncSystem.all(std::move(resolvedBuffers))
       .thenInWorkerThread(
           [pResult = std::move(pResult)](
-              std::vector<ExternalBufferLoadResult>&& loadResults) mutable {
+              std::vector<ExternalBufferLoadResult>&& loadResults) {
             for (auto& bufferResult : loadResults) {
               if (!bufferResult.success) {
                 pResult->warnings.push_back(


### PR DESCRIPTION
A vsgCs user provided an ASAN log that showed that GltfReader::postprocessGltf() was leaking, and the problem was that release() was called on the unique_ptr pointing to the GltfReaderResult before it was moved. Unless I'm missing some subtlety, it should be fine to do the move and then let the unique_ptr destructor deallocate / destroy that object; that happpens after the lambda body is exited.