### PR TITLE
Fixed sending empty authorization header `Authorization: Bearer` when no access token is provided.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 
 - Fixed crash when unloading tilesets with raster overlays when the `EllipsoidTilesetLoader` was used.
 - Fixed incorrect handling of legacy maximumLevel property when the `TilesetJsonLoader` was used.
+- Fixed sending empty authorization header `Authorization: Bearer` when no access token is provided while using `CesiumIonTilesetLoader`. Prevents potential future issues with some servers including GP3D Tiles.
 
 ### v0.48.0 - 2025-06-02
 

--- a/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
+++ b/Cesium3DTilesSelection/src/CesiumIonTilesetLoader.cpp
@@ -212,9 +212,11 @@ mainThreadLoadTilesetJsonFromAssetEndpoint(
   }
 
   std::vector<CesiumAsync::IAssetAccessor::THeader> requestHeaders;
-  requestHeaders.emplace_back(
-      "Authorization",
-      "Bearer " + endpoint.accessToken);
+  if (!endpoint.accessToken.empty()) {
+    requestHeaders.emplace_back(
+        "Authorization",
+        "Bearer " + endpoint.accessToken);
+  }
 
   return TilesetJsonLoader::createLoader(
              externals,
@@ -279,9 +281,11 @@ mainThreadLoadLayerJsonFromAssetEndpoint(
   }
 
   std::vector<CesiumAsync::IAssetAccessor::THeader> requestHeaders;
-  requestHeaders.emplace_back(
-      "Authorization",
-      "Bearer " + endpoint.accessToken);
+  if (!endpoint.accessToken.empty()) {
+    requestHeaders.emplace_back(
+        "Authorization",
+        "Bearer " + endpoint.accessToken);
+  }
 
   std::string url =
       CesiumUtility::Uri::resolve(endpoint.url, "layer.json", true);


### PR DESCRIPTION
Fixes: #1196
Fixed sending empty authorization header `Authorization: Bearer` when no access token is provided while using `CesiumIonTilesetLoader`. Prevents potential future issues with some servers including GP3D Tiles.