### PR TITLE
Fix crash when unloading ellipsoid tileset with raster overlays

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 - Added `CesiumVectorData` library for loading data from vector formats. Currently only GeoJSON is supported.
 
+##### Fixes :wrench:
+
+- Fixed crash when unloading tilesets with raster overlays when the `EllipsoidTilesetLoader` was used.
+
 ### v0.48.0 - 2025-06-02
 
 ##### Breaking Changes :mega:

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -738,6 +738,8 @@ TilesetContentManager::TilesetContentManager(
   this->_upsampler.setOwner(*this);
 
   CESIUM_ASSERT(this->_pLoader != nullptr);
+  this->_overlayCollection.setLoadedTileEnumerator(
+      LoadedTileEnumerator(this->_pRootTile.get()));
   this->_pLoader->setOwner(*this);
   this->_rootTileAvailablePromise.resolve();
 }


### PR DESCRIPTION
Closes CesiumGS/cesium-unreal#1682. As documented in that issue, when creating a tileset using the `EllipsoidTilesetLoader`, if the tileset has raster overlays, it will crash when unloading. This turns out to be a result of simply forgetting to pass the `LoadedTileEnumerator` to the `RasterOverlayCollection` when using the `TilesetContentManager` constructor that is currently only used by the `EllipsoidTilesetLoader`. 