### PR TITLE
Added rowPitch field to ImageAssetMipPosition struct. 

### DIFF
--- a/CesiumGltf/include/CesiumGltf/ImageAsset.h
+++ b/CesiumGltf/include/CesiumGltf/ImageAsset.h
@@ -25,8 +25,7 @@ struct CESIUMGLTF_API ImageAssetMipPosition {
   size_t byteSize;
 
   /**
-   * @brief The pitch (or stride) between rows of a texture image level in
-   * bytes.
+   * @brief The pitch (or stride) between rows of this mip in bytes.
    */
   size_t rowPitch;
 };

--- a/CesiumGltf/include/CesiumGltf/ImageAsset.h
+++ b/CesiumGltf/include/CesiumGltf/ImageAsset.h
@@ -23,6 +23,12 @@ struct CESIUMGLTF_API ImageAssetMipPosition {
    * @brief The size in bytes of this mip.
    */
   size_t byteSize;
+
+  /**
+   * @brief The pitch (or stride) between rows of a texture image level in
+   * bytes.
+   */
+  size_t rowPitch;
 };
 
 /**

--- a/CesiumGltfReader/src/ImageDecoder.cpp
+++ b/CesiumGltfReader/src/ImageDecoder.cpp
@@ -28,8 +28,6 @@
 #define STB_IMAGE_RESIZE_STATIC
 #include <stb_image_resize2.h>
 
-#include <thread>
-
 namespace CesiumGltfReader {
 
 using namespace CesiumGltf;

--- a/CesiumGltfReader/src/ImageDecoder.cpp
+++ b/CesiumGltfReader/src/ImageDecoder.cpp
@@ -28,6 +28,8 @@
 #define STB_IMAGE_RESIZE_STATIC
 #include <stb_image_resize2.h>
 
+#include <thread>
+
 namespace CesiumGltfReader {
 
 using namespace CesiumGltf;
@@ -231,8 +233,10 @@ ImageReaderResult ImageDecoder::readImage(
                   &imageOffset);
               ktx_size_t imageSize =
                   ktxTexture_GetImageSize(ktxTexture(pTexture), level);
+              ktx_uint32_t rowPitch =
+                  ktxTexture_GetRowPitch(ktxTexture(pTexture), level);
 
-              image.mipPositions[level] = {imageOffset, imageSize};
+              image.mipPositions[level] = {imageOffset, imageSize, rowPitch};
             }
           } else {
             CESIUM_ASSERT(pTexture->numLevels == 1);
@@ -390,13 +394,16 @@ std::optional<std::string> ImageDecoder::generateMipMaps(ImageAsset& image) {
     totalPixelCount += mipWidth * mipHeight;
   }
 
+  const size_t imageRowPitch =
+      static_cast<size_t>(image.width * image.channels * image.bytesPerChannel);
   // Byte size of the base image.
-  const size_t imageByteSize = static_cast<size_t>(
-      image.width * image.height * image.channels * image.bytesPerChannel);
+  const size_t imageByteSize =
+      imageRowPitch * static_cast<size_t>(image.height);
 
   image.mipPositions.resize(mipCount);
   image.mipPositions[0].byteOffset = 0;
   image.mipPositions[0].byteSize = imageByteSize;
+  image.mipPositions[0].rowPitch = imageRowPitch;
 
   image.pixelData.resize(static_cast<size_t>(
       totalPixelCount * image.channels * image.bytesPerChannel));
@@ -421,11 +428,13 @@ std::optional<std::string> ImageDecoder::generateMipMaps(ImageAsset& image) {
       mipHeight >>= 1;
     }
 
-    byteSize = static_cast<size_t>(
-        mipWidth * mipHeight * image.channels * image.bytesPerChannel);
+    size_t rowPitch =
+        static_cast<size_t>(mipWidth * image.channels * image.bytesPerChannel);
+    byteSize = rowPitch * static_cast<size_t>(mipHeight);
 
     image.mipPositions[mipIndex].byteOffset = byteOffset;
     image.mipPositions[mipIndex].byteSize = byteSize;
+    image.mipPositions[mipIndex].rowPitch = rowPitch;
 
     if (!ImageDecoder::unsafeResize(
             &image.pixelData[lastByteOffset],

--- a/CesiumRasterOverlays/src/GeoJsonDocumentRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/GeoJsonDocumentRasterOverlay.cpp
@@ -606,8 +606,8 @@ public:
                 result.pImage->mipPositions.emplace_back(
                     CesiumGltf::ImageAssetMipPosition{
                         totalSize,
-                        (size_t)(rowPitch * height),
-                        (size_t)rowPitch});
+                        size_t(rowPitch * height),
+                        size_t(rowPitch)});
                 totalSize += result.pImage->mipPositions[i].byteSize;
               }
               result.pImage->pixelData.resize(totalSize, std::byte{0});

--- a/CesiumRasterOverlays/src/GeoJsonDocumentRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/GeoJsonDocumentRasterOverlay.cpp
@@ -601,11 +601,13 @@ public:
               for (uint32_t i = 0; i < mipLevels; i++) {
                 const int32_t width = std::max(textureSize.x >> i, 1);
                 const int32_t height = std::max(textureSize.y >> i, 1);
+                const int32_t rowPitch = width * result.pImage->channels *
+                                         result.pImage->bytesPerChannel;
                 result.pImage->mipPositions.emplace_back(
                     CesiumGltf::ImageAssetMipPosition{
                         totalSize,
-                        (size_t)(width * height * result.pImage->channels *
-                                 result.pImage->bytesPerChannel)});
+                        (size_t)(rowPitch * height),
+                        (size_t)rowPitch});
                 totalSize += result.pImage->mipPositions[i].byteSize;
               }
               result.pImage->pixelData.resize(totalSize, std::byte{0});

--- a/CesiumVectorData/test/TestVectorRasterizer.cpp
+++ b/CesiumVectorData/test/TestVectorRasterizer.cpp
@@ -250,7 +250,10 @@ TEST_CASE("VectorRasterizer::rasterize") {
     for (size_t i = 0; i < 4; i++) {
       int32_t width = 256 >> i;
       int32_t height = 256 >> i;
-      asset->mipPositions[i] = {totalSize, (size_t)(width * height * 4), (size_t)(width * 4)};
+      asset->mipPositions[i] = {
+          totalSize,
+          (size_t)(width * height * 4),
+          (size_t)(width * 4)};
       totalSize += asset->mipPositions[i].byteSize;
     }
 

--- a/CesiumVectorData/test/TestVectorRasterizer.cpp
+++ b/CesiumVectorData/test/TestVectorRasterizer.cpp
@@ -250,7 +250,7 @@ TEST_CASE("VectorRasterizer::rasterize") {
     for (size_t i = 0; i < 4; i++) {
       int32_t width = 256 >> i;
       int32_t height = 256 >> i;
-      asset->mipPositions[i] = {totalSize, (size_t)(width * height * 4)};
+      asset->mipPositions[i] = {totalSize, (size_t)(width * height * 4), (size_t)(width * 4)};
       totalSize += asset->mipPositions[i].byteSize;
     }
 

--- a/CesiumVectorData/test/TestVectorRasterizer.cpp
+++ b/CesiumVectorData/test/TestVectorRasterizer.cpp
@@ -252,8 +252,8 @@ TEST_CASE("VectorRasterizer::rasterize") {
       int32_t height = 256 >> i;
       asset->mipPositions[i] = {
           totalSize,
-          (size_t)(width * height * 4),
-          (size_t)(width * 4)};
+          size_t(width * height * 4),
+          size_t(width * 4)};
       totalSize += asset->mipPositions[i].byteSize;
     }
 


### PR DESCRIPTION
Added `ImageAssetMipPosition::rowPitch` field. This is used in `cesium-unity` when loading textures when flipping them vertically to match Unity's U-right, V-up convention. 

This should be released in conjunction with https://github.com/CesiumGS/cesium-unity/pull/611 . 