### PR TITLE
glTF modifier: fixed case of raster overlays

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - The `CesiumVectorOverlays::VectorTilesRasterOverlay` now supports styling via specifying a `VectorStylingProvider` through the `pStylingProvider` parameter in `VectorTilesRasterOverlayOptions`.
+- Fixed potential crashes when using the glTF modifier on a tileset also using raster overlays (such as cartographic polygons).
 
 ### v0.64.0 - 2026-09-01
 

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
@@ -251,6 +251,24 @@ public:
    */
   void replaceWithModifiedModel() noexcept;
 
+  /**
+   * @brief Returns whether this tile is currently being up-sampled.
+   * It should only be called by the main thread.
+   */
+  bool isBeingUpSampled() const noexcept;
+
+  /**
+   * @brief Increment the current up-sampling task count.
+   * It should only be called by the main thread.
+   */
+  void incrementUpSamplingTaskCount() const noexcept;
+
+  /**
+   * @brief Decrement the current up-sampling task count.
+   * It should only be called by the main thread.
+   */
+  void decrementUpSamplingTaskCount() const noexcept;
+
 private:
   CesiumGltf::Model _model;
   void* _pRenderResources;
@@ -258,6 +276,7 @@ private:
   GltfModifierState _modifierState;
   std::optional<CesiumGltf::Model> _modifiedModel;
   void* _pModifiedRenderResources;
+  mutable int32_t _activeUpSamplingTaskCount;
 
   CesiumRasterOverlays::RasterOverlayDetails _rasterOverlayDetails;
   std::vector<CesiumUtility::Credit> _credits;

--- a/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
+++ b/Cesium3DTilesSelection/include/Cesium3DTilesSelection/TileContent.h
@@ -261,6 +261,24 @@ public:
    */
   void replaceWithModifiedModel() noexcept;
 
+  /**
+   * @brief Returns whether this tile is currently being up-sampled.
+   * It should only be called by the main thread.
+   */
+  bool isBeingUpSampled() const noexcept;
+
+  /**
+   * @brief Increment the current up-sampling task count.
+   * It should only be called by the main thread.
+   */
+  void incrementUpSamplingTaskCount() const noexcept;
+
+  /**
+   * @brief Decrement the current up-sampling task count.
+   * It should only be called by the main thread.
+   */
+  void decrementUpSamplingTaskCount() const noexcept;
+
 private:
   CesiumGltf::Model _model;
   void* _pRenderResources;
@@ -268,6 +286,7 @@ private:
   GltfModifierState _modifierState;
   std::optional<CesiumGltf::Model> _modifiedModel;
   void* _pModifiedRenderResources;
+  mutable int32_t _activeUpSamplingTaskCount;
 
   CesiumRasterOverlays::RasterOverlayDetails _rasterOverlayDetails;
   std::vector<CesiumUtility::Credit> _credits;

--- a/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
+++ b/Cesium3DTilesSelection/src/RasterOverlayUpsampler.cpp
@@ -58,9 +58,21 @@ RasterOverlayUpsampler::loadTileContent(const TileLoadInput& loadInput) {
         TileLoadResult::createFailedResult(loadInput.pAssetAccessor, nullptr));
   }
 
+  if (pParentRenderContent->getGltfModifierState() ==
+      GltfModifierState::WorkerRunning) {
+    // Parent is currently being modified, so it would be useless to upsample
+    // the version about to be replaced - also, its rasterOverlayProjections
+    // may have been emptied in order to be recomputed as well.
+    return loadInput.asyncSystem.createResolvedFuture(
+        TileLoadResult::createRetryLaterResult(
+            loadInput.pAssetAccessor,
+            nullptr));
+  }
+
   size_t index = 0;
   const std::vector<CesiumGeospatial::Projection>& parentProjections =
       pParentRenderContent->getRasterOverlayDetails().rasterOverlayProjections;
