### PR TITLE
Add more utility functions to `CesiumUtility::Uri`

### DIFF
--- a/CesiumUtility/include/CesiumUtility/Uri.h
+++ b/CesiumUtility/include/CesiumUtility/Uri.h
@@ -85,6 +85,36 @@ public:
   std::string_view getPath() const;
 
   /**
+   * @brief Returns the filename portion of the URI.
+   *
+   * For example, for the URI `http://example.com/file.txt`, this will return
+   * `file.txt`.
+   *
+   * @return The filename, or empty string if the URI could not be parsed.
+   */
+  std::string_view getFileName() const;
+
+  /**
+   * @brief Returns the filename portion of the URI without any extension.
+   *
+   * For example, for the URI `http://example.com/file.txt`, this will return
+   * `file`.
+   *
+   * @return The stem, or empty string if the URI could not be parsed.
+   */
+  std::string_view getStem() const;
+
+  /**
+   * @brief Returns the extension portion of the URI, if present.
+   *
+   * For example, for the URI `http://example.com/file.txt`, this will return
+   * `.txt`.
+   *
+   * @return The extension, or empty string if the URI could not be parsed.
+   */
+  std::string_view getExtension() const;
+
+  /**
    * @brief Gets the query portion of the URI.
    *
    * @return The path, or empty string if the URI could not be parsed.

--- a/CesiumUtility/src/Uri.cpp
+++ b/CesiumUtility/src/Uri.cpp
@@ -146,6 +146,72 @@ std::string_view Uri::getPath() const {
   return this->_url->get_pathname();
 }
 
+std::string_view Uri::getFileName() const {
+  if (!this->isValid()) {
+    return {};
+  }
+
+  uint32_t pathLength = this->_url->get_pathname_length();
+  // If the pathname is empty or just "/", there's no filename.
+  if (pathLength <= 1) {
+    return {};
+  }
+
+  const std::string_view path = this->_url->get_pathname();
+  const uint32_t end = pathLength - 1;
+  for (uint32_t i = end; i >= 0; i--) {
+    if (path[i] != '/') {
+      continue;
+    }
+
+    // Last char of pathname is '/', so no filename
+    if (i == end) {
+      return {};
+    }
+
+    return path.substr(i + 1, end - i);
+  }
+
+  // If we've gotten this far, the whole pathname is the filename
+  return path;
+}
+
+std::string_view Uri::getStem() const {
+  const std::string_view filename = this->getFileName();
+  if (filename.empty()) {
+    return {};
+  }
+
+  const size_t end = filename.size() - 1;
+  for (size_t i = end; i >= 0; i--) {
+    if (filename[i] == '.') {
+      return filename.substr(0, i);
+    }
+  }
+
+  // No extension found, the whole filename is the stem.
+  return filename;
+}
+
+std::string_view Uri::getExtension() const {
+  const std::string_view filename = this->getFileName();
+  if (filename.empty()) {
+    return {};
+  }
+
+  const size_t end = filename.size() - 1;
+  for (size_t i = end; i > 0; i--) {
+    if (filename[i] != '.') {
+      continue;
+    }
+
+    return filename.substr(i, end - i + 1);
+  }
+
+  // No extension found.
+  return {};
+}
+
 void Uri::setPath(const std::string_view& path) {
   this->_url->set_pathname(path);
 }

--- a/CesiumUtility/test/TestUri.cpp
+++ b/CesiumUtility/test/TestUri.cpp
@@ -256,3 +256,42 @@ TEST_CASE("UriQuery") {
     CHECK(query.toQueryString() == "query=foo&%7Bthis%7D=%7Banother%7D");
   }
 }
+
+TEST_CASE("Uri::getFileName") {
+  CHECK(Uri("test.txt").getFileName() == "test.txt");
+  CHECK(Uri("http://example.com/test.txt").getFileName() == "test.txt");
+  CHECK(Uri("http://example.com/a/b/c/test.txt").getFileName() == "test.txt");
+  CHECK(
+      Uri("file:///C:\\Example\\Directory\\test.txt").getFileName() ==
+      "test.txt");
+  CHECK(Uri("http://example.com/").getFileName() == "");
+  CHECK(Uri("http://example.com/a/b/c/").getFileName() == "");
+}
+
+TEST_CASE("Uri::getStem") {
+  CHECK(Uri("test.txt").getStem() == "test");
+  CHECK(Uri("http://example.com/test.txt").getStem() == "test");
+  CHECK(Uri("http://example.com/a/b/c/test.txt").getStem() == "test");
+  CHECK(Uri("http://example.com/a/b/c/test.").getStem() == "test");
+  CHECK(Uri("http://example.com/a/b/c/test").getStem() == "test");
+  CHECK(Uri("file:///C:\\Example\\Directory\\test.txt").getStem() == "test");
+  CHECK(Uri("http://example.com/").getStem() == "");
+  CHECK(Uri("http://example.com/a/b/c/").getStem() == "");
+  CHECK(Uri("http://example.com/a/b/c").getStem() == "c");
+  CHECK(Uri("http://example.com/a/b/c/.txt").getStem() == "");
+}
+
+TEST_CASE("Uri::getExtension") {
+  CHECK(Uri("test.txt").getExtension() == ".txt");
+  CHECK(Uri("http://example.com/test.txt").getExtension() == ".txt");
+  CHECK(Uri("http://example.com/a/b/c/test.txt").getExtension() == ".txt");
+  CHECK(Uri("http://example.com/a/b/c/test.").getExtension() == ".");
+  CHECK(Uri("http://example.com/a/b/c/test").getExtension() == "");
+  CHECK(
+      Uri("file:///C:\\Example\\Directory\\test.txt").getExtension() == ".txt");
+  CHECK(Uri("http://example.com/").getExtension() == "");
+  CHECK(Uri("http://example.com/a/b/c").getExtension() == "");
+  CHECK(Uri("http://example.com/a/b/c/.hidden").getExtension() == "");
+  CHECK(Uri("http://example.com/a/b/c/.").getExtension() == "");
+  CHECK(Uri("http://example.com/a/b/c/..").getExtension() == "");
+}


### PR DESCRIPTION
Closes #1176. This PR adds a few new methods to `CesiumUtility::Uri`:
- `getFileName` returns the filename, if any (`http://example.com/test.txt` -> `test.txt`)
- `getStem` returns the filename without an extension, if any (`http://example.com/test.txt` -> `test`)
- `getExtension` returns the extension, if any (`http://example.com/test.txt` -> `.txt`)