### PR TITLE
Add `ITwinGeospatialFeaturesRasterOverlay` for rasterizing Geospatial Features from iTwin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### ? - ?
 
 ##### Breaking Changes :mega:
+
 - Renamed `CesiumITwinClient::Connection::getAccessToken` to `CesiumITwinClient::Connection::getAuthenticationToken`.
 - Renamed `CesiumITwinClient::Connection::setAccessToken` to `CesiumITwinClient::Connection::setAuthenticationToken`.
 
@@ -13,6 +14,7 @@
 - Added support for the [iTwin Geospatial Features API](https://developer.bentley.com/apis/geospatial-features/overview/).
   - Added `CesiumITwinClient::Connection::geospatialFeatureCollections` to query for all feature collections within an iTwin.
   - Added `CesiumITwinClient::Connection::geospatialFeatures` to query features within a feature collection.
+- Added `CesiumITwinClient::ITwinGeospatialFeaturesRasterOverlay` for displaying Geospatial Features loaded from iTwin as a raster overlay.
 
 ##### Fixes :wrench:
 

--- a/CesiumITwinClient/CMakeLists.txt
+++ b/CesiumITwinClient/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(CesiumITwinClient
         CesiumClientCommon
         CesiumGeometry
         CesiumGeospatial
+        CesiumRasterOverlays
         CesiumVectorData
     PRIVATE
         modp_b64::modp_b64

--- a/CesiumITwinClient/include/CesiumITwinClient/ITwinGeospatialFeaturesRasterOverlay.h
+++ b/CesiumITwinClient/include/CesiumITwinClient/ITwinGeospatialFeaturesRasterOverlay.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <CesiumAsync/AsyncSystem.h>
+#include <CesiumGeospatial/CartographicPolygon.h>
+#include <CesiumGeospatial/Ellipsoid.h>
+#include <CesiumGeospatial/Projection.h>
+#include <CesiumITwinClient/Connection.h>
+#include <CesiumITwinClient/Library.h>
+#include <CesiumRasterOverlays/GeoJsonDocumentRasterOverlay.h>
+#include <CesiumRasterOverlays/RasterOverlay.h>
+#include <CesiumRasterOverlays/RasterOverlayTileProvider.h>
+#include <CesiumUtility/Color.h>
+#include <CesiumUtility/IntrusivePointer.h>
+#include <CesiumVectorData/GeoJsonDocument.h>
+#include <CesiumVectorData/VectorStyle.h>
+
+#include <spdlog/fwd.h>
+
+#include <memory>
+#include <string>
+
+namespace CesiumITwinClient {
+
+/**
+ * @brief A raster overlay made from rasterizing a \ref
+ * CesiumVectorData::VectorDocument.
+ */
+class CESIUMITWINCLIENT_API ITwinGeospatialFeaturesRasterOverlay final
+    : public CesiumRasterOverlays::RasterOverlay {
+
+public:
+  /**
+   * @brief Creates a new ITwinGeospatialFeaturesRasterOverlay.
+   *
+   * @param name The user-given name of this polygon layer.
+   * @param iTwinId The ID of the iTwin to obtain the features from.
+   * @param collectionId The ID of the Geospatial Features Collection to obtain
+   * the features from.
+   * @param pConnection The connection to the iTwin API to use.
+   * @param geoJsonOptions Options to configure the GeoJSON overlay.
+   * @param overlayOptions Options to use for this RasterOverlay.
+   */
+  ITwinGeospatialFeaturesRasterOverlay(
+      const std::string& name,
+      const std::string& iTwinId,
+      const std::string& collectionId,
+      const CesiumUtility::IntrusivePointer<Connection>& pConnection,
+      const CesiumRasterOverlays::GeoJsonDocumentRasterOverlayOptions&
+          geoJsonOptions,
+      const CesiumRasterOverlays::RasterOverlayOptions& overlayOptions = {});
+  virtual ~ITwinGeospatialFeaturesRasterOverlay() override;
+
+  virtual CesiumAsync::Future<CreateTileProviderResult> createTileProvider(
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+      const std::shared_ptr<CesiumUtility::CreditSystem>& pCreditSystem,
+      const std::shared_ptr<
+          CesiumRasterOverlays::IPrepareRasterOverlayRendererResources>&
+          pPrepareRendererResources,
+      const std::shared_ptr<spdlog::logger>& pLogger,
+      CesiumUtility::IntrusivePointer<const RasterOverlay> pOwner)
+      const override;
+
+private:
+  std::string _iTwinId;
+  std::string _collectionId;
+  CesiumUtility::IntrusivePointer<Connection> _pConnection;
+  CesiumRasterOverlays::GeoJsonDocumentRasterOverlayOptions _options;
+};
+} // namespace CesiumITwinClient

--- a/CesiumITwinClient/src/ITwinGeospatialFeaturesRasterOverlay.cpp
+++ b/CesiumITwinClient/src/ITwinGeospatialFeaturesRasterOverlay.cpp
@@ -1,0 +1,140 @@
+#include <CesiumAsync/AsyncSystem.h>
+#include <CesiumAsync/Future.h>
+#include <CesiumAsync/IAssetAccessor.h>
+#include <CesiumAsync/SharedAssetDepot.h>
+#include <CesiumGeospatial/BoundingRegionBuilder.h>
+#include <CesiumGeospatial/Cartographic.h>
+#include <CesiumGeospatial/GeographicProjection.h>
+#include <CesiumGeospatial/GlobeRectangle.h>
+#include <CesiumGeospatial/Projection.h>
+#include <CesiumGltf/ImageAsset.h>
+#include <CesiumITwinClient/ITwinGeospatialFeaturesRasterOverlay.h>
+#include <CesiumRasterOverlays/GeoJsonDocumentRasterOverlay.h>
+#include <CesiumRasterOverlays/Library.h>
+#include <CesiumRasterOverlays/RasterOverlay.h>
+#include <CesiumRasterOverlays/RasterOverlayTile.h>
+#include <CesiumRasterOverlays/RasterOverlayTileProvider.h>
+#include <CesiumUtility/Color.h>
+#include <CesiumUtility/CreditSystem.h>
+#include <CesiumUtility/IntrusivePointer.h>
+#include <CesiumVectorData/GeoJsonDocument.h>
+#include <CesiumVectorData/GeoJsonObject.h>
+#include <CesiumVectorData/VectorRasterizer.h>
+#include <CesiumVectorData/VectorStyle.h>
+
+#include <glm/common.hpp>
+#include <glm/ext/vector_int2.hpp>
+#include <nonstd/expected.hpp>
+#include <spdlog/logger.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace CesiumGeometry;
+using namespace CesiumGeospatial;
+using namespace CesiumRasterOverlays;
+using namespace CesiumUtility;
+using namespace CesiumVectorData;
+
+namespace CesiumITwinClient {
+
+ITwinGeospatialFeaturesRasterOverlay::ITwinGeospatialFeaturesRasterOverlay(
+    const std::string& name,
+    const std::string& iTwinId,
+    const std::string& collectionId,
+    const CesiumUtility::IntrusivePointer<Connection>& pConnection,
+    const CesiumRasterOverlays::GeoJsonDocumentRasterOverlayOptions&
+        geoJsonOptions,
+    const CesiumRasterOverlays::RasterOverlayOptions& overlayOptions)
+    : RasterOverlay(name, overlayOptions),
+      _iTwinId(iTwinId),
+      _collectionId(collectionId),
+      _pConnection(pConnection),
+      _options(geoJsonOptions) {}
+
+ITwinGeospatialFeaturesRasterOverlay::~ITwinGeospatialFeaturesRasterOverlay() =
+    default;
+
+CesiumAsync::Future<RasterOverlay::CreateTileProviderResult>
+ITwinGeospatialFeaturesRasterOverlay::createTileProvider(
+    const CesiumAsync::AsyncSystem& asyncSystem,
+    const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor,
+    const std::shared_ptr<CreditSystem>& pCreditSystem,
+    const std::shared_ptr<IPrepareRasterOverlayRendererResources>&
+        pPrepareRendererResources,
+    const std::shared_ptr<spdlog::logger>& pLogger,
+    CesiumUtility::IntrusivePointer<const RasterOverlay> pOwner) const {
+
+  pOwner = pOwner ? pOwner : this;
+
+  return this->_pConnection
+      ->geospatialFeatures(this->_iTwinId, this->_collectionId)
+      .thenInWorkerThread(
+          [asyncSystem, pConnection = this->_pConnection](
+              Result<PagedList<GeoJsonFeature>>&& result) mutable {
+            if (!result.value) {
+              return asyncSystem.createResolvedFuture(
+                  Result<std::vector<GeoJsonFeature>>(result.errors));
+            }
+
+            return result.value->allAfter(asyncSystem, pConnection);
+          })
+      .thenInWorkerThread(
+          [asyncSystem,
+           name = this->getName(),
+           vectorOptions = this->_options,
+           options = this->getOptions(),
+           pAssetAccessor,
+           pCreditSystem,
+           pPrepareRendererResources,
+           pLogger,
+           pOwner](Result<std::vector<GeoJsonFeature>>&& result)
+              -> CesiumAsync::Future<RasterOverlay::CreateTileProviderResult> {
+            if (!result.value) {
+              return asyncSystem.createResolvedFuture<
+                  RasterOverlay::CreateTileProviderResult>(
+                  nonstd::make_unexpected(RasterOverlayLoadFailureDetails{
+                      RasterOverlayLoadType::CesiumIon,
+                      nullptr,
+                      fmt::format(
+                          "Errors while loading geospatial features: {}",
+                          CesiumUtility::joinToString(
+                              result.errors.errors,
+                              ", "))}));
+            }
+
+            std::vector<GeoJsonObject> objects;
+            objects.reserve(result.value->size());
+
+            for (GeoJsonFeature& feature : *result.value) {
+              objects.emplace_back(std::move(feature));
+            }
+
+            std::shared_ptr<GeoJsonDocument> pDocument =
+                std::make_shared<GeoJsonDocument>(
+                    GeoJsonObject{GeoJsonFeatureCollection{
+                        std::move(objects),
+                        std::nullopt,
+                        {},
+                        std::nullopt}},
+                    std::vector<VectorDocumentAttribution>{});
+            GeoJsonDocumentRasterOverlay geoJsonOverlay(
+                name,
+                std::move(pDocument),
+                vectorOptions,
+                options);
+
+            return geoJsonOverlay.createTileProvider(
+                asyncSystem,
+                pAssetAccessor,
+                pCreditSystem,
+                pPrepareRendererResources,
+                pLogger,
+                pOwner);
+          });
+}
+
+} // namespace CesiumITwinClient


### PR DESCRIPTION
The original `itwin-feature-overlay` branch got pretty messy with all the iterations to all of its dependent branches, so I went ahead and put it back together on a fresh branch. This PR adds a `ITwinGeospatialFeaturesRasterOverlay` that builds on the support added from the iTwin Geospatial Features API as well as the `GeoJsonDocumentRasterOverlay` added in `vector-rasterizer`. 

Currently, the raster overlay just requests all available geospatial features and merges them together into one GeoJSON document. In theory, it's possible to use the `bbox` parameter of the Geospatial Features API to treat it like a tile server, allowing us to stream features rather than loading them all up front. But this adds quite a bit of complexity, and perhaps some undesired tradeoffs (when we're zoomed all the way out, which features do we show and which do we ignore?), so I think it's best to get it in like this and iterate on it if users keep running up against that limitation.