### PR TITLE
Add `SubtreeWriter::writeSubtreeBinary`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Change Log
 
+### v0.48.0 - 2025-06-02
+
+##### Breaking Changes :mega:
+
+- Renamed `SubtreeWriter::writeSubtree` to `SubtreeWriter::writeSubtreeJson`.
+
+##### Additions :tada:
+
+- Added `SubtreeWriter::writeSubtreeBinary`.
+
 ### v0.47.0 - 2025-05-01
 
 ##### Breaking Changes :mega:

--- a/Cesium3DTilesWriter/include/Cesium3DTilesWriter/SubtreeWriter.h
+++ b/Cesium3DTilesWriter/include/Cesium3DTilesWriter/SubtreeWriter.h
@@ -3,6 +3,8 @@
 #include <Cesium3DTilesWriter/Library.h>
 #include <CesiumJsonWriter/ExtensionWriterContext.h>
 
+#include <span>
+
 // forward declarations
 namespace Cesium3DTiles {
 struct Subtree;
@@ -12,11 +14,12 @@ namespace Cesium3DTilesWriter {
 
 /**
  * @brief The result of writing a subtree with
- * {@link SubtreeWriter::writeSubtree}.
+ * {@link SubtreeWriter::writeSubtreeJson} or {@link SubtreeWriter::writeSubtreeBinary}.
  */
 struct CESIUM3DTILESWRITER_API SubtreeWriterResult {
   /**
-   * @brief The final generated std::vector<std::byte> of the subtree JSON.
+   * @brief The final generated std::vector<std::byte> of the subtree JSON or
+   * subtree binary.
    */
   std::vector<std::byte> subtreeBytes;
 
@@ -36,7 +39,8 @@ struct CESIUM3DTILESWRITER_API SubtreeWriterResult {
  */
 struct CESIUM3DTILESWRITER_API SubtreeWriterOptions {
   /**
-   * @brief If the subtree JSON should be pretty printed.
+   * @brief If the subtree JSON should be pretty printed. Usable with subtree
+   * JSON or subtree binary (not advised).
    */
   bool prettyPrint = false;
 };
@@ -62,15 +66,35 @@ public:
   const CesiumJsonWriter::ExtensionWriterContext& getExtensions() const;
 
   /**
-   * @brief Serializes the provided subtree object into a byte vector using the
-   * provided flags to convert.
+   * @brief Serializes the provided subtree into a subtree JSON byte vector.
+   *
+   * Ignores internal data such as {@link Cesium3DTiles::BufferCesium} when
+   * serializing the subtree. Internal data must be saved as external files. The
+   * buffer.uri field must be set accordingly prior to calling this function.
    *
    * @param subtree The subtree.
    * @param options Options for how to write the subtree.
    * @return The result of writing the subtree.
    */
-  SubtreeWriterResult writeSubtree(
+  SubtreeWriterResult writeSubtreeJson(
       const Cesium3DTiles::Subtree& subtree,
+      const SubtreeWriterOptions& options = SubtreeWriterOptions()) const;
+
+  /**
+   * @brief Serializes the provided subtree into a subtree binary byte vector.
+   *
+   * The first buffer object implicitly refers to the subtree binary section
+   * and should not have a uri. Ignores internal data such as
+   * {@link Cesium3DTiles::BufferCesium}.
+   *
+   * @param subtree The subtree.
+   * @param bufferData The buffer data to store in the subtree binary section.
+   * @param options Options for how to write the subtree.
+   * @return The result of writing the subtree.
+   */
+  SubtreeWriterResult writeSubtreeBinary(
+      const Cesium3DTiles::Subtree& subtree,
+      const std::span<const std::byte>& bufferData,
       const SubtreeWriterOptions& options = SubtreeWriterOptions()) const;
 
 private:

--- a/Cesium3DTilesWriter/src/SubtreeWriter.cpp
+++ b/Cesium3DTilesWriter/src/SubtreeWriter.cpp
@@ -4,11 +4,86 @@
 #include <Cesium3DTilesWriter/SubtreeWriter.h>
 #include <CesiumJsonWriter/JsonWriter.h>
 #include <CesiumJsonWriter/PrettyJsonWriter.h>
+#include <CesiumUtility/Assert.h>
 #include <CesiumUtility/Tracing.h>
 
+#include <cstring>
 #include <memory>
+#include <span>
+#include <vector>
 
 namespace Cesium3DTilesWriter {
+
+namespace {
+
+[[nodiscard]] size_t
+getPadding(size_t byteCount, size_t byteAlignment) noexcept {
+  CESIUM_ASSERT(byteAlignment > 0);
+  size_t remainder = byteCount % byteAlignment;
+  size_t padding = remainder == 0 ? 0 : byteAlignment - remainder;
+  return padding;
+}
+
+void writeSubtreeBuffer(
+    SubtreeWriterResult& result,
+    const std::span<const std::byte>& jsonData,
+    const std::span<const std::byte>& bufferData) {
+  size_t byteAlignment = 8;
+  size_t headerSize = 24;
+
+  size_t jsonPaddingSize =
+      getPadding(headerSize + jsonData.size(), byteAlignment);
+  size_t jsonDataSize = jsonData.size() + jsonPaddingSize;
+  size_t subtreeSize = headerSize + jsonDataSize;
+
+  size_t binaryPaddingSize = 0;
+  size_t binaryDataSize = 0;
+
+  if (bufferData.size() > 0) {
+    binaryPaddingSize =
+        getPadding(subtreeSize + bufferData.size(), byteAlignment);
+    binaryDataSize = bufferData.size() + binaryPaddingSize;
+    subtreeSize += binaryDataSize;
+  }
+
+  std::vector<std::byte>& subtree = result.subtreeBytes;
+  subtree.resize(subtreeSize);
+  uint8_t* subtree8 = reinterpret_cast<uint8_t*>(subtree.data());
+  uint32_t* subtree32 = reinterpret_cast<uint32_t*>(subtree.data());
+  uint64_t* subtree64 = reinterpret_cast<uint64_t*>(subtree.data());
+
+  // Subtree header
+  size_t byteOffset = 0;
+  subtree8[byteOffset++] = 's';
+  subtree8[byteOffset++] = 'u';
+  subtree8[byteOffset++] = 'b';
+  subtree8[byteOffset++] = 't';
+  subtree32[byteOffset / 4] = 1;
+  byteOffset += 4;
+  subtree64[byteOffset / 8] = static_cast<uint64_t>(jsonDataSize);
+  byteOffset += 8;
+  subtree64[byteOffset / 8] = static_cast<uint64_t>(binaryDataSize);
+  byteOffset += 8;
+
+  // JSON section
+  memcpy(subtree8 + byteOffset, jsonData.data(), jsonData.size());
+  byteOffset += jsonData.size();
+
+  // JSON section padding
+  memset(subtree8 + byteOffset, ' ', jsonPaddingSize);
+  byteOffset += jsonPaddingSize;
+
+  if (bufferData.size() > 0) {
+    // Binary section
+    memcpy(subtree8 + byteOffset, bufferData.data(), bufferData.size());
+    byteOffset += bufferData.size();
+
+    // Binary section padding
+    memset(subtree8 + byteOffset, 0, binaryPaddingSize);
+  }
+}
+
+} // namespace
 
 SubtreeWriter::SubtreeWriter() { registerWriterExtensions(this->_context); }
 
@@ -21,10 +96,10 @@ SubtreeWriter::getExtensions() const {
   return this->_context;
 }
 
-SubtreeWriterResult SubtreeWriter::writeSubtree(
+SubtreeWriterResult SubtreeWriter::writeSubtreeJson(
     const Cesium3DTiles::Subtree& subtree,
     const SubtreeWriterOptions& options) const {
-  CESIUM_TRACE("SubtreeWriter::writeSubtree");
+  CESIUM_TRACE("SubtreeWriter::writeSubtreeJson");
 
   const CesiumJsonWriter::ExtensionWriterContext& context =
       this->getExtensions();
@@ -45,4 +120,41 @@ SubtreeWriterResult SubtreeWriter::writeSubtree(
 
   return result;
 }
+
+SubtreeWriterResult SubtreeWriter::writeSubtreeBinary(
+    const Cesium3DTiles::Subtree& subtree,
+    const std::span<const std::byte>& bufferData,
+    const SubtreeWriterOptions& options) const {
+  CESIUM_TRACE("SubtreeWriter::writeSubtreeBinary");
+
+  const CesiumJsonWriter::ExtensionWriterContext& context =
+      this->getExtensions();
+
+  SubtreeWriterResult result;
+  std::unique_ptr<CesiumJsonWriter::JsonWriter> writer;
+
+  if (options.prettyPrint) {
+    writer = std::make_unique<CesiumJsonWriter::PrettyJsonWriter>();
+  } else {
+    writer = std::make_unique<CesiumJsonWriter::JsonWriter>();
+  }
+
+  SubtreeJsonWriter::write(subtree, *writer, context);
+  std::vector<std::byte> jsonData = writer->toBytes();
+
+  writeSubtreeBuffer(result, std::span(jsonData), bufferData);
+
+  result.errors.insert(
+      result.errors.end(),
+      writer->getErrors().begin(),
+      writer->getErrors().end());
+
+  result.warnings.insert(
+      result.warnings.end(),
+      writer->getWarnings().begin(),
+      writer->getWarnings().end());
+
+  return result;
+}
+
 } // namespace Cesium3DTilesWriter

--- a/Cesium3DTilesWriter/src/SubtreeWriter.cpp
+++ b/Cesium3DTilesWriter/src/SubtreeWriter.cpp
@@ -7,6 +7,8 @@
 #include <CesiumUtility/Assert.h>
 #include <CesiumUtility/Tracing.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <span>

--- a/Cesium3DTilesWriter/test/TestSubtreeWriter.cpp
+++ b/Cesium3DTilesWriter/test/TestSubtreeWriter.cpp
@@ -1,0 +1,520 @@
+#include <Cesium3DTiles/Buffer.h>
+#include <Cesium3DTilesReader/SubtreeFileReader.h>
+#include <Cesium3DTilesReader/SubtreeReader.h>
+#include <Cesium3DTilesReader/SubtreesReader.h>
+#include <Cesium3DTilesWriter/SubtreeWriter.h>
+#include <CesiumJsonWriter/ExtensionWriterContext.h>
+#include <CesiumNativeTests/SimpleAssetAccessor.h>
+#include <CesiumNativeTests/SimpleAssetRequest.h>
+#include <CesiumNativeTests/SimpleAssetResponse.h>
+#include <CesiumNativeTests/SimpleTaskProcessor.h>
+#include <CesiumUtility/ExtensibleObject.h>
+
+#include <doctest/doctest.h>
+#include <rapidjson/document.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+using namespace CesiumNativeTests;
+
+namespace {
+void check(const std::string& input, const std::string& expectedOutput) {
+  Cesium3DTilesReader::SubtreeReader reader;
+  auto readResult = reader.readFromJson(std::span(
+      reinterpret_cast<const std::byte*>(input.c_str()),
+      input.size()));
+  REQUIRE(readResult.errors.empty());
+  REQUIRE(readResult.warnings.empty());
+  REQUIRE(readResult.value.has_value());
+
+  Cesium3DTiles::Subtree& subtree = readResult.value.value();
+
+  Cesium3DTilesWriter::SubtreeWriter writer;
+  Cesium3DTilesWriter::SubtreeWriterResult writeResult =
+      writer.writeSubtreeJson(subtree);
+  const auto subtreeBytes = writeResult.subtreeBytes;
+
+  REQUIRE(writeResult.errors.empty());
+  REQUIRE(writeResult.warnings.empty());
+
+  const std::string subtreeString(
+      reinterpret_cast<const char*>(subtreeBytes.data()),
+      subtreeBytes.size());
+
+  rapidjson::Document subtreeJson;
+  subtreeJson.Parse(subtreeString.c_str());
+
+  rapidjson::Document expectedJson;
+  expectedJson.Parse(expectedOutput.c_str());
+
+  REQUIRE(subtreeJson == expectedJson);
+}
+
+bool hasSpaces(const std::string& input) {
+  return std::count_if(input.begin(), input.end(), [](unsigned char c) {
+    return std::isspace(c);
+  });
+}
+
+struct ExtensionSubtreeTest final : public CesiumUtility::ExtensibleObject {
+  static inline constexpr const char* ExtensionName = "PRIVATE_subtree_test";
+};
+
+} // namespace
+
+TEST_CASE("Writes subtree JSON") {
+  std::string string = R"(
+    {
+      "buffers": [
+        {
+          "name": "Availability Buffer",
+          "uri": "availability.bin",
+          "byteLength": 48
+        },
+        {
+          "name": "Metadata Buffer",
+          "uri": "metadata.bin",
+          "byteLength": 6512
+        }
+      ],
+      "bufferViews": [
+        { "buffer": 0, "byteOffset": 0, "byteLength": 11 },
+        { "buffer": 0, "byteOffset": 16, "byteLength": 32 },
+        { "buffer": 1, "byteOffset": 0, "byteLength": 2040 },
+        { "buffer": 1, "byteOffset": 2040, "byteLength": 1530 },
+        { "buffer": 1, "byteOffset": 3576, "byteLength": 344 },
+        { "buffer": 1, "byteOffset": 3920, "byteLength": 1024 },
+        { "buffer": 1, "byteOffset": 4944, "byteLength": 240 },
+        { "buffer": 1, "byteOffset": 5184, "byteLength": 122 },
+        { "buffer": 1, "byteOffset": 5312, "byteLength": 480 },
+        { "buffer": 1, "byteOffset": 5792, "byteLength": 480 },
+        { "buffer": 1, "byteOffset": 6272, "byteLength": 240 }
+      ],
+      "propertyTables": [
+        {
+          "class": "tile",
+          "count": 85,
+          "properties": {
+            "horizonOcclusionPoint": {
+              "values": 2
+            },
+            "countries": {
+              "values": 3,
+              "arrayOffsets": 4,
+              "stringOffsets": 5
+            }
+          }
+        },
+        {
+          "class": "content",
+          "count": 60,
+          "properties": {
+            "attributionIds": {
+              "values": 6,
+              "arrayOffsets": 7,
+              "arrayOffsetType": "UINT16"
+            },
+            "minimumHeight": {
+              "values": 8
+            },
+            "maximumHeight": {
+              "values": 9
+            },
+            "triangleCount": {
+              "values": 10,
+              "min": 520,
+              "max": 31902
+            }
+          }
+        }
+      ],
+      "tileAvailability": {
+        "constant": 1
+      },
+      "contentAvailability": [{
+        "bitstream": 0,
+        "availableCount": 60
+      }],
+      "childSubtreeAvailability": {
+        "bitstream": 1
+      },
+      "tileMetadata": 0,
+      "contentMetadata": [1],
+      "subtreeMetadata": {
+        "class": "subtree",
+        "properties": {
+          "attributionStrings": [
+            "Source A",
+            "Source B",
+            "Source C",
+            "Source D"
+          ]
+        }
+      }
+    }
+  )";
+
+  check(string, string);
+}
+
+TEST_CASE("Writes subtree JSON with extras") {
+  std::string string = R"(
+    {
+      "tileAvailability": {
+        "constant": 1
+      },
+      "contentAvailability": [{
+        "constant": 1
+      }],
+      "childSubtreeAvailability": {
+        "constant": 1
+      },
+      "extras": {
+        "A": "Hello",
+        "B": 1234567,
+        "C": {
+          "C1": {},
+          "C2": [1,2,3,4,5],
+          "C3": true
+        }
+      }
+    }
+  )";
+
+  check(string, string);
+}
+
+TEST_CASE("Writes subtree JSON with custom extension") {
+  std::string string = R"(
+    {
+      "tileAvailability": {
+        "constant": 1
+      },
+      "contentAvailability": [{
+        "constant": 1
+      }],
+      "childSubtreeAvailability": {
+        "constant": 1
+      },
+      "extensions": {
+        "A": {
+          "test": "Hello"
+        },
+        "B": {
+          "another": "Goodbye"
+        }
+      }
+    }
+  )";
+
+  check(string, string);
+}
+
+TEST_CASE("Writes subtree JSON with unregistered extension") {
+  Cesium3DTiles::Subtree subtree;
+  subtree.addExtension<ExtensionSubtreeTest>();
+
+  SUBCASE("Reports a warning if the extension is enabled") {
+    Cesium3DTilesWriter::SubtreeWriter writer;
+    Cesium3DTilesWriter::SubtreeWriterResult result =
+        writer.writeSubtreeJson(subtree);
+    REQUIRE(!result.warnings.empty());
+  }
+
+  SUBCASE("Does not report a warning if the extension is disabled") {
+    Cesium3DTilesWriter::SubtreeWriter writer;
+    writer.getExtensions().setExtensionState(
+        ExtensionSubtreeTest::ExtensionName,
+        CesiumJsonWriter::ExtensionState::Disabled);
+    Cesium3DTilesWriter::SubtreeWriterResult result =
+        writer.writeSubtreeJson(subtree);
+    REQUIRE(result.warnings.empty());
+  }
+}
+
+TEST_CASE("Writes subtree JSON with default values removed") {
+  std::string string = R"(
+    {
+      "buffers": [
+        {
+          "name": "Availability Buffer",
+          "uri": "availability.bin",
+          "byteLength": 48
+        },
+        {
+          "name": "Metadata Buffer",
+          "uri": "metadata.bin",
+          "byteLength": 6512
+        }
+      ],
+      "bufferViews": [
+        { "buffer": 0, "byteOffset": 0, "byteLength": 11 },
+        { "buffer": 0, "byteOffset": 16, "byteLength": 32 },
+        { "buffer": 1, "byteOffset": 0, "byteLength": 2040 },
+        { "buffer": 1, "byteOffset": 2040, "byteLength": 1530 },
+        { "buffer": 1, "byteOffset": 3576, "byteLength": 344 },
+        { "buffer": 1, "byteOffset": 3920, "byteLength": 1024 },
+        { "buffer": 1, "byteOffset": 4944, "byteLength": 240 },
+        { "buffer": 1, "byteOffset": 5184, "byteLength": 122 },
+        { "buffer": 1, "byteOffset": 5312, "byteLength": 480 },
+        { "buffer": 1, "byteOffset": 5792, "byteLength": 480 },
+        { "buffer": 1, "byteOffset": 6272, "byteLength": 240 }
+      ],
+      "propertyTables": [
+        {
+          "class": "tile",
+          "count": 85,
+          "properties": {
+            "horizonOcclusionPoint": {
+              "values": 2
+            },
+            "countries": {
+              "values": 3,
+              "arrayOffsets": 4,
+              "stringOffsets": 5,
+              "arrayOffsetType": "UINT32",
+              "stringOffsetType": "UINT32"
+            }
+          }
+        },
+        {
+          "class": "content",
+          "count": 60,
+          "properties": {
+            "attributionIds": {
+              "values": 6,
+              "arrayOffsets": 7,
+              "arrayOffsetType": "UINT16"
+            },
+            "minimumHeight": {
+              "values": 8
+            },
+            "maximumHeight": {
+              "values": 9
+            },
+            "triangleCount": {
+              "values": 10,
+              "min": 520,
+              "max": 31902
+            }
+          }
+        }
+      ],
+      "tileAvailability": {
+        "constant": 1
+      },
+      "contentAvailability": [{
+        "bitstream": 0,
+        "availableCount": 60
+      }],
+      "childSubtreeAvailability": {
+        "bitstream": 1
+      },
+      "tileMetadata": 0,
+      "contentMetadata": [1],
+      "subtreeMetadata": {
+        "class": "subtree",
+        "properties": {
+          "attributionStrings": [
+            "Source A",
+            "Source B",
+            "Source C",
+            "Source D"
+          ]
+        }
+      }
+    }
+  )";
+
+  std::string expected = R"(
+    {
+      "buffers": [
+        {
+          "name": "Availability Buffer",
+          "uri": "availability.bin",
+          "byteLength": 48
+        },
+        {
+          "name": "Metadata Buffer",
+          "uri": "metadata.bin",
+          "byteLength": 6512
+        }
+      ],
+      "bufferViews": [
+        { "buffer": 0, "byteOffset": 0, "byteLength": 11 },
+        { "buffer": 0, "byteOffset": 16, "byteLength": 32 },
+        { "buffer": 1, "byteOffset": 0, "byteLength": 2040 },
+        { "buffer": 1, "byteOffset": 2040, "byteLength": 1530 },
+        { "buffer": 1, "byteOffset": 3576, "byteLength": 344 },
+        { "buffer": 1, "byteOffset": 3920, "byteLength": 1024 },
+        { "buffer": 1, "byteOffset": 4944, "byteLength": 240 },
+        { "buffer": 1, "byteOffset": 5184, "byteLength": 122 },
+        { "buffer": 1, "byteOffset": 5312, "byteLength": 480 },
+        { "buffer": 1, "byteOffset": 5792, "byteLength": 480 },
+        { "buffer": 1, "byteOffset": 6272, "byteLength": 240 }
+      ],
+      "propertyTables": [
+        {
+          "class": "tile",
+          "count": 85,
+          "properties": {
+            "horizonOcclusionPoint": {
+              "values": 2
+            },
+            "countries": {
+              "values": 3,
+              "arrayOffsets": 4,
+              "stringOffsets": 5
+            }
+          }
+        },
+        {
+          "class": "content",
+          "count": 60,
+          "properties": {
+            "attributionIds": {
+              "values": 6,
+              "arrayOffsets": 7,
+              "arrayOffsetType": "UINT16"
+            },
+            "minimumHeight": {
+              "values": 8
+            },
+            "maximumHeight": {
+              "values": 9
+            },
+            "triangleCount": {
+              "values": 10,
+              "min": 520,
+              "max": 31902
+            }
+          }
+        }
+      ],
+      "tileAvailability": {
+        "constant": 1
+      },
+      "contentAvailability": [{
+        "bitstream": 0,
+        "availableCount": 60
+      }],
+      "childSubtreeAvailability": {
+        "bitstream": 1
+      },
+      "tileMetadata": 0,
+      "contentMetadata": [1],
+      "subtreeMetadata": {
+        "class": "subtree",
+        "properties": {
+          "attributionStrings": [
+            "Source A",
+            "Source B",
+            "Source C",
+            "Source D"
+          ]
+        }
+      }
+    }
+  )";
+
+  check(string, expected);
+}
+
+TEST_CASE("Writes subtree JSON with prettyPrint") {
+  Cesium3DTiles::Subtree subtree;
+
+  Cesium3DTilesWriter::SubtreeWriter writer;
+  Cesium3DTilesWriter::SubtreeWriterOptions options;
+  options.prettyPrint = false;
+
+  Cesium3DTilesWriter::SubtreeWriterResult writeResult =
+      writer.writeSubtreeJson(subtree, options);
+  const std::vector<std::byte>& subtreeBytesCompact = writeResult.subtreeBytes;
+
+  std::string subtreeStringCompact(
+      reinterpret_cast<const char*>(subtreeBytesCompact.data()),
+      subtreeBytesCompact.size());
+
+  REQUIRE_FALSE(hasSpaces(subtreeStringCompact));
+
+  options.prettyPrint = true;
+  writeResult = writer.writeSubtreeJson(subtree, options);
+  const std::vector<std::byte>& subtreeBytesPretty = writeResult.subtreeBytes;
+  std::string subtreeStringPretty(
+      reinterpret_cast<const char*>(subtreeBytesPretty.data()),
+      subtreeBytesPretty.size());
+
+  REQUIRE(hasSpaces(subtreeStringPretty));
+}
+
+TEST_CASE("Writes subtree binary") {
+  const std::vector<std::byte> bufferData{
+      std::byte('H'),
+      std::byte('e'),
+      std::byte('l'),
+      std::byte('l'),
+      std::byte('o'),
+      std::byte('W'),
+      std::byte('o'),
+      std::byte('r'),
+      std::byte('l'),
+      std::byte('d'),
+      std::byte('!')};
+
+  Cesium3DTiles::Subtree subtree;
+  Cesium3DTiles::Buffer buffer;
+  buffer.byteLength = static_cast<int64_t>(bufferData.size());
+  subtree.buffers.push_back(buffer);
+
+  Cesium3DTilesWriter::SubtreeWriter writer;
+  Cesium3DTilesWriter::SubtreeWriterResult writeResult =
+      writer.writeSubtreeBinary(subtree, std::span(bufferData));
+  const std::vector<std::byte>& subtreeBytes = writeResult.subtreeBytes;
+
+  REQUIRE(writeResult.errors.empty());
+  REQUIRE(writeResult.warnings.empty());
+
+  // Now read the subtree back
+  auto pMockTaskProcessor = std::make_shared<SimpleTaskProcessor>();
+  CesiumAsync::AsyncSystem asyncSystem{pMockTaskProcessor};
+
+  auto pMockSubtreeResponse = std::make_unique<SimpleAssetResponse>(
+      uint16_t(200),
+      "0.subtree",
+      CesiumAsync::HttpHeaders{},
+      subtreeBytes);
+
+  auto pMockSubtreeRequest = std::make_unique<SimpleAssetRequest>(
+      "GET",
+      "0.subtree",
+      CesiumAsync::HttpHeaders{},
+      std::move(pMockSubtreeResponse));
+
+  std::map<std::string, std::shared_ptr<SimpleAssetRequest>> mapUrlToRequest{
+      {"0.subtree", std::move(pMockSubtreeRequest)}};
+
+  auto pMockAssetAccessor =
+      std::make_shared<SimpleAssetAccessor>(std::move(mapUrlToRequest));
+
+  Cesium3DTilesReader::SubtreeFileReader reader;
+  CesiumJsonReader::ReadJsonResult<Cesium3DTiles::Subtree> readResult =
+      reader.load(asyncSystem, pMockAssetAccessor, "0.subtree")
+          .waitInMainThread();
+
+  REQUIRE(readResult.errors.empty());
+  REQUIRE(readResult.warnings.empty());
+  REQUIRE(readResult.value.has_value());
+
+  Cesium3DTiles::Subtree& readSubtree = readResult.value.value();
+  const std::vector<std::byte> readSubtreeBuffer =
+      readSubtree.buffers[0].cesium.data;
+
+  REQUIRE(readSubtreeBuffer == bufferData);
+  REQUIRE(readSubtree.buffers[0].byteLength == 11);
+}

--- a/CesiumGltfWriter/include/CesiumGltfWriter/GltfWriter.h
+++ b/CesiumGltfWriter/include/CesiumGltfWriter/GltfWriter.h
@@ -73,7 +73,7 @@ public:
   /**
    * @brief Serializes the provided model into a glTF JSON byte vector.
    *
-   * @details Ignores internal data such as {@link CesiumGltf::BufferCesium}
+   * Ignores internal data such as {@link CesiumGltf::BufferCesium}
    * and {@link CesiumGltf::ImageAsset} when serializing the glTF. Internal
    * data must either be converted to data uris or saved as external files. The
    * buffer.uri and image.uri fields must be set accordingly prior to calling
@@ -90,7 +90,7 @@ public:
   /**
    * @brief Serializes the provided model into a glb byte vector.
    *
-   * @details The first buffer object implicitly refers to the GLB binary chunk
+   * The first buffer object implicitly refers to the GLB binary chunk
    * and should not have a uri. Ignores internal data such as
    * {@link CesiumGltf::BufferCesium} and {@link CesiumGltf::ImageAsset}.
    *

--- a/CesiumGltfWriter/test/TestGltfWriter.cpp
+++ b/CesiumGltfWriter/test/TestGltfWriter.cpp
@@ -267,6 +267,26 @@ TEST_CASE("Writes glTF with custom extension") {
   check(string, string);
 }
 
+TEST_CASE("Writes glTF with unregistered extension") {
+  CesiumGltf::Model model;
+  model.addExtension<ExtensionModelTest>();
+
+  SUBCASE("Reports a warning if the extension is enabled") {
+    CesiumGltfWriter::GltfWriter writer;
+    CesiumGltfWriter::GltfWriterResult result = writer.writeGltf(model);
+    REQUIRE(!result.warnings.empty());
+  }
+
+  SUBCASE("Does not report a warning if the extension is disabled") {
+    CesiumGltfWriter::GltfWriter writer;
+    writer.getExtensions().setExtensionState(
+        ExtensionModelTest::ExtensionName,
+        CesiumJsonWriter::ExtensionState::Disabled);
+    CesiumGltfWriter::GltfWriterResult result = writer.writeGltf(model);
+    REQUIRE(result.warnings.empty());
+  }
+}
+
 TEST_CASE("Writes glTF with default values removed") {
   std::string string = R"(
     {
@@ -607,24 +627,4 @@ TEST_CASE("Reports an error if asked to write a GLB larger than 4GB") {
       writer.writeGlb(model, buffer.cesium.data);
   REQUIRE(!result.errors.empty());
   CHECK(result.gltfBytes.empty());
-}
-
-TEST_CASE("Handles models with unregistered extension") {
-  CesiumGltf::Model model;
-  model.addExtension<ExtensionModelTest>();
-
-  SUBCASE("Reports a warning if the extension is enabled") {
-    CesiumGltfWriter::GltfWriter writer;
-    CesiumGltfWriter::GltfWriterResult result = writer.writeGltf(model);
-    REQUIRE(!result.warnings.empty());
-  }
-
-  SUBCASE("Does not report a warning if the extension is disabled") {
-    CesiumGltfWriter::GltfWriter writer;
-    writer.getExtensions().setExtensionState(
-        ExtensionModelTest::ExtensionName,
-        CesiumJsonWriter::ExtensionState::Disabled);
-    CesiumGltfWriter::GltfWriterResult result = writer.writeGltf(model);
-    REQUIRE(result.warnings.empty());
-  }
 }


### PR DESCRIPTION
Adds `SubtreeWriter::writeSubtreeBinary` for writing the [subtree binary format](https://github.com/CesiumGS/3d-tiles/tree/main/specification/ImplicitTiling#subtree-binary-format). Previously we only supported writing the JSON format.