### PR TITLE
Fix FeatureCollection visitor to check geometry style

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 - Added `BoundingRegionBuilder::expandToIncludeBoundingRegion`.
 
+##### Fixes :wrench:
+
+- Fixed a bug in `CesiumRasterOverlays::GeoJsonDocumentRasterOverlay` where styles set on geometry objects within a FeatureCollection were not applied. The FeatureCollection visitor now checks the geometry's style instead of the Feature wrapper's style, and the fallback chain correctly consults the collection-level style.
+
 ### v0.59.0 - 2026-04-01
 
 ##### Breaking Changes :mega:

--- a/CesiumRasterOverlays/src/GeoJsonDocumentRasterOverlay.cpp
+++ b/CesiumRasterOverlays/src/GeoJsonDocumentRasterOverlay.cpp
@@ -369,11 +369,12 @@ struct GeoJsonChildVisitor {
     for (const GeoJsonObject& feature : collection.features) {
       const GeoJsonFeature* pFeature = feature.getIf<GeoJsonFeature>();
       if (pFeature && pFeature->geometry) {
-        const std::optional<VectorStyle>& geometryStyle = feature.getStyle();
+        const std::optional<VectorStyle>& geometryStyle =
+            pFeature->geometry->getStyle();
         const std::optional<VectorStyle>& featureStyle =
             geometryStyle ? geometryStyle : pFeature->style;
         const std::optional<VectorStyle>& collectionStyle =
-            featureStyle ? featureStyle : pFeature->style;
+            featureStyle ? featureStyle : collection.style;
         addPrimitivesToData(
             pFeature->geometry.get(),
             data,

--- a/CesiumRasterOverlays/test/TestGeoJsonDocumentRasterOverlay.cpp
+++ b/CesiumRasterOverlays/test/TestGeoJsonDocumentRasterOverlay.cpp
@@ -81,6 +81,96 @@ CesiumGltf::ImageAsset rasterizeOverlayTile(
   }
   return *pTile->getImage();
 }
+
+CesiumGltf::ImageAsset rasterizeOverlayTileFromDocument(
+    const GlobeRectangle& rectangle,
+    const glm::dvec2& imageSize,
+    GeoJsonDocument&& document,
+    const GeoJsonDocumentRasterOverlayOptions& overlayOptions) {
+  AsyncSystem asyncSystem(
+      std::make_shared<CesiumNativeTests::SimpleTaskProcessor>());
+
+  IntrusivePointer<GeoJsonDocumentRasterOverlay> pOverlay;
+  pOverlay.emplace(
+      asyncSystem,
+      "overlay0",
+      std::make_shared<GeoJsonDocument>(std::move(document)),
+      overlayOptions);
+
+  std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor =
+      std::make_shared<CesiumNativeTests::SimpleAssetAccessor>(
+          std::map<
+              std::string,
+              std::shared_ptr<CesiumNativeTests::SimpleAssetRequest>>());
+
+  IntrusivePointer<ActivatedRasterOverlay> pActivated = pOverlay->activate(
+      RasterOverlayExternals{
+          .pAssetAccessor = pAssetAccessor,
+          .pPrepareRendererResources = nullptr,
+          .asyncSystem = asyncSystem,
+          .pCreditSystem = nullptr,
+          .pLogger = spdlog::default_logger()},
+      Ellipsoid::WGS84);
+
+  pActivated->getReadyEvent().waitInMainThread();
+
+  REQUIRE(pActivated->getTileProvider() != nullptr);
+  GeographicProjection projection(Ellipsoid::WGS84);
+  const CesiumGeometry::Rectangle& tileRect = projection.project(rectangle);
+
+  IntrusivePointer<RasterOverlayTile> pTile =
+      pActivated->getTile(tileRect, imageSize);
+  pActivated->loadTile(*pTile);
+  while (pTile->getState() != RasterOverlayTile::LoadState::Loaded) {
+    asyncSystem.dispatchMainThreadTasks();
+  }
+  return *pTile->getImage();
+}
+
+bool imageHasPixelWithColor(
+    const CesiumGltf::ImageAsset& image,
+    uint8_t r,
+    uint8_t g,
+    uint8_t b,
+    uint8_t a) {
+  REQUIRE(image.channels == 4);
+  REQUIRE(image.bytesPerChannel == 1);
+  for (int32_t y = 0; y < image.height; y++) {
+    for (int32_t x = 0; x < image.width; x++) {
+      size_t idx = static_cast<size_t>((y * image.width + x) * 4);
+      if (idx + 3 < image.pixelData.size() &&
+          static_cast<uint8_t>(image.pixelData[idx]) == r &&
+          static_cast<uint8_t>(image.pixelData[idx + 1]) == g &&
+          static_cast<uint8_t>(image.pixelData[idx + 2]) == b &&
+          static_cast<uint8_t>(image.pixelData[idx + 3]) == a) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+GeoJsonDocument createFeatureCollectionWithLineString(
+    const std::optional<VectorStyle>& geometryStyle,
+    const std::optional<VectorStyle>& featureStyle,
+    const std::optional<VectorStyle>& collectionStyle) {
+  GeoJsonLineString lineString;
+  lineString.coordinates = {
+      glm::dvec3(0.0, 0.0, 0.0),
+      glm::dvec3(5.0, 0.0, 0.0)};
+  lineString.style = geometryStyle;
+
+  GeoJsonFeature feature;
+  feature.geometry =
+      std::make_unique<GeoJsonObject>(GeoJsonObject{std::move(lineString)});
+  feature.style = featureStyle;
+
+  GeoJsonFeatureCollection collection;
+  collection.features.push_back(GeoJsonObject{std::move(feature)});
+  collection.style = collectionStyle;
+
+  return GeoJsonDocument(GeoJsonObject{std::move(collection)}, {});
+}
 } // namespace
 
 TEST_CASE(
@@ -340,4 +430,153 @@ TEST_CASE("GeoJsonDocumentRasterOverlay can correctly rasterize line strings "
         std::filesystem::path(CesiumRasterOverlays_TEST_DATA_DIR) /
             "equator-antimeridian.tga");
   }
+}
+
+TEST_CASE("GeoJsonDocumentRasterOverlay FeatureCollection uses geometry style "
+          "over feature and collection styles") {
+  const VectorStyle geometryStyle{
+      LineStyle{
+          ColorStyle{Color{0, 255, 0, 255}, ColorMode::Normal},
+          2.0,
+          LineWidthMode::Pixels},
+      PolygonStyle{std::nullopt, std::nullopt}};
+  const VectorStyle featureStyle{
+      LineStyle{
+          ColorStyle{Color{0, 0, 255, 255}, ColorMode::Normal},
+          2.0,
+          LineWidthMode::Pixels},
+      PolygonStyle{std::nullopt, std::nullopt}};
+  const VectorStyle collectionStyle{
+      LineStyle{
+          ColorStyle{Color{255, 255, 0, 255}, ColorMode::Normal},
+          2.0,
+          LineWidthMode::Pixels},
+      PolygonStyle{std::nullopt, std::nullopt}};
+
+  GeoJsonDocumentRasterOverlayOptions options{
+      VectorStyle{
+          LineStyle{
+              ColorStyle{Color{255, 0, 0, 255}, ColorMode::Normal},
+              2.0,
+              LineWidthMode::Pixels},
+          PolygonStyle{std::nullopt, std::nullopt}},
+      Ellipsoid::WGS84,
+      0};
+
+  GeoJsonDocument doc = createFeatureCollectionWithLineString(
+      geometryStyle,
+      featureStyle,
+      collectionStyle);
+
+  CesiumGltf::ImageAsset image = rasterizeOverlayTileFromDocument(
+      GlobeRectangle::fromDegrees(-1.0, -5.0, 6.0, 5.0),
+      glm::dvec2(256, 256),
+      std::move(doc),
+      options);
+
+  CHECK(imageHasPixelWithColor(image, 0, 255, 0, 255));
+  CHECK_FALSE(imageHasPixelWithColor(image, 0, 0, 255, 255));
+  CHECK_FALSE(imageHasPixelWithColor(image, 255, 255, 0, 255));
+  CHECK_FALSE(imageHasPixelWithColor(image, 255, 0, 0, 255));
+}
+
+TEST_CASE("GeoJsonDocumentRasterOverlay FeatureCollection falls back to "
+          "feature style when geometry has no style") {
+  const VectorStyle featureStyle{
+      LineStyle{
+          ColorStyle{Color{0, 0, 255, 255}, ColorMode::Normal},
+          2.0,
+          LineWidthMode::Pixels},
+      PolygonStyle{std::nullopt, std::nullopt}};
+  const VectorStyle collectionStyle{
+      LineStyle{
+          ColorStyle{Color{255, 255, 0, 255}, ColorMode::Normal},
+          2.0,
+          LineWidthMode::Pixels},
+      PolygonStyle{std::nullopt, std::nullopt}};
+
+  GeoJsonDocumentRasterOverlayOptions options{
+      VectorStyle{
+          LineStyle{
+              ColorStyle{Color{255, 0, 0, 255}, ColorMode::Normal},
+              2.0,
+              LineWidthMode::Pixels},
+          PolygonStyle{std::nullopt, std::nullopt}},
+      Ellipsoid::WGS84,
+      0};
+
+  GeoJsonDocument doc = createFeatureCollectionWithLineString(
+      std::nullopt,
+      featureStyle,
+      collectionStyle);
+
+  CesiumGltf::ImageAsset image = rasterizeOverlayTileFromDocument(
+      GlobeRectangle::fromDegrees(-1.0, -5.0, 6.0, 5.0),
+      glm::dvec2(256, 256),
+      std::move(doc),
+      options);
+
+  CHECK(imageHasPixelWithColor(image, 0, 0, 255, 255));
+  CHECK_FALSE(imageHasPixelWithColor(image, 255, 255, 0, 255));
+  CHECK_FALSE(imageHasPixelWithColor(image, 255, 0, 0, 255));
+}
+
+TEST_CASE("GeoJsonDocumentRasterOverlay FeatureCollection falls back to "
+          "collection style when geometry and feature have no style") {
+  const VectorStyle collectionStyle{
+      LineStyle{
+          ColorStyle{Color{255, 255, 0, 255}, ColorMode::Normal},
+          2.0,
+          LineWidthMode::Pixels},
+      PolygonStyle{std::nullopt, std::nullopt}};
+
+  GeoJsonDocumentRasterOverlayOptions options{
+      VectorStyle{
+          LineStyle{
+              ColorStyle{Color{255, 0, 0, 255}, ColorMode::Normal},
+              2.0,
+              LineWidthMode::Pixels},
+          PolygonStyle{std::nullopt, std::nullopt}},
+      Ellipsoid::WGS84,
+      0};
+
+  GeoJsonDocument doc = createFeatureCollectionWithLineString(
+      std::nullopt,
+      std::nullopt,
+      collectionStyle);
+
+  CesiumGltf::ImageAsset image = rasterizeOverlayTileFromDocument(
+      GlobeRectangle::fromDegrees(-1.0, -5.0, 6.0, 5.0),
+      glm::dvec2(256, 256),
+      std::move(doc),
+      options);
+
+  CHECK(imageHasPixelWithColor(image, 255, 255, 0, 255));
+  CHECK_FALSE(imageHasPixelWithColor(image, 255, 0, 0, 255));
+}
+
+TEST_CASE("GeoJsonDocumentRasterOverlay FeatureCollection falls back to "
+          "default style when no styles are set") {
+  GeoJsonDocumentRasterOverlayOptions options{
+      VectorStyle{
+          LineStyle{
+              ColorStyle{Color{255, 0, 0, 255}, ColorMode::Normal},
+              2.0,
+              LineWidthMode::Pixels},
+          PolygonStyle{std::nullopt, std::nullopt}},
+      Ellipsoid::WGS84,
+      0};
+
+  GeoJsonDocument doc = createFeatureCollectionWithLineString(
+      std::nullopt,
+      std::nullopt,
+      std::nullopt);
+
+  CesiumGltf::ImageAsset image = rasterizeOverlayTileFromDocument(
+      GlobeRectangle::fromDegrees(-1.0, -5.0, 6.0, 5.0),
+      glm::dvec2(256, 256),
+      std::move(doc),
+      options);
+
+  CHECK(imageHasPixelWithColor(image, 255, 0, 0, 255));
 }

--- a/CesiumRasterOverlays/test/TestGeoJsonDocumentRasterOverlay.cpp
+++ b/CesiumRasterOverlays/test/TestGeoJsonDocumentRasterOverlay.cpp
@@ -31,57 +31,6 @@ using namespace CesiumVectorData;
 const size_t BENCHMARK_ITERATIONS = 100000;
 
 namespace {
-CesiumGltf::ImageAsset rasterizeOverlayTile(
-    const GlobeRectangle& rectangle,
-    const glm::dvec2& imageSize,
-    const std::filesystem::path& testDataPath,
-    const GeoJsonDocumentRasterOverlayOptions& overlayOptions) {
-  AsyncSystem asyncSystem(
-      std::make_shared<CesiumNativeTests::SimpleTaskProcessor>());
-
-  Result<GeoJsonDocument> docResult =
-      GeoJsonDocument::fromGeoJson(readFile(testDataPath));
-  CHECK(!docResult.errors.hasErrors());
-  CHECK(docResult.errors.warnings.empty());
-  REQUIRE(docResult.value);
-
-  IntrusivePointer<GeoJsonDocumentRasterOverlay> pOverlay;
-  pOverlay.emplace(
-      asyncSystem,
-      "overlay0",
-      std::make_shared<GeoJsonDocument>(std::move(*docResult.value)),
-      overlayOptions);
-
-  std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor =
-      std::make_shared<CesiumNativeTests::SimpleAssetAccessor>(
-          std::map<
-              std::string,
-              std::shared_ptr<CesiumNativeTests::SimpleAssetRequest>>());
-
-  IntrusivePointer<ActivatedRasterOverlay> pActivated = pOverlay->activate(
-      RasterOverlayExternals{
-          .pAssetAccessor = pAssetAccessor,
-          .pPrepareRendererResources = nullptr,
-          .asyncSystem = asyncSystem,
-          .pCreditSystem = nullptr,
-          .pLogger = spdlog::default_logger()},
-      Ellipsoid::WGS84);
-
-  pActivated->getReadyEvent().waitInMainThread();
-
-  REQUIRE(pActivated->getTileProvider() != nullptr);
-  GeographicProjection projection(Ellipsoid::WGS84);
-  const CesiumGeometry::Rectangle& tileRect = projection.project(rectangle);
-
-  IntrusivePointer<RasterOverlayTile> pTile =
-      pActivated->getTile(tileRect, imageSize);
-  pActivated->loadTile(*pTile);
-  while (pTile->getState() != RasterOverlayTile::LoadState::Loaded) {
-    asyncSystem.dispatchMainThreadTasks();
-  }
-  return *pTile->getImage();
-}
-
 CesiumGltf::ImageAsset rasterizeOverlayTileFromDocument(
     const GlobeRectangle& rectangle,
     const glm::dvec2& imageSize,
@@ -127,6 +76,24 @@ CesiumGltf::ImageAsset rasterizeOverlayTileFromDocument(
   return *pTile->getImage();
 }
 
+CesiumGltf::ImageAsset rasterizeOverlayTile(
+    const GlobeRectangle& rectangle,
+    const glm::dvec2& imageSize,
+    const std::filesystem::path& testDataPath,
+    const GeoJsonDocumentRasterOverlayOptions& overlayOptions) {
+  Result<GeoJsonDocument> docResult =
+      GeoJsonDocument::fromGeoJson(readFile(testDataPath));
+  CHECK(!docResult.errors.hasErrors());
+  CHECK(docResult.errors.warnings.empty());
+  REQUIRE(docResult.value);
+
+  return rasterizeOverlayTileFromDocument(
+      rectangle,
+      imageSize,
+      std::move(*docResult.value),
+      overlayOptions);
+}
+
 bool imageHasPixelWithColor(
     const CesiumGltf::ImageAsset& image,
     uint8_t r,
@@ -135,11 +102,14 @@ bool imageHasPixelWithColor(
     uint8_t a) {
   REQUIRE(image.channels == 4);
   REQUIRE(image.bytesPerChannel == 1);
+  REQUIRE(
+      static_cast<size_t>(
+          image.width * image.height * image.channels *
+          image.bytesPerChannel) == image.pixelData.size());
   for (int32_t y = 0; y < image.height; y++) {
     for (int32_t x = 0; x < image.width; x++) {
       size_t idx = static_cast<size_t>((y * image.width + x) * 4);
-      if (idx + 3 < image.pixelData.size() &&
-          static_cast<uint8_t>(image.pixelData[idx]) == r &&
+      if (static_cast<uint8_t>(image.pixelData[idx]) == r &&
           static_cast<uint8_t>(image.pixelData[idx + 1]) == g &&
           static_cast<uint8_t>(image.pixelData[idx + 2]) == b &&
           static_cast<uint8_t>(image.pixelData[idx + 3]) == a) {


### PR DESCRIPTION
Fix GeoJSON FeatureCollection visitor not reading geometry styles
                                                     
The GeoJsonFeatureCollection visitor in GeoJsonDocumentRasterOverlay was checking the style on the Feature wrapper object instead of the geometry inside it. This caused programmatically-set styles via SetStyle() on geometry objects to be silently ignored when the root object is a FeatureCollection (the common case for GeoJSON documents).

Additionally, the style fallback chain incorrectly fell back to
pFeature->style a second time instead of collection.style, meaning collection-level styles were never consulted.

The GeoJsonFeature visitor already handled this correctly by checking feature.geometry->getStyle(). This change aligns the FeatureCollection visitor with that behavior.

Fixes CesiumGS/cesium-unity#672

## Author Checklist

- [x] I have submitted a Contributor License Agreement (only needed once).
- [x] I have done a full self-review of my code.
- [x] I have updated CHANGES.md with a short summary of my change (for user-facing changes).
- [x] I have added or updated unit tests to ensure consistent code coverage as necessary.
- [x] I have updated the documentation as necessary.