### PR TITLE
OrientedBoundingBox::computeDistanceSquaredToPosition can potentially use degenerate axes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 
 - Fixed crash when unloading tilesets with raster overlays when the `EllipsoidTilesetLoader` was used.
 - Fixed incorrect handling of legacy maximumLevel property when the `TilesetJsonLoader` was used.
+- Fixed `OrientedBoundingBox::computeDistanceSquaredToPosition()` calculation when `OrientedBoundingBox` has degenerate axes.
 
 ### v0.48.0 - 2025-06-02
 

--- a/CesiumGeometry/src/OrientedBoundingBox.cpp
+++ b/CesiumGeometry/src/OrientedBoundingBox.cpp
@@ -125,6 +125,7 @@ double OrientedBoundingBox::computeDistanceSquaredToPosition(
 
     validAxis2 = glm::normalize(glm::cross(validAxis1, crossVector));
     validAxis3 = glm::normalize(glm::cross(validAxis1, validAxis2));
+    
     if (uValid) {
       v = validAxis2;
       w = validAxis3;

--- a/CesiumGeometry/src/OrientedBoundingBox.cpp
+++ b/CesiumGeometry/src/OrientedBoundingBox.cpp
@@ -70,11 +70,11 @@ double OrientedBoundingBox::computeDistanceSquaredToPosition(
   if (uValid) {
     u /= uHalf;
   }
-  
+
   if (vValid) {
     v /= vHalf;
   }
-  
+
   if (wValid) {
     w /= wHalf;
   }
@@ -125,7 +125,7 @@ double OrientedBoundingBox::computeDistanceSquaredToPosition(
 
     validAxis2 = glm::normalize(glm::cross(validAxis1, crossVector));
     validAxis3 = glm::normalize(glm::cross(validAxis1, validAxis2));
-    
+
     if (uValid) {
       v = validAxis2;
       w = validAxis3;

--- a/CesiumGeometry/src/OrientedBoundingBox.cpp
+++ b/CesiumGeometry/src/OrientedBoundingBox.cpp
@@ -3,6 +3,7 @@
 #include <CesiumGeometry/CullingResult.h>
 #include <CesiumGeometry/OrientedBoundingBox.h>
 #include <CesiumGeometry/Plane.h>
+#include <CesiumUtility/Math.h>
 
 #include <glm/common.hpp>
 #include <glm/ext/matrix_double3x3.hpp>
@@ -62,9 +63,89 @@ double OrientedBoundingBox::computeDistanceSquaredToPosition(
   const double vHalf = glm::length(v);
   const double wHalf = glm::length(w);
 
-  u /= uHalf;
-  v /= vHalf;
-  w /= wHalf;
+  bool uValid = true;
+  bool vValid = true;
+  bool wValid = true;
+
+  if (uHalf > 0) {
+    u /= uHalf;
+  } else {
+    uValid = false;
+  }
+
+  if (vHalf > 0) {
+    v /= vHalf;
+  } else {
+    vValid = false;
+  }
+
+  if (wHalf > 0) {
+    w /= wHalf;
+  } else {
+    wValid = false;
+  }
+
+  int numberOfDegenerateAxes = !uValid + !vValid + !wValid;
+  glm::dvec3 validAxis1;
+  glm::dvec3 validAxis2;
+  glm::dvec3 validAxis3;
+
+  if (numberOfDegenerateAxes == 1) {
+    glm::dvec3 degenerateAxis = u;
+    validAxis1 = v;
+    validAxis2 = w;
+
+    if (!vValid) {
+      degenerateAxis = v;
+      validAxis1 = u;
+    } else if (!wValid) {
+      degenerateAxis = w;
+      validAxis2 = u;
+    }
+
+    validAxis3 = glm::cross(validAxis1, validAxis2);
+
+    if (!uValid) {
+      u = validAxis3;
+    } else if (!vValid) {
+      v = validAxis3;
+    } else {
+      w = validAxis3;
+    }
+  } else if (numberOfDegenerateAxes == 2) {
+    if (uValid) {
+      validAxis1 = u;
+    } else if (vValid) {
+      validAxis1 = v;
+    } else {
+      validAxis1 = w;
+    }
+
+    glm::dvec3 crossVector{0, 1, 0};
+    if (CesiumUtility::Math::equalsEpsilon(
+            validAxis1,
+            crossVector,
+            CesiumUtility::Math::Epsilon3)) {
+      crossVector = {1, 0, 0};
+    }
+
+    validAxis2 = glm::normalize(glm::cross(validAxis1, crossVector));
+    validAxis3 = glm::normalize(glm::cross(validAxis1, validAxis2));
+    if (uValid) {
+      v = validAxis2;
+      w = validAxis3;
+    } else if (vValid) {
+      w = validAxis2;
+      u = validAxis3;
+    } else if (wValid) {
+      u = validAxis2;
+      v = validAxis3;
+    }
+  } else {
+    u = {1, 0, 0};
+    v = {0, 1, 0};
+    w = {0, 0, 1};
+  }
 
   const glm::dvec3 pPrime(
       glm::dot(offset, u),

--- a/CesiumGeometry/src/OrientedBoundingBox.cpp
+++ b/CesiumGeometry/src/OrientedBoundingBox.cpp
@@ -63,26 +63,20 @@ double OrientedBoundingBox::computeDistanceSquaredToPosition(
   const double vHalf = glm::length(v);
   const double wHalf = glm::length(w);
 
-  bool uValid = true;
-  bool vValid = true;
-  bool wValid = true;
+  bool uValid = uHalf > 0;
+  bool vValid = vHalf > 0;
+  bool wValid = wHalf > 0;
 
-  if (uHalf > 0) {
+  if (uValid) {
     u /= uHalf;
-  } else {
-    uValid = false;
   }
-
-  if (vHalf > 0) {
+  
+  if (vValid) {
     v /= vHalf;
-  } else {
-    vValid = false;
   }
-
-  if (wHalf > 0) {
+  
+  if (wValid) {
     w /= wHalf;
-  } else {
-    wValid = false;
   }
 
   const int numberOfDegenerateAxes = !uValid + !vValid + !wValid;

--- a/CesiumGeometry/src/OrientedBoundingBox.cpp
+++ b/CesiumGeometry/src/OrientedBoundingBox.cpp
@@ -85,7 +85,7 @@ double OrientedBoundingBox::computeDistanceSquaredToPosition(
     wValid = false;
   }
 
-  int numberOfDegenerateAxes = !uValid + !vValid + !wValid;
+  const int numberOfDegenerateAxes = !uValid + !vValid + !wValid;
   glm::dvec3 validAxis1;
   glm::dvec3 validAxis2;
   glm::dvec3 validAxis3;
@@ -141,7 +141,7 @@ double OrientedBoundingBox::computeDistanceSquaredToPosition(
       u = validAxis2;
       v = validAxis3;
     }
-  } else {
+  } else if (numberOfDegenerateAxes == 3) {
     u = {1, 0, 0};
     v = {0, 1, 0};
     w = {0, 0, 1};

--- a/CesiumGeometry/test/TestOrientedBoundingBox.cpp
+++ b/CesiumGeometry/test/TestOrientedBoundingBox.cpp
@@ -327,9 +327,9 @@ TEST_CASE("OrientedBoundingBox::intersectPlane") {
       TestCase{
           glm::dvec3(-5.1, 0.0, 0.1),
           glm::dmat3(glm::rotate(
-            glm::scale(glm::dmat4(), glm::dvec3(1.5, 80.4, 2.6)),
-            1.2,
-            glm::dvec3(0.5, 1.5, -1.2)))}};
+              glm::scale(glm::dmat4(), glm::dvec3(1.5, 80.4, 2.6)),
+              1.2,
+              glm::dvec3(0.5, 1.5, -1.2)))}};
 
   for (auto& testCase : testCases) {
     testIntersectPlane(testCase);

--- a/CesiumGeometry/test/TestOrientedBoundingBox.cpp
+++ b/CesiumGeometry/test/TestOrientedBoundingBox.cpp
@@ -375,11 +375,11 @@ TEST_CASE("OrientedBoundingBox::computeDistanceSquaredToPosition example") {
 
 TEST_CASE(
     "OrientedBoundingBox::computeDistanceSquaredToPosition degenerate axes") {
-  struct TestCase {
+  struct DegenerateAxesTestCase {
     OrientedBoundingBox box;
     double distance;
   };
-  std::vector<TestCase> tests{
+  std::vector<DegenerateAxesTestCase> tests{
       {{glm::dvec3(1.0, 0.0, 0.0), glm::dmat3(0.0)}, 1},
       {{glm::dvec3(1.0, 0.0, 0.0), glm::dmat3{{1, 0, 0}, {0, 0, 0}, {0, 0, 0}}},
        0},

--- a/CesiumGeometry/test/TestOrientedBoundingBox.cpp
+++ b/CesiumGeometry/test/TestOrientedBoundingBox.cpp
@@ -373,6 +373,25 @@ TEST_CASE("OrientedBoundingBox::computeDistanceSquaredToPosition example") {
   CHECK(boxes[1].getCenter().x == 1.0);
 }
 
+TEST_CASE("OrientedBoundingBox::computeDistanceSquaredToPosition degenerate axes") {
+  struct TestCase {
+    OrientedBoundingBox box;
+    double distance;
+  };
+  std::vector<TestCase> tests {
+    { {glm::dvec3(1.0, 0.0, 0.0), glm::dmat3(0.0) }, 1 },
+    { {glm::dvec3(1.0, 0.0, 0.0), glm::dmat3 {{1,0,0},{0,0,0},{0,0,0}}}, 0 },
+    { {glm::dvec3(1.0, 0.0, 0.0), glm::dmat3 {{1,0,0},{0,1,0},{0,0,0}}}, 0 },
+    { {glm::dvec3(1.0, 0.0, 0.0), glm::dmat3 {{0,0,0},{0,1,0},{0,0,1}}}, 1 }
+  };
+  glm::dvec3 cameraPosition {0,0,0};
+
+  for (const auto& testCase : tests) {
+    double d = testCase.box.computeDistanceSquaredToPosition(cameraPosition);
+    CHECK(d == testCase.distance);
+  }
+}
+
 TEST_CASE("OrientedBoundingBox::toAxisAligned") {
   SUBCASE("simple box that is already axis-aligned") {
     OrientedBoundingBox obb(

--- a/CesiumGeometry/test/TestOrientedBoundingBox.cpp
+++ b/CesiumGeometry/test/TestOrientedBoundingBox.cpp
@@ -326,10 +326,11 @@ TEST_CASE("OrientedBoundingBox::intersectPlane") {
       // arbitrary box
       TestCase{
           glm::dvec3(-5.1, 0.0, 0.1),
-          glm::dmat3(glm::rotate(
-              glm::scale(glm::dmat4(), glm::dvec3(1.5, 80.4, 2.6)),
-              1.2,
-              glm::dvec3(0.5, 1.5, -1.2)))}};
+          glm::dmat3(
+              glm::rotate(
+                  glm::scale(glm::dmat4(), glm::dvec3(1.5, 80.4, 2.6)),
+                  1.2,
+                  glm::dvec3(0.5, 1.5, -1.2)))}};
 
   for (auto& testCase : testCases) {
     testIntersectPlane(testCase);
@@ -373,18 +374,21 @@ TEST_CASE("OrientedBoundingBox::computeDistanceSquaredToPosition example") {
   CHECK(boxes[1].getCenter().x == 1.0);
 }
 
-TEST_CASE("OrientedBoundingBox::computeDistanceSquaredToPosition degenerate axes") {
+TEST_CASE(
+    "OrientedBoundingBox::computeDistanceSquaredToPosition degenerate axes") {
   struct TestCase {
     OrientedBoundingBox box;
     double distance;
   };
-  std::vector<TestCase> tests {
-    { {glm::dvec3(1.0, 0.0, 0.0), glm::dmat3(0.0) }, 1 },
-    { {glm::dvec3(1.0, 0.0, 0.0), glm::dmat3 {{1,0,0},{0,0,0},{0,0,0}}}, 0 },
-    { {glm::dvec3(1.0, 0.0, 0.0), glm::dmat3 {{1,0,0},{0,1,0},{0,0,0}}}, 0 },
-    { {glm::dvec3(1.0, 0.0, 0.0), glm::dmat3 {{0,0,0},{0,1,0},{0,0,1}}}, 1 }
-  };
-  glm::dvec3 cameraPosition {0,0,0};
+  std::vector<TestCase> tests{
+      {{glm::dvec3(1.0, 0.0, 0.0), glm::dmat3(0.0)}, 1},
+      {{glm::dvec3(1.0, 0.0, 0.0), glm::dmat3{{1, 0, 0}, {0, 0, 0}, {0, 0, 0}}},
+       0},
+      {{glm::dvec3(1.0, 0.0, 0.0), glm::dmat3{{1, 0, 0}, {0, 1, 0}, {0, 0, 0}}},
+       0},
+      {{glm::dvec3(1.0, 0.0, 0.0), glm::dmat3{{0, 0, 0}, {0, 1, 0}, {0, 0, 1}}},
+       1}};
+  glm::dvec3 cameraPosition{0, 0, 0};
 
   for (const auto& testCase : tests) {
     double d = testCase.box.computeDistanceSquaredToPosition(cameraPosition);

--- a/CesiumGeometry/test/TestOrientedBoundingBox.cpp
+++ b/CesiumGeometry/test/TestOrientedBoundingBox.cpp
@@ -326,11 +326,10 @@ TEST_CASE("OrientedBoundingBox::intersectPlane") {
       // arbitrary box
       TestCase{
           glm::dvec3(-5.1, 0.0, 0.1),
-          glm::dmat3(
-              glm::rotate(
-                  glm::scale(glm::dmat4(), glm::dvec3(1.5, 80.4, 2.6)),
-                  1.2,
-                  glm::dvec3(0.5, 1.5, -1.2)))}};
+          glm::dmat3(glm::rotate(
+            glm::scale(glm::dmat4(), glm::dvec3(1.5, 80.4, 2.6)),
+            1.2,
+            glm::dvec3(0.5, 1.5, -1.2)))}};
 
   for (auto& testCase : testCases) {
     testIntersectPlane(testCase);


### PR DESCRIPTION
## Description

Corrected `OrientedBoundingBox::computeDistanceSquaredToPosition()` to account for degenerate half axes. 

## Author checklist

- [X] I have done a full self-review of my code.
- [X] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- [X] I have added or updated unit tests to ensure consistent code coverage as necessary.
- ~[ ] I have updated the documentation as necessary.~

## Testing plan

Added unit tests for degenerate axes case.
