### PR TITLE
Add move constructor / assignment operator for TileProviderAndTile.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Added a move constructor and assignment operator to `TileProviderAndTile`. This is important to prevent it from inadvertently incrementing/decrementing non-thread-safe reference counts from the wrong thread while being moved.
+
 ### v0.51.0 - 2025-09-02
 
 ##### Breaking Changes :mega:

--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/RasterOverlayTileProvider.h
@@ -133,7 +133,16 @@ struct TileProviderAndTile {
    * RasterOverlayTile used for this tile. */
   CesiumUtility::IntrusivePointer<RasterOverlayTile> pTile;
 
+  TileProviderAndTile(
+      const CesiumUtility::IntrusivePointer<RasterOverlayTileProvider>&
+          pTileProvider_,
+      const CesiumUtility::IntrusivePointer<RasterOverlayTile>&
+          pTile_) noexcept;
   ~TileProviderAndTile() noexcept;
+  TileProviderAndTile(const TileProviderAndTile&) = delete;
+  TileProviderAndTile& operator=(const TileProviderAndTile&) = delete;
+  TileProviderAndTile(TileProviderAndTile&&) noexcept;
+  TileProviderAndTile& operator=(TileProviderAndTile&&) noexcept;
 };
 
 /**

--- a/CesiumRasterOverlays/src/RasterOverlayTileProvider.cpp
+++ b/CesiumRasterOverlays/src/RasterOverlayTileProvider.cpp
@@ -436,10 +436,22 @@ void RasterOverlayTileProvider::finalizeTileLoad(
   }
 }
 
+TileProviderAndTile::TileProviderAndTile(
+    const CesiumUtility::IntrusivePointer<RasterOverlayTileProvider>&
+        pTileProvider_,
+    const CesiumUtility::IntrusivePointer<RasterOverlayTile>& pTile_) noexcept
+    : pTileProvider(pTileProvider_), pTile(pTile_) {}
+
 TileProviderAndTile::~TileProviderAndTile() noexcept {
   // Ensure the tile is released before the tile provider.
   pTile = nullptr;
   pTileProvider = nullptr;
 }
+
+TileProviderAndTile::TileProviderAndTile(TileProviderAndTile&&) noexcept =
+    default;
+
+TileProviderAndTile&
+TileProviderAndTile::operator=(TileProviderAndTile&&) noexcept = default;
 
 } // namespace CesiumRasterOverlays


### PR DESCRIPTION
`TileProviderAndTile` has an explicit destructor. Therefore, the compiler does not generate a move constructor:

> If no user-defined move constructors are provided for a class type, and all of the following is true:
> 
> - ...
> - there is no user-declared destructor.
> - ...
>
> Then the compiler will declare a move constructor as a non-[explicit](https://en.cppreference.com/w/cpp/language/explicit.html) inline public member of its class with the signature T::T(T&&).

https://en.cppreference.com/w/cpp/language/move_constructor.html

This could result in the `AsyncSystem` copying an instance of this class in a non-main thread, which is disastrous because the IntrusivePointers it holds are to non-thread-safe classes. Moving is safe.