### PR TITLE
Add `TreeTraversalState::diff`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Additions :tada:
+
+- Added `diff` method to `TreeTraversalState`.
+
 ### v0.48.0 - 2025-06-02
 
 ##### Breaking Changes :mega:

--- a/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
+++ b/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
@@ -323,12 +323,12 @@ public:
    * function is given the node pointer, the old state, and the new state, in
    * that order.
    */
-  template <typename TCallback> void diff(TCallback&& callback) {
-    size_t previousIndex = 0;
-    size_t currentIndex = 0;
+  template <typename TCallback> void diff(TCallback&& callback) const {
+    int64_t previousIndex = 0;
+    int64_t currentIndex = 0;
 
-    while (previousIndex < this->_previousTraversal.size() &&
-           currentIndex > this->_currentTraversal.size()) {
+    while (previousIndex < int64_t(this->_previousTraversal.size()) &&
+           currentIndex < int64_t(this->_currentTraversal.size())) {
       const TraversalData& previousData =
           this->_previousTraversal[previousIndex];
       const TraversalData& currentData = this->_currentTraversal[currentIndex];
@@ -349,31 +349,30 @@ public:
       bool currentTraversalVisitedChildren =
           currentData.nextSiblingIndex > currentIndex + 1;
 
-      if (previousTraversalVisitedChildren == currentTraversalVisitedChildren) {
-        ++previousIndex;
-        ++currentIndex;
-      } else if (previousTraversalVisitedChildren) {
+      ++previousIndex;
+      ++currentIndex;
+
+      if (previousTraversalVisitedChildren &&
+          !currentTraversalVisitedChildren) {
         while (previousIndex < previousData.nextSiblingIndex) {
           const TraversalData& skipped =
               this->_previousTraversal[previousIndex];
           callback(skipped.pNode, skipped.state, TState());
           ++previousIndex;
         }
-
-        ++currentIndex;
-      } else {
+      } else if (
+          currentTraversalVisitedChildren &&
+          !previousTraversalVisitedChildren) {
         while (currentIndex < currentData.nextSiblingIndex) {
           const TraversalData& skipped = this->_currentTraversal[currentIndex];
           callback(skipped.pNode, TState(), skipped.state);
           ++currentIndex;
         }
-
-        ++previousIndex;
       }
     }
 
-    CESIUM_ASSERT(previousIndex == this->_previousTraversal.size());
-    CESIUM_ASSERT(currentIndex == this->_currentTraversal.size());
+    CESIUM_ASSERT(previousIndex == int64_t(this->_previousTraversal.size()));
+    CESIUM_ASSERT(currentIndex == int64_t(this->_currentTraversal.size()));
   }
 
 private:

--- a/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
+++ b/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
@@ -318,12 +318,27 @@ public:
    * callback for each case where a node had a different state in the two
    * traversals.
    *
+   * The callback is also invoked:
+   *
+   *   * For each node that was visited previously but was not visited in the
+   * current traversal. In this case, the current state provided to the callback
+   * is a default-constructed `TState` instance.
+   *   * For each node that was not visited previously but was visited in the
+   * current traversal. In this case, the previous state provided to the
+   * callback is a default-constructed `TState` instance.
+   *
+   * This method should only be called after the {@link finishNode} for the
+   * root node, and before {@link beginTraversal}. In other words, it should
+   * not be called while a traversal is in progress.
+   *
    * @tparam TCallback The type of the callback.
    * @param callback The callback to be invoked for each difference. The
    * function is given the node pointer, the old state, and the new state, in
    * that order.
    */
   template <typename TCallback> void diff(TCallback&& callback) const {
+    CESIUM_ASSERT(this->_parentIndices.empty());
+
     int64_t previousIndex = 0;
     int64_t currentIndex = 0;
 

--- a/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
+++ b/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
@@ -330,8 +330,9 @@ public:
     while (previousIndex < int64_t(this->_previousTraversal.size()) &&
            currentIndex < int64_t(this->_currentTraversal.size())) {
       const TraversalData& previousData =
-          this->_previousTraversal[previousIndex];
-      const TraversalData& currentData = this->_currentTraversal[currentIndex];
+          this->_previousTraversal[size_t(previousIndex)];
+      const TraversalData& currentData =
+          this->_currentTraversal[size_t(currentIndex)];
 
       CESIUM_ASSERT(previousData.pNode == currentData.pNode);
       if (previousData.pNode != currentData.pNode) {
@@ -356,7 +357,7 @@ public:
           !currentTraversalVisitedChildren) {
         while (previousIndex < previousData.nextSiblingIndex) {
           const TraversalData& skipped =
-              this->_previousTraversal[previousIndex];
+              this->_previousTraversal[size_t(previousIndex)];
           callback(skipped.pNode, skipped.state, TState());
           ++previousIndex;
         }
@@ -364,7 +365,8 @@ public:
           currentTraversalVisitedChildren &&
           !previousTraversalVisitedChildren) {
         while (currentIndex < currentData.nextSiblingIndex) {
-          const TraversalData& skipped = this->_currentTraversal[currentIndex];
+          const TraversalData& skipped =
+              this->_currentTraversal[size_t(currentIndex)];
           callback(skipped.pNode, TState(), skipped.state);
           ++currentIndex;
         }

--- a/CesiumUtility/test/TestTreeTraversalState.cpp
+++ b/CesiumUtility/test/TestTreeTraversalState.cpp
@@ -184,19 +184,23 @@ TEST_CASE("TreeTraversalState") {
       traversalState.beginNode(&a);
         REQUIRE(traversalState.previousState() != nullptr);
         CHECK(*traversalState.previousState() == 1);
+        traversalState.currentState() = 1;
 
         traversalState.beginNode(&b);
           REQUIRE(traversalState.previousState() != nullptr);
           CHECK(*traversalState.previousState() == 2);
+          traversalState.currentState() = 2;
         traversalState.finishNode(&b);
 
         traversalState.beginNode(&c);
           REQUIRE(traversalState.previousState() != nullptr);
           CHECK(*traversalState.previousState() == 3);
+          traversalState.currentState() = 3;
 
           traversalState.beginNode(&e);
             REQUIRE(traversalState.previousState() != nullptr);
             CHECK(*traversalState.previousState() == 5);
+            traversalState.currentState() = 5;
 
             traversalState.beginNode(&g);
               CHECK(traversalState.previousState() == nullptr);
@@ -208,6 +212,7 @@ TEST_CASE("TreeTraversalState") {
           traversalState.beginNode(&f);
             REQUIRE(traversalState.previousState() != nullptr);
             CHECK(*traversalState.previousState() == 6);
+            traversalState.currentState() = 6;
           traversalState.finishNode(&f);
 
         traversalState.finishNode(&c);
@@ -215,10 +220,20 @@ TEST_CASE("TreeTraversalState") {
         traversalState.beginNode(&d);
           REQUIRE(traversalState.previousState() != nullptr);
           CHECK(*traversalState.previousState() == 4);
+          traversalState.currentState() = 4;
         traversalState.finishNode(&d);
 
       traversalState.finishNode(&a);
       // clang-format on
+
+      SUBCASE("and diff reports the differences") {
+        std::vector<std::tuple<Node*, int, int>> differences =
+            getDifferences(traversalState);
+        REQUIRE(differences.size() == 1);
+        CHECK(std::get<0>(differences[0]) == &g);
+        CHECK(std::get<1>(differences[0]) == int());
+        CHECK(std::get<2>(differences[0]) == 7);
+      }
     }
 
     SUBCASE("Second traversal can add two new levels") {
@@ -230,19 +245,23 @@ TEST_CASE("TreeTraversalState") {
       traversalState.beginNode(&a);
         REQUIRE(traversalState.previousState() != nullptr);
         CHECK(*traversalState.previousState() == 1);
+        traversalState.currentState() = 1;
 
         traversalState.beginNode(&b);
           REQUIRE(traversalState.previousState() != nullptr);
           CHECK(*traversalState.previousState() == 2);
+          traversalState.currentState() = 2;
         traversalState.finishNode(&b);
 
         traversalState.beginNode(&c);
           REQUIRE(traversalState.previousState() != nullptr);
           CHECK(*traversalState.previousState() == 3);
+          traversalState.currentState() = 3;
 
           traversalState.beginNode(&e);
             REQUIRE(traversalState.previousState() != nullptr);
             CHECK(*traversalState.previousState() == 5);
+            traversalState.currentState() = 5;
 
             traversalState.beginNode(&g);
               CHECK(traversalState.previousState() == nullptr);
@@ -259,6 +278,7 @@ TEST_CASE("TreeTraversalState") {
           traversalState.beginNode(&f);
             REQUIRE(traversalState.previousState() != nullptr);
             CHECK(*traversalState.previousState() == 6);
+            traversalState.currentState() = 6;
           traversalState.finishNode(&f);
 
         traversalState.finishNode(&c);
@@ -266,10 +286,23 @@ TEST_CASE("TreeTraversalState") {
         traversalState.beginNode(&d);
           REQUIRE(traversalState.previousState() != nullptr);
           CHECK(*traversalState.previousState() == 4);
+          traversalState.currentState() = 4;
         traversalState.finishNode(&d);
 
       traversalState.finishNode(&a);
       // clang-format on
+
+      SUBCASE("and diff reports the differences") {
+        std::vector<std::tuple<Node*, int, int>> differences =
+            getDifferences(traversalState);
+        REQUIRE(differences.size() == 2);
+        CHECK(std::get<0>(differences[0]) == &g);
+        CHECK(std::get<1>(differences[0]) == int());
+        CHECK(std::get<2>(differences[0]) == 7);
+        CHECK(std::get<0>(differences[1]) == &h);
+        CHECK(std::get<1>(differences[1]) == int());
+        CHECK(std::get<2>(differences[1]) == 8);
+      }
     }
 
     SUBCASE(
@@ -396,24 +429,46 @@ TEST_CASE("TreeTraversalState") {
       traversalState.beginNode(&a);
         REQUIRE(traversalState.previousState() != nullptr);
         CHECK(*traversalState.previousState() == 1);
+        traversalState.currentState() = 1;
 
         traversalState.beginNode(&b);
           REQUIRE(traversalState.previousState() != nullptr);
           CHECK(*traversalState.previousState() == 2);
+          traversalState.currentState() = 2;
         traversalState.finishNode(&b);
 
         traversalState.beginNode(&c);
           REQUIRE(traversalState.previousState() != nullptr);
           CHECK(*traversalState.previousState() == 3);
+          traversalState.currentState() = 3;
         traversalState.finishNode(&c);
 
         traversalState.beginNode(&d);
           REQUIRE(traversalState.previousState() != nullptr);
           CHECK(*traversalState.previousState() == 4);
+          traversalState.currentState() = 4;
         traversalState.finishNode(&d);
 
       traversalState.finishNode(&a);
       // clang-format on
+
+      SUBCASE("and diff reports the differences") {
+        std::vector<std::tuple<Node*, int, int>> differences =
+            getDifferences(traversalState);
+        REQUIRE(differences.size() == 4);
+        CHECK(std::get<0>(differences[0]) == &e);
+        CHECK(std::get<1>(differences[0]) == 5);
+        CHECK(std::get<2>(differences[0]) == int());
+        CHECK(std::get<0>(differences[1]) == &g);
+        CHECK(std::get<1>(differences[1]) == 7);
+        CHECK(std::get<2>(differences[1]) == int());
+        CHECK(std::get<0>(differences[2]) == &h);
+        CHECK(std::get<1>(differences[2]) == 8);
+        CHECK(std::get<2>(differences[2]) == int());
+        CHECK(std::get<0>(differences[3]) == &f);
+        CHECK(std::get<1>(differences[3]) == 6);
+        CHECK(std::get<2>(differences[3]) == int());
+      }
     }
   }
 
@@ -474,11 +529,13 @@ TEST_CASE("TreeTraversalState") {
       traversalState.currentState() = 1;
       REQUIRE(traversalState.previousState() != nullptr);
       CHECK(*traversalState.previousState() == 1);
+      traversalState.currentState() = 1;
 
       traversalState.beginNode(&b);
         traversalState.currentState() = 2;
         REQUIRE(traversalState.previousState() != nullptr);
         CHECK(*traversalState.previousState() == 2);
+        traversalState.currentState() = 2;
 
         traversalState.beginNode(&f);
           traversalState.currentState() = 6;
@@ -496,22 +553,37 @@ TEST_CASE("TreeTraversalState") {
         traversalState.currentState() = 3;
         REQUIRE(traversalState.previousState() != nullptr);
         CHECK(*traversalState.previousState() == 3);
+        traversalState.currentState() = 3;
 
         traversalState.beginNode(&d);
           traversalState.currentState() = 4;
           REQUIRE(traversalState.previousState() != nullptr);
           CHECK(*traversalState.previousState() == 4);
+          traversalState.currentState() = 4;
         traversalState.finishNode(&d);
 
         traversalState.beginNode(&e);
           traversalState.currentState() = 5;
           REQUIRE(traversalState.previousState() != nullptr);
           CHECK(*traversalState.previousState() == 5);
+          traversalState.currentState() = 5;
         traversalState.finishNode(&e);
 
       traversalState.finishNode(&c);
 
     traversalState.finishNode(&a);
     // clang-format on
+
+    SUBCASE("and diff reports the differences") {
+      std::vector<std::tuple<Node*, int, int>> differences =
+          getDifferences(traversalState);
+      REQUIRE(differences.size() == 2);
+      CHECK(std::get<0>(differences[0]) == &f);
+      CHECK(std::get<1>(differences[0]) == int());
+      CHECK(std::get<2>(differences[0]) == 6);
+      CHECK(std::get<0>(differences[1]) == &g);
+      CHECK(std::get<1>(differences[1]) == int());
+      CHECK(std::get<2>(differences[1]) == 7);
+    }
   }
 }


### PR DESCRIPTION
Adds a `diff` method to `TreeTraversalState`. This method calls a callback function for each state instance that is different in the current traversal compared to the previous one.

The idea is that this allows us to report per-view-group tile state changes. We can use that to build a system that keeps points on terrain as a tileset refines/unrefines.

I think this is in pretty good shape, but I've marked it draft for now. The next parts we build on top of it might end up influencing the design.