### PR TITLE
Update `constant`/`bitstream` when setting availability

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@
 
 - Added `SubtreeWriter::writeSubtreeBinary`.
 
+##### Fixes :wrench:
+
+- Fixed a bug where `SubtreeAvailability` wasn't updating the `constant` and `bitstream` properties of the availability object when converting constant availability to a bitstream.
+
 ### v0.47.0 - 2025-05-01
 
 ##### Breaking Changes :mega:

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
@@ -419,6 +419,7 @@ private:
       uint32_t relativeTileLevel,
       uint64_t relativeTileMortonId,
       AvailabilityView& availabilityView,
+      Cesium3DTiles::Availability& availability,
       bool isAvailable) noexcept;
 
   bool isAvailableUsingBufferView(

--- a/Cesium3DTilesContent/src/SubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/src/SubtreeAvailability.cpp
@@ -272,6 +272,7 @@ void SubtreeAvailability::setTileAvailable(
       relativeTileLevel,
       relativeTileMortonId,
       this->_tileAvailability,
+      this->_subtree.tileAvailability,
       isAvailable);
 }
 
@@ -349,6 +350,7 @@ void SubtreeAvailability::setContentAvailable(
         relativeTileLevel,
         relativeTileMortonId,
         this->_contentAvailability[contentId],
+        this->_subtree.contentAvailability[contentId],
         isAvailable);
   }
 }
@@ -388,7 +390,8 @@ namespace {
 void convertConstantAvailabilityToBitstream(
     Subtree& subtree,
     uint64_t numberOfTiles,
-    SubtreeAvailability::AvailabilityView& availabilityView) {
+    SubtreeAvailability::AvailabilityView& availabilityView,
+    Availability& availability) {
   const SubtreeAvailability::SubtreeConstantAvailability*
       pConstantAvailability =
           std::get_if<SubtreeAvailability::SubtreeConstantAvailability>(
@@ -430,6 +433,9 @@ void convertConstantAvailabilityToBitstream(
       buffer.cesium.data.data() + start,
       buffer.cesium.data.data() + end);
   availabilityView = SubtreeAvailability::SubtreeBufferViewAvailability{view};
+
+  availability.bitstream = int32_t(subtree.bufferViews.size() - 1);
+  availability.constant.reset();
 }
 
 } // namespace
@@ -450,7 +456,8 @@ void SubtreeAvailability::setSubtreeAvailable(
       convertConstantAvailabilityToBitstream(
           this->_subtree,
           numberOfTilesInNextLevel,
-          this->_subtreeAvailability);
+          this->_subtreeAvailability,
+          this->_subtree.childSubtreeAvailability);
     }
   }
 
@@ -512,6 +519,7 @@ void SubtreeAvailability::setAvailable(
     uint32_t relativeTileLevel,
     uint64_t relativeTileMortonId,
     AvailabilityView& availabilityView,
+    Availability& availability,
     bool isAvailable) noexcept {
   const SubtreeConstantAvailability* pConstantAvailability =
       std::get_if<SubtreeConstantAvailability>(&availabilityView);
@@ -528,7 +536,8 @@ void SubtreeAvailability::setAvailable(
       convertConstantAvailabilityToBitstream(
           this->_subtree,
           numberOfTilesInSubtree,
-          availabilityView);
+          availabilityView,
+          availability);
     }
   }
 

--- a/Cesium3DTilesContent/test/TestSubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/test/TestSubtreeAvailability.cpp
@@ -1023,6 +1023,7 @@ TEST_CASE("SubtreeAvailability modifications") {
   REQUIRE(maybeAvailability);
 
   SubtreeAvailability& availability = *maybeAvailability;
+  const Subtree& subtree = availability.getSubtree();
 
   SUBCASE("initially has all tiles available, and no content or subtrees "
           "available") {
@@ -1063,6 +1064,9 @@ TEST_CASE("SubtreeAvailability modifications") {
         QuadtreeTileID(0, 0, 0),
         QuadtreeTileID(4, 15, 15)));
 
+    CHECK_UNARY(subtree.tileAvailability.bitstream);
+    CHECK_UNARY_FALSE(subtree.tileAvailability.constant);
+
     availability.setContentAvailable(
         QuadtreeTileID(0, 0, 0),
         QuadtreeTileID(4, 15, 15),
@@ -1078,6 +1082,9 @@ TEST_CASE("SubtreeAvailability modifications") {
         QuadtreeTileID(4, 15, 15),
         0));
 
+    CHECK_UNARY(subtree.contentAvailability[0].bitstream);
+    CHECK_UNARY_FALSE(subtree.contentAvailability[0].constant);
+
     availability.setSubtreeAvailable(
         QuadtreeTileID(0, 0, 0),
         QuadtreeTileID(5, 31, 31),
@@ -1089,5 +1096,8 @@ TEST_CASE("SubtreeAvailability modifications") {
     CHECK(availability.isSubtreeAvailable(
         QuadtreeTileID(0, 0, 0),
         QuadtreeTileID(5, 31, 31)));
+
+    CHECK_UNARY(subtree.childSubtreeAvailability.bitstream);
+    CHECK_UNARY_FALSE(subtree.childSubtreeAvailability.constant);
   }
 }


### PR DESCRIPTION
Fixed a bug where `SubtreeAvailability` wasn't updating the `constant` and `bitstream` properties of the `availability` object when converting constant availability to a bitstream.

This meant the subtree wasn't getting updated:

```json
  "childSubtreeAvailability": {
    "constant": 0
  },
```

After this fix it should look like

```json
  "childSubtreeAvailability": {
    "bitstream": 0
  },
```