### PR TITLE
Fix Tile reference counting assertion with implicit tiling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 - Renamed `SubtreeWriter::writeSubtree` to `SubtreeWriter::writeSubtreeJson`.
 - `SubtreeAvailability::createEmpty` now requires a boolean parameter to set initial tile availability.
-- `Cesium3DTilesSelection::Tile` constructors taking initial empty or external content now also require that a `TileID` be supplied.
+- `Cesium3DTilesSelection::Tile` constructors that take initially empty or external content now also require a `TileID` to be supplied.
 
 ##### Additions :tada:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Renamed `SubtreeWriter::writeSubtree` to `SubtreeWriter::writeSubtreeJson`.
 - `SubtreeAvailability::createEmpty` now requires a boolean parameter to set initial tile availability.
+- `Cesium3DTilesSelection::Tile` constructors taking initial empty or external content now also require that a `TileID` be supplied.
 
 ##### Additions :tada:
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
@@ -136,19 +136,33 @@ public:
    * with this constructor.
    *
    * @param pLoader The {@link TilesetContentLoader} that is used to load the tile.
+   * @param tileID The ID of this tile. If not specified, the ID will initially
+   * be an empty string.
    */
-  explicit Tile(TilesetContentLoader* pLoader) noexcept;
+  explicit Tile(
+      TilesetContentLoader* pLoader,
+      const TileID& tileID = {}) noexcept;
 
   /**
    * @brief Construct a tile with an external content and a loader that is
    * associated with this tile. Tile has ContentLoaded status when initializing
    * with this constructor.
    *
+   * If the supplied `TileID` is not an empty string, the tile's reference count
+   * will be incremented on account of the the loaded, referencable content.
+   * Otherwise, if it is an empty string, the reference count will not be
+   * incremented. It is essential that this be accounted for later if the tile
+   * ID is changed in order to avoid reference count assertion failures at
+   * tileset destruction.
+   *
    * @param pLoader The {@link TilesetContentLoader} that is assiocated with this tile.
+   * @param tileID The ID of this tile. If it is an empty string, then the
+   * external content will not be unloable.
    * @param externalContent External content that is associated with this tile.
    */
   Tile(
       TilesetContentLoader* pLoader,
+      const TileID& tileID,
       std::unique_ptr<TileExternalContent>&& externalContent) noexcept;
 
   /**
@@ -156,10 +170,22 @@ public:
    * associated with this tile. Tile has ContentLoaded status when initializing
    * with this constructor.
    *
+   * If the supplied `TileID` is not an empty string, the tile's reference count
+   * will be incremented on account of the the loaded, referencable content.
+   * Otherwise, if it is an empty string, the reference count will not be
+   * incremented. It is essential that this be accounted for later if the tile
+   * ID is changed in order to avoid reference count assertion failures at
+   * tileset destruction.
+   *
    * @param pLoader The {@link TilesetContentLoader} that is assiocated with this tile.
+   * @param tileID The ID of this tile. If it is an empty string, then the
+   * empty content will not be unloable.
    * @param emptyContent A content tag indicating that the tile has no content.
    */
