### PR TITLE
MSVC PageList next/prev bug fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - `Cesium3DTilesetSelection::Tileset::getRootTileAvailableEvent` will now resolve even when a `Tileset` is constructed with invalid source parameters, instead of hanging indefinitely.
+- Fixed compilation error with MSVC when using custom `CesiumITwinClient::PagedList` types.
 
 ### v0.58.0 - 2026-03-02
 

--- a/CesiumITwinClient/include/CesiumITwinClient/PagedList.h
+++ b/CesiumITwinClient/include/CesiumITwinClient/PagedList.h
@@ -128,8 +128,9 @@ public:
   CesiumAsync::Future<CesiumUtility::Result<PagedList<T>>>
   next(CesiumAsync::AsyncSystem& asyncSystem, Connection& connection) const {
     if (!this->_nextUrl.has_value()) {
-      return asyncSystem.createResolvedFuture<CesiumUtility::Result<PagedList<T>>>(
-          CesiumUtility::Result<PagedList<T>>(CesiumUtility::ErrorList{}));
+      return asyncSystem
+          .createResolvedFuture<CesiumUtility::Result<PagedList<T>>>(
+              CesiumUtility::Result<PagedList<T>>(CesiumUtility::ErrorList{}));
     }
 
     return _operation(connection, *this->_nextUrl);
@@ -145,8 +146,9 @@ public:
   CesiumAsync::Future<CesiumUtility::Result<PagedList<T>>>
   prev(CesiumAsync::AsyncSystem& asyncSystem, Connection& connection) const {
     if (!this->_prevUrl.has_value()) {
-      return asyncSystem.createResolvedFuture<CesiumUtility::Result<PagedList<T>>>(
-          CesiumUtility::Result<PagedList<T>>(CesiumUtility::ErrorList{}));
+      return asyncSystem
+          .createResolvedFuture<CesiumUtility::Result<PagedList<T>>>(
+              CesiumUtility::Result<PagedList<T>>(CesiumUtility::ErrorList{}));
     }
 
     return _operation(connection, *this->_prevUrl);


### PR DESCRIPTION
Fixes #1317. Only two lines changed, [PagedList.h](https://github.com/CesiumGS/cesium-native/blob/main/CesiumITwinClient/include/CesiumITwinClient/PagedList.h) would fail to compile with MSVC if a user initialized their own PagedList<T>. The fix was to initialize with `ErrorList{}` instead of `nullopt`.

Please let me know if I need to do anything else for this PR. I have signed the CLA.