### PR TITLE
Force CI clang-tidy job to use CMake 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install latest ninja and cmake
         uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "3.31.6"
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.9
         with:


### PR DESCRIPTION
Currently, the clang-tidy CI task is set up to use the latest version of CMake available, for reasons that probably made sense at the time. Unfortunately, CMake just released version 4.0.0, which breaks compatibility with older versions of CMake. This is causing our CI to fail. Explicitly specifying that we want CMake 3.31.6 solves the issue.