-  Tile(TilesetContentLoader* pLoader, TileEmptyContent emptyContent) noexcept;
+  Tile(
+      TilesetContentLoader* pLoader,
+      const TileID& tileID,
+      TileEmptyContent emptyContent) noexcept;
 
   /**
    * @brief Default destructor, which clears all resources associated with this
@@ -615,6 +641,7 @@ private:
       TileConstructorImpl tag,
       TileLoadState loadState,
       TilesetContentLoader* pLoader,
+      const TileID& tileID,
       TileContentArgs&&... args);
 
   void setParent(Tile* pParent) noexcept;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
@@ -149,7 +149,7 @@ public:
    * with this constructor.
    *
    * If the supplied `TileID` is not an empty string, the tile's reference count
-   * will be incremented on account of the the loaded, referencable content.
+   * will be incremented on account of the loaded, referencable content.
    * Otherwise, if it is an empty string, the reference count will not be
    * incremented. It is essential that this be accounted for later if the tile
    * ID is changed in order to avoid reference count assertion failures at
@@ -157,7 +157,7 @@ public:
    *
    * @param pLoader The {@link TilesetContentLoader} that is assiocated with this tile.
    * @param tileID The ID of this tile. If it is an empty string, then the
-   * external content will not be unloable.
+   * external content will not be unloadable.
    * @param externalContent External content that is associated with this tile.
    */
   Tile(
@@ -171,7 +171,7 @@ public:
    * with this constructor.
    *
    * If the supplied `TileID` is not an empty string, the tile's reference count
-   * will be incremented on account of the the loaded, referencable content.
+   * will be incremented on account of the loaded, referencable content.
    * Otherwise, if it is an empty string, the reference count will not be
    * incremented. It is essential that this be accounted for later if the tile
    * ID is changed in order to avoid reference count assertion failures at
@@ -179,7 +179,7 @@ public:
    *
    * @param pLoader The {@link TilesetContentLoader} that is assiocated with this tile.
    * @param tileID The ID of this tile. If it is an empty string, then the
-   * empty content will not be unloable.
+   * empty content will not be unloadable.
    * @param emptyContent A content tag indicating that the tile has no content.
    */
   Tile(

--- a/Cesium3DTilesSelection/src/EllipsoidTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/EllipsoidTilesetLoader.cpp
@@ -59,7 +59,7 @@ EllipsoidTilesetLoader::EllipsoidTilesetLoader(const Ellipsoid& ellipsoid)
   std::unique_ptr<EllipsoidTilesetLoader> pCustomLoader =
       std::make_unique<EllipsoidTilesetLoader>(options.ellipsoid);
   std::unique_ptr<Tile> pRootTile =
-      std::make_unique<Tile>(pCustomLoader.get(), TileEmptyContent{});
+      std::make_unique<Tile>(pCustomLoader.get(), TileID(), TileEmptyContent{});
 
   pRootTile->setRefine(TileRefine::Replace);
   pRootTile->setUnconditionallyRefine();

--- a/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitOctreeLoader.cpp
@@ -118,9 +118,9 @@ std::vector<Tile> populateSubtree(
                 relativeChildLevel,
                 relativeChildMortonID,
                 0)) {
-          children.emplace_back(&loader);
+          children.emplace_back(&loader, childID);
         } else {
-          children.emplace_back(&loader, TileEmptyContent{});
+          children.emplace_back(&loader, childID, TileEmptyContent{});
         }
 
         Tile& child = children.back();
@@ -131,7 +131,6 @@ std::vector<Tile> populateSubtree(
             ellipsoid));
         child.setGeometricError(tile.getGeometricError() * 0.5);
         child.setRefine(tile.getRefine());
-        child.setTileID(childID);
       }
     }
   }

--- a/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/src/ImplicitQuadtreeLoader.cpp
@@ -128,9 +128,9 @@ std::vector<Tile> populateSubtree(
                 relativeChildLevel,
                 relativeChildMortonID,
                 0)) {
-          children.emplace_back(&loader);
+          children.emplace_back(&loader, childID);
         } else {
-          children.emplace_back(&loader, TileEmptyContent{});
+          children.emplace_back(&loader, childID, TileEmptyContent{});
         }
 
         Tile& child = children.back();
@@ -141,7 +141,6 @@ std::vector<Tile> populateSubtree(
             ellipsoid));
         child.setGeometricError(tile.getGeometricError() * 0.5);
         child.setRefine(tile.getRefine());
-        child.setTileID(childID);
       }
     }
   }

--- a/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
+++ b/Cesium3DTilesSelection/src/LayerJsonTerrainLoader.cpp
@@ -137,7 +137,7 @@ convertToTilesetContentLoaderResult(
       std::move(loadLayersResult.layers));
 
   std::unique_ptr<Tile> pRootTile =
-      std::make_unique<Tile>(pLoader.get(), TileEmptyContent());
+      std::make_unique<Tile>(pLoader.get(), TileID(), TileEmptyContent());
   pRootTile->setUnconditionallyRefine();
   pRootTile->setBoundingVolume(*loadLayersResult.boundingVolume);
 

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -53,25 +53,29 @@ void TileReferenceCountTracker::addEntry(
 }
 #endif
 
-Tile::Tile(TilesetContentLoader* pLoader) noexcept
-    : Tile(TileConstructorImpl{}, TileLoadState::Unloaded, pLoader) {}
+Tile::Tile(TilesetContentLoader* pLoader, const TileID& tileID) noexcept
+    : Tile(TileConstructorImpl{}, TileLoadState::Unloaded, pLoader, tileID) {}
 
 Tile::Tile(
     TilesetContentLoader* pLoader,
+    const TileID& tileID,
     std::unique_ptr<TileExternalContent>&& externalContent) noexcept
     : Tile(
           TileConstructorImpl{},
           TileLoadState::ContentLoaded,
           pLoader,
+          tileID,
           TileContent(std::move(externalContent))) {}
 
 Tile::Tile(
     TilesetContentLoader* pLoader,
+    const TileID& tileID,
     TileEmptyContent emptyContent) noexcept
     : Tile(
           TileConstructorImpl{},
           TileLoadState::ContentLoaded,
           pLoader,
+          tileID,
           emptyContent) {}
 
 template <typename... TileContentArgs, typename TileContentEnable>
