### PR TITLE
Fixed incorrect handling of legacy maximumLevel property in TilesetJsonLoader.cpp

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 ##### Fixes :wrench:
 
 - Fixed crash when unloading tilesets with raster overlays when the `EllipsoidTilesetLoader` was used.
+- Fixed incorrect handling of legacy maximumLevel property when the `TilesetJsonLoader` was used.
 
 ### v0.48.0 - 2025-06-02
 

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -402,7 +402,7 @@ void parseImplicitTileset(
   bool isMaximumLevel = false;
   if (availableLevelsIt == implicitTiling.MemberEnd()) {
     // old version of implicit uses maximumLevel instead of availableLevels.
-    // they have similar semantic except that max = index available = count
+    // They have similar semantics, except that "maximum" = index while "available" = count
     availableLevelsIt = implicitTiling.FindMember("maximumLevel");
     isMaximumLevel = true;
   }

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -402,7 +402,8 @@ void parseImplicitTileset(
   bool isMaximumLevel = false;
   if (availableLevelsIt == implicitTiling.MemberEnd()) {
     // old version of implicit uses maximumLevel instead of availableLevels.
-    // They have similar semantics, except that "maximum" = index while "available" = count
+    // They have similar semantics, except that "maximum" = index while
+    // "available" = count
     availableLevelsIt = implicitTiling.FindMember("maximumLevel");
     isMaximumLevel = true;
   }
@@ -431,7 +432,8 @@ void parseImplicitTileset(
 
   // create implicit loaders
   uint32_t subtreeLevels = subtreeLevelsIt->value.GetUint();
-  uint32_t availableLevels = availableLevelsIt->value.GetUint() + uint32_t(isMaximumLevel);
+  uint32_t availableLevels =
+      availableLevelsIt->value.GetUint() + uint32_t(isMaximumLevel);
   const char* subtreesUri = subtreesUriIt->value.GetString();
   const char* subdivisionScheme = tilingSchemeIt->value.GetString();
 

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -431,7 +431,7 @@ void parseImplicitTileset(
 
   // create implicit loaders
   uint32_t subtreeLevels = subtreeLevelsIt->value.GetUint();
-  uint32_t availableLevels = availableLevelsIt->value.GetUint() + isMaximumLevel;
+  uint32_t availableLevels = availableLevelsIt->value.GetUint() + uint32_t(isMaximumLevel);
   const char* subtreesUri = subtreesUriIt->value.GetString();
   const char* subdivisionScheme = tilingSchemeIt->value.GetString();
 

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -399,10 +399,12 @@ void parseImplicitTileset(
   auto subtreeLevelsIt = implicitTiling.FindMember("subtreeLevels");
   auto subtreesIt = implicitTiling.FindMember("subtrees");
   auto availableLevelsIt = implicitTiling.FindMember("availableLevels");
+  bool isMaximumLevel = false;
   if (availableLevelsIt == implicitTiling.MemberEnd()) {
     // old version of implicit uses maximumLevel instead of availableLevels.
-    // They have the same semantic
+    // they have similar semantic except that max = index available = count
     availableLevelsIt = implicitTiling.FindMember("maximumLevel");
+    isMaximumLevel = true;
   }
 
   // check that all the required properties above are available
@@ -429,7 +431,7 @@ void parseImplicitTileset(
 
   // create implicit loaders
   uint32_t subtreeLevels = subtreeLevelsIt->value.GetUint();
-  uint32_t availableLevels = availableLevelsIt->value.GetUint();
+  uint32_t availableLevels = availableLevelsIt->value.GetUint() + isMaximumLevel;
   const char* subtreesUri = subtreesUriIt->value.GetString();
   const char* subdivisionScheme = tilingSchemeIt->value.GetString();
 


### PR DESCRIPTION
Fixed incorrect handling of legacy maximumLevel property in TilesetJsonLoader.cpp by adding one to availableLevels when implicit loader for it is created. 