### PR TITLE
Pass Tile SSEs to ViewUpdateResult

### DIFF
--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -532,10 +532,12 @@ private:
       const TilesetFrameState& frameState,
       Tile& tile,
       double tilePriority,
+      double tileSse,
       ViewUpdateResult& result);
   TraversalDetails _renderInnerTile(
       const TilesetFrameState& frameState,
       Tile& tile,
+      double tileSse,
       ViewUpdateResult& result);
   bool _kickDescendantsAndRenderTile(
       const TilesetFrameState& frameState,
@@ -545,7 +547,8 @@ private:
       size_t firstRenderedDescendantIndex,
       const TilesetViewGroup::LoadQueueCheckpoint& loadQueueBeforeChildren,
       bool queuedForLoad,
-      double tilePriority);
+      double tilePriority,
+      double tileSse);
   TileOcclusionState _checkOcclusion(const Tile& tile);
 
   TraversalDetails _visitTile(
@@ -555,6 +558,7 @@ private:
       bool ancestorMeetsSse,
       Tile& tile,
       double tilePriority,
+      double tileSse,
       ViewUpdateResult& result);
 
   struct CullResult {
@@ -574,11 +578,11 @@ private:
       const TilesetFrameState& frameState,
       const std::vector<double>& distances,
       CullResult& cullResult);
-  bool _meetsSse(
+  double _computeSse(
       const std::vector<ViewState>& frustums,
       const Tile& tile,
-      const std::vector<double>& distances,
-      bool culled) const noexcept;
+      const std::vector<double>& distances) const noexcept;
+  bool _meetsSseThreshold(double sse, bool culled) const noexcept;
 
   TraversalDetails _visitTileIfNeeded(
       const TilesetFrameState& frameState,
@@ -613,6 +617,7 @@ private:
       Tile& tile,
       ViewUpdateResult& result,
       double tilePriority,
+      double tileSse,
       bool queuedForLoad);
 
   void _unloadCachedTiles(double timeBudget) noexcept;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ViewUpdateResult.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ViewUpdateResult.h
@@ -24,17 +24,25 @@ public:
    * @brief The tiles that were selected by the tileset traversal this frame.
    * These tiles should be rendered by the client.
    *
-   * Tiles in this list may be fading in if
-   * {@link TilesetOptions::enableLodTransitionPeriod} is true.
+   * Tiles in this list may be fading in if \ref
+   * TilesetOptions::enableLodTransitionPeriod is true.
    */
   std::vector<Tile::Pointer> tilesToRenderThisFrame;
 
   /**
+   * @brief The computed screen space error of the tiles selected by the
+   * tileset traversal this frame. The values correspond to the tiles linked in
+   * \ref tilesToRenderThisFrame, and may be used by the client to influence
+   * rendering behavior.
+   */
+  std::vector<double> tileScreenSpaceErrorThisFrame;
+
+  /**
    * @brief Tiles on this list are no longer selected for rendering.
    *
-   * If {@link TilesetOptions::enableLodTransitionPeriod} is true they may be
-   * fading out. If a tile's {TileRenderContent::lodTransitionPercentage} is 0
-   * or lod transitions are disabled, the tile should be hidden right away.
+   * If \ref TilesetOptions::enableLodTransitionPeriod is true they may be
+   * fading out. If a tile's \ref TileRenderContent::lodTransitionPercentage is
+   * 0 or LOD transitions are disabled, the tile should be hidden right away.
    */
   std::unordered_set<Tile::Pointer> tilesFadingOut;
 

--- a/Cesium3DTilesSelection/src/TilesetViewGroup.cpp
+++ b/Cesium3DTilesSelection/src/TilesetViewGroup.cpp
@@ -125,6 +125,7 @@ void TilesetViewGroup::startNewFrame(
   this->_updateResult.maxDepthVisited = 0;
 
   this->_updateResult.tilesToRenderThisFrame.clear();
+  this->_updateResult.tileScreenSpaceErrorThisFrame.clear();
 
   if (!tileset.getOptions().enableLodTransitionPeriod) {
     this->_updateResult.tilesFadingOut.clear();


### PR DESCRIPTION
In this PR, `updateViewGroup` will return the SSE values for selected tiles in a parallel vector in `ViewUpdateResult`.

This was used to help prototype voxel rendering, where SSE is incorporated into a selection metric to influence what tiles are retained as the view is changed. However, I'm making this a draft because I'm not entirely happy with that approach.