@@ -79,10 +83,11 @@ Tile::Tile(
     TileConstructorImpl,
     TileLoadState loadState,
     TilesetContentLoader* pLoader,
+    const TileID& tileID,
     TileContentArgs&&... args)
     : _pParent(nullptr),
       _children(),
-      _id(""s),
+      _id(tileID),
       _boundingVolume(OrientedBoundingBox(glm::dvec3(), glm::dmat3())),
       _viewerRequestVolume(),
       _contentBoundingVolume(),

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -583,8 +583,10 @@ std::optional<Tile> parseTileJsonRecursively(
 
   if (implicitTilingJson) {
     // mark this tile as external
-    Tile tile{&currentLoader, std::make_unique<TileExternalContent>()};
-    tile.setTileID("");
+    Tile tile{
+        &currentLoader,
+        TileID(),
+        std::make_unique<TileExternalContent>()};
     tile.setTransform(tileTransform);
     tile.setBoundingVolume(tileBoundingVolume);
     tile.setViewerRequestVolume(tileViewerRequestVolume);
@@ -899,9 +901,9 @@ TilesetJsonLoader::createLoader(
 
   result.pRootTile = std::make_unique<Tile>(
       children[0].getLoader(),
+      TileID(),
       std::make_unique<TileExternalContent>());
 
-  result.pRootTile->setTileID("");
   result.pRootTile->setTransform(children[0].getTransform());
   result.pRootTile->setBoundingVolume(children[0].getBoundingVolume());
   result.pRootTile->setUnconditionallyRefine();

--- a/Cesium3DTilesSelection/test/TestImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/test/TestImplicitOctreeLoader.cpp
@@ -768,7 +768,7 @@ TEST_CASE("Test tile subdivision for implicit octree loader") {
     }
 
     // The seven tiles without content should have referencing EmptyContent.
-    // The fourth should not yet have any referencing content because it has not
+    // The eighth should not yet have any referencing content because it has not
     // been loaded.
     CHECK(childrenWithReferencingContent == 7);
   }

--- a/Cesium3DTilesSelection/test/TestImplicitOctreeLoader.cpp
+++ b/Cesium3DTilesSelection/test/TestImplicitOctreeLoader.cpp
@@ -708,4 +708,68 @@ TEST_CASE("Test tile subdivision for implicit octree loader") {
       CHECK(region_2_3_1_1.getMaximumHeight() == Approx(50.0));
     }
   }
+
+  SUBCASE("Child tiles without content initially have empty content") {
+    OrientedBoundingBox loaderBoundingVolume{glm::dvec3(0.0), glm::dmat3(20.0)};
+    ImplicitOctreeLoader loader{
+        "tileset.json",
+        "content/{level}.{x}.{y}.{z}.b3dm",
+        "subtrees/{level}.{x}.{y}.{z}.json",
+        5,
+        5,
+        loaderBoundingVolume};
+
+    // add subtree with all tiles, but no content available.
+    std::optional<SubtreeAvailability> maybeAvailability =
+        SubtreeAvailability::createEmpty(
+            ImplicitTileSubdivisionScheme::Octree,
+            5,
+            true);
+    REQUIRE(maybeAvailability);
+    SubtreeAvailability availability = std::move(*maybeAvailability);
+
+    // Mark content for a tile available
+    availability.setContentAvailable(
+        OctreeTileID{0, 0, 0, 0},
+        OctreeTileID{1, 1, 1, 1},
+        0,
+        true);
+    loader.addSubtreeAvailability(
+        OctreeTileID{0, 0, 0, 0},
+        std::move(availability));
+
+    // check subdivide root tile first
+    Tile tile(&loader);
+    tile.setTileID(OctreeTileID(0, 0, 0, 0));
+    tile.setBoundingVolume(loaderBoundingVolume);
+
+    auto tileChildrenResult = loader.createTileChildren(tile);
+    CHECK(tileChildrenResult.state == TileLoadResultState::Success);
+
+    REQUIRE(tileChildrenResult.children.size() == 8);
+
+    size_t childrenWithReferencingContent = 0;
+
+    for (Tile& child : tileChildrenResult.children) {
+      if (child.hasReferencingContent()) {
+        ++childrenWithReferencingContent;
+
+        REQUIRE(child.getReferenceCount() == 1);
+        child.getContent().setContentKind(TileUnknownContent());
+
+        // In a perfect world the above might release the reference, but it
+        // won't. Release it manually so we won't assert when the Tile goes out
+        // of scope.
+        REQUIRE(child.getReferenceCount() == 1);
+        child.releaseReference();
+      } else {
+        REQUIRE(child.getReferenceCount() == 0);
+      }
+    }
+
+    // The seven tiles without content should have referencing EmptyContent.
+    // The fourth should not yet have any referencing content because it has not
+    // been loaded.
+    CHECK(childrenWithReferencingContent == 7);
+  }
 }

