### PR TITLE
Fix water mask in upsampled tiles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 
 - Fixed a bug where `SubtreeAvailability` wasn't updating the `constant` and `bitstream` properties of the availability object when converting constant availability to a bitstream.
 - Fixed a bug where `SubtreeAvailability` attempted to update buffer data that was no longer valid.
+- Fixed a bug introduced in v0.47.0 that caused tiles upsampled for raster overlays to lose their water mask.
 
 ### v0.47.0 - 2025-05-01
 

--- a/CesiumRasterOverlays/src/RasterOverlayUtilities.cpp
+++ b/CesiumRasterOverlays/src/RasterOverlayUtilities.cpp
@@ -1466,7 +1466,10 @@ bool upsampleTrianglesPrimitiveForRasterOverlays(
 
   // add skirts to extras to be upsampled later if needed
   if (hasSkirt) {
-    primitive.extras = SkirtMeshMetadata::createGltfExtras(*skirtMeshMetadata);
+    CesiumUtility::JsonValue::Object extras =
+        SkirtMeshMetadata::createGltfExtras(*skirtMeshMetadata);
+    extras.merge(std::move(primitive.extras));
+    primitive.extras = std::move(extras);
   }
 
   primitive.indices = static_cast<int>(indexAccessorIndex);

--- a/CesiumRasterOverlays/test/TestUpsampleGltfForRasterOverlay.cpp
+++ b/CesiumRasterOverlays/test/TestUpsampleGltfForRasterOverlay.cpp
@@ -1071,6 +1071,66 @@ TEST_CASE("upsampleGltfForRasterOverlay with UNSIGNED_SHORT indices") {
           skirtHeight * 0.5);
     }
   }
+
+  SUBCASE("Check water mask properties come through on their own") {
+    primitive.extras["OnlyWater"] = true;
+
+    Model upsampledModel =
+        *RasterOverlayUtilities::upsampleGltfForRasterOverlays(
+            model,
+            lowerLeft,
+            false);
+
+    REQUIRE(upsampledModel.meshes.size() == 1);
+    const Mesh& upsampledMesh = upsampledModel.meshes.back();
+
+    REQUIRE(upsampledMesh.primitives.size() == 1);
+    const MeshPrimitive& upsampledPrimitive = upsampledMesh.primitives.back();
+
+    auto it = upsampledPrimitive.extras.find("OnlyWater");
+    REQUIRE(it != upsampledPrimitive.extras.end());
+    REQUIRE(it->second.isBool());
+    CHECK(it->second.getBool() == true);
+  }
+
+  SUBCASE("Check water mask properties come through when there is also skirt "
+          "metadata") {
+    double skirtHeight = 12.0;
+    SkirtMeshMetadata skirtMeshMetadata;
+    skirtMeshMetadata.noSkirtIndicesBegin = 0;
+    skirtMeshMetadata.noSkirtIndicesCount =
+        static_cast<uint32_t>(indices.size());
+    skirtMeshMetadata.meshCenter = center;
+    skirtMeshMetadata.skirtWestHeight = skirtHeight;
+    skirtMeshMetadata.skirtSouthHeight = skirtHeight;
+    skirtMeshMetadata.skirtEastHeight = skirtHeight;
+    skirtMeshMetadata.skirtNorthHeight = skirtHeight;
+
+    primitive.extras = SkirtMeshMetadata::createGltfExtras(skirtMeshMetadata);
+
+    primitive.extras["OnlyWater"] = true;
+
+    Model upsampledModel =
+        *RasterOverlayUtilities::upsampleGltfForRasterOverlays(
+            model,
+            lowerLeft,
+            false);
+
+    REQUIRE(upsampledModel.meshes.size() == 1);
+    const Mesh& upsampledMesh = upsampledModel.meshes.back();
+
+    REQUIRE(upsampledMesh.primitives.size() == 1);
+    const MeshPrimitive& upsampledPrimitive = upsampledMesh.primitives.back();
+
+    auto it = upsampledPrimitive.extras.find("OnlyWater");
+    REQUIRE(it != upsampledPrimitive.extras.end());
+    REQUIRE(it->second.isBool());
+    CHECK(it->second.getBool() == true);
+
+    it = upsampledPrimitive.extras.find("skirtMeshMetadata");
+    REQUIRE(it != upsampledPrimitive.extras.end());
+    CHECK(it->second.isObject());
+  }
 }
 
 TEST_CASE("upsampleGltfForRasterOverlay with UNSIGNED_BYTE indices") {


### PR DESCRIPTION
Fixes CesiumGS/cesium-unreal#1674

After some recent refactoring, the water mask was inadvertently getting clobbered by the skirt mesh metadata while upsampling.