### PR TITLE
Move vcpkg baseline to latest, to fix cpp-httplib's CVE-2025-53629 …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ if(CESIUM_USE_EZVCPKG)
     list(APPEND PACKAGES_ALL ${PACKAGES_TEST})
 
     ezvcpkg_fetch(
-        COMMIT dbe35ceb30c688bf72e952ab23778e009a578f18
+        COMMIT 9824d05f8d9548720ba3331f4baba3e2d6c1693b
         PACKAGES ${PACKAGES_ALL}
         # Clean the build trees after building, so that we don't use a ton a disk space on the CI cache
         CLEAN_BUILDTREES

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
     "default-registry": {
         "kind": "git",
-        "baseline": "dbe35ceb30c688bf72e952ab23778e009a578f18",
+        "baseline": "9824d05f8d9548720ba3331f4baba3e2d6c1693b",
         "repository": "https://github.com/microsoft/vcpkg"
     },
     "registries": [


### PR DESCRIPTION
… in version 0.20.1 (High severity CVE, fixed in 0.23+)

I built cesium-native and ran the tests for the Release configuration on Windows-x64 without any problem.