### PR TITLE
Set VCPKG_TARGET_TRIPLET even when using ezvcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,9 +53,16 @@ if (NOT VCPKG_TRIPLET)
     else()
         set(VCPKG_TRIPLET "${DETECTED_VCPKG_TRIPLET}")
     endif()
-    if (NOT CESIUM_USE_EZVCPKG)
-        set(VCPKG_TARGET_TRIPLET "${VCPKG_TRIPLET}")
-    endif()
+
+    # If we're using ezvcpkg, ezvcpkg will update CMAKE_TOOLCHAIN_FILE to point to the vcpkg toolchain.
+    # Which means that when we hit the `project` function call below, cmake will load the vcpkg
+    # toolchain file. If VCPKG_TARGET_TRIPLET isn't set by that time, vcpkg will set it itself, and
+    # maybe not to what we want. So set VCPKG_TARGET_TRIPLET explicit here so that we're sure to get
+    # the right one.
+    #
+    # If we're _not_ using ezvcpkg, then we also must set VCPKG_TARGET_TRIPLET, but for a different reason.
+    # VCPKG_TRIPLET is only an ezvcpkg thing, vcpkg itself only knows about VCPKG_TARGET_TRIPLET.
+    set(VCPKG_TARGET_TRIPLET "${VCPKG_TRIPLET}")
 endif()
 
 message(STATUS "VCPKG_TRIPLET ${VCPKG_TRIPLET}")


### PR DESCRIPTION
I noticed some really surprising behavior yesterday. The first time you run cmake configure in a _clean_ build directory on a Windows system, we'll correctly use the `x64-windows-static-md` vcpkg triplet:

> PS D:\github\cesium-native2> cmake -B build -S .
-- Building for: Visual Studio 17 2022
-- VCPKG_TRIPLET x64-windows-static-md
-- VCPKG_TARGET_TRIPLET
-- VCPKG_PLATFORM_TOOLSET_VERSION
-- VCPKG_OVERLAY_PORTS D:/github/cesium-native2/extern/vcpkg/ports
-- VCPKG_OVERLAY_TRIPLETS
-- EZVCPKG v0.1 starting up
        Website: https://github.com/jherico/ezvcpkg
-- EZVCPKG initializing
        commit:     2025.09.17
        repository: https://github.com/microsoft/vcpkg.git
        local dir:  d:/ezvcpkg/2025.09.17
-- EZVCPKG Building/Verifying package asyncplusplus using triplet x64-windows-static-md
...

But if we immediately run it again afterward, it instead uses the `x64-windows` triplet! 😱 

> PS D:\github\cesium-native2> cmake -B build -S .
-- VCPKG_TRIPLET x64-windows
-- VCPKG_TARGET_TRIPLET x64-windows
-- VCPKG_PLATFORM_TOOLSET_VERSION
-- VCPKG_OVERLAY_PORTS D:/github/cesium-native2/extern/vcpkg/ports
-- VCPKG_OVERLAY_TRIPLETS
-- EZVCPKG v0.1 starting up
        Website: https://github.com/jherico/ezvcpkg
-- EZVCPKG initializing
        commit:     2025.09.17
        repository: https://github.com/microsoft/vcpkg.git
        local dir:  d:/ezvcpkg/2025.09.17
-- EZVCPKG Building/Verifying package asyncplusplus using triplet x64-windows
...

What's happening here is that the first time we configure, neither `VCPKG_TRIPLET` nor `VCPKG_TARGET_TRIPLET` are set. Our custom logic correctly deduces that we want to use `x64-windows-static-md`, sets `VCPKG_TRIPLET` to this value, and then invokes ezvcpkg. ezvcpkg correctly uses the value of this variable when invoking the vcpkg command-line tool.

However, after the package installation is complete, ezvcpkg sets `CMAKE_TOOLCHAIN_FILE` to `vcpkg.cmake` (a toolchain file included with vcpkg). So when we hit the `project()` function call in our `CMakeLists.txt`, this toolchain file gets loaded and executed.

vcpkg doesn't know anything about a variable called `VCPKG_TRIPLET`. So it uses its own triplet detection logic to come up with `x64-windows` and then stores this in the `VCPKG_TARGET_TRIPLET` variable. This variable is stored in the cmake cache, so it is persisted to the next run. Somehow `find_package` is still able to find the packages associated with the `x64-windows-static-md` triplet. I didn't really look into how this works. So all is well on this first configure run.

Now on the second configure run, `VCPKG_TARGET_TRIPLET=x64-windows` is in the CMake cache, as mentioned above. So our `CMakeLists.txt` sees that and skips all of our custom detection logic. Thus, we end up using `x64-windows` from then on.

We were already setting `VCPKG_TARGET_TRIPLET` to the detected `VCPKG_TRIPLET` value in _non-ezvcpkg_ scenarios. In this PR, we do this in the ezvcpkg path, too. This avoids letting `vcpkg.cmake` set this variable itself.

