### PR TITLE
Replace bad `begin()` use with `data()`

### DIFF
--- a/CesiumGltf/include/CesiumGltf/PropertyArrayView.h
+++ b/CesiumGltf/include/CesiumGltf/PropertyArrayView.h
@@ -476,11 +476,12 @@ public:
       : _storage(rhs._storage), _view() {
     // Reconstruct spans so they point to this copy's data.
     size_t valueSpanSize = rhs._view._values.size();
+    size_t offsetSpanSize = this->_storage.size() - valueSpanSize;
     this->_view = PropertyArrayView<std::string_view>(
         std::span<const std::byte>(this->_storage.data(), valueSpanSize),
         std::span<const std::byte>(
-            this->_storage.begin() + static_cast<int32_t>(valueSpanSize),
-            this->_storage.end()),
+            this->_storage.data() + static_cast<int32_t>(valueSpanSize),
+            offsetSpanSize),
         rhs._view._stringOffsetType,
         rhs._view.size());
   }
@@ -490,11 +491,12 @@ public:
     this->_storage = rhs._storage;
     // Reconstruct spans so they point to this copy's data.
     size_t valueSpanSize = rhs._view._values.size();
+    size_t offsetSpanSize = this->_storage.size() - valueSpanSize;
     this->_view = PropertyArrayView<std::string_view>(
         std::span<const std::byte>(this->_storage.data(), valueSpanSize),
         std::span<const std::byte>(
-            this->_storage.begin() + static_cast<int32_t>(valueSpanSize),
-            this->_storage.end()),
+            this->_storage.data() + static_cast<int32_t>(valueSpanSize),
+            offsetSpanSize),
         rhs._view._stringOffsetType,
         rhs._view.size());
     return *this;


### PR DESCRIPTION
Mistake I made in #1283 where for some reason, I used `.begin()` instead of `.data()` on a `std::vector<std::byte>`. For some reason this doesn't cause CI to fail here, but it results in compilation errors for non-Windows platforms in Cesium for Unreal ([example](https://github.com/CesiumGS/cesium-unreal/actions/runs/19967266724/job/57262296692)).