### PR TITLE
Don't parse non-object credits from Google 2D Maps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug in `GoogleMapTilesRasterOverlay` that tried to parse credits from an erroneous viewport service response.
+
 ### v0.52.0 - 2025-10-01
 
 ##### Breaking Changes :mega:

--- a/CesiumRasterOverlays/src/GoogleMapTilesRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/GoogleMapTilesRasterOverlay.cpp
@@ -711,7 +711,6 @@ CesiumAsync::Future<rapidjson::Document> fetchViewportData(
                   pRequest->url(),
                   document.GetParseError(),
                   document.GetErrorOffset());
-              return document;
             }
 
             return document;
@@ -889,7 +888,7 @@ Future<void> GoogleMapTilesRasterOverlayTileProvider::loadCredits() {
             uint32_t(i),
             Rectangle(-180.0, -90.0, 180.0, 90.0))
             .thenInMainThread([](rapidjson::Document&& document) {
-              if (document.HasParseError()) {
+              if (document.HasParseError() || !document.IsObject()) {
                 return std::string();
               }
 


### PR DESCRIPTION
This PR addresses a bug that @david-lively discovered https://github.com/CesiumGS/cesium-unity/pull/612/. Unfortunately I didn't discover it while testing because it was an assertion failure that only triggered in Debug builds.

Google's Roadmap layer consistently returns an Error 500 for one of its tiles. The credit-loading logic didn't account for the fact that an empty JSON document gets returned for this tile, and it tried to access properties on this non-object document. This solves it by simply checking whether the document is a valid object.