### PR TITLE
Fix code generation for internal properties

### DIFF
--- a/tools/generate-classes/index.js
+++ b/tools/generate-classes/index.js
@@ -207,10 +207,10 @@ function processSchemas() {
 
   while (schemas.length > 0) {
     const schema = schemas.pop();
-    if (processed[schema.sourcePath]) {
+    if (processed[schema.title]) {
       continue;
     }
-    processed[schema.sourcePath] = true;
+    processed[schema.title] = true;
 
     if ((options.config.classes[schema.title] || {}).manuallyDefined) {
       continue;


### PR DESCRIPTION
`generate-classes` wasn't generating files for internal properties (example [here](https://github.com/CesiumGS/3d-tiles/blob/99c8d804914be74a11c423cb995438803fcfec8d/extensions/3DTILES_dynamic/schema/3DTILES_dynamic_content.json#L11-L20)). The root schema and internal property schemas have the same `sourcePath` so internal properties would get skipped. Fixed by using `title` instead of `sourcePath` as the key for the processed cache.

If you run `npm run generate-gltf` and `npm run generate-3d-tiles` on this branch you won't see any changes, but on https://github.com/CesiumGS/cesium-native/tree/3d-tiles-dynamic you'll see that `DynamicContentDynamicContentsValue.h` gets generated properly.