### PR TITLE
Report credits with destroyed source as removed.

### DIFF
--- a/CesiumUtility/include/CesiumUtility/CreditSystem.h
+++ b/CesiumUtility/include/CesiumUtility/CreditSystem.h
@@ -315,6 +315,11 @@ private:
   CreditsSnapshot _snapshot;
   std::vector<int32_t> _referenceCountScratch;
 
+  // These are credits that were shown in the last snapshot but whose
+  // CreditSources have since been destroyed. They need to be reported in
+  // removedCredits in the next snapshot.
+  std::vector<Credit> _shownCreditsDestroyed;
+
   // Each entry in this vector is an index into _credits that is unused and can
   // be reused for a new credit.
   std::vector<size_t> _unusedCreditRecords;

--- a/CesiumUtility/test/TestCreditSystem.cpp
+++ b/CesiumUtility/test/TestCreditSystem.cpp
@@ -243,7 +243,7 @@ TEST_CASE("Test CreditSystem with CreditSources") {
   }
 
   SUBCASE("when the source of a credit last frame is destroyed, that credit is "
-          "not reported") {
+          "reported in removedCredits") {
     std::unique_ptr<CreditSource> pTempSourceA =
         std::make_unique<CreditSource>(creditSystem);
     Credit credit0 = creditSystem.createCredit(*pTempSourceA, html0);
@@ -257,13 +257,14 @@ TEST_CASE("Test CreditSystem with CreditSources") {
     // this credit would show up in the `removedCredits`.
     creditSystem.removeCreditReference(credit0);
 
-    // Destroy the source. Now, the removed credit should no longer be reported
-    // in the next snapshot.
+    // Destroy the source. The removed credit should still be reported in the
+    // next snapshot.
     pTempSourceA.reset();
 
     const CreditsSnapshot& snapshot1 = creditSystem.getSnapshot();
     CHECK(snapshot1.currentCredits.empty());
-    CHECK(snapshot1.removedCredits.empty());
+    CHECK(snapshot1.removedCredits.size() == 1);
+    CHECK(snapshot1.removedCredits[0] == credit0);
   }
 
   SUBCASE("CreditSystem may be destroyed before CreditSource") {


### PR DESCRIPTION
This fixes the problem reported here:
https://github.com/CesiumGS/cesium-native/pull/1273#issuecomment-3571618454

> 1. Create two copies of Cesium World Terrain.
> 2. Set the first copy's Show Credits On Screen = true. Note the credits appearing on-screen.
> 3. Delete the first copy. Note that the credits are still shown on screen.

The above report is for Cesium for Unity, but the same thing happens in Unreal.

This isn't exactly a new problem. Previously, two credits with the same HTML were the same credit, even if they came from a different source or had a different `showOnScreen` flag.

Whichever source created the credit second would override the `showOnScreen` flag.

Removing the source that wanted a credit to be on screen wouldn't suddenly set showOnScreen=false, so it would stay on screen. So... pretty much the same thing.

But now, after #1273, credits from different sources are separate credits, so we're in a position where we can easily fix this. That's what this PR does. The problem was that the credits that were:

a) shown last frame, and
b) created by a credit source that had since been destroyed

were not reported in the `removedCredits` field of the snapshot. There wasn't any particularly good reason for this. I just had to add a tiny bit more bookkeeping to make it possible.

The destroyed credits will simply return an error string when asked for its HTML, but it's still useful for them to be there if they were being used as some kind of key. Because of the way our credit handling works in Unreal and Unity, just their existence in `removedCredits` fixes the bug reported at the top, even though they're never used.