### PR TITLE
Update GitHub CI runner Ubuntu versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-      - name: Install latest ninja and cmake
+      - name: Install latest CMake 3 and Ninja
         uses: lukka/get-cmake@latest
         with:
           cmakeVersion: "3.31.6"
@@ -161,8 +161,10 @@ jobs:
       CACHE_KEY: "${{ matrix.platform }}-${{matrix.compiler}}"
     runs-on: ${{ matrix.platform }}
     steps:
-      - name: Install ninja
-        uses: seanmiddleditch/gha-setup-ninja@master
+      - name: Install latest CMake 3 and Ninja
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "3.31.6"
       - name: Install nasm
         uses: ilammy/setup-nasm@v1
       - name: Check out repository code
@@ -184,8 +186,8 @@ jobs:
       - name: Set CC and CXX
         if: ${{ matrix.compiler == 'clang' && matrix.platform != 'macos-13'}}
         run: |
-          echo "CC=clang-12" >> "$GITHUB_ENV"
-          echo "CXX=clang++-12" >> "$GITHUB_ENV"
+          echo "CC=clang-18" >> "$GITHUB_ENV"
+          echo "CXX=clang++-18" >> "$GITHUB_ENV"
       - name: Make more swap space available
         if: ${{ matrix.platform != 'macos-13'}}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,15 +147,15 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [ gcc, clang ]
-        platform: [ ubuntu-22.04, ubuntu-20.04, macos-13 ]
+        platform: [ ubuntu-24.04, ubuntu-22.04, macos-13 ]
         build_type: [Debug, RelWithDebInfo]
         exclude:
           - compiler: clang
-            platform: ubuntu-22.04
+            platform: ubuntu-24.04
           - compiler: gcc
             platform: macos-13
           - compiler: gcc
-            platform: ubuntu-20.04
+            platform: ubuntu-22.04
     name: "${{matrix.platform}} / ${{matrix.compiler}} / ${{matrix.build_type}}"
     env:
       CACHE_KEY: "${{ matrix.platform }}-${{matrix.compiler}}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,8 +186,8 @@ jobs:
       - name: Set CC and CXX
         if: ${{ matrix.compiler == 'clang' && matrix.platform != 'macos-13'}}
         run: |
-          echo "CC=clang-18" >> "$GITHUB_ENV"
-          echo "CXX=clang++-18" >> "$GITHUB_ENV"
+          echo "CC=clang" >> "$GITHUB_ENV"
+          echo "CXX=clang++" >> "$GITHUB_ENV"
       - name: Make more swap space available
         if: ${{ matrix.platform != 'macos-13'}}
         run: |


### PR DESCRIPTION
Closes #1149. The Ubuntu 20.04 CI runner will be deprecated on April 15th. This change updates the 20.04 and 22.04 runners to 22.04 and 24.04 respectively.