### PR TITLE
Only provide `const` access to the root tile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Breaking Changes :mega:
 
 - `Tileset::getRootTile` now only provides a const pointer to the root `Tile`, even when called on a non-const `Tileset`. Most modifications tile tile instances owned by the tileset would be unsafe.
+- `ViewUpdateResult` now holds pointers to const `Tile` instances.
 - The `slowlyGetCurrentStates` and `slowlyGetPreviousStates` methods of `TreeTraversalState` now return the state map with a raw pointer to a constant node as the key, even if the node pointer type is a smart pointer.
 - `DebugTileStateDatabase::recordTileState` now expects the states to be provided as `std::unordered_map<const Tile*, TileSelectionState>` instead of `std::unordered_map<IntrusivePointer<Tile>, TileSelectionState>`.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ##### Breaking Changes :mega:
 
-- `Tileset::getRootTile` now only provides a const pointer to the root `Tile`, even when called on a non-const `Tileset`. Most modifications tile tile instances owned by the tileset would be unsafe.
+- The `getRootTile`, `loadedTiles`, and `forEachLoadedTile` methods on `Tileset` now only provide a const pointer to `Tile` instances, even when called on a non-const `Tileset`. Most modifications to tile instances owned by the tileset would be unsafe.
 - `ViewUpdateResult` now holds pointers to const `Tile` instances.
 - The `slowlyGetCurrentStates` and `slowlyGetPreviousStates` methods of `TreeTraversalState` now return the state map with a raw pointer to a constant node as the key, even if the node pointer type is a smart pointer.
 - `DebugTileStateDatabase::recordTileState` now expects the states to be provided as `std::unordered_map<const Tile*, TileSelectionState>` instead of `std::unordered_map<IntrusivePointer<Tile>, TileSelectionState>`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,18 @@
 # Change Log
 
+### ? - ?
+
+##### Breaking Changes :mega:
+
+- `Tileset::getRootTile` now only provides a const pointer to the root `Tile`, even when called on a non-const `Tileset`. Most modifications tile tile instances owned by the tileset would be unsafe.
+- The `slowlyGetCurrentStates` and `slowlyGetPreviousStates` methods of `TreeTraversalState` now return the state map with a raw pointer to a constant node as the key, even if the node pointer type is a smart pointer.
+- `DebugTileStateDatabase::recordTileState` now expects the states to be provided as `std::unordered_map<const Tile*, TileSelectionState>` instead of `std::unordered_map<IntrusivePointer<Tile>, TileSelectionState>`.
+
+##### Additions :tada:
+
+- Added `element_type` to `IntrusivePointer`, allowing it to be used with `std::pointer_types`.
+- Added implicit conversion of `IntrusivePointer<T>` to `T*`.
+
 ### v0.50.0 - 2025-08-01
 
 ##### Breaking Changes :mega:

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/DebugTileStateDatabase.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/DebugTileStateDatabase.h
@@ -72,7 +72,7 @@ public:
   void recordTileState(
       int32_t frameNumber,
       const Tile& tile,
-      const std::unordered_map<Tile::Pointer, TileSelectionState>& states);
+      const std::unordered_map<const Tile*, TileSelectionState>& states);
 
 private:
   struct Impl;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tile.h
@@ -131,6 +131,15 @@ public:
   using Pointer = CesiumUtility::IntrusivePointer<Tile>;
 
   /**
+   * @brief A reference counting pointer to a const `Tile`.
+   *
+   * An instance of this pointer type will keep the `Tile` from being destroyed,
+   * and it may also keep its content from unloading. See {@link addReference}
+   * for details.
+   */
+  using ConstPointer = CesiumUtility::IntrusivePointer<const Tile>;
+
+  /**
    * @brief Construct a tile with unknown content and a loader that is used to
    * load the content of this tile. Tile has Unloaded status when initializing
    * with this constructor.
@@ -576,7 +585,7 @@ public:
    * added. This can help debug reference counts when compiled with
    * `CESIUM_DEBUG_TILE_UNLOADING`.
    */
-  void addReference(const char* reason = nullptr) noexcept;
+  void addReference(const char* reason = nullptr) const noexcept;
 
   /**
    * @brief Removes a reference from this tile. A live reference will keep this
@@ -600,7 +609,7 @@ public:
    * removed. This can help debug reference counts when compiled with
    * `CESIUM_DEBUG_TILE_UNLOADING`.
    */
-  void releaseReference(const char* reason = nullptr) noexcept;
+  void releaseReference(const char* reason = nullptr) const noexcept;
 
   /**
    * @brief Gets the current number of references to this tile.
@@ -691,7 +700,7 @@ private:
   // mapped raster overlay
   std::vector<RasterMappedTo3DTile> _rasterTiles;
 
-  int32_t _referenceCount;
+  mutable int32_t _referenceCount;
 
   friend class TilesetContentManager;
   friend class MockTilesetContentManagerTestFixture;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileLoadRequester.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileLoadRequester.h
@@ -64,7 +64,7 @@ public:
    *
    * @return The next tile to load in a worker thread.
    */
