### PR TITLE
Fix use-after-free bug in `SubtreeAvailability`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug where `SubtreeAvailability` wasn't updating the `constant` and `bitstream` properties of the availability object when converting constant availability to a bitstream.
+- Fixed a bug where `SubtreeAvailability` attempted to update buffer data that was no longer valid.
 
 ### v0.47.0 - 2025-05-01
 

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
@@ -432,6 +432,14 @@ private:
       AvailabilityView& availabilityView,
       bool isAvailable) noexcept;
 
+  void updateAvailabilityViews();
+
+  void convertConstantAvailabilityToBitstream(
+      Cesium3DTiles::Subtree& subtree,
+      uint64_t numberOfTiles,
+      SubtreeAvailability::AvailabilityView& availabilityView,
+      Cesium3DTiles::Availability& availability);
+
   uint32_t _powerOf2;
   uint32_t _levelsInSubtree;
   Cesium3DTiles::Subtree _subtree;

--- a/Cesium3DTilesContent/src/SubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/src/SubtreeAvailability.cpp
@@ -385,61 +385,6 @@ bool SubtreeAvailability::isSubtreeAvailable(
       checkSubtreeID));
 }
 
-namespace {
-
-void convertConstantAvailabilityToBitstream(
-    Subtree& subtree,
-    uint64_t numberOfTiles,
-    SubtreeAvailability::AvailabilityView& availabilityView,
-    Availability& availability) {
-  const SubtreeAvailability::SubtreeConstantAvailability*
-      pConstantAvailability =
-          std::get_if<SubtreeAvailability::SubtreeConstantAvailability>(
-              &availabilityView);
-  if (!pConstantAvailability)
-    return;
-
-  bool oldValue = pConstantAvailability->constant;
-
-  uint64_t numberOfBytes = numberOfTiles / 8;
-  if (numberOfBytes * 8 < numberOfTiles)
-    ++numberOfBytes;
-
-  BufferView& bufferView = subtree.bufferViews.emplace_back();
-  bufferView.buffer = 0;
-  bufferView.byteLength = int64_t(numberOfBytes);
-
-  Buffer& buffer = !subtree.buffers.empty() ? subtree.buffers[0]
-                                            : subtree.buffers.emplace_back();
-
-  int64_t start = buffer.byteLength;
-
-  // Align the new bufferView to a multiple of 8 bytes, as required by the spec.
-  int64_t paddingRemainder = start % 8;
-  if (paddingRemainder > 0) {
-    start += 8 - paddingRemainder;
-  }
-
-  int64_t end = start + int64_t(numberOfBytes);
-
-  bufferView.byteOffset = start;
-  buffer.byteLength = end;
-
-  buffer.cesium.data.resize(
-      size_t(buffer.byteLength),
-      oldValue ? std::byte(0xFF) : std::byte(0x00));
-
-  std::span<std::byte> view(
-      buffer.cesium.data.data() + start,
-      buffer.cesium.data.data() + end);
-  availabilityView = SubtreeAvailability::SubtreeBufferViewAvailability{view};
-
-  availability.bitstream = int32_t(subtree.bufferViews.size() - 1);
-  availability.constant.reset();
-}
-
-} // namespace
-
 void SubtreeAvailability::setSubtreeAvailable(
     uint64_t relativeSubtreeMortonId,
     bool isAvailable) noexcept {
@@ -608,6 +553,118 @@ void SubtreeAvailability::setAvailableUsingBufferView(
   } else {
     pBufferViewAvailability->view[byteIndex] &= ~(std::byte(1) << bitIndex);
   }
+}
+
+namespace {
+
+void updateAvailabilityView(
+    Subtree& subtree,
+    SubtreeAvailability::AvailabilityView& availabilityView,
+    Availability& availability) {
+  if (!std::holds_alternative<
+          SubtreeAvailability::SubtreeBufferViewAvailability>(
+          availabilityView)) {
+    return;
+  }
+
+  CESIUM_ASSERT(
+      availability.bitstream && *availability.bitstream >= 0 &&
+      size_t(*availability.bitstream) < subtree.bufferViews.size());
+
+  const BufferView& bufferView =
+      subtree.bufferViews[size_t(*availability.bitstream)];
+
+  CESIUM_ASSERT(
+      bufferView.buffer >= 0 &&
+      size_t(bufferView.buffer) < subtree.buffers.size());
+
+  Buffer& buffer = subtree.buffers[size_t(bufferView.buffer)];
+
+  std::span<std::byte> view(
+      buffer.cesium.data.data() + bufferView.byteOffset,
+      buffer.cesium.data.data() + bufferView.byteOffset +
+          bufferView.byteLength);
+
+  availabilityView = SubtreeAvailability::SubtreeBufferViewAvailability{view};
+}
+
+} // namespace
+
+void SubtreeAvailability::updateAvailabilityViews() {
+  updateAvailabilityView(
+      this->_subtree,
+      this->_tileAvailability,
+      this->_subtree.tileAvailability);
+
+  updateAvailabilityView(
+      this->_subtree,
+      this->_subtreeAvailability,
+      this->_subtree.childSubtreeAvailability);
+
+  CESIUM_ASSERT(
+      this->_contentAvailability.size() ==
+      this->_subtree.contentAvailability.size());
+
+  for (size_t i = 0; i < this->_contentAvailability.size(); ++i) {
+    updateAvailabilityView(
+        this->_subtree,
+        this->_contentAvailability[i],
+        this->_subtree.contentAvailability[i]);
+  }
+}
+
+void SubtreeAvailability::convertConstantAvailabilityToBitstream(
+    Subtree& subtree,
+    uint64_t numberOfTiles,
+    SubtreeAvailability::AvailabilityView& availabilityView,
+    Availability& availability) {
+  const SubtreeAvailability::SubtreeConstantAvailability*
+      pConstantAvailability =
+          std::get_if<SubtreeAvailability::SubtreeConstantAvailability>(
+              &availabilityView);
+  if (!pConstantAvailability)
+    return;
+
+  bool oldValue = pConstantAvailability->constant;
+
+  uint64_t numberOfBytes = numberOfTiles / 8;
+  if (numberOfBytes * 8 < numberOfTiles)
+    ++numberOfBytes;
+
+  BufferView& bufferView = subtree.bufferViews.emplace_back();
+  bufferView.buffer = 0;
+  bufferView.byteLength = int64_t(numberOfBytes);
+
+  Buffer& buffer = !subtree.buffers.empty() ? subtree.buffers[0]
+                                            : subtree.buffers.emplace_back();
+
+  int64_t start = buffer.byteLength;
+
+  // Align the new bufferView to a multiple of 8 bytes, as required by the spec.
+  int64_t paddingRemainder = start % 8;
+  if (paddingRemainder > 0) {
+    start += 8 - paddingRemainder;
+  }
+
+  int64_t end = start + int64_t(numberOfBytes);
+
+  bufferView.byteOffset = start;
+  buffer.byteLength = end;
+
+  buffer.cesium.data.resize(
+      size_t(buffer.byteLength),
+      oldValue ? std::byte(0xFF) : std::byte(0x00));
+
+  std::span<std::byte> view(
+      buffer.cesium.data.data() + start,
+      buffer.cesium.data.data() + end);
+  availabilityView = SubtreeAvailability::SubtreeBufferViewAvailability{view};
+
+  availability.bitstream = int32_t(subtree.bufferViews.size() - 1);
+  availability.constant.reset();
+
+  // Fix spans that may have been invalidated when the buffer grew
+  this->updateAvailabilityViews();
 }
 
 } // namespace Cesium3DTilesContent

--- a/Cesium3DTilesContent/test/TestSubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/test/TestSubtreeAvailability.cpp
@@ -1099,5 +1099,14 @@ TEST_CASE("SubtreeAvailability modifications") {
 
     CHECK_UNARY(subtree.childSubtreeAvailability.bitstream);
     CHECK_UNARY_FALSE(subtree.childSubtreeAvailability.constant);
+
+    // Check that tile availability is still correct - e.g. spans are updated
+    // after the buffer grows
+    CHECK(availability.isTileAvailable(
+        QuadtreeTileID(0, 0, 0),
+        QuadtreeTileID(0, 0, 0)));
+    CHECK(!availability.isTileAvailable(
+        QuadtreeTileID(0, 0, 0),
+        QuadtreeTileID(4, 15, 15)));
   }
 }


### PR DESCRIPTION
Steps to reproduce

1. Create unavailable subtree
2. Set a tile's availability to true
3. Set a content's availability to true
4. Set a tile's availability to true
5. `undefined behavior`

Step 3 causes `subtree.buffers[0].cesium.data` to grow which invalidates the span held onto by tile availability.

Fixed by updating all the spans when `convertConstantAvailabilityToBitstream` is called so that they point to valid memory.