### PR TITLE
Add `RasterOverlayExternals`, make `RasterOverlayTileProvider::loadTileImage` receive a const `RasterOverlayTile`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Change Log
 
+### ? - ?
+
+##### Breaking Changes :mega:
+
+- `RasterOverlayTileProvider::loadTileImage` now receives a const `RasterOverlayTile`.
+
+##### Additions :tada:
+
+- Added `RasterOverlayExternals` class. This is similar to `TilesetExternals` and is a more convenient way to pass around the various external interfaces that raster overlays use.
+
 ### v0.51.0 - 2025-09-02
 
 ##### Breaking Changes :mega:

--- a/Cesium3DTilesSelection/src/EmptyRasterOverlayTileProvider.cpp
+++ b/Cesium3DTilesSelection/src/EmptyRasterOverlayTileProvider.cpp
@@ -27,7 +27,7 @@ EmptyRasterOverlayTileProvider::EmptyRasterOverlayTileProvider(
 
 CesiumAsync::Future<CesiumRasterOverlays::LoadedRasterOverlayImage>
 EmptyRasterOverlayTileProvider::loadTileImage(
-    CesiumRasterOverlays::RasterOverlayTile& /*overlayTile*/) {
+    const CesiumRasterOverlays::RasterOverlayTile& /*overlayTile*/) {
   return this->getAsyncSystem()
       .createResolvedFuture<CesiumRasterOverlays::LoadedRasterOverlayImage>({});
 }

--- a/Cesium3DTilesSelection/src/EmptyRasterOverlayTileProvider.h
+++ b/Cesium3DTilesSelection/src/EmptyRasterOverlayTileProvider.h
@@ -14,7 +14,8 @@ public:
 
 protected:
   virtual CesiumAsync::Future<CesiumRasterOverlays::LoadedRasterOverlayImage>
-  loadTileImage(CesiumRasterOverlays::RasterOverlayTile& overlayTile) override;
+  loadTileImage(
+      const CesiumRasterOverlays::RasterOverlayTile& overlayTile) override;
 };
 
 } // namespace Cesium3DTilesSelection

--- a/Cesium3DTilesSelection/test/TestTilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/test/TestTilesetContentManager.cpp
@@ -1334,7 +1334,7 @@ TEST_CASE("Test the tileset content manager's post processing for gltf") {
                 coverageRectangle) {}
 
       CesiumAsync::Future<LoadedRasterOverlayImage>
