### PR TITLE
Fix modp_b64 search fail when path to ezvcpkg contains a directory named debug

### DIFF
--- a/cmake/modules/Findmodp_b64.cmake
+++ b/cmake/modules/Findmodp_b64.cmake
@@ -9,7 +9,7 @@ find_library(modp_b64_DEBUG_LIBRARIES
 
 # vcpkg specific locations for debug libraries if they are not already found
 set(modpbase64SavePrefixPath ${CMAKE_PREFIX_PATH})
-list(FILTER CMAKE_PREFIX_PATH INCLUDE REGEX "/debug")
+list(FILTER CMAKE_PREFIX_PATH INCLUDE REGEX "/debug$")
 find_library(modp_b64_DEBUG_LIBRARIES
   NAMES
   modpbase64
@@ -18,7 +18,7 @@ find_library(modp_b64_DEBUG_LIBRARIES
 set(CMAKE_PREFIX_PATH ${modpbase64SavePrefixPath})
 
 set(modpbase64SavePrefixPath ${CMAKE_PREFIX_PATH})
-list(FILTER CMAKE_PREFIX_PATH EXCLUDE REGEX "/debug")
+list(FILTER CMAKE_PREFIX_PATH EXCLUDE REGEX "/debug$")
 find_library(modp_b64_LIBRARIES NAMES modpbase64 libmodpbase64)
 set(CMAKE_PREFIX_PATH ${modpbase64SavePrefixPath})
 


### PR DESCRIPTION
Example path to ezvcpkg:

EZVCPKG_BASEDIR=D:\out\debug\ezvcpkg

Current code clears the list of search paths when trying to find modp_b64 libraries and therefore search fails.

Fix is to simply filter the search paths which contains /debug only at the end of all search paths.