### PR TITLE
Avoid duplicate Google logo

### DIFF
--- a/CesiumRasterOverlays/include/CesiumRasterOverlays/GoogleMapTilesRasterOverlay.h
+++ b/CesiumRasterOverlays/include/CesiumRasterOverlays/GoogleMapTilesRasterOverlay.h
@@ -49,6 +49,15 @@ struct GoogleMapTilesExistingSession {
   std::string imageFormat;
 
   /**
+   * @brief Whether or not the @ref GoogleMapTilesRasterOverlay should show the
+   * Google Maps logo.
+   *
+   * Google requires the logo to be shown, so setting this to false is only
+   * valid when something else is already showing the logo.
+   */
+  bool showLogo = true;
+
+  /**
    * @brief The base URL for the Google Maps Tiles API.
    */
   std::string apiBaseUrl{"https://tile.googleapis.com/"};

--- a/CesiumRasterOverlays/src/GoogleMapTilesRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/GoogleMapTilesRasterOverlay.cpp
@@ -249,7 +249,8 @@ GoogleMapTilesRasterOverlay::createTileProvider(
             session.key,
             maximumZoomLevel,
             session.tileWidth,
-            session.tileHeight);
+            session.tileHeight,
+            session.showLogo);
 
     // Start loading credits, but don't wait for the load to finish.
     pTileProvider->loadCredits();
@@ -459,7 +460,8 @@ GoogleMapTilesRasterOverlay::createNewSession(
                     this->_newSessionParameters->key,
                     maximumZoomLevel,
                     static_cast<uint32_t>(tileWidth),
-                    static_cast<uint32_t>(tileHeight));
+                    static_cast<uint32_t>(tileHeight),
+                    true);
 
             // Start loading credits, but don't wait for the load to finish.
             pTileProvider->loadCredits();
@@ -504,7 +506,8 @@ GoogleMapTilesRasterOverlayTileProvider::
         const std::string& key,
         uint32_t maximumLevel,
         uint32_t imageWidth,
-        uint32_t imageHeight)
+        uint32_t imageHeight,
+        bool showLogo)
     : QuadtreeRasterOverlayTileProvider(
           pOwner,
           asyncSystem,
@@ -527,7 +530,7 @@ GoogleMapTilesRasterOverlayTileProvider::
       _credits(),
       _availableTiles(createTilingScheme(pOwner), maximumLevel),
       _availableAvailability(createTilingScheme(pOwner), maximumLevel) {
-  if (pCreditSystem) {
+  if (pCreditSystem && showLogo) {
     this->_googleCredit =
         pCreditSystem->createCredit(GOOGLE_MAPS_LOGO_HTML, true);
   }

--- a/CesiumRasterOverlays/src/GoogleMapTilesRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/GoogleMapTilesRasterOverlay.cpp
@@ -153,7 +153,8 @@ public:
       const std::string& key,
       uint32_t maximumLevel,
       uint32_t imageWidth,
-      uint32_t imageHeight);
+      uint32_t imageHeight,
+      bool showLogo);
 
   CesiumAsync::Future<void>
   loadAvailability(const CesiumGeometry::QuadtreeTileID& tileID) const;

--- a/CesiumRasterOverlays/src/IonRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/IonRasterOverlay.cpp
@@ -575,6 +575,7 @@ IonRasterOverlay::TileProvider::CreateTileProvider::operator()(
             .tileWidth = google2D.tileWidth,
             .tileHeight = google2D.tileHeight,
             .imageFormat = google2D.imageFormat,
+            .showLogo = false,
             .apiBaseUrl = google2D.url,
         },
         this->pOwner->getOptions());


### PR DESCRIPTION
Don't show two Google Maps logos when loading Google Maps via Cesium ion.
