### PR TITLE
Add boolean availability parameter in `SubtreeAvailability::createEmpty`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Breaking Changes :mega:
 
 - Renamed `SubtreeWriter::writeSubtree` to `SubtreeWriter::writeSubtreeJson`.
+- `SubtreeAvailability::createEmpty` now requires a boolean parameter to set initial tile availability.
 
 ##### Additions :tada:
 

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
@@ -60,14 +60,14 @@ public:
    * @param subdivisionScheme The subdivision scheme of the subtree (quadtree or
    * octree).
    * @param levelsInSubtree The number of levels in this subtree.
-   * @param allTilesAvailable Whether to make all tiles initially available.
+   * @param setTilesAvailable Whether to make all tiles initially available.
    * @return The subtree availability, or std::nullopt if the subtree definition
    * is invalid.
    */
   static std::optional<SubtreeAvailability> createEmpty(
       ImplicitTileSubdivisionScheme subdivisionScheme,
       uint32_t levelsInSubtree,
-      bool allTilesAvailable) noexcept;
+      bool allTilesetTilesAvailablesAvailable) noexcept;
 
   /**
    * @brief Asynchronously loads a subtree from a URL. The resource downloaded

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
@@ -67,7 +67,7 @@ public:
   static std::optional<SubtreeAvailability> createEmpty(
       ImplicitTileSubdivisionScheme subdivisionScheme,
       uint32_t levelsInSubtree,
-      bool allTilesetTilesAvailablesAvailable) noexcept;
+      bool setTilesAvailable) noexcept;
 
   /**
    * @brief Asynchronously loads a subtree from a URL. The resource downloaded

--- a/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
+++ b/Cesium3DTilesContent/include/Cesium3DTilesContent/SubtreeAvailability.h
@@ -54,18 +54,20 @@ public:
       Cesium3DTiles::Subtree&& subtree) noexcept;
 
   /**
-   * @brief Creates an empty instance with all tiles initially available, while
-   * all content and subtrees are initially unavailable.
+   * @brief Creates an empty instance with the specified tile availability. All
+   * content and subtrees are initially unavailable regardless of this value.
    *
    * @param subdivisionScheme The subdivision scheme of the subtree (quadtree or
    * octree).
    * @param levelsInSubtree The number of levels in this subtree.
+   * @param allTilesAvailable Whether to make all tiles initially available.
    * @return The subtree availability, or std::nullopt if the subtree definition
    * is invalid.
    */
   static std::optional<SubtreeAvailability> createEmpty(
       ImplicitTileSubdivisionScheme subdivisionScheme,
-      uint32_t levelsInSubtree) noexcept;
+      uint32_t levelsInSubtree,
+      bool allTilesAvailable) noexcept;
 
   /**
    * @brief Asynchronously loads a subtree from a URL. The resource downloaded

--- a/Cesium3DTilesContent/src/SubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/src/SubtreeAvailability.cpp
@@ -135,10 +135,10 @@ std::optional<SubtreeAvailability::AvailabilityView> parseAvailabilityView(
 /*static*/ std::optional<SubtreeAvailability> SubtreeAvailability::createEmpty(
     ImplicitTileSubdivisionScheme subdivisionScheme,
     uint32_t levelsInSubtree,
-    bool allTilesAvailable) noexcept {
+    bool setTilesAvailable) noexcept {
   Subtree subtree;
   subtree.tileAvailability.constant =
-      allTilesAvailable ? Cesium3DTiles::Availability::Constant::AVAILABLE
+      setTilesAvailable ? Cesium3DTiles::Availability::Constant::AVAILABLE
                         : Cesium3DTiles::Availability::Constant::UNAVAILABLE;
   subtree.contentAvailability.emplace_back().constant =
       Cesium3DTiles::Availability::Constant::UNAVAILABLE;

--- a/Cesium3DTilesContent/src/SubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/src/SubtreeAvailability.cpp
@@ -134,10 +134,12 @@ std::optional<SubtreeAvailability::AvailabilityView> parseAvailabilityView(
 
 /*static*/ std::optional<SubtreeAvailability> SubtreeAvailability::createEmpty(
     ImplicitTileSubdivisionScheme subdivisionScheme,
-    uint32_t levelsInSubtree) noexcept {
+    uint32_t levelsInSubtree,
+    bool allTilesAvailable) noexcept {
   Subtree subtree;
   subtree.tileAvailability.constant =
-      Cesium3DTiles::Availability::Constant::AVAILABLE;
+      allTilesAvailable ? Cesium3DTiles::Availability::Constant::AVAILABLE
+                        : Cesium3DTiles::Availability::Constant::UNAVAILABLE;
   subtree.contentAvailability.emplace_back().constant =
       Cesium3DTiles::Availability::Constant::UNAVAILABLE;
   subtree.childSubtreeAvailability.constant =

--- a/Cesium3DTilesContent/test/TestSubtreeAvailability.cpp
+++ b/Cesium3DTilesContent/test/TestSubtreeAvailability.cpp
@@ -1015,11 +1015,50 @@ TEST_CASE("Test parsing subtree format") {
   }
 }
 
+TEST_CASE("Test SubtreeAvailability::createEmpty") {
+  SUBCASE("With no tiles available") {
+    std::optional<SubtreeAvailability> maybeAvailability =
+        SubtreeAvailability::createEmpty(
+            ImplicitTileSubdivisionScheme::Quadtree,
+            5,
+            false);
+    REQUIRE(maybeAvailability);
+
+    SubtreeAvailability& availability = *maybeAvailability;
+
+    CHECK_FALSE(availability.isTileAvailable(
+        QuadtreeTileID(0, 0, 0),
+        QuadtreeTileID(0, 0, 0)));
+    CHECK_FALSE(availability.isTileAvailable(
+        QuadtreeTileID(0, 0, 0),
+        QuadtreeTileID(4, 15, 15)));
+  }
+
+  SUBCASE("With all tiles available") {
+    std::optional<SubtreeAvailability> maybeAvailability =
+        SubtreeAvailability::createEmpty(
+            ImplicitTileSubdivisionScheme::Quadtree,
+            5,
+            true);
+    REQUIRE(maybeAvailability);
+
+    SubtreeAvailability& availability = *maybeAvailability;
+
+    CHECK(availability.isTileAvailable(
+        QuadtreeTileID(0, 0, 0),
+        QuadtreeTileID(0, 0, 0)));
+    CHECK(availability.isTileAvailable(
+        QuadtreeTileID(0, 0, 0),
+        QuadtreeTileID(4, 15, 15)));
+  }
+}
+
 TEST_CASE("SubtreeAvailability modifications") {
   std::optional<SubtreeAvailability> maybeAvailability =
       SubtreeAvailability::createEmpty(
           ImplicitTileSubdivisionScheme::Quadtree,
-          5);
+          5,
+          true);
   REQUIRE(maybeAvailability);
 
   SubtreeAvailability& availability = *maybeAvailability;


### PR DESCRIPTION
This PR adds `setTilesAvailable` to `SubtreeAvailability::createEmpty`. The default behavior was sufficiently documented (initializing all tiles as available), but a bit unexpected because of the implications of "empty". Either way, it helps to have the option to explicitly set how to initialize the tile availability.