### PR TITLE
Fix crash by clearing raster overlays associated with tiles with non-render content

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@
 - Added `convertAccessorTypeToPropertyType` and `convertPropertyTypeToAccessorType` to `CesiumGltf::PropertyType`.
 - Added support for building in `vcpkg` manifest mode.
 
+##### Fixes :wrench:
+
+- Fixed a bug that could cause an assertion failure or crash when unloading a tileset with raster overlays and external tilesets.
+
 ### v0.46.0 - 2025-04-01
 
 ##### Additions :tada:

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -1448,6 +1448,11 @@ void TilesetContentManager::setTileContent(
           "TilesetContentManager::setTileContent");
     }
 
+    // Only render content should have raster overlays.
+    if (!tile.getContent().isRenderContent()) {
+      tile.getMappedRasterTiles().clear();
+    }
+
     if (result.tileInitializer) {
       result.tileInitializer(tile);
     }


### PR DESCRIPTION
Fixes CesiumGS/cesium-unreal#1660

The assertion failure described in the issue above was caused by the following:

1. A raster overlay was added to a Tileset that employs external tilesets (Google Photorealistic 3D Tiles).
2. Raster overlays are mapped to `Tile` instances before the `Tile` content is loaded. At that time, we have no way of knowing that content might be an external tileset rather than a glTF.
3. When an external tileset is unloaded, we do not clear its raster overlays (I guess because it isn't expected to have any).
4. Prior to this PR, we weren't clearing raster overlays upon loading content and noticing it's not renderable.

As a result, "placeholder" raster overlays added to an external tileset prior to loading it were not released when the `RasterOverlayTileProvider` was destroyed. This failed an assertion meant to ensure `RasterOverlayTileProvider` outlives all of its `RasterOverlayTile` instances.