### PR TITLE
vcpkg branch: Tweak AWS credential handling on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,9 @@ jobs:
     steps:
       - name: Capture AWS secrets
         uses: aws-actions/configure-aws-credentials@v2
-        env:
-          AWS_S3_USERNAME: ${{ secrets.AWS_INTERNAL_SERVICES_VCPKG_ACCESS_KEY }}
-          AWS_S3_PASSWORD: ${{ secrets.AWS_INTERNAL_SERVICES_VCPKG_SECRET_KEY }}
         with:
-          aws-access-key-id: ${{ env.AWS_S3_USERNAME }}
-          aws-secret-access-key: ${{ env.AWS_S3_PASSWORD }}
+          aws-access-key-id: ${{ secrets.AWS_INTERNAL_SERVICES_VCPKG_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_INTERNAL_SERVICES_VCPKG_SECRET_KEY }}
           aws-region: us-east-1
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: cesium-native
 on: [push, pull_request]
 env:
   VCPKG_BINARY_SOURCES: 'clear;x-aws,s3://cesium-builds/vcpkg/cesium-native-cache/,readwrite'
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_INTERNAL_SERVICES_VCPKG_ACCESS_KEY }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_INTERNAL_SERVICES_VCPKG_SECRET_KEY }}
+  AWS_REGION: us-east-1
 jobs:
   QuickChecks:
     name: "Quick Checks"
@@ -17,12 +20,6 @@ jobs:
     name: "Linting"
     runs-on: ubuntu-24.04
     steps:
-      - name: Capture AWS secrets
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_INTERNAL_SERVICES_VCPKG_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_INTERNAL_SERVICES_VCPKG_SECRET_KEY }}
-          aws-region: us-east-1
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Install latest ninja and cmake
@@ -73,10 +70,6 @@ jobs:
 
   Documentation:
     runs-on: ubuntu-22.04
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_INTERNAL_SERVICES_VCPKG_ACCESS_KEY }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_INTERNAL_SERVICES_VCPKG_SECRET_KEY }}
-      AWS_REGION: us-east-1
     steps:
       - name: Install Doxygen
         run: |
@@ -115,9 +108,6 @@ jobs:
     name: "${{matrix.platform}} / ${{matrix.build_type}}"
     env:
       CACHE_KEY: "${{ matrix.platform }}"
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_INTERNAL_SERVICES_VCPKG_ACCESS_KEY }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_INTERNAL_SERVICES_VCPKG_SECRET_KEY }}
-      AWS_REGION: us-east-1
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install ninja
@@ -161,9 +151,6 @@ jobs:
     name: "${{matrix.platform}} / ${{matrix.compiler}} / ${{matrix.build_type}}"
     env:
       CACHE_KEY: "${{ matrix.platform }}-${{matrix.compiler}}"
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_INTERNAL_SERVICES_VCPKG_ACCESS_KEY }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_INTERNAL_SERVICES_VCPKG_SECRET_KEY }}
-      AWS_REGION: us-east-1
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install ninja


### PR DESCRIPTION
This is a PR into #1026 to simplify how AWS credentials are handled. I primarily opened it to make it sure it doesn't fail in some surprising way, and I'm going to merge it now that it appears to be working well.