-  virtual Tile* getNextTileToLoadInWorkerThread() = 0;
+  virtual const Tile* getNextTileToLoadInWorkerThread() = 0;
 
   /**
    * @brief Determines if this requester has any more tiles that need to be
@@ -92,7 +92,7 @@ public:
    *
    * @return The next tile to load in the main thread.
    */
-  virtual Tile* getNextTileToLoadInMainThread() = 0;
+  virtual const Tile* getNextTileToLoadInMainThread() = 0;
 
   /**
    * @brief Unregister this requester with the {link Tileset} with which it is

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -278,16 +278,6 @@ public:
    */
   LoadedConstTileEnumerator loadedTiles() const;
 
-  /** @copydoc loadedTiles */
-  LoadedTileEnumerator loadedTiles();
-
-  /**
-   * @brief Invokes a function for each tile that is currently loaded.
-   *
-   * @param callback The function to invoke.
-   */
-  void forEachLoadedTile(const std::function<void(Tile& tile)>& callback);
-
   /**
    * @brief Invokes a function for each tile that is currently loaded.
    *

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/Tileset.h
@@ -193,9 +193,6 @@ public:
    *
    * This may be `nullptr` if there is currently no root tile.
    */
-  Tile* getRootTile() noexcept;
-
-  /** @copydoc Tileset::getRootTile() */
   const Tile* getRootTile() const noexcept;
 
   /**

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetViewGroup.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetViewGroup.h
@@ -211,12 +211,12 @@ public:
   /** @inheritdoc */
   bool hasMoreTilesToLoadInWorkerThread() const override;
   /** @inheritdoc */
-  Tile* getNextTileToLoadInWorkerThread() override;
+  const Tile* getNextTileToLoadInWorkerThread() override;
 
   /** @inheritdoc */
   bool hasMoreTilesToLoadInMainThread() const override;
   /** @inheritdoc */
-  Tile* getNextTileToLoadInMainThread() override;
+  const Tile* getNextTileToLoadInMainThread() override;
 
 private:
   double _weight = 1.0;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ViewUpdateResult.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/ViewUpdateResult.h
@@ -27,7 +27,7 @@ public:
    * Tiles in this list may be fading in if
    * {@link TilesetOptions::enableLodTransitionPeriod} is true.
    */
-  std::vector<Tile::Pointer> tilesToRenderThisFrame;
+  std::vector<Tile::ConstPointer> tilesToRenderThisFrame;
 
   /**
    * @brief Tiles on this list are no longer selected for rendering.
@@ -36,7 +36,7 @@ public:
    * fading out. If a tile's {TileRenderContent::lodTransitionPercentage} is 0
    * or lod transitions are disabled, the tile should be hidden right away.
    */
