### PR TITLE
Fix warning-as-error on Android (from Unity build).

### DIFF
--- a/CesiumRasterOverlays/src/IonRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/IonRasterOverlay.cpp
@@ -188,7 +188,7 @@ IonRasterOverlay::createTileProvider(
                     pHolder->pProvider = nullptr;
                   });
             }
-            return result;
+            return std::move(result);
           });
 }
 


### PR DESCRIPTION
Failing cesium-unity build that this is meant to fix:
https://github.com/CesiumGS/cesium-unity/actions/runs/16641252767/job/47091836713

I'm going to merge this myself once CI passes.