### PR TITLE
Revert to CESIUM_ASSERT instead of static_assert.

### DIFF
--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -133,7 +133,8 @@ template <typename ElementType>
 ElementType assembleVecNValue(const std::span<uint8_t> bytes) noexcept {
   ElementType result = ElementType();
 
-  constexpr glm::length_t N = TypeToDimensions<ElementType>::dimensions;
+  [[maybe_unused]] constexpr glm::length_t N =
+      TypeToDimensions<ElementType>::dimensions;
   using T = typename ElementType::value_type;
 
   CESIUM_ASSERT(

--- a/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyTexturePropertyView.h
@@ -140,9 +140,8 @@ ElementType assembleVecNValue(const std::span<uint8_t> bytes) noexcept {
       sizeof(T) <= 2 && "Components cannot be larger than two bytes in size.");
 
   if constexpr (std::is_same_v<T, int16_t>) {
-    static_assert(
-        N == 2,
-        "Only vec2s can contain two-byte integer components.");
+    CESIUM_ASSERT(
+        N == 2 && "Only vec2s can contain two-byte integer components.");
     uint16_t x = static_cast<uint16_t>(bytes[0]) |
                  static_cast<uint16_t>(static_cast<uint16_t>(bytes[1]) << 8);
     uint16_t y = static_cast<uint16_t>(bytes[2]) |
@@ -153,9 +152,8 @@ ElementType assembleVecNValue(const std::span<uint8_t> bytes) noexcept {
   }
 
   if constexpr (std::is_same_v<T, uint16_t>) {
-    static_assert(
-        N == 2,
-        "Only vec2s can contain two-byte integer components.");
+    CESIUM_ASSERT(
+        N == 2 && "Only vec2s can contain two-byte integer components.");
     result[0] = static_cast<uint16_t>(bytes[0]) |
                 static_cast<uint16_t>(static_cast<uint16_t>(bytes[1]) << 8);
     result[1] = static_cast<uint16_t>(bytes[2]) |


### PR DESCRIPTION
After merging #1133, I tried to build Cesium for Unreal with cesium-native's main and got compiler errors caused by the change in `assembleVecNValue` of some `CESIUM_ASSERT`s to `static_assert`s. It would be nice if that invalid execution path were never even compiled, but that does not appear to be the case, and I can't see any obvious way to make it so. So this PR goes back to the runtime assertions.

Here's the complete error with the static_asserts in place:

```
1>F:\cesium\cesium-unreal-samples\Plugins\cesium-unreal\Source\ThirdParty\include\CesiumGltf\PropertyTexturePropertyView.h(144): error C2338: static_assert failed: 'Only vec2s can contain two-byte integer components.'
1>F:\cesium\cesium-unreal-samples\Plugins\cesium-unreal\Source\ThirdParty\include\CesiumGltf\PropertyTexturePropertyView.h(144): note: the template instantiation context (the oldest one first) is
1>F:\cesium\cesium-unreal-samples\Plugins\cesium-unreal\Source\CesiumRuntime\Private\CesiumPropertyTextureProperty.cpp(429): note: see reference to function template instantiation 'TResult `anonymous-namespace'::propertyTexturePropertyCallback<const std::string,UCesiumPropertyTexturePropertyBlueprintLibrary::GetSwizzle::<lambda_1>>(const std::any &,const FCesiumMetadataValueType &,bool,Callback &&)' being compiled
1>        with
1>        [
1>            TResult=const std::string,
1>            Callback=UCesiumPropertyTexturePropertyBlueprintLibrary::GetSwizzle::<lambda_1>
1>        ]
1>F:\cesium\cesium-unreal-samples\Plugins\cesium-unreal\Source\CesiumRuntime\Private\CesiumPropertyTextureProperty.cpp(306): note: see reference to function template instantiation 'TResult `anonymous-namespace'::vecNPropertyTexturePropertyCallback<false,const std::string,UCesiumPropertyTexturePropertyBlueprintLibrary::GetSwizzle::<lambda_1>>(const std::any &,const FCesiumMetadataValueType &,Callback &&)' being compiled
1>        with
1>        [
1>            TResult=const std::string,
1>            Callback=UCesiumPropertyTexturePropertyBlueprintLibrary::GetSwizzle::<lambda_1>
1>        ]
1>F:\cesium\cesium-unreal-samples\Plugins\cesium-unreal\Source\CesiumRuntime\Private\CesiumPropertyTextureProperty.cpp(244): note: see reference to function template instantiation 'TResult `anonymous-namespace'::vecNPropertyTexturePropertyCallback<4,false,const std::string,UCesiumPropertyTexturePropertyBlueprintLibrary::GetSwizzle::<lambda_1>>(const std::any &,const FCesiumMetadataValueType &,Callback &&)' being compiled
1>        with
1>        [
1>            TResult=const std::string,
1>            Callback=UCesiumPropertyTexturePropertyBlueprintLibrary::GetSwizzle::<lambda_1>
1>        ]
1>F:\cesium\cesium-unreal-samples\Plugins\cesium-unreal\Source\CesiumRuntime\Private\CesiumPropertyTextureProperty.cpp(192): note: see reference to function template instantiation 'TResult `anonymous-namespace'::propertyTexturePropertyCallback<glm::vec<4,glm::int16,glm::packed_highp>,false,const std::string,UCesiumPropertyTexturePropertyBlueprintLibrary::GetSwizzle::<lambda_1>>(const std::any &,Callback &&)' being compiled
1>        with
1>        [
1>            TResult=const std::string,
1>            Callback=UCesiumPropertyTexturePropertyBlueprintLibrary::GetSwizzle::<lambda_1>
1>        ]
1>F:\cesium\cesium-unreal-samples\Plugins\cesium-unreal\Source\CesiumRuntime\Private\CesiumPropertyTextureProperty.cpp(38): note: see reference to function template instantiation 'std::string UCesiumPropertyTexturePropertyBlueprintLibrary::GetSwizzle::<lambda_1>::operator ()<CesiumGltf::PropertyTexturePropertyView<glm::vec<4,glm::int16,glm::packed_highp>,false>>(const _T1 &) const' being compiled
1>        with
1>        [
1>            _T1=CesiumGltf::PropertyTexturePropertyView<glm::vec<4,glm::int16,glm::packed_highp>,false>
1>        ]
1>F:\cesium\cesium-unreal-samples\Plugins\cesium-unreal\Source\CesiumRuntime\Private\CesiumPropertyTextureProperty.cpp(433): note: see reference to class template instantiation 'CesiumGltf::PropertyTexturePropertyView<glm::vec<4,glm::int16,glm::packed_highp>,false>' being compiled
1>F:\cesium\cesium-unreal-samples\Plugins\cesium-unreal\Source\ThirdParty\include\CesiumGltf\PropertyTexturePropertyView.h(531): note: while compiling class template member function 'glm::vec<4,glm::int16,glm::packed_highp> CesiumGltf::PropertyTexturePropertyView<glm::vec<4,glm::int16,glm::packed_highp>,false>::getRaw(double,double) noexcept const'
1>F:\cesium\cesium-unreal-samples\Plugins\cesium-unreal\Source\CesiumRuntime\Private\CesiumPropertyTextureProperty.cpp(769): note: see the first reference to 'CesiumGltf::PropertyTexturePropertyView<glm::vec<4,glm::int16,glm::packed_highp>,false>::getRaw' in 'UCesiumPropertyTexturePropertyBlueprintLibrary::GetRawValue::<lambda_1>::operator ()'
1>F:\cesium\cesium-unreal-samples\Plugins\cesium-unreal\Source\ThirdParty\include\CesiumGltf\PropertyTexturePropertyView.h(539): note: see reference to function template instantiation 'glm::vec<4,glm::int16,glm::packed_highp> CesiumGltf::assembleValueFromChannels<ElementType>(const std::span<uint8_t,18446744073709551615>) noexcept' being compiled
1>        with
1>        [
1>            ElementType=glm::vec<4,glm::int16,glm::packed_highp>
1>        ]
1>F:\cesium\cesium-unreal-samples\Plugins\cesium-unreal\Source\ThirdParty\include\CesiumGltf\PropertyTexturePropertyView.h(229): note: see reference to function template instantiation 'ElementType CesiumGltf::assembleVecNValue<ElementType>(const std::span<uint8_t,18446744073709551615>) noexcept' being compiled
1>        with
1>        [
1>            ElementType=glm::vec<4,glm::int16,glm::packed_highp>
1>        ]
```