-  std::unordered_set<Tile::Pointer> tilesFadingOut;
+  std::unordered_set<Tile::ConstPointer> tilesFadingOut;
 
   /**
    * @brief The number of tiles in the worker thread load queue.

--- a/Cesium3DTilesSelection/src/DebugTileStateDatabase.cpp
+++ b/Cesium3DTilesSelection/src/DebugTileStateDatabase.cpp
@@ -220,7 +220,7 @@ void DebugTileStateDatabase::recordTileState(
 void DebugTileStateDatabase::recordTileState(
     int32_t frameNumber,
     const Tile& tile,
-    const std::unordered_map<Tile::Pointer, TileSelectionState>& states) {
+    const std::unordered_map<const Tile*, TileSelectionState>& states) {
   int status = CESIUM_SQLITE(sqlite3_reset)(this->_pImpl->writeTileState.get());
   if (status != SQLITE_OK) {
     return;

--- a/Cesium3DTilesSelection/src/Tile.cpp
+++ b/Cesium3DTilesSelection/src/Tile.cpp
@@ -362,7 +362,7 @@ bool isContentReferenced(const Tile& tile) {
 
 } // namespace
 
-void Tile::addReference([[maybe_unused]] const char* reason) noexcept {
+void Tile::addReference([[maybe_unused]] const char* reason) const noexcept {
   ++this->_referenceCount;
 
 #ifdef CESIUM_DEBUG_TILE_UNLOADING
@@ -396,11 +396,13 @@ void Tile::addReference([[maybe_unused]] const char* reason) noexcept {
   // "ineligible for content unloading" with the TilesetContentManager.
   if (isContentReferenced(*this) && this->_pLoader &&
       this->_pLoader->getOwner()) {
-    this->_pLoader->getOwner()->markTileIneligibleForContentUnloading(*this);
+    this->_pLoader->getOwner()->markTileIneligibleForContentUnloading(
+        const_cast<Tile&>(*this));
   }
 }
 
-void Tile::releaseReference([[maybe_unused]] const char* reason) noexcept {
+void Tile::releaseReference(
+    [[maybe_unused]] const char* reason) const noexcept {
   CESIUM_ASSERT(this->_referenceCount > 0);
   --this->_referenceCount;
 
@@ -424,7 +426,8 @@ void Tile::releaseReference([[maybe_unused]] const char* reason) noexcept {
   // content will be unloaded immediately.
   if (!isContentReferenced(*this) && this->_pLoader &&
       this->_pLoader->getOwner()) {
-    this->_pLoader->getOwner()->markTileEligibleForContentUnloading(*this);
+    this->_pLoader->getOwner()->markTileEligibleForContentUnloading(
+        const_cast<Tile&>(*this));
   }
 
   // When the reference count goes from 1 to 0, this Tile is once again

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -170,10 +170,6 @@ void Tileset::setShowCreditsOnScreen(bool showCreditsOnScreen) noexcept {
   }
 }
 
-Tile* Tileset::getRootTile() noexcept {
-  return this->_pTilesetContentManager->getRootTile();
-}
-
 const Tile* Tileset::getRootTile() const noexcept {
   return this->_pTilesetContentManager->getRootTile();
 }
@@ -392,7 +388,7 @@ const ViewUpdateResult& Tileset::updateViewGroup(
 
   ViewUpdateResult& result = viewGroup.getViewUpdateResult();
 
-  Tile* pRootTile = this->getRootTile();
+  Tile* pRootTile = this->_pTilesetContentManager->getRootTile();
   if (!pRootTile) {
     return result;
   }
@@ -438,7 +434,7 @@ void Tileset::loadTiles() {
 
   this->_asyncSystem.dispatchMainThreadTasks();
 
-  Tile* pRootTile = this->getRootTile();
+  Tile* pRootTile = this->_pTilesetContentManager->getRootTile();
   if (!pRootTile) {
     // If the root tile is marked as ready, but doesn't actually exist, then
     // the tileset couldn't load. Fail any outstanding height requests.

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -491,20 +491,6 @@ LoadedConstTileEnumerator Tileset::loadedTiles() const {
           : nullptr);
 }
 
-LoadedTileEnumerator Tileset::loadedTiles() {
-  return LoadedTileEnumerator(
-      this->_pTilesetContentManager
-          ? this->_pTilesetContentManager->getRootTile()
-          : nullptr);
-}
-
-void Tileset::forEachLoadedTile(
-    const std::function<void(Tile& tile)>& callback) {
-  for (Tile& tile : this->loadedTiles()) {
-    callback(tile);
-  }
-}
-
 void Tileset::forEachLoadedTile(
     const std::function<void(const Tile& tile)>& callback) const {
   for (const Tile& tile : this->loadedTiles()) {

--- a/Cesium3DTilesSelection/src/Tileset.cpp
+++ b/Cesium3DTilesSelection/src/Tileset.cpp
@@ -259,8 +259,8 @@ void Tileset::_updateLodTransitions(
     // Update fade out
     for (auto tileIt = result.tilesFadingOut.begin();
          tileIt != result.tilesFadingOut.end();) {
-      TileRenderContent* pRenderContent =
-          (*tileIt)->getContent().getRenderContent();
+      TileRenderContent* pRenderContent = const_cast<TileRenderContent*>(
+          (*tileIt)->getContent().getRenderContent());
 
       if (!pRenderContent) {
         // This tile is done fading out and was immediately kicked from the
@@ -287,9 +287,9 @@ void Tileset::_updateLodTransitions(
     }
 
     // Update fade in
-    for (const Tile::Pointer& pTile : result.tilesToRenderThisFrame) {
-      TileRenderContent* pRenderContent =
-          pTile->getContent().getRenderContent();
+    for (const Tile::ConstPointer& pTile : result.tilesToRenderThisFrame) {
+      TileRenderContent* pRenderContent = const_cast<TileRenderContent*>(
+          pTile->getContent().getRenderContent());
       if (pRenderContent) {
         float transitionPercentage =
             pRenderContent->getLodTransitionFadePercentage();
@@ -307,9 +307,9 @@ void Tileset::_updateLodTransitions(
   } else {
     // If there are any tiles still fading in, set them to fully visible right
     // away.
-    for (const Tile::Pointer& pTile : result.tilesToRenderThisFrame) {
-      TileRenderContent* pRenderContent =
-          pTile->getContent().getRenderContent();
+    for (const Tile::ConstPointer& pTile : result.tilesToRenderThisFrame) {
+      TileRenderContent* pRenderContent = const_cast<TileRenderContent*>(
+          pTile->getContent().getRenderContent());
       if (pRenderContent) {
         pRenderContent->setLodTransitionFadePercentage(1.0f);
       }
@@ -321,7 +321,7 @@ const ViewUpdateResult& Tileset::updateViewGroupOffline(
     TilesetViewGroup& viewGroup,
     const std::vector<ViewState>& frustums) {
   ViewUpdateResult& updateResult = viewGroup.getViewUpdateResult();
-  std::vector<Tile::Pointer> tilesSelectedPrevFrame =
+  std::vector<Tile::ConstPointer> tilesSelectedPrevFrame =
       updateResult.tilesToRenderThisFrame;
 
   // TODO: fix the fading for offline case
@@ -335,18 +335,18 @@ const ViewUpdateResult& Tileset::updateViewGroupOffline(
 
   updateResult.tilesFadingOut.clear();
 
-  std::unordered_set<Tile*> uniqueTilesToRenderThisFrame;
+  std::unordered_set<const Tile*> uniqueTilesToRenderThisFrame;
   uniqueTilesToRenderThisFrame.reserve(
       updateResult.tilesToRenderThisFrame.size());
-  for (const Tile::Pointer& pTile : updateResult.tilesToRenderThisFrame) {
+  for (const Tile::ConstPointer& pTile : updateResult.tilesToRenderThisFrame) {
     uniqueTilesToRenderThisFrame.insert(pTile.get());
   }
 
-  for (const Tile::Pointer& pTile : tilesSelectedPrevFrame) {
+  for (const Tile::ConstPointer& pTile : tilesSelectedPrevFrame) {
     if (uniqueTilesToRenderThisFrame.find(pTile.get()) ==
         uniqueTilesToRenderThisFrame.end()) {
-      TileRenderContent* pRenderContent =
-          pTile->getContent().getRenderContent();
+      TileRenderContent* pRenderContent = const_cast<TileRenderContent*>(
+          pTile->getContent().getRenderContent());
       if (pRenderContent) {
         pRenderContent->setLodTransitionFadePercentage(1.0f);
         updateResult.tilesFadingOut.insert(pTile);
@@ -1124,7 +1124,7 @@ bool Tileset::_kickDescendantsAndRenderTile(
       });
 
   // Remove all descendants from the render list and add this tile.
-  std::vector<Tile::Pointer>& renderList = result.tilesToRenderThisFrame;
+  std::vector<Tile::ConstPointer>& renderList = result.tilesToRenderThisFrame;
   renderList.erase(
       renderList.begin() +
           static_cast<std::vector<Tile*>::iterator::difference_type>(

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -1544,7 +1544,7 @@ namespace {
 class WeightedRoundRobin {
 public:
   typedef bool (TileLoadRequester::*HasMoreTilesToLoad)() const;
-  typedef Tile* (TileLoadRequester::*GetNextTileToLoad)();
+  typedef const Tile* (TileLoadRequester::*GetNextTileToLoad)();
 
   WeightedRoundRobin(
       double& roundRobinValue,
@@ -1584,7 +1584,7 @@ public:
 
     TileLoadRequester& requester = *this->_requestersWithRequests[index];
 
-    Tile* pToLoad = std::invoke(this->_getNextTileToLoad, requester);
+    const Tile* pToLoad = std::invoke(this->_getNextTileToLoad, requester);
     CESIUM_ASSERT(pToLoad);
 
     if (!pToLoad || !std::invoke(this->_hasMoreTilesToLoad, requester)) {
@@ -1593,7 +1593,9 @@ public:
       this->recomputeRequesterFractions();
     }
 
-    return pToLoad;
+    // The Tile is const from the perspective of the TileLoadRequester. But the
+    // TilesetContentManager is going to load it, so cast away the const.
+    return const_cast<Tile*>(pToLoad);
   }
 
 private:

--- a/Cesium3DTilesSelection/src/TilesetHeightQuery.cpp
+++ b/Cesium3DTilesSelection/src/TilesetHeightQuery.cpp
@@ -253,7 +253,7 @@ bool TilesetHeightRequest::hasMoreTilesToLoadInWorkerThread() const {
   return !this->tilesToLoad.empty();
 }
 
-Tile* TilesetHeightRequest::getNextTileToLoadInWorkerThread() {
+const Tile* TilesetHeightRequest::getNextTileToLoadInWorkerThread() {
   Tile* pResult = nullptr;
 
   auto it = this->tilesToLoad.begin();
@@ -270,7 +270,9 @@ bool TilesetHeightRequest::hasMoreTilesToLoadInMainThread() const {
   return false;
 }
 
-Tile* TilesetHeightRequest::getNextTileToLoadInMainThread() { return nullptr; }
+const Tile* TilesetHeightRequest::getNextTileToLoadInMainThread() {
+  return nullptr;
+}
 
 void Cesium3DTilesSelection::TilesetHeightRequest::failHeightRequests(
     std::list<TilesetHeightRequest>& heightRequests,

--- a/Cesium3DTilesSelection/src/TilesetHeightQuery.h
+++ b/Cesium3DTilesSelection/src/TilesetHeightQuery.h
@@ -154,12 +154,12 @@ struct TilesetHeightRequest : public TileLoadRequester {
   /** @inheritdoc */
   bool hasMoreTilesToLoadInWorkerThread() const override;
   /** @inheritdoc */