+  CESIUM_ASSERT(!parentProjections.empty());
   for (const RasterMappedTo3DTile& mapped : pParent->getMappedRasterTiles()) {
     if (mapped.isMoreDetailAvailable()) {
       const CesiumGeospatial::Projection& projection =
@@ -79,13 +91,24 @@ RasterOverlayUpsampler::loadTileContent(const TileLoadInput& loadInput) {
       getProjectionEllipsoid(projection);
 
   const CesiumGltf::Model& parentModel = pParentRenderContent->getModel();
-  return loadInput.asyncSystem.runInWorkerThread(
-      [&parentModel,
-       ellipsoid,
-       transform = loadInput.tile.getTransform(),
-       textureCoordinateIndex = index,
-       tileID = *pTileID,
-       pAssetAccessor = loadInput.pAssetAccessor]() mutable {
+
+  pParentRenderContent->incrementUpSamplingTaskCount();
+  return loadInput.asyncSystem
+      .runInWorkerThread([&parentModel,
+                          pParentRenderContent,
+                          ellipsoid,
+                          transform = loadInput.tile.getTransform(),
+                          textureCoordinateIndex = index,
+                          tileID = *pTileID,
+                          pAssetAccessor = loadInput.pAssetAccessor]() mutable {
+        if (pParentRenderContent->getGltfModifierState() ==
+            GltfModifierState::WorkerRunning) {
+          // Parent tile is being modified, no need to spend time upsampling an
+          // obsolete version.
+          return TileLoadResult::createRetryLaterResult(
+              pAssetAccessor,
+              nullptr);
+        }
         auto model = RasterOverlayUtilities::upsampleGltfForRasterOverlays(
             parentModel,
             tileID,
@@ -119,6 +142,11 @@ RasterOverlayUpsampler::loadTileContent(const TileLoadInput& loadInput) {
             {},
             TileLoadResultState::Success,
             ellipsoid};
+      })
+      .thenInMainThread([pParentRenderContent](TileLoadResult&& result) {
+        CESIUM_ASSERT(pParentRenderContent->isBeingUpSampled());
+        pParentRenderContent->decrementUpSamplingTaskCount();
+        return std::move(result);
       });
 }
 

--- a/Cesium3DTilesSelection/src/TileContent.cpp
+++ b/Cesium3DTilesSelection/src/TileContent.cpp
@@ -20,6 +20,7 @@ TileRenderContent::TileRenderContent(CesiumGltf::Model&& model)
       _modifierState{GltfModifierState::Idle},
       _modifiedModel{},
       _pModifiedRenderResources(nullptr),
+      _activeUpSamplingTaskCount(0),
       _rasterOverlayDetails{},
       _credits{},
       _lodTransitionFadePercentage{0.0f} {}
@@ -72,6 +73,7 @@ void TileRenderContent::resetModifiedModelAndRenderResources() noexcept {
 
 void TileRenderContent::replaceWithModifiedModel() noexcept {
   CESIUM_ASSERT(this->_modifiedModel);
+  CESIUM_ASSERT(!this->isBeingUpSampled());
   if (this->_modifiedModel) {
     this->_model = std::move(*this->_modifiedModel);
     // reset after move because this is tested for nullopt in
@@ -80,6 +82,19 @@ void TileRenderContent::replaceWithModifiedModel() noexcept {
     this->_pRenderResources = this->_pModifiedRenderResources;
     this->_pModifiedRenderResources = nullptr;
   }
+}
+
+bool TileRenderContent::isBeingUpSampled() const noexcept {
+  return this->_activeUpSamplingTaskCount > 0;
+}
+
+void TileRenderContent::incrementUpSamplingTaskCount() const noexcept {
+  this->_activeUpSamplingTaskCount++;
+}
+
+void TileRenderContent::decrementUpSamplingTaskCount() const noexcept {
+  CESIUM_ASSERT(this->_activeUpSamplingTaskCount > 0);
+  this->_activeUpSamplingTaskCount--;
 }
 
 const RasterOverlayDetails&

--- a/Cesium3DTilesSelection/src/TilesetContentManager.cpp
+++ b/Cesium3DTilesSelection/src/TilesetContentManager.cpp
@@ -567,15 +567,21 @@ postProcessContentInWorkerThread(
 
   std::optional<int64_t> version =
       pGltfModifier ? pGltfModifier->getCurrentVersion() : std::nullopt;
+  const bool needsApplyGltfModifier = (pGltfModifier && version);
 
   auto asyncSystem = tileLoadInfo.asyncSystem;
 
   result.initialBoundingVolume = tileLoadInfo.tileBoundingVolume;
   result.initialContentBoundingVolume = tileLoadInfo.tileContentBoundingVolume;
 
-  postProcessGltfInWorkerThread(result, std::move(projections), tileLoadInfo);
+  // Important: post-process must be performed *after* GltfModifier, as it does
+  // add attribute _CESIUMOVERLAY_xxx, which is required for raster overlays.
+  if (!needsApplyGltfModifier) {
+    postProcessGltfInWorkerThread(result, std::move(projections), tileLoadInfo);
+  }
 
-  auto applyGltfModifier = [&]() {
+  auto applyGltfModifier = [&](std::vector<CesiumGeospatial::Projection>&&
+                                   projections) {
     // Apply the glTF modifier right away, otherwise it will be
     // triggered immediately after the renderer-side resources
     // have been created, which is both inefficient and a cause
@@ -593,7 +599,10 @@ postProcessContentInWorkerThread(
             .tileTransform = tileLoadInfo.tileTransform})
         .thenInWorkerThread(
             [result = std::move(result),
-             version](std::optional<GltfModifierOutput>&& modified) mutable {
+             version,
+             projections = std::move(projections),
+             tileLoadInfo = std::move(tileLoadInfo)](
+                std::optional<GltfModifierOutput>&& modified) mutable {
               if (modified) {
                 result.contentKind = std::move(modified->modifiedModel);
               }
@@ -604,14 +613,22 @@ postProcessContentInWorkerThread(
                 GltfModifierVersionExtension::setVersion(*pModel, *version);
               }
 
-              return result;
-            })
-        .thenPassThrough(std::move(tileLoadInfo));
+              // Important: post-process must be performed *after* the model
+              // is modified.
+              postProcessGltfInWorkerThread(
+                  result,
+                  std::move(projections),
+                  tileLoadInfo);
+
+              return std::make_tuple(
+                  std::move(tileLoadInfo),
+                  std::move(result));
+            });
   };
 
   CesiumAsync::Future<std::tuple<TileContentLoadInfo, TileLoadResult>> future =
-      pGltfModifier && version
-          ? applyGltfModifier()
+      needsApplyGltfModifier
+          ? applyGltfModifier(std::move(projections))
           : tileLoadInfo.asyncSystem.createResolvedFuture(std::move(result))
                 .thenPassThrough(std::move(tileLoadInfo));
 
@@ -991,6 +1008,25 @@ void TilesetContentManager::reapplyGltfModifier(
   CESIUM_ASSERT(externals.pGltfModifier->getCurrentVersion());
   int64_t version = externals.pGltfModifier->getCurrentVersion().value_or(-1);
 
+  // Ensure raster overlays will be recomputed for this tile, BUT restore
+  // overlay details afterwards, or the tile could be unloaded in
+  // #updateDoneState (see test on status.firstIndexWithMissingProjection).
+  auto const rasterOverlayDetails =
+      pRenderContent->getRasterOverlayDetails();
+  pRenderContent->setRasterOverlayDetails({});
+  std::vector<CesiumGeospatial::Projection> projections =
+      this->_overlayCollection.addTileOverlays(tile, tilesetOptions);
+  pRenderContent->setRasterOverlayDetails(rasterOverlayDetails);
+
+  TileContentLoadInfo tileLoadInfo{
+      this->_externals.asyncSystem,
+      this->_externals.pAssetAccessor,
+      this->_externals.pPrepareRendererResources,
+      this->_externals.pLogger,
+      this->_pSharedAssetSystem,
+      tilesetOptions.contentOptions,
+      tile};
+
   // It is safe to capture the TilesetExternals and Model by reference because
   // the TilesetContentManager guarantees both will continue to exist and are
   // immutable while modification is in progress.
@@ -1022,13 +1058,15 @@ void TilesetContentManager::reapplyGltfModifier(
                            tileBoundingVolume = tile.getBoundingVolume(),
                            tileContentBoundingVolume =
                                tile.getContentBoundingVolume(),
-                           rendererOptions = tilesetOptions.rendererOptions](
-                              std::optional<GltfModifierOutput>&& modified) {
+                           rendererOptions = tilesetOptions.rendererOptions,
+                           tileLoadInfo = std::move(tileLoadInfo),
+                           ellipsoid = tilesetOptions.ellipsoid,
+                           projections = std::move(projections)](
+                              std::optional<GltfModifierOutput>&&
+                                  modified) mutable {
         TileLoadResult tileLoadResult;
         tileLoadResult.state = TileLoadResultState::Success;
         tileLoadResult.pAssetAccessor = externals.pAssetAccessor;
-        tileLoadResult.rasterOverlayDetails =
-            pRenderContent->getRasterOverlayDetails();
         tileLoadResult.initialBoundingVolume = tileBoundingVolume;
         tileLoadResult.initialContentBoundingVolume = tileContentBoundingVolume;
 
@@ -1042,10 +1080,24 @@ void TilesetContentManager::reapplyGltfModifier(
           }
         }
 
+        tileLoadResult.ellipsoid = ellipsoid;
         if (modified) {
           tileLoadResult.contentKind = std::move(modified->modifiedModel);
+
+          // Apply post-process to the modified model.
+          postProcessGltfInWorkerThread(
+              tileLoadResult,
+              std::move(projections),
+              tileLoadInfo);
+          if (tileLoadResult.rasterOverlayDetails) {
+            pRenderContent->setRasterOverlayDetails(
+                *tileLoadResult.rasterOverlayDetails);
+          }
         } else {
+          // No modification could be reapplied => we'll keep previous model and
+          // render resources.
           tileLoadResult.contentKind = previousModel;
+          tileLoadResult.state = TileLoadResultState::Failed;
         }
 
         if (modified && externals.pPrepareRendererResources) {
@@ -1111,15 +1163,18 @@ void TilesetContentManager::reapplyGltfModifier(
           pRenderContent->setGltfModifierState(GltfModifierState::WorkerDone);
 
           // The modified model is up-to-date with the version that triggered
-          // this run.
+          // this run (even though the modification did nothing or failed, as it
+          // can happen for upsampling typically).
           CesiumGltf::Model& modifiedModel =
               std::get<CesiumGltf::Model>(pair.result.contentKind);
           GltfModifierVersionExtension::setVersion(modifiedModel, version);
 
-          pRenderContent->setModifiedModelAndRenderResources(
-              std::move(modifiedModel),
-              pair.pRenderResources);
-          this->_externals.pGltfModifier->onWorkerThreadApplyComplete(*pTile);
+          if (pair.result.state == TileLoadResultState::Success) {
+            pRenderContent->setModifiedModelAndRenderResources(
+                std::move(modifiedModel),
+                pair.pRenderResources);
+            this->_externals.pGltfModifier->onWorkerThreadApplyComplete(*pTile);
+          }
         }
       })
       .catchInMainThread(
@@ -1601,6 +1656,14 @@ void TilesetContentManager::finishLoading(
 
   if (this->_externals.pGltfModifier &&
       this->_externals.pGltfModifier->needsMainThreadModification(tile)) {
+
+    if (pRenderContent->isBeingUpSampled()) {
+      // If this tile is currently being up-sampled in a worker thread, we
+      // cannot replace its model. Return so that we do not block the main
+      // thread (finishLoading will be called again later).
+      return;
+    }
+
     // Free outdated render resources before replacing them.
     if (this->_externals.pPrepareRendererResources) {
       this->_externals.pPrepareRendererResources->free(

--- a/CesiumRasterOverlays/src/RasterOverlayUtilities.cpp
+++ b/CesiumRasterOverlays/src/RasterOverlayUtilities.cpp
@@ -594,8 +594,8 @@ RasterOverlayUtilities::upsampleGltfForRasterOverlays(
         mesh.primitives.erase(mesh.primitives.begin() + ptrdiff_t(i));
         --i;
       }
-      containsPrimitives |= !mesh.primitives.empty();
     }
+    containsPrimitives |= !mesh.primitives.empty();
   }
 
   return containsPrimitives ? std::make_optional<Model>(std::move(result))


### PR DESCRIPTION
GltfModifier: made it compatible with raster overlays (the initial revision of Gltf modifier was just ignoring them - so as soon as a modification was re-triggered, any cut-out polygon applied to the model would just be lost)
    
- raster overlays (computed as post-process) need to be recomputed *after* the modification step.    
- in the case of the re-apply path (see _reapplyGltfModifier_), we need to restore the initial tile bounding volume, because the post-process can lead to set an empty bounding volume, which would trigger plenty of false positive errors when re-running the post-process on the tile.
- for up-sampled tiles, the re-apply path consists in up-sampling the modified parent (and not run the modifier on the current up-sampled tile...)
- in the the re-apply path, we must take the result of the modification step into account: if the modification step fails (which can now happen in case of up-sampling...), we still keep the current model, but we should notify the next step to avoid a crash when trying to set null resources to the rendered tile
- added a shared-mutex in TileRenderContent to fix a potential crash when the game thread is replacing the parent tile's content (replaceWithModifiedModel) while a worker thread is currently up-sapling it for one of its children