### PR TITLE
Fix reusing the If-None-Match header for future requests

### DIFF
--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -2034,6 +2034,15 @@ void TilesetContentManager::propagateTilesetContentLoaderResult(
           creditResult.showOnScreen));
     }
 
+    {
+      // Remove the If-None-Match header if exists to avoid adding it to other requests
+      CesiumAsync::CaseInsensitiveCompare cmp;
+      std::erase_if(result.requestHeaders,
+        [&](const CesiumAsync::IAssetAccessor::THeader& h) {
+          return !cmp(h.first, "If-None-Match") && !cmp("If-None-Match", h.first);
+        });
+    }
+
     this->_requestHeaders = std::move(result.requestHeaders);
     this->_pLoader = std::move(result.pLoader);
     this->_pRootTile = std::move(result.pRootTile);

--- a/CesiumAsync/src/CachingAssetAccessor.cpp
+++ b/CesiumAsync/src/CachingAssetAccessor.cpp
@@ -256,6 +256,10 @@ Future<std::shared_ptr<IAssetRequest>> CachingAssetAccessor::get(
                                 *pRequestToStore,
                                 cacheControl)) {
 
+                          // Remove the If-None-Match header if exists to avoid reusing it in future requests
+                          HttpHeaders headers = pRequestToStore->headers();
+                          headers.erase("If-None-Match");
+
                           pCacheDatabase->storeEntry(
                               calculateCacheKey(*pRequestToStore),
                               calculateExpiryTime(
@@ -263,7 +267,7 @@ Future<std::shared_ptr<IAssetRequest>> CachingAssetAccessor::get(
                                   cacheControl),
                               pRequestToStore->url(),
                               pRequestToStore->method(),
-                              pRequestToStore->headers(),
+                              headers,
                               pResponseToStore->statusCode(),
                               pResponseToStore->headers(),
                               pResponseToStore->data());


### PR DESCRIPTION
Fixes #1190 

It avoids storing the If-None-Match header in the cache and in the TilesetContentManager. This avoids Cesium Native to reuse this header to download tiles that are not in the cache.