-  Tile* getNextTileToLoadInWorkerThread() override;
+  const Tile* getNextTileToLoadInWorkerThread() override;
 
   /** @inheritdoc */
   bool hasMoreTilesToLoadInMainThread() const override;
   /** @inheritdoc */
-  Tile* getNextTileToLoadInMainThread() override;
+  const Tile* getNextTileToLoadInMainThread() override;
 
   /**
    * @brief Cancels all outstanding height requests and rejects the associated

--- a/Cesium3DTilesSelection/src/TilesetViewGroup.cpp
+++ b/Cesium3DTilesSelection/src/TilesetViewGroup.cpp
@@ -232,7 +232,7 @@ bool TilesetViewGroup::hasMoreTilesToLoadInWorkerThread() const {
   return !this->_workerThreadLoadQueue.empty();
 }
 
-Tile* TilesetViewGroup::getNextTileToLoadInWorkerThread() {
+const Tile* TilesetViewGroup::getNextTileToLoadInWorkerThread() {
   CESIUM_ASSERT(!this->_workerThreadLoadQueue.empty());
   if (this->_workerThreadLoadQueue.empty())
     return nullptr;
@@ -246,7 +246,7 @@ bool TilesetViewGroup::hasMoreTilesToLoadInMainThread() const {
   return !this->_mainThreadLoadQueue.empty();
 }
 
-Tile* TilesetViewGroup::getNextTileToLoadInMainThread() {
+const Tile* TilesetViewGroup::getNextTileToLoadInMainThread() {
   CESIUM_ASSERT(!this->_mainThreadLoadQueue.empty());
   if (this->_mainThreadLoadQueue.empty())
     return nullptr;

--- a/Cesium3DTilesSelection/src/TilesetViewGroup.cpp
+++ b/Cesium3DTilesSelection/src/TilesetViewGroup.cpp
@@ -188,7 +188,8 @@ void TilesetViewGroup::finishFrame(
     }
 
     // Add per-tile credits for tiles selected this frame.
-    for (const Tile::Pointer& pTile : updateResult.tilesToRenderThisFrame) {
+    for (const Tile::ConstPointer& pTile :
+         updateResult.tilesToRenderThisFrame) {
       const std::vector<RasterMappedTo3DTile>& mappedRasterTiles =
           pTile->getMappedRasterTiles();
       // raster overlay tile credits

--- a/Cesium3DTilesSelection/test/TestTileLoadRequester.cpp
+++ b/Cesium3DTilesSelection/test/TestTileLoadRequester.cpp
@@ -25,9 +25,9 @@ public:
 
   Tile* getNextTileToLoadInWorkerThread() override {
     CESIUM_ASSERT(!this->_workerThread.empty());
-    Tile* pResult = this->_workerThread.back();
+    const Tile* pResult = this->_workerThread.back();
     this->_workerThread.pop_back();
-    return pResult;
+    return const_cast<Tile*>(pResult);
   }
 
   bool hasMoreTilesToLoadInMainThread() const override {
@@ -36,32 +36,38 @@ public:
 
   Tile* getNextTileToLoadInMainThread() override {
     CESIUM_ASSERT(!this->_mainThread.empty());
-    Tile* pResult = this->_mainThread.back();
+    const Tile* pResult = this->_mainThread.back();
     this->_mainThread.pop_back();
-    return pResult;
+    return const_cast<Tile*>(pResult);
   }
 
   // Extra methods for testing
   void setWeight(double weight) { this->_weight = weight; }
-  void setWorkerThreadQueue(const std::vector<Tile*>& newQueue) {
+  void setWorkerThreadQueue(const std::vector<const Tile*>& newQueue) {
+    std::span<Tile*> newQueueCast(
+        const_cast<Tile**>(newQueue.data()),
+        newQueue.size());
     this->_keepAlive.insert(
         this->_keepAlive.end(),
-        newQueue.begin(),
-        newQueue.end());
+        newQueueCast.begin(),
+        newQueueCast.end());
     this->_workerThread = newQueue;
   }
-  void setMainThreadQueue(const std::vector<Tile*>& newQueue) {
+  void setMainThreadQueue(const std::vector<const Tile*>& newQueue) {
+    std::span<Tile*> newQueueCast(
+        const_cast<Tile**>(newQueue.data()),
+        newQueue.size());
     this->_keepAlive.insert(
         this->_keepAlive.end(),
-        newQueue.begin(),
-        newQueue.end());
+        newQueueCast.begin(),
+        newQueueCast.end());
     this->_mainThread = newQueue;
   }
 
 private:
   double _weight = 1.0;
-  std::vector<Tile*> _workerThread;
-  std::vector<Tile*> _mainThread;
+  std::vector<const Tile*> _workerThread;
+  std::vector<const Tile*> _mainThread;
   std::vector<Tile::Pointer> _keepAlive;
 };
 
@@ -104,7 +110,7 @@ TEST_CASE("TileLoadRequester") {
 
     auto pTileset = EllipsoidTilesetLoader::createTileset(externals);
 
-    Tile* pRoot = pTileset->getRootTile();
+    const Tile* pRoot = pTileset->getRootTile();
     REQUIRE(pRoot != nullptr);
     REQUIRE(pRoot->getChildren().size() == 2);
     REQUIRE(pRoot->getState() == TileLoadState::ContentLoaded);
@@ -113,7 +119,7 @@ TEST_CASE("TileLoadRequester") {
       TestTileLoadRequester requester;
       pTileset->registerLoadRequester(requester);
 
-      Tile* pToLoad = &pRoot->getChildren()[1];
+      const Tile* pToLoad = &pRoot->getChildren()[1];
       CHECK(pToLoad->getState() == TileLoadState::Unloaded);
 
       // loadTiles won't load the tile because nothing has requested it yet.
@@ -171,7 +177,7 @@ TEST_CASE("TileLoadRequester") {
         std::move(pRootTile),
         options);
 
-    Tile* pRoot = pTileset->getRootTile();
+    const Tile* pRoot = pTileset->getRootTile();
     REQUIRE(pRoot != nullptr);
     REQUIRE(pRoot->getChildren().size() == 100);
 
@@ -187,21 +193,23 @@ TEST_CASE("TileLoadRequester") {
       pTileset->registerLoadRequester(reqVeryLow);
       pTileset->registerLoadRequester(reqVeryHigh);
 
-      std::vector<Tile*> pointers(pRoot->getChildren().size());
+      std::vector<const Tile*> pointers(pRoot->getChildren().size());
       std::transform(
           pRoot->getChildren().begin(),
           pRoot->getChildren().end(),
           pointers.begin(),
-          [](Tile& tile) { return &tile; });
+          [](const Tile& tile) { return &tile; });
 
       reqNormal.setWorkerThreadQueue(
-          std::vector<Tile*>(pointers.begin(), pointers.begin() + 20));
-      reqExtra.setWorkerThreadQueue(
-          std::vector<Tile*>(pointers.begin() + 20, pointers.begin() + 40));
-      reqVeryLow.setWorkerThreadQueue(
-          std::vector<Tile*>(pointers.begin() + 40, pointers.begin() + 60));
+          std::vector<const Tile*>(pointers.begin(), pointers.begin() + 20));
+      reqExtra.setWorkerThreadQueue(std::vector<const Tile*>(
+          pointers.begin() + 20,
+          pointers.begin() + 40));
+      reqVeryLow.setWorkerThreadQueue(std::vector<const Tile*>(
+          pointers.begin() + 40,
+          pointers.begin() + 60));
       reqVeryHigh.setWorkerThreadQueue(
-          std::vector<Tile*>(pointers.begin() + 80, pointers.end()));
+          std::vector<const Tile*>(pointers.begin() + 80, pointers.end()));
 
       std::vector<const TestTileLoadRequester*> requestersOutOfTiles;
 

--- a/Cesium3DTilesSelection/test/TestTileLoadRequester.cpp
+++ b/Cesium3DTilesSelection/test/TestTileLoadRequester.cpp
@@ -23,7 +23,7 @@ public:
     return !this->_workerThread.empty();
   }
 
-  Tile* getNextTileToLoadInWorkerThread() override {
+  const Tile* getNextTileToLoadInWorkerThread() override {
     CESIUM_ASSERT(!this->_workerThread.empty());
     const Tile* pResult = this->_workerThread.back();
     this->_workerThread.pop_back();
@@ -34,7 +34,7 @@ public:
     return !this->_mainThread.empty();
   }
 
-  Tile* getNextTileToLoadInMainThread() override {
+  const Tile* getNextTileToLoadInMainThread() override {
     CESIUM_ASSERT(!this->_mainThread.empty());
     const Tile* pResult = this->_mainThread.back();
     this->_mainThread.pop_back();

--- a/Cesium3DTilesSelection/test/TestTileLoadRequester.cpp
+++ b/Cesium3DTilesSelection/test/TestTileLoadRequester.cpp
@@ -27,7 +27,7 @@ public:
     CESIUM_ASSERT(!this->_workerThread.empty());
     const Tile* pResult = this->_workerThread.back();
     this->_workerThread.pop_back();
-    return const_cast<Tile*>(pResult);
+    return pResult;
   }
 
   bool hasMoreTilesToLoadInMainThread() const override {
@@ -38,7 +38,7 @@ public:
     CESIUM_ASSERT(!this->_mainThread.empty());
     const Tile* pResult = this->_mainThread.back();
     this->_mainThread.pop_back();
-    return const_cast<Tile*>(pResult);
+    return pResult;
   }
 
   // Extra methods for testing

--- a/Cesium3DTilesSelection/test/TestTilesetSelectionAlgorithm.cpp
+++ b/Cesium3DTilesSelection/test/TestTilesetSelectionAlgorithm.cpp
@@ -617,7 +617,8 @@ TEST_CASE("Test additive refinement") {
           tileset.updateViewGroup(tileset.getDefaultViewGroup(), {viewState});
       tileset.loadTiles();
 
-      const std::vector<Tile::Pointer>& ttr = result.tilesToRenderThisFrame;
+      const std::vector<Tile::ConstPointer>& ttr =
+          result.tilesToRenderThisFrame;
       REQUIRE(ttr.size() == 7);
 
       REQUIRE(root->getState() == TileLoadState::Done);
@@ -652,7 +653,8 @@ TEST_CASE("Test additive refinement") {
           tileset.updateViewGroup(tileset.getDefaultViewGroup(), {viewState});
       tileset.loadTiles();
 
-      const std::vector<Tile::Pointer>& ttr = result.tilesToRenderThisFrame;
+      const std::vector<Tile::ConstPointer>& ttr =
+          result.tilesToRenderThisFrame;
       REQUIRE(ttr.size() == 8);
 
       // root is done loading and rendered.

--- a/Cesium3DTilesSelection/test/TestTilesetSelectionAlgorithm.cpp
+++ b/Cesium3DTilesSelection/test/TestTilesetSelectionAlgorithm.cpp
@@ -765,10 +765,10 @@ TEST_CASE("Render any tiles even when one of children can't be rendered for "
   initializeTileset(tileset);
   ViewState viewState = zoomToTileset(tileset);
 
-  Tile* pTilesetJson = tileset.getRootTile();
+  const Tile* pTilesetJson = tileset.getRootTile();
   REQUIRE(pTilesetJson);
   REQUIRE(pTilesetJson->getChildren().size() == 1);
-  Tile* root = &pTilesetJson->getChildren()[0];
+  const Tile* root = &pTilesetJson->getChildren()[0];
 
   REQUIRE(!doesTileMeetSSE(viewState, *root, tileset));
   REQUIRE(root->getState() == TileLoadState::ContentLoading);
@@ -1206,10 +1206,11 @@ TEST_CASE("Makes metadata available once root tile is loaded") {
   Tileset tileset(tilesetExternals, "tileset.json");
   initializeTileset(tileset);
 
-  Tile* pRoot = tileset.getRootTile();
+  const Tile* pRoot = tileset.getRootTile();
   REQUIRE(pRoot);
 
-  TileExternalContent* pExternal = pRoot->getContent().getExternalContent();
+  const TileExternalContent* pExternal =
+      pRoot->getContent().getExternalContent();
   REQUIRE(pExternal);
 
   const TilesetMetadata& metadata = pExternal->metadata;
@@ -1262,16 +1263,16 @@ TEST_CASE("Makes metadata available on external tilesets") {
   Tileset tileset(tilesetExternals, "tileset.json");
   initializeTileset(tileset);
 
-  Tile* pTilesetJson = tileset.getRootTile();
+  const Tile* pTilesetJson = tileset.getRootTile();
   REQUIRE(pTilesetJson);
   REQUIRE(pTilesetJson->getChildren().size() == 1);
 
-  Tile* pRoot = &pTilesetJson->getChildren()[0];
+  const Tile* pRoot = &pTilesetJson->getChildren()[0];
   REQUIRE(pRoot);
   REQUIRE(pRoot->getChildren().size() == 5);
-  Tile* pExternal = &pRoot->getChildren()[4];
+  const Tile* pExternal = &pRoot->getChildren()[4];
 
-  TileExternalContent* pExternalContent = nullptr;
+  const TileExternalContent* pExternalContent = nullptr;
 
   for (int i = 0; i < 10 && pExternalContent == nullptr; ++i) {
     ViewState zoomToTileViewState = zoomToTile(*pExternal);
@@ -1634,8 +1635,8 @@ void runUnconditionallyRefinedTestCase(const TilesetOptions& options) {
   // On the first update, we should refine down to the grandchild tile, even
   // though no tiles are loaded yet.
   initializeTileset(tileset);
-  Tile& child = tileset.getRootTile()->getChildren()[0];
-  Tile& grandchild = child.getChildren()[0];
+  const Tile& child = tileset.getRootTile()->getChildren()[0];
+  const Tile& grandchild = child.getChildren()[0];
 
   auto states = viewGroup.getTraversalState().slowlyGetCurrentStates();
 

--- a/Cesium3DTilesSelection/test/TestTilesetViewGroup.cpp
+++ b/Cesium3DTilesSelection/test/TestTilesetViewGroup.cpp
@@ -19,10 +19,10 @@ using namespace CesiumUtility;
 namespace {
 
 // Get the maximum level of any of the tiles in the list
-uint32_t getMaxLevel(const std::vector<Tile::Pointer>& tiles) {
+uint32_t getMaxLevel(const std::vector<Tile::ConstPointer>& tiles) {
   uint32_t result = 0;
 
-  for (const Tile::Pointer& pTile : tiles) {
+  for (const Tile::ConstPointer& pTile : tiles) {
     const QuadtreeTileID* pID =
         std::get_if<QuadtreeTileID>(&pTile->getTileID());
     if (pID != nullptr) {
@@ -76,7 +76,7 @@ TEST_CASE("TilesetViewGroup") {
         externals.asyncSystem.dispatchMainThreadTasks();
       }
 
-      std::vector<Tile::Pointer> farViewTiles;
+      std::vector<Tile::ConstPointer> farViewTiles;
 
       {
         const ViewUpdateResult& farResult = farGroup.getViewUpdateResult();

--- a/CesiumUtility/include/CesiumUtility/IntrusivePointer.h
+++ b/CesiumUtility/include/CesiumUtility/IntrusivePointer.h
@@ -191,6 +191,12 @@ public:
   explicit operator bool() const noexcept { return this->_p != nullptr; }
 
   /**
+   * @brief Implicit conversion to `bool`, being `true` iff this is not the
+   * `nullptr`.
+   */
+  explicit operator bool() noexcept { return this->_p != nullptr; }
+
+  /**
    * @brief Returns the internal pointer.
    */
   T* get() const noexcept { return this->_p; }