-      loadTileImage(RasterOverlayTile& overlayTile) override {
+      loadTileImage(const RasterOverlayTile& overlayTile) override {
         CesiumUtility::IntrusivePointer<CesiumGltf::ImageAsset> pImage;
         CesiumGltf::ImageAsset& image = pImage.emplace();
         image.width = 1;

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/QuadtreeRasterOverlayTileProvider.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/QuadtreeRasterOverlayTileProvider.h
@@ -125,7 +125,7 @@ protected:
 
 private:
   virtual CesiumAsync::Future<LoadedRasterOverlayImage>
-  loadTileImage(RasterOverlayTile& overlayTile) override final;
+  loadTileImage(const RasterOverlayTile& overlayTile) override final;
 
   struct LoadedQuadtreeImage
       : public CesiumUtility::SharedAsset<LoadedQuadtreeImage> {

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayExternals.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayExternals.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <CesiumAsync/AsyncSystem.h>
+#include <CesiumAsync/IAssetAccessor.h>
+#include <CesiumRasterOverlays/IPrepareRasterOverlayRendererResources.h>
+#include <CesiumRasterOverlays/Library.h>
+#include <CesiumUtility/CreditSystem.h>
+
+#include <spdlog/spdlog.h>
+
+#include <memory>
+
+namespace CesiumRasterOverlays {
+
+/**
+ * @brief External interfaces used by a {@link RasterOverlay}.
+ */
+class CESIUMRASTEROVERLAYS_API RasterOverlayExternals final {
+public:
+  /**
+   * @brief The {@link CesiumAsync::IAssetAccessor} that is used to download
+   * raster overlay tiles and other assets.
+   *
+   * This may only be `nullptr` if the raster overlay does not attempt to
+   * download any resources.
+   */
+  std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor;
+
+  /**
+   * @brief The {@link IPrepareRasterOverlayRendererResources} that is used to
+   * create renderer-specific resources for raster overlay tiles.
+   *
+   * This may be `nullptr` if the renderer does not need to create any resources
+   * for raster overlays.
+   */
+  std::shared_ptr<IPrepareRasterOverlayRendererResources>
+      pPrepareRendererResources;
+
+  /**
+   * @brief The async system to use to do work in threads.
+   */
+  CesiumAsync::AsyncSystem asyncSystem;
+
+  /**
+   * @brief The {@link CesiumUtility::CreditSystem} that can be used to manage
+   * credit strings and periodically query which credits to show and and which
+   * to remove from the screen.
+   *
+   * While not recommended, this may be `nullptr` if the client does not need to
+   * receive credits.
+   */
+  std::shared_ptr<CesiumUtility::CreditSystem> pCreditSystem;
+
+  /**
+   * @brief A spdlog logger that will receive log messages.
+   *
+   * If not specified, defaults to `spdlog::default_logger()`.
+   */
+  std::shared_ptr<spdlog::logger> pLogger = spdlog::default_logger();
+};
+
+} // namespace CesiumRasterOverlays

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayExternals.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayExternals.h
@@ -13,12 +13,12 @@
 namespace CesiumRasterOverlays {
 
 /**
- * @brief External interfaces used by a {@link RasterOverlay}.
+ * @brief External interfaces used by a @ref RasterOverlay.
  */
 class CESIUMRASTEROVERLAYS_API RasterOverlayExternals final {
 public:
   /**
-   * @brief The {@link CesiumAsync::IAssetAccessor} that is used to download
+   * @brief The @ref CesiumAsync::IAssetAccessor that is used to download
    * raster overlay tiles and other assets.
    *
    * This may only be `nullptr` if the raster overlay does not attempt to
@@ -27,7 +27,7 @@ public:
   std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor;
 
   /**
-   * @brief The {@link IPrepareRasterOverlayRendererResources} that is used to
+   * @brief The @ref IPrepareRasterOverlayRendererResources that is used to
    * create renderer-specific resources for raster overlay tiles.
    *
    * This may be `nullptr` if the renderer does not need to create any resources
@@ -42,9 +42,9 @@ public:
   CesiumAsync::AsyncSystem asyncSystem;
 
   /**
-   * @brief The {@link CesiumUtility::CreditSystem} that can be used to manage
-   * credit strings and periodically query which credits to show and and which
-   * to remove from the screen.
+   * @brief The @ref CesiumUtility::CreditSystem that can be used to manage
+   * credit strings and periodically query which credits to show and which to
+   * remove from the screen.
    *
    * While not recommended, this may be `nullptr` if the client does not need to
    * receive credits.

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <CesiuMRasterOverlays/RasterOverlayExternals.h>
 #include <CesiumAsync/IAssetAccessor.h>
 #include <CesiumGeospatial/Projection.h>
 #include <CesiumGltfReader/GltfReader.h>
 #include <CesiumRasterOverlays/Library.h>
+#include <CesiumRasterOverlays/RasterOverlayExternals.h>
 #include <CesiumUtility/Assert.h>
 #include <CesiumUtility/CreditSystem.h>
 #include <CesiumUtility/ErrorList.h>

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <CesiuMRasterOverlays/RasterOverlayExternals.h>
 #include <CesiumAsync/IAssetAccessor.h>
 #include <CesiumGeospatial/Projection.h>
 #include <CesiumGltfReader/GltfReader.h>
@@ -152,12 +153,36 @@ public:
    * @see RasterOverlayTileProvider::isPlaceholder
    *
    * @param pOwner The raster overlay that created this tile provider.
-   * @param asyncSystem The async system used to do work in threads.
-   * @param pAssetAccessor The interface used to obtain assets (tiles, etc.) for
-   * this raster overlay.
-   * @param pCreditSystem The credit system that receives this tile provider's
-   * credits.
+   * @param externals The external interfaces for use by the raster overlay.
    * @param ellipsoid The {@link CesiumGeospatial::Ellipsoid}.
+   */
+  RasterOverlayTileProvider(
+      const CesiumUtility::IntrusivePointer<const RasterOverlay>& pOwner,
+      const RasterOverlayExternals& externals,
+      const CesiumGeospatial::Ellipsoid& ellipsoid
+          CESIUM_DEFAULT_ELLIPSOID) noexcept;
+
+  /**
+   * @brief Creates a new instance.
+   *
+   * @param pOwner The raster overlay that created this tile provider.
+   * @param externals The external interfaces for use by the raster overlay.
+   * @param credit The {@link CesiumUtility::Credit} for this tile provider, if it exists.
+   * @param projection The {@link CesiumGeospatial::Projection}.
+   * @param coverageRectangle The rectangle that bounds all the area covered by
+   * this overlay, expressed in projected coordinates.
+   */
+  RasterOverlayTileProvider(
+      const CesiumUtility::IntrusivePointer<const RasterOverlay>& pOwner,
+      const RasterOverlayExternals& externals,
+      std::optional<CesiumUtility::Credit> credit,
+      const CesiumGeospatial::Projection& projection,
+      const CesiumGeometry::Rectangle& coverageRectangle) noexcept;
+
+  /**
+   * Constructs a placeholder tile provider.
+   * @deprecated Use the overload that takes a \ref RasterOverlayExternals
+   * instead.
    */
   RasterOverlayTileProvider(
       const CesiumUtility::IntrusivePointer<const RasterOverlay>& pOwner,
@@ -169,21 +194,8 @@ public:
 
   /**
    * @brief Creates a new instance.
-   *
-   * @param pOwner The raster overlay that created this tile provider.
-   * @param asyncSystem The async system used to do work in threads.
-   * @param pAssetAccessor The interface used to obtain assets (tiles, etc.) for
-   * this raster overlay.
-   * @param pCreditSystem The credit system that receives this tile provider's
-   * credits.
-   * @param credit The {@link CesiumUtility::Credit} for this tile provider, if it exists.
-   * @param pPrepareRendererResources The interface used to prepare raster
-   * images for rendering.
-   * @param pLogger The logger to which to send messages about the tile provider
-   * and tiles.
-   * @param projection The {@link CesiumGeospatial::Projection}.
-   * @param coverageRectangle The rectangle that bounds all the area covered by
-   * this overlay, expressed in projected coordinates.
+   * @deprecated Use the overload that takes a \ref RasterOverlayExternals
+   * instead.
    */
   RasterOverlayTileProvider(
       const CesiumUtility::IntrusivePointer<const RasterOverlay>& pOwner,
@@ -226,70 +238,56 @@ public:
    * So the placeholder system gives us a way to defer the mapping of raster
    * overlay tiles to geometry tiles until that mapping can be determined.
    */
-  bool isPlaceholder() const noexcept { return this->_pPlaceholder != nullptr; }
+  bool isPlaceholder() const noexcept;
 
   /**
    * @brief Returns the {@link RasterOverlay} that created this instance.
    */
-  RasterOverlay& getOwner() noexcept { return *this->_pOwner; }
+  RasterOverlay& getOwner() noexcept;
 
   /** @copydoc getOwner */
-  const RasterOverlay& getOwner() const noexcept { return *this->_pOwner; }
+  const RasterOverlay& getOwner() const noexcept;
 
   /**
    * @brief Get the system to use for asychronous requests and threaded work.
    */
   const std::shared_ptr<CesiumAsync::IAssetAccessor>&
-  getAssetAccessor() const noexcept {
-    return this->_pAssetAccessor;
-  }
+  getAssetAccessor() const noexcept;
 
   /**
    * @brief Get the credit system that receives credits from this tile provider.
    */
   const std::shared_ptr<CesiumUtility::CreditSystem>&
-  getCreditSystem() const noexcept {
-    return this->_pCreditSystem;
-  }
+  getCreditSystem() const noexcept;
 
   /**
    * @brief Gets the async system used to do work in threads.
    */
-  const CesiumAsync::AsyncSystem& getAsyncSystem() const noexcept {
-    return this->_asyncSystem;
-  }
+  const CesiumAsync::AsyncSystem& getAsyncSystem() const noexcept;
 
   /**
    * @brief Gets the interface used to prepare raster overlay images for
    * rendering.
    */
   const std::shared_ptr<IPrepareRasterOverlayRendererResources>&
-  getPrepareRendererResources() const noexcept {
-    return this->_pPrepareRendererResources;
-  }
+  getPrepareRendererResources() const noexcept;
 
   /**
    * @brief Gets the logger to which to send messages about the tile provider
    * and tiles.
    */
-  const std::shared_ptr<spdlog::logger>& getLogger() const noexcept {
-    return this->_pLogger;
-  }
+  const std::shared_ptr<spdlog::logger>& getLogger() const noexcept;
 
   /**
    * @brief Returns the {@link CesiumGeospatial::Projection} of this instance.
    */
-  const CesiumGeospatial::Projection& getProjection() const noexcept {
-    return this->_projection;
-  }
+  const CesiumGeospatial::Projection& getProjection() const noexcept;
 
   /**
    * @brief Returns the coverage {@link CesiumGeometry::Rectangle} of this
    * instance.
    */
-  const CesiumGeometry::Rectangle& getCoverageRectangle() const noexcept {
-    return this->_coverageRectangle;
-  }
+  const CesiumGeometry::Rectangle& getCoverageRectangle() const noexcept;
 
   /**
    * @brief Returns a new {@link RasterOverlayTile} with the given
@@ -317,15 +315,12 @@ public:
   /**
    * @brief Gets the number of bytes of tile data that are currently loaded.
    */
-  int64_t getTileDataBytes() const noexcept { return this->_tileDataBytes; }
+  int64_t getTileDataBytes() const noexcept;
 
   /**
    * @brief Returns the number of tiles that are currently loading.
    */
-  uint32_t getNumberOfTilesLoading() const noexcept {
-    CESIUM_ASSERT(this->_totalTilesCurrentlyLoading > -1);
-    return static_cast<uint32_t>(this->_totalTilesCurrentlyLoading);
-  }
+  uint32_t getNumberOfTilesLoading() const noexcept;
 
   /**
    * @brief Removes a no-longer-referenced tile from this provider's cache and
@@ -342,9 +337,7 @@ public:
   /**
    * @brief Get the per-TileProvider {@link CesiumUtility::Credit} if one exists.
    */
-  const std::optional<CesiumUtility::Credit>& getCredit() const noexcept {
-    return _credit;
-  }
+  const std::optional<CesiumUtility::Credit>& getCredit() const noexcept;
 
   /**
    * @brief Loads a tile immediately, without throttling requests.
@@ -395,7 +388,7 @@ protected:
    * @return A future that resolves to the image or error information.
    */
   virtual CesiumAsync::Future<LoadedRasterOverlayImage>
-  loadTileImage(RasterOverlayTile& overlayTile) = 0;
+  loadTileImage(const RasterOverlayTile& overlayTile) = 0;
 
   /**
    * @brief Loads an image from a URL and optionally some request headers.
@@ -442,13 +435,8 @@ private:
   };
 
   CesiumUtility::IntrusivePointer<RasterOverlay> _pOwner;
-  CesiumAsync::AsyncSystem _asyncSystem;
-  std::shared_ptr<CesiumAsync::IAssetAccessor> _pAssetAccessor;
-  std::shared_ptr<CesiumUtility::CreditSystem> _pCreditSystem;
+  RasterOverlayExternals _externals;
   std::optional<CesiumUtility::Credit> _credit;
-  std::shared_ptr<IPrepareRasterOverlayRendererResources>
-      _pPrepareRendererResources;
-  std::shared_ptr<spdlog::logger> _pLogger;
   CesiumGeospatial::Projection _projection;
   CesiumGeometry::Rectangle _coverageRectangle;
   CesiumUtility::IntrusivePointer<RasterOverlayTile> _pPlaceholder;

--- a/CesiumRasterOverlays/src/DebugColorizeTilesRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/DebugColorizeTilesRasterOverlay.cpp
@@ -52,7 +52,7 @@ public:
   }
 
   virtual CesiumAsync::Future<LoadedRasterOverlayImage>
-  loadTileImage(RasterOverlayTile& overlayTile) override {
+  loadTileImage(const RasterOverlayTile& overlayTile) override {
     LoadedRasterOverlayImage result;
 
     // Indicate that there is no more detail available so that tiles won't get

--- a/CesiumRasterOverlays/src/GeoJsonDocumentRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/GeoJsonDocumentRasterOverlay.cpp
@@ -545,7 +545,7 @@ public:
   }
 
   virtual CesiumAsync::Future<LoadedRasterOverlayImage>
-  loadTileImage(RasterOverlayTile& overlayTile) override {
+  loadTileImage(const RasterOverlayTile& overlayTile) override {
     // Choose the texture size according to the geometry screen size and raster
     // SSE, but no larger than the maximum texture size.
     const RasterOverlayOptions& options = this->getOwner().getOptions();

--- a/CesiumRasterOverlays/src/QuadtreeRasterOverlayTileProvider.cpp
+++ b/CesiumRasterOverlays/src/QuadtreeRasterOverlayTileProvider.cpp
@@ -463,7 +463,7 @@ void blitImage(
 
 CesiumAsync::Future<LoadedRasterOverlayImage>
 QuadtreeRasterOverlayTileProvider::loadTileImage(
-    RasterOverlayTile& overlayTile) {
+    const RasterOverlayTile& overlayTile) {
   // Figure out which quadtree level we need, and which tiles from that level.
   // Load each needed tile (or pull it from cache).
   std::vector<CesiumAsync::SharedFuture<ResultPointer<LoadedQuadtreeImage>>>

--- a/CesiumRasterOverlays/src/RasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/RasterOverlay.cpp
@@ -34,7 +34,7 @@ public:
             ellipsoid) {}
 
   virtual CesiumAsync::Future<LoadedRasterOverlayImage>
-  loadTileImage(RasterOverlayTile& /* overlayTile */) override {
+  loadTileImage(const RasterOverlayTile& /* overlayTile */) override {
     return this->getAsyncSystem()
         .createResolvedFuture<LoadedRasterOverlayImage>({});
   }

--- a/CesiumRasterOverlays/src/RasterOverlayTileProvider.cpp
+++ b/CesiumRasterOverlays/src/RasterOverlayTileProvider.cpp
@@ -9,6 +9,7 @@
 #include <CesiumGltfReader/ImageDecoder.h>
 #include <CesiumRasterOverlays/IPrepareRasterOverlayRendererResources.h>
 #include <CesiumRasterOverlays/RasterOverlay.h>
+#include <CesiumRasterOverlays/RasterOverlayExternals.h>
 #include <CesiumRasterOverlays/RasterOverlayTile.h>
 #include <CesiumRasterOverlays/RasterOverlayTileProvider.h>
 #include <CesiumUtility/Assert.h>

--- a/CesiumRasterOverlays/src/RasterOverlayTileProvider.cpp
+++ b/CesiumRasterOverlays/src/RasterOverlayTileProvider.cpp
@@ -42,17 +42,11 @@ namespace CesiumRasterOverlays {
 
 RasterOverlayTileProvider::RasterOverlayTileProvider(
     const CesiumUtility::IntrusivePointer<const RasterOverlay>& pOwner,
-    const CesiumAsync::AsyncSystem& asyncSystem,
-    const std::shared_ptr<IAssetAccessor>& pAssetAccessor,
-    const std::shared_ptr<CesiumUtility::CreditSystem>& pCreditSystem,
+    const RasterOverlayExternals& externals,
     const CesiumGeospatial::Ellipsoid& ellipsoid) noexcept
     : _pOwner(const_intrusive_cast<RasterOverlay>(pOwner)),
-      _asyncSystem(asyncSystem),
-      _pAssetAccessor(pAssetAccessor),
-      _pCreditSystem(pCreditSystem),
+      _externals(externals),
       _credit(std::nullopt),
-      _pPrepareRendererResources(nullptr),
-      _pLogger(nullptr),
       _projection(CesiumGeospatial::GeographicProjection(ellipsoid)),
       _coverageRectangle(CesiumGeospatial::GeographicProjection::
                              computeMaximumProjectedRectangle(ellipsoid)),
@@ -61,6 +55,39 @@ RasterOverlayTileProvider::RasterOverlayTileProvider(
       _totalTilesCurrentlyLoading(0),
       _throttledTilesCurrentlyLoading(0),
       _destructionCompleteDetails() {}
+
+RasterOverlayTileProvider::RasterOverlayTileProvider(
+    const CesiumUtility::IntrusivePointer<const RasterOverlay>& pOwner,
+    const RasterOverlayExternals& externals,
+    std::optional<CesiumUtility::Credit> credit,
+    const CesiumGeospatial::Projection& projection,
+    const CesiumGeometry::Rectangle& coverageRectangle) noexcept
+    : _pOwner(const_intrusive_cast<RasterOverlay>(pOwner)),
+      _externals(externals),
+      _credit(credit),
+      _projection(projection),
+      _coverageRectangle(coverageRectangle),
+      _pPlaceholder(nullptr),
+      _tileDataBytes(0),
+      _totalTilesCurrentlyLoading(0),
+      _throttledTilesCurrentlyLoading(0),
+      _destructionCompleteDetails() {}
+
+RasterOverlayTileProvider::RasterOverlayTileProvider(
+    const CesiumUtility::IntrusivePointer<const RasterOverlay>& pOwner,
+    const CesiumAsync::AsyncSystem& asyncSystem,
+    const std::shared_ptr<IAssetAccessor>& pAssetAccessor,
+    const std::shared_ptr<CesiumUtility::CreditSystem>& pCreditSystem,
+    const CesiumGeospatial::Ellipsoid& ellipsoid) noexcept
+    : RasterOverlayTileProvider(
+          pOwner,
+          RasterOverlayExternals{
+              .pAssetAccessor = pAssetAccessor,
+              .pPrepareRendererResources = nullptr,
+              .asyncSystem = asyncSystem,
+              .pCreditSystem = pCreditSystem,
+              .pLogger = nullptr},
+          ellipsoid) {}
 
 RasterOverlayTileProvider::RasterOverlayTileProvider(
     const CesiumUtility::IntrusivePointer<const RasterOverlay>& pOwner,
@@ -73,20 +100,17 @@ RasterOverlayTileProvider::RasterOverlayTileProvider(
     const std::shared_ptr<spdlog::logger>& pLogger,
     const CesiumGeospatial::Projection& projection,
     const Rectangle& coverageRectangle) noexcept
-    : _pOwner(const_intrusive_cast<RasterOverlay>(pOwner)),
-      _asyncSystem(asyncSystem),
-      _pAssetAccessor(pAssetAccessor),
-      _pCreditSystem(pCreditSystem),
-      _credit(credit),
-      _pPrepareRendererResources(pPrepareRendererResources),
-      _pLogger(pLogger),
-      _projection(projection),
-      _coverageRectangle(coverageRectangle),
-      _pPlaceholder(nullptr),
-      _tileDataBytes(0),
-      _totalTilesCurrentlyLoading(0),
-      _throttledTilesCurrentlyLoading(0),
-      _destructionCompleteDetails() {}
+    : RasterOverlayTileProvider(
+          pOwner,
+          RasterOverlayExternals{
+              .pAssetAccessor = pAssetAccessor,
+              .pPrepareRendererResources = pPrepareRendererResources,
+              .asyncSystem = asyncSystem,
+              .pCreditSystem = pCreditSystem,
+              .pLogger = pLogger},
+          credit,
+          projection,
+          coverageRectangle) {}
 
 RasterOverlayTileProvider::~RasterOverlayTileProvider() noexcept {
   // Explicitly release the placeholder first, because RasterOverlayTiles must
@@ -104,7 +128,7 @@ RasterOverlayTileProvider::~RasterOverlayTileProvider() noexcept {
 CesiumAsync::SharedFuture<void>&
 RasterOverlayTileProvider::getAsyncDestructionCompleteEvent() {
   if (!this->_destructionCompleteDetails) {
-    auto promise = this->_asyncSystem.createPromise<void>();
+    auto promise = this->_externals.asyncSystem.createPromise<void>();
     auto sharedFuture = promise.getFuture().share();
     this->_destructionCompleteDetails.emplace(DestructionCompleteDetails{
         std::move(promise),
@@ -112,6 +136,53 @@ RasterOverlayTileProvider::getAsyncDestructionCompleteEvent() {
   }
 
   return this->_destructionCompleteDetails->future;
+}
+
+bool RasterOverlayTileProvider::isPlaceholder() const noexcept {
+  return this->_pPlaceholder != nullptr;
+}
+
+RasterOverlay& RasterOverlayTileProvider::getOwner() noexcept {
+  return *this->_pOwner;
+}
+
+const RasterOverlay& RasterOverlayTileProvider::getOwner() const noexcept {
+  return *this->_pOwner;
+}
+
+const std::shared_ptr<CesiumAsync::IAssetAccessor>&
+RasterOverlayTileProvider::getAssetAccessor() const noexcept {
+  return this->_externals.pAssetAccessor;
+}
+
+const std::shared_ptr<CesiumUtility::CreditSystem>&
+RasterOverlayTileProvider::getCreditSystem() const noexcept {
+  return this->_externals.pCreditSystem;
+}
+
+const CesiumAsync::AsyncSystem&
+RasterOverlayTileProvider::getAsyncSystem() const noexcept {
+  return this->_externals.asyncSystem;
+}
+
+const std::shared_ptr<IPrepareRasterOverlayRendererResources>&
+RasterOverlayTileProvider::getPrepareRendererResources() const noexcept {
+  return this->_externals.pPrepareRendererResources;
+}
+
+const std::shared_ptr<spdlog::logger>&
+RasterOverlayTileProvider::getLogger() const noexcept {
+  return this->_externals.pLogger;
+}
+
+const CesiumGeospatial::Projection&
+RasterOverlayTileProvider::getProjection() const noexcept {
+  return this->_projection;
+}
+
+const CesiumGeometry::Rectangle&
+RasterOverlayTileProvider::getCoverageRectangle() const noexcept {
+  return this->_coverageRectangle;
 }
 
 CesiumUtility::IntrusivePointer<RasterOverlayTile>
@@ -129,11 +200,25 @@ RasterOverlayTileProvider::getTile(
   return new RasterOverlayTile(*this, targetScreenPixels, rectangle);
 }
 
+int64_t RasterOverlayTileProvider::getTileDataBytes() const noexcept {
+  return this->_tileDataBytes;
+}
+
+uint32_t RasterOverlayTileProvider::getNumberOfTilesLoading() const noexcept {
+  CESIUM_ASSERT(this->_totalTilesCurrentlyLoading > -1);
+  return static_cast<uint32_t>(this->_totalTilesCurrentlyLoading);
+}
+
 void RasterOverlayTileProvider::removeTile(RasterOverlayTile* pTile) noexcept {
   CESIUM_ASSERT(pTile->getReferenceCount() == 0);
   if (pTile->getImage()) {
     this->_tileDataBytes -= pTile->getImage()->sizeBytes;
   }
+}
+
+const std::optional<CesiumUtility::Credit>&
+RasterOverlayTileProvider::getCredit() const noexcept {
+  return _credit;
 }
 
 CesiumAsync::Future<TileProviderAndTile>
@@ -281,7 +366,7 @@ struct LoadResult {
  * @param rendererOptions Renderer options
  * @return The `LoadResult`
  */
-static LoadResult createLoadResultFromLoadedImage(
+LoadResult createLoadResultFromLoadedImage(
     const std::shared_ptr<IPrepareRasterOverlayRendererResources>&
         pPrepareRendererResources,
     const std::shared_ptr<spdlog::logger>& pLogger,

--- a/CesiumRasterOverlays/src/RasterizedPolygonsOverlay.cpp
+++ b/CesiumRasterOverlays/src/RasterizedPolygonsOverlay.cpp
@@ -156,7 +156,7 @@ public:
         _invertSelection(invertSelection) {}
 
   virtual CesiumAsync::Future<LoadedRasterOverlayImage>
-  loadTileImage(RasterOverlayTile& overlayTile) override {
+  loadTileImage(const RasterOverlayTile& overlayTile) override {
     // Choose the texture size according to the geometry screen size and raster
     // SSE, but no larger than the maximum texture size.
     const RasterOverlayOptions& options = this->getOwner().getOptions();


### PR DESCRIPTION
This is some light but slightly noisy raster overlay refactoring.

- Added `RasterOverlayExternals` to wrap up all the little interfaces that raster overlays use. I've so far not threaded this throughout the whole system. Mostly because it's pending some other WIP changes.
- `loadTileImage` now receives a const reference to the `RasterOverlayTile`. There's no good reason this method should modify the tile.
- Moved implementations of some `RasterOverlayTileProvider` methods to the .cpp file.