### PR TITLE
Added a null check before using RasterOverlayTile overlay tileprovider

### DIFF
--- a/CesiumRasterOverlays/src/RasterOverlayTile.cpp
+++ b/CesiumRasterOverlays/src/RasterOverlayTile.cpp
@@ -37,11 +37,14 @@ RasterOverlayTile::RasterOverlayTile(
 RasterOverlayTile::~RasterOverlayTile() {
   this->_pActivatedOverlay->removeTile(this);
 
-  RasterOverlayTileProvider& tileProvider =
-      *this->_pActivatedOverlay->getTileProvider();
+  RasterOverlayTileProvider* tileProvider =
+      this->_pActivatedOverlay->getTileProvider();
+
+  if (!tileProvider)
+    return;
 
   const std::shared_ptr<IPrepareRasterOverlayRendererResources>&
-      pPrepareRendererResources = tileProvider.getPrepareRendererResources();
+      pPrepareRendererResources = tileProvider->getPrepareRendererResources();
 
   if (pPrepareRendererResources) {
     void* pLoadThreadResult =


### PR DESCRIPTION
The `RasterOverlayTile` destructor assumed that the activated overlay had a valid tileProvider, which was not necessarily always the case when working with Azure overlays. 