### PR TITLE
Fix raster overlay crash with external tilesets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug in `Tileset::updateViewGroupOffline` that would cause it to get stuck in an endless loop when invoked with no frustums.
+- Fixed a bug that could lead to a crash when using raster overlays with tilesets that use "external tilesets", such as Google Photorealistic 3D Tiles.
 
 ### v0.50.0 - 2025-08-01
 

--- a/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayCollection.cpp
@@ -102,19 +102,26 @@ void RasterOverlayCollection::add(
   // Add a placeholder for this overlay to existing geometry tiles.
   for (Tile& tile : this->_loadedTiles) {
     // The tile rectangle and geometric error don't matter for a placeholder.
-    // - When a tile is transitioned from Unloaded to Loading, raster overlay
-    // tiles will be mapped to the tile automatically by TilesetContentManager,
-    // so we don't need to map the raster tiles to this unloaded or unloading
-    // tile now.
+    // - When a tile is transitioned from Unloaded (or FailedTemporarily) to
+    // ContentLoading, raster overlay tiles will be mapped to the tile
+    // automatically by TilesetContentManager, so we don't need to map the
+    // raster tiles to this unloaded or unloading tile now.
     // - When a tile is already failed to load, there is no need to map the
     // raster tiles to the tile as it is not rendered any way
     TileLoadState tileState = tile.getState();
-    if (tileState != TileLoadState::Unloaded &&
-        tileState != TileLoadState::Unloading &&
-        tileState != TileLoadState::Failed) {
-      tile.getMappedRasterTiles().emplace_back(
-          pPlaceholder->getTile(Rectangle(), glm::dvec2(0.0)),
-          -1);
+    if (tileState == TileLoadState::ContentLoading ||
+        tileState == TileLoadState::ContentLoaded ||
+        tileState == TileLoadState::Done) {
+      // Only tiles with renderable content should have raster overlays
+      // attached. In the ContentLoading state, we won't know yet whether the
+      // content is renderable, so assume that it is for now and
+      // `setTileContent` will clear them out if necessary.
+      if (tile.getContent().isRenderContent() ||
+          tileState == TileLoadState::ContentLoading) {
+        tile.getMappedRasterTiles().emplace_back(
+            pPlaceholder->getTile(Rectangle(), glm::dvec2(0.0)),
+            -1);
+      }
     }
   }
 

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -1231,6 +1231,13 @@ UnloadTileContentResult TilesetContentManager::unloadTileContent(Tile& tile) {
     return UnloadTileContentResult::Remove;
   }
 
+  // Detach raster tiles first so that the renderer's tile free
+  // process doesn't need to worry about them.
+  for (RasterMappedTo3DTile& mapped : tile.getMappedRasterTiles()) {
+    mapped.detachFromTile(*this->_externals.pPrepareRendererResources, tile);
+  }
+  tile.getMappedRasterTiles().clear();
+
   if (content.isExternalContent()) {
     // We can unload an external content tile with one reference, because this
     // represents the external content itself. Any more than that indicates
@@ -1246,13 +1253,6 @@ UnloadTileContentResult TilesetContentManager::unloadTileContent(Tile& tile) {
     tile.releaseReference("UnloadTileContent: External");
     return UnloadTileContentResult::RemoveAndClearChildren;
   }
-
-  // Detach raster tiles first so that the renderer's tile free
-  // process doesn't need to worry about them.
-  for (RasterMappedTo3DTile& mapped : tile.getMappedRasterTiles()) {
-    mapped.detachFromTile(*this->_externals.pPrepareRendererResources, tile);
-  }
-  tile.getMappedRasterTiles().clear();
 
   // Unload the renderer resources and clear any raster overlay tiles. We can do
   // this even if the tile can't be fully unloaded because this tile's geometry


### PR DESCRIPTION
This should fix the instability we've recently been seeing with clipping polygons and Google Photorealistic 3D Tiles. Here's the sequence that I think leads to the crash:

1. A new raster overlay is added to Google Photorealistic 3D Tiles.
2. A placeholder for the new overlay is added to all tiles that are already loaded.
3. The code wasn't checking to ensure the tiles were renderable, so it was added to external tileset tiles, too.
4. The unloadTileContent has a newish separate path for external tilesets, which returns before raster overlays are detached.
5. So unloaded external tilesets keep their (useless) raster overlays.
6. Later, the raster overlay is removed.
7. Unloaded tiles aren't enumerated by the LoadedTileEnumerator, so the mapped raster overlay tiles are not removed from the external tileset tiles.
8. When we destroy the placeholder tile provider, we detect that there are still placeholder tiles (attached to the unloaded external tileset tiles), triggering an assertion failure.
9. In release builds, we eventually crash or have sketchy behavior due to violation of the assertion condition (A RasterOverlayTile outliving its RasterOverlayTileProvider, mostly).

But even with that understanding of what's happening, it's remarkably hard to reproduce consistently. Which makes it hard to be 100% sure it's fixed.

In any case, this PR fixes this in two ways that I think should be pretty reliable:

- Raster overlay placeholders are no longer added to tiles that are known to not be renderable (e.g., loaded external tilesets).
- When a tile's content is unloaded, its raster overlays are now detached. Even if the content being unloaded is an external tileset. This should cover us in case one sneaks through the above (though I don't know of a way that can happen).

See also #1161, which previously fixed a very similar bug.