### PR TITLE
Add a "render-readiness" flag on tiles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@
 - Added an overload of `Math::equalsEpsilon` for glm matrices.
 - A tile's bounding volume and content bounding volume are now included in `TileLoadResult` for use in `prepareInLoadThread`.
 - Added `convertAccessorTypeToPropertyType` and `convertPropertyTypeToAccessorType` to `CesiumGltf::PropertyType`.
+- Added `Cesium3DTilesSelection::Tile::setRenderEngineReadiness(bool)`: pass false to delay the point at which the tile can be shown, while waiting for some asynchronous post-processing to finish for example.
 
 ##### Fixes :wrench:
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
@@ -476,6 +476,14 @@ public:
   bool isRenderable() const noexcept;
 
   /**
+   *  @brief Normally, tiles are assumed immediately renderable when they reach
+   *  TileLoadState::Done status: render engine can toggle readiness off to
+   *  signify that the tile should not be considered renderable until the flag
+   *  is turned on again.
+   */
+  void setRenderEngineReadiness(bool const renderEngineReady) noexcept;
+
+  /**
    * @brief Determines if this tile has mesh content.
    */
   bool isRenderContent() const noexcept;
@@ -660,6 +668,7 @@ private:
   TilesetContentLoader* _pLoader;
   TileLoadState _loadState;
   bool _mightHaveLatentChildren;
+  bool _renderEngineReadiness = true; ///< Relevant only when _loadState is Done
 
   // mapped raster overlay
   std::vector<RasterMappedTo3DTile> _rasterTiles;

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -215,6 +215,8 @@ bool Tile::isRenderable() const noexcept {
   }
 
   if (getState() == TileLoadState::Done) {
+    if (!_renderEngineReadiness)
+      return false;
     // An unconditionally-refined tile is never renderable... UNLESS it has no
     // children, in which case waiting longer will be futile.
     if (!getUnconditionallyRefine() || this->_children.empty()) {
@@ -228,6 +230,10 @@ bool Tile::isRenderable() const noexcept {
   }
 
   return false;
+}
+
+void Tile::setRenderEngineReadiness(bool const renderEngineReady) noexcept {
+  _renderEngineReadiness = renderEngineReady;
 }
 
 bool Tile::isRenderContent() const noexcept {


### PR DESCRIPTION
Render engine or user-developer customizations can toggle it off to delay the point at which the tile can be shown, while waiting for some asynchronous post-processing to finish