### PR TITLE
Make more properties from tileset.json available on `TilesetMetadata`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 
 - Added `element_type` to `IntrusivePointer`, allowing it to be used with `std::pointer_types`.
 - Added implicit conversion of `IntrusivePointer<T>` to `T*`.
+- All properties and extensions from `tileset.json`, except `"root"`, are now parsed into `TilesetMetadata` when a tileset is loaded by `Cesium3DTilesSelection::Tileset`.
 
 ### v0.50.0 - 2025-08-01
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetMetadata.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TilesetMetadata.h
@@ -1,12 +1,17 @@
 #pragma once
 
+#include <Cesium3DTiles/Asset.h>
 #include <Cesium3DTiles/GroupMetadata.h>
+#include <Cesium3DTiles/Properties.h>
 #include <Cesium3DTiles/Schema.h>
+#include <Cesium3DTiles/Statistics.h>
 #include <Cesium3DTilesSelection/Library.h>
 #include <CesiumAsync/SharedFuture.h>
+#include <CesiumUtility/ExtensibleObject.h>
 
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace CesiumAsync {
@@ -18,11 +23,23 @@ namespace Cesium3DTilesSelection {
 
 /**
  * @brief Holds the metadata associated with a {@link Tileset} or an external
- * tileset.
+ * tileset. This holds all of the fields of {@link Cesium3DTiles::Tileset}
+ * except for the root tile.
  */
-class CESIUM3DTILESSELECTION_API TilesetMetadata {
+class CESIUM3DTILESSELECTION_API TilesetMetadata
+    : public CesiumUtility::ExtensibleObject {
 public:
   ~TilesetMetadata() noexcept;
+
+  /**
+   * @brief Metadata about the entire tileset.
+   */
+  Cesium3DTiles::Asset asset;
+
+  /**
+   * @brief A dictionary object of metadata about per-feature properties.
+   */
+  std::unordered_map<std::string, Cesium3DTiles::Properties> properties;
 
   /**
    * @brief An object defining the structure of metadata classes and enums. When
@@ -37,6 +54,11 @@ public:
   std::optional<std::string> schemaUri;
 
   /**
+   * @brief An object containing statistics about metadata entities.
+   */
+  std::optional<Cesium3DTiles::Statistics> statistics;
+
+  /**
    * @brief An array of groups that tile content may belong to. Each element of
    * this array is a metadata entity that describes the group. The tile content
    * `group` property is an index into this array.
@@ -47,6 +69,24 @@ public:
    * @brief A metadata entity that is associated with this tileset.
    */
   std::optional<Cesium3DTiles::MetadataEntity> metadata;
+
+  /**
+   * @brief The error, in meters, introduced if this tileset is not rendered. At
+   * runtime, the geometric error is used to compute screen space error (SSE),
+   * i.e., the error measured in pixels.
+   */
+  std::optional<double> geometricError;
+
+  /**
+   * @brief Names of 3D Tiles extensions used somewhere in this tileset.
+   */
+  std::vector<std::string> extensionsUsed;
+
+  /**
+   * @brief Names of 3D Tiles extensions required to properly load this tileset.
+   * Each element of this array shall also be contained in `extensionsUsed`.
+   */
+  std::vector<std::string> extensionsRequired;
 
   /**
    * @brief Asynchronously loads the {@link schema} from the {@link schemaUri}.

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -847,7 +847,7 @@ TilesetContentManager::TilesetContentManager(
                            pLogger,
                            url,
                            pCompletedRequest->headers(),
-                           tilesetJson,
+                           std::move(tilesetJson),
                            ellipsoid)
                     .thenImmediately(
                         [](TilesetContentLoaderResult<TilesetContentLoader>&&

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.cpp
@@ -761,6 +761,7 @@ void removeRootPropertyAndParseTilesetMetadata(
           CesiumUtility::Uri::resolve(baseUrl, *tileset.schemaUri);
     }
     metadata.statistics = std::move(tileset.statistics);
+    metadata.unknownProperties = std::move(tileset.unknownProperties);
   }
 }
 

--- a/Cesium3DTilesSelection/src/TilesetJsonLoader.h
+++ b/Cesium3DTilesSelection/src/TilesetJsonLoader.h
@@ -49,7 +49,7 @@ public:
       const std::shared_ptr<spdlog::logger>& pLogger,
       const std::string& tilesetJsonUrl,
       const CesiumAsync::HttpHeaders& requestHeaders,
-      const rapidjson::Document& tilesetJson,
+      rapidjson::Document&& tilesetJson,
       const CesiumGeospatial::Ellipsoid& ellipsoid CESIUM_DEFAULT_ELLIPSOID);
 
 protected:


### PR DESCRIPTION
This is  PR into #1221 so merge that first.

We continue to have an unfortunate distinction between `Cesium3DTiles::Tileset` and `Cesium3DTilesSelection::Tileset`. This PR doesn't fix that, but it does make a more complete set of information from tileset.json available on the `Selection` version of `Tileset`. It expands the `TilesetMetadata` class added in #709 to include every tileset property in the 3D Tiles schema, including extensions.

This should enable us to avoid the custom JSON parsing method, `parseTilesetJson`, on the `GltfModifier` class in #1186. In addition to being easier for users (no need to deal with RapidJSON), it avoids a likely backward compatibility issue in the future if and when we consolidate our two `Tileset` classes.