--- a/Cesium3DTilesSelection/test/TestImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/test/TestImplicitQuadtreeLoader.cpp
@@ -566,4 +566,68 @@ TEST_CASE("Test tile subdivision for implicit quadtree loader") {
         std::get<S2CellBoundingVolume>(tile_1_1_1.getBoundingVolume());
     CHECK(box_1_1_1.getCellID().toToken() == "14");
   }
+
+  SUBCASE("Child tiles without content initially have empty content") {
+    OrientedBoundingBox loaderBoundingVolume{glm::dvec3(0.0), glm::dmat3(20.0)};
+    ImplicitQuadtreeLoader loader{
+        "tileset.json",
+        "content/{level}.{x}.{y}.b3dm",
+        "subtrees/{level}.{x}.{y}.json",
+        5,
+        5,
+        loaderBoundingVolume};
+
+    // add subtree with all tiles, but no content available.
+    std::optional<SubtreeAvailability> maybeAvailability =
+        SubtreeAvailability::createEmpty(
+            ImplicitTileSubdivisionScheme::Quadtree,
+            5,
+            true);
+    REQUIRE(maybeAvailability);
+    SubtreeAvailability availability = std::move(*maybeAvailability);
+
+    // Mark content for a tile available
+    availability.setContentAvailable(
+        QuadtreeTileID{0, 0, 0},
+        QuadtreeTileID{1, 1, 1},
+        0,
+        true);
+    loader.addSubtreeAvailability(
+        QuadtreeTileID{0, 0, 0},
+        std::move(availability));
+
+    // check subdivide root tile first
+    Tile tile(&loader);
+    tile.setTileID(QuadtreeTileID(0, 0, 0));
+    tile.setBoundingVolume(loaderBoundingVolume);
+
+    auto tileChildrenResult = loader.createTileChildren(tile);
+    CHECK(tileChildrenResult.state == TileLoadResultState::Success);
+
+    REQUIRE(tileChildrenResult.children.size() == 4);
+
+    size_t childrenWithReferencingContent = 0;
+
+    for (Tile& child : tileChildrenResult.children) {
+      if (child.hasReferencingContent()) {
+        ++childrenWithReferencingContent;
+
+        REQUIRE(child.getReferenceCount() == 1);
+        child.getContent().setContentKind(TileEmptyContent());
+
+        // In a perfect world the above might release the reference, but it
+        // won't. Release it manually so we won't assert when the Tile goes out
+        // of scope.
+        REQUIRE(child.getReferenceCount() == 1);
+        child.releaseReference();
+      } else {
+        REQUIRE(child.getReferenceCount() == 0);
+      }
+    }
+
+    // The three tiles without content should have referencing EmptyContent.
+    // The fourth should not yet have any referencing content because it has not
+    // been loaded.
+    CHECK(childrenWithReferencingContent == 3);
+  }
 }

