### PR TITLE
Update ktx overlay port

### DIFF
--- a/extern/vcpkg/ports/ktx/portfile.cmake
+++ b/extern/vcpkg/ports/ktx/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kring/KTX-Software # KhronosGroup/KTX-Software
     REF "v${VERSION}"
-    SHA512 fa20457fc0f0b117f4d6b406baa338091a85bcc46f60ca440dcd483388c67c550c81da3618d70d748e12850e32e0c1d82e9e8dc8522849074f40cc455723ac97
+    SHA512 9986aa911b5bd52d5aabe465578a0bd3906fb07b846bace3ebd0c72bd3d021a71abd307c3089674833dc695e87ec4cd136ee67881a38939bc5f42d731253234b
     HEAD_REF master
 )
 file(REMOVE "${SOURCE_PATH}/other_include/zstd_errors.h")

--- a/extern/vcpkg/ports/ktx/vcpkg.json
+++ b/extern/vcpkg/ports/ktx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ktx",
-  "version-semver": "4.4.2-plus-vcpkg-patches",
+  "version-semver": "4.4.2-plus-vcpkg-patches-2",
   "description": [
     "The Khronos KTX library and tools.",
     "Functions for writing and reading KTX files, and instantiating OpenGL®, OpenGL ES™️ and Vulkan® textures from them."


### PR DESCRIPTION
The important change here is to make it not define `DEBUG` and `_DEBUG` symbols. This breaks cesium-unreal, which uses the release CRT in debug builds.

If you're seeing errors like this, then this PR should be the fix:

```
1>CesiumGltfReader.lib(ImageDecoder.obj) : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in SharedPCH.UnrealEd.Project.NonOptimized.NoValFmtStr.ValApi.Cpp20.InclOrderUnreal5_4.h.obj
1>CesiumGltfReader.lib(ImageDecoder.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MDd_DynamicDebug' doesn't match value 'MD_DynamicRelease' in SharedPCH.UnrealEd.Project.NonOptimized.NoValFmtStr.ValApi.Cpp20.InclOrderUnreal5_4.h.obj
1>CesiumGltfReader.lib(GltfReader.obj) : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in SharedPCH.UnrealEd.Project.NonOptimized.NoValFmtStr.ValApi.Cpp20.InclOrderUnreal5_4.h.obj
1>CesiumGltfReader.lib(GltfReader.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MDd_DynamicDebug' doesn't match value 'MD_DynamicRelease' in SharedPCH.UnrealEd.Project.NonOptimized.NoValFmtStr.ValApi.Cpp20.InclOrderUnreal5_4.h.obj
...
```
