### PR TITLE
Fix build on iOS prior to v13.

### DIFF
--- a/CesiumCurl/include/CesiumCurl/CurlAssetAccessor.h
+++ b/CesiumCurl/include/CesiumCurl/CurlAssetAccessor.h
@@ -57,6 +57,8 @@ struct CESIUMCURL_API CurlAssetAccessorOptions {
   /**
    * @brief Whether a PUT or POST to a `file:` URL is allowed to create file
    * system directories to hold the target file.
+   *
+   * This property has no effect when targetting a version of iOS prior to 13.
    */
   bool allowDirectoryCreation{false};
 

--- a/CesiumCurl/src/CurlAssetAccessor.cpp
+++ b/CesiumCurl/src/CurlAssetAccessor.cpp
@@ -469,6 +469,8 @@ Future<std::shared_ptr<IAssetRequest>> CurlAssetAccessor::request(
             pThis->_options.requestHeaders,
             std::move(payloadCopy));
 
+    // These APIs don't exist in iOS versions prior to 13.
+#if !defined(TARGET_OS_IOS) || __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
         // libcurl will not automatically create the target directory when
         // PUTting to a `file:///` URL. So we do that manually here.
         if (pThis->_options.allowDirectoryCreation && isFile(pRequest->url())) {
@@ -478,6 +480,7 @@ Future<std::shared_ptr<IAssetRequest>> CurlAssetAccessor::request(
             std::filesystem::create_directories(filePath.parent_path());
           }
         }
+#endif
 
         CurlHandle curl(pThis.get());
 


### PR DESCRIPTION
iOS prior to version 13 is missing `std::filesystem` capabilities used by `CurlAssetAccessor`. It's only used to create directories in PUTs to file URLs, and off by default anyway. So this PR ifdefs out the feature out on older iOS versions in order to make it compile.