### PR TITLE
Exclude unused functions which triggered a build error on XCode 16, clang 17

### DIFF
--- a/CesiumCurl/src/CurlAssetAccessor.cpp
+++ b/CesiumCurl/src/CurlAssetAccessor.cpp
@@ -419,20 +419,6 @@ Future<std::shared_ptr<IAssetRequest>> CurlAssetAccessor::get(
       });
 }
 
-namespace {
-
-constexpr std::string_view fileScheme("file:");
-
-bool isFile(const std::string& url) {
-  return Uri(url).getScheme() == fileScheme;
-}
-
-std::string convertFileUriToFilename(const std::string& url) {
-  return Uri::uriPathToNativePath(std::string(Uri(url).getPath()));
-}
-
-} // namespace
-
 Future<std::shared_ptr<IAssetRequest>> CurlAssetAccessor::request(
     const AsyncSystem& asyncSystem,
     const std::string& verb,

--- a/CesiumCurl/src/CurlAssetAccessor.cpp
+++ b/CesiumCurl/src/CurlAssetAccessor.cpp
@@ -433,7 +433,6 @@ std::string convertFileUriToFilename(const std::string& url) {
 } // namespace
 #endif
 
-
 Future<std::shared_ptr<IAssetRequest>> CurlAssetAccessor::request(
     const AsyncSystem& asyncSystem,
     const std::string& verb,

--- a/CesiumCurl/src/CurlAssetAccessor.cpp
+++ b/CesiumCurl/src/CurlAssetAccessor.cpp
@@ -419,6 +419,21 @@ Future<std::shared_ptr<IAssetRequest>> CurlAssetAccessor::get(
       });
 }
 
+#if !defined(TARGET_OS_IOS) || __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+namespace {
+constexpr std::string_view fileScheme("file:");
+
+bool isFile(const std::string& url) {
+  return Uri(url).getScheme() == fileScheme;
+}
+
+std::string convertFileUriToFilename(const std::string& url) {
+  return Uri::uriPathToNativePath(std::string(Uri(url).getPath()));
+}
+} // namespace
+#endif
+
+
 Future<std::shared_ptr<IAssetRequest>> CurlAssetAccessor::request(
     const AsyncSystem& asyncSystem,
     const std::string& verb,


### PR DESCRIPTION
When building on MacOS 15.3.1, XCode 16.4 clang 17.0, two warnings are generated (and treated as errors) due to unused functions in `CesiumCurl/src/CurlAssetAccessor.cpp`.  
This PR adds an `#if` block around those functions to exclude them on iOS devices with version < 13. 