### PR TITLE
Include query parameters when loading external subtree buffers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - Fixed incorrect handling of legacy maximumLevel property when the `TilesetJsonLoader` was used.
 - Fixed `OrientedBoundingBox::computeDistanceSquaredToPosition()` calculation when `OrientedBoundingBox` has degenerate axes.
 - Fixed sending empty authorization header `Authorization: Bearer` when no access token is provided while using `CesiumIonTilesetLoader`. Prevents potential future issues with some servers including GP3D Tiles.
+- Fixed a bug in `SubtreeFileReader` where it did not include query parameters from the base URL when requesting an external subtree buffer.
 
 ### v0.48.0 - 2025-06-02
 

--- a/Cesium3DTilesReader/src/SubtreeFileReader.cpp
+++ b/Cesium3DTilesReader/src/SubtreeFileReader.cpp
@@ -287,7 +287,7 @@ Future<ReadJsonResult<Subtree>> SubtreeFileReader::postprocess(
   for (size_t i = 0; i < buffers.size(); ++i) {
     const Buffer& buffer = buffers[i];
     if (buffer.uri && !buffer.uri->empty()) {
-      std::string bufferUrl = CesiumUtility::Uri::resolve(url, *buffer.uri);
+      std::string bufferUrl = CesiumUtility::Uri::resolve(url, *buffer.uri, true);
       bufferRequests.emplace_back(requestBuffer(
           pAssetAccessor,
           asyncSystem,


### PR DESCRIPTION
Even though it's a somewhat unusual thing to do, we always include query parameters from the base URL when resolving a relative URL. This is essential when those query parameters include authorization information, but is pretty common.

This PR fixes a bug where we weren't including those query parameters when loading external subtree buffers in implicit tiling.