### PR TITLE
Include `Tile.h` in `ViewUpdateResult.h`

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ViewUpdateResult.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ViewUpdateResult.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <Cesium3DTilesSelection/Library.h>
+#include <Cesium3DTilesSelection/Tile.h>
 
 #include <cstdint>
 #include <unordered_set>
 #include <vector>
 
 namespace Cesium3DTilesSelection {
-class Tile;
 
 /**
  * @brief Reports the results of {@link Tileset::updateViewGroup}.


### PR DESCRIPTION
This was needed to compile the `multiple-views` changes in Cesium for Unity. The build step could not resolve the `std::vector<Tile::Pointer>`s in `ViewUpdateResult` unless we included `Tile.h`.