--- a/Cesium3DTilesSelection/test/TestImplicitQuadtreeLoader.cpp
+++ b/Cesium3DTilesSelection/test/TestImplicitQuadtreeLoader.cpp
@@ -613,7 +613,7 @@ TEST_CASE("Test tile subdivision for implicit quadtree loader") {
         ++childrenWithReferencingContent;
 
         REQUIRE(child.getReferenceCount() == 1);
-        child.getContent().setContentKind(TileEmptyContent());
+        child.getContent().setContentKind(TileUnknownContent());
 
         // In a perfect world the above might release the reference, but it
         // won't. Release it manually so we won't assert when the Tile goes out

--- a/Cesium3DTilesSelection/test/TestTilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/test/TestTilesetContentManager.cpp
@@ -476,6 +476,7 @@ TEST_CASE("Test tile state machine") {
     pMockedLoader->mockCreateTileChildren = {{}, TileLoadResultState::Success};
     pMockedLoader->mockCreateTileChildren.children.emplace_back(
         pMockedLoader.get(),
+        TileID(),
         TileEmptyContent());
 
     // create tile
@@ -582,6 +583,7 @@ TEST_CASE("Test tile state machine") {
     pMockedLoader->mockCreateTileChildren = {{}, TileLoadResultState::Success};
     pMockedLoader->mockCreateTileChildren.children.emplace_back(
         pMockedLoader.get(),
+        TileID(),
         TileEmptyContent());
 
     // create tile
@@ -659,6 +661,7 @@ TEST_CASE("Test tile state machine") {
     pMockedLoader->mockCreateTileChildren = {{}, TileLoadResultState::Success};
     pMockedLoader->mockCreateTileChildren.children.emplace_back(
         pMockedLoader.get(),
+        TileID(),
         TileEmptyContent());
 
     // create tile
@@ -1799,6 +1802,7 @@ TEST_CASE("IPrepareRendererResources::prepareInLoadThread parameters") {
     pMockedLoader->mockCreateTileChildren = {{}, TileLoadResultState::Success};
     pMockedLoader->mockCreateTileChildren.children.emplace_back(
         pMockedLoader.get(),
+        TileID(),
         TileEmptyContent());
 
     // create tile


### PR DESCRIPTION
@j9liu found a tileset that was causing reference count assertion errors when clicking "Refresh Tileset" in Cesium for Unreal. The problem essentially boiled down to the fact that the tileset used implicit tiling and some tiles that exist but do not have content, and as a result `ImplicitOctreeLoader` (also quadtree) creates tiles that initially have `TileEmptyContent`. Loaded content (including empty content) "sometimes" counts as a reference against the Tile. In this case, `addReference` was not being called when the tile was initially created with empty content, but `releaseReference` _was_ being called when the tile's content was unloaded. Oops!

This is more complicated than I'd like it to be. Loaded content counts as a `Tile` reference so that we don't destroy the tile before its content is unloaded. But we only want to do that for tile that _can_ be unloaded, right? And our rule is that we can only unload content if the tile has a valid ID, because without a valid ID, there's no possible way we can _reload_ the content if we unload it. Unloading content that we can't reload will break the tileset.

So, the overly-complicated rule is that content only counts as a reference against the `Tile` when the `Tile` also has an ID.

The `Tile` constructor has this code:

```cpp
if (this->hasReferencingContent()) {
  // Add a reference for the loaded content.
  this->addReference("Constructor with content");
}
```

Which looks like it should do the job.

Unfortunately, `hasReferencingContent` will _always_ return false, because at the time this code is invoke, the `Tile` can't possibly have an ID yet. So we're never adding a content reference.

In the vast majority of cases, this is fine. Most tiles with initial content will never get an ID anyway.

But in `ImplicitQuadtreeLoader` and `ImplicitOctreeLoader`, a `Tile` was constructed like this:

```cpp
if (subtreeAvailability.isContentAvailable(
                relativeChildLevel,
                relativeChildMortonID,
                0)) {
  children.emplace_back(&loader);
} else {
  children.emplace_back(&loader, TileEmptyContent{});
}

Tile& child = children.back();
// ...
child.setTileID(childID);
```

So, when an implicit tile doesn't have content available, we created it with `TileEmptyContent`, which will _not_ add a reference, as described above. And _then_ we give it an ID, which makes this `TileEmptyContent` unloadable, and when it's unloaded the reference count will be decremented. That's a `releaseReference` without an `addReference`, which eventually causes an assertion failure.

There are a number of possible solutions to this. The one I went with in this PR is not necessarily the best, but it's simple and low impact, and at least makes this sort of problem less likely to happen in the future.

I changed the `Tile` constructors that take content to _also_ require a `TileID`. With the `TileID` supplied at construction time, the constructor code will properly increment the reference count when it needs to do so.

It's still possible to subvert this system and run into reference counting issues by initially supplying a default `TileID` (empty string) and changing it later, but... don't do that. Really the `Tile` class could use some refactoring to better control its own internal state and make this sort of problem impossible. That's a much bigger change, though.