--- a/CesiumUtility/include/CesiumUtility/IntrusivePointer.h
+++ b/CesiumUtility/include/CesiumUtility/IntrusivePointer.h
@@ -18,8 +18,13 @@ namespace CesiumUtility {
  *
  * @tparam T The type of object controlled.
  */
-template <class T> class IntrusivePointer final {
+template <typename T> class IntrusivePointer final {
 public:
+  /**
+   * @brief The type pointed to by this pointer.
+   */
+  using element_type = T;
+
   /**
    * @brief Default constructor.
    */
@@ -69,6 +74,16 @@ public:
    * @brief Default destructor.
    */
   ~IntrusivePointer() noexcept { this->releaseReference(); }
+
+  /**
+   * @brief Implicitly converts this implicit pointer to a raw pointer.
+   */
+  operator T*() noexcept { return this->_p; }
+
+  /**
+   * @brief Implicitly converts this implicit pointer to a raw pointer.
+   */
+  operator const T*() const noexcept { return this->_p; }
 
   /**
    * @brief Constructs a new instance and assigns it to this IntrusivePointer.

--- a/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
+++ b/CesiumUtility/include/CesiumUtility/TreeTraversalState.h
@@ -3,10 +3,14 @@
 #include <CesiumUtility/Assert.h>
 
 #include <cstddef>
+#include <memory>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
 namespace CesiumUtility {
+
+template <typename T> class IntrusivePointer;
 
 /**
  * @brief Associates state (arbitrary data) with each node during partial,
@@ -34,6 +38,22 @@ namespace CesiumUtility {
  */
 template <typename TNodePointer, typename TState> class TreeTraversalState {
 public:
+  /**
+   * @brief The instance type of the node.
+   */
+  using TNodeInstance = std::remove_cvref_t<
+      typename std::pointer_traits<TNodePointer>::element_type>;
+
+  /**
+   * @brief A raw pointer to a node.
+   */
+  using TRawNodePointer = TNodeInstance*;
+
+  /**
+   * @brief A raw pointer to a const node.
+   */
+  using TRawConstNodePointer = const TNodeInstance*;
+
   /**
    * @brief Gets the total number of nodes that were visited in the previous
    * traversal.
@@ -297,7 +317,8 @@ public:
    *
    * @return The mapping of nodes to current traversal states.
    */
-  std::unordered_map<TNodePointer, TState> slowlyGetCurrentStates() const {
+  std::unordered_map<TRawConstNodePointer, TState>
+  slowlyGetCurrentStates() const {
     return this->slowlyGetStates(this->_currentTraversal);
   }
 
@@ -309,7 +330,8 @@ public:
    *
    * @return The mapping of nodes to previous traversal states.
    */
-  std::unordered_map<TNodePointer, TState> slowlyGetPreviousStates() const {
+  std::unordered_map<TRawConstNodePointer, TState>
+  slowlyGetPreviousStates() const {
     return this->slowlyGetStates(this->_previousTraversal);
   }
 
@@ -374,9 +396,9 @@ private:
     return this->_currentTraversal[size_t(currentIndex)];
   }
 
-  std::unordered_map<TNodePointer, TState>
+  std::unordered_map<TRawConstNodePointer, TState>
   slowlyGetStates(const std::vector<TraversalData>& traversalData) const {
-    std::unordered_map<TNodePointer, TState> result;
+    std::unordered_map<TRawConstNodePointer, TState> result;
 
     for (const TraversalData& data : traversalData) {
       result[data.pNode] = data.state;


### PR DESCRIPTION
The `getRootTile` method on `Tileset` returns a pointer to the root tile, once there is one. Previously, the returned pointer would be to const if called on a const Tileset, and to non-const otherwise. After this PR, the returned pointer is _always_ to const.

This is an important improvement because some modifications to `Tile` and the data it holds are unsafe, even when done from the main thread. For example, upsampling for raster overlays happens in a worker thread, which is given a pointer to the parent tile's glTF. The `Tileset` makes sure this is safe, but if users are allowed to make arbitrary modifications to `Tile` while this is happening, then there is potential for undefined behavior. And #1186 introduces another place where a tile's model is read in a background thread.

Fortunately, almost nothing that I'm aware of is using the non-const version of `getRootTile`. There's only one place in cesium-unreal, and it's in a test, and is solved by simply adding a missing `const`. So this is just tightening things up hopefully without a large impact on users.

Other changes in this PR:

* `slowlyGetCurrentStates` and `slowlyGetPreviousStates` on `TreeTraversalState` now use a const raw pointer as the key in the map. Because if you only have access to `const Tile` instances, it's a hassle to provide an `IntrusivePointer<Tile>` just for map lookup.
* `IntrusivePointer<T>` now has an `element_type` typedef, making it play nicely with `std::pointer_traits`. This was motivated by the change above.

