### PR TITLE
Install zlib when CesiumCurl is enabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
 - Added `CreditReferencer::isCreditReferenced`, which can be used to determine if the referencer is currently referencing a particular `Credit`.
 - `CreditSystem::getSnapshot` now takes an optional parameter specifying if and how to filter `Credits` with identical HTML strings.
 
+##### Fixes :wrench:
+
+- The cmake install process previously didn't install `zlib`, which is required by `libcurl`.
+
 ### v0.54.0 - 2025-11-17
 
 ##### Additions :tada:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ else()
 endif()
 
 if(NOT CESIUM_DISABLE_CURL)
-    list(APPEND PACKAGES_PRIVATE curl)
+    list(APPEND PACKAGES_PRIVATE curl zlib)
 endif()
 
 if(NOT CESIUM_DISABLE_LIBJPEG_TURBO)


### PR DESCRIPTION
This fixes a problem identified by a Bentley-internal user. The `CesiumCurl` library depends on `curl`, which in turn depends on `zlib`. But the cmake install process was not copying zlib to the output directory along with the rest of the dependencies because the dependency wasn't declared explicitly.
