### PR TITLE
Support quantized attributes in AccessorUtility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 - Upgraded vcpkg to `2026.04.27`.
 - `PositionAccessorType` and `NormalAccessorType` are now variant types to support quantized attributes enabled by `KHR_mesh_quantization`.
-- The `AccessorView` constructor overload that takes raw buffer data now requires an additional `normalized` argument.
+- The `AccessorView` and `AccessorWriter` constructor overloads that take raw buffer data now require an additional `normalized` argument.
 - The `getQuaternionAccessorView` overload that takes an accessor pointer now takes an accessor reference.
 
 ##### Additions :tada:
@@ -16,7 +16,7 @@
 - Added `NormalFromAccessor` visitor for reading normals from a `NormalAccessorType`.
 - Added `QuaternionFromAccessor` visitor for reading quaternions from a `QuaternionAccessorType`.
 - Updated `TexCoordAccessorType` to support additional quantized variants enabled by `KHR_mesh_quantization`.
-- Added `AccessorView::normalized()` getter.
+- Added `AccessorView::normalized()` and `AccessorWRiter::normalized()` getters.
 
 ### v0.61.0 - 2026-06-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,10 +5,18 @@
 ##### Breaking Changes :mega:
 
 - Upgraded vcpkg to `2026.04.27`.
+- `PositionAccessorType` and `NormalAccessorType` are now variant types to support quantized attributes enabled by `KHR_mesh_quantization`.
+- The `AccessorView` constructor overload that takes raw buffer data now requires an additional `normalized` argument.
+- The `getQuaternionAccessorView` overload that takes an accessor pointer now takes an accessor reference.
 
 ##### Additions :tada:
 
 - Added a constructor overload for `Cesium3DTilesSelection::ITwinRealityDataContentLoaderFactory` to override the iTwin Cesium Reality Data base URL. This makes it possible to connect to alternate servers (e.g., staging, QA, mock servers).
+- Added `PositionFromAccessor` visitor for reading positions from a `PositionAccessorType`.
+- Added `NormalFromAccessor` visitor for reading normals from a `NormalAccessorType`.
+- Added `QuaternionFromAccessor` visitor for reading quaternions from a `QuaternionAccessorType`.
+- Updated `TexCoordAccessorType` to support additional quantized variants enabled by `KHR_mesh_quantization`.
+- Added `AccessorView::normalized()` getter.
 
 ### v0.61.0 - 2026-06-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
 - Upgraded vcpkg to `2026.04.27`.
 - `PositionAccessorType` and `NormalAccessorType` are now variant types to support quantized attributes enabled by `KHR_mesh_quantization`.
 - The `AccessorView` and `AccessorWriter` constructor overloads that take raw buffer data now require an additional `normalized` argument.
-- The `getQuaternionAccessorView` overload that takes an accessor pointer now takes an accessor reference.
+- The `getQuaternionAccessorView` overload that took an accessor pointer now takes an accessor reference.
 
 ##### Additions :tada:
 
@@ -16,7 +16,7 @@
 - Added `NormalFromAccessor` visitor for reading normals from a `NormalAccessorType`.
 - Added `QuaternionFromAccessor` visitor for reading quaternions from a `QuaternionAccessorType`.
 - Updated `TexCoordAccessorType` to support additional quantized variants enabled by `KHR_mesh_quantization`.
-- Added `AccessorView::normalized()` and `AccessorWRiter::normalized()` getters.
+- Added `AccessorView::normalized()` and `AccessorWriter::normalized()` getters.
 
 ### v0.61.0 - 2026-06-01
 

--- a/Cesium3DTilesContent/src/I3dmToGltfConverter.cpp
+++ b/Cesium3DTilesContent/src/I3dmToGltfConverter.cpp
@@ -689,30 +689,30 @@ std::vector<glm::dmat4> getMeshGpuInstancingTransforms(
     return instances;
   };
 
-  const Accessor* translations = getInstanceAccessor("TRANSLATION");
-  const Accessor* rotations = getInstanceAccessor("ROTATION");
-  const Accessor* scales = getInstanceAccessor("SCALE");
+  const Accessor* pTranslations = getInstanceAccessor("TRANSLATION");
+  const Accessor* pRotations = getInstanceAccessor("ROTATION");
+  const Accessor* pScales = getInstanceAccessor("SCALE");
   int64_t count = 0;
-  if (translations) {
-    count = translations->count;
+  if (pTranslations) {
+    count = pTranslations->count;
   }
-  if (rotations) {
+  if (pRotations) {
     if (count == 0) {
-      count = rotations->count;
-    } else if (count != rotations->count) {
+      count = pRotations->count;
+    } else if (count != pRotations->count) {
       return errorOut(fmt::format(
           "instance rotation count {} not consistent with {}",
-          rotations->count,
+          pRotations->count,
           count));
     }
   }
-  if (scales) {
+  if (pScales) {
     if (count == 0) {
-      count = scales->count;
-    } else if (count != scales->count) {
+      count = pScales->count;
+    } else if (count != pScales->count) {
       return errorOut(fmt::format(
           "instance scale count {} not consistent with {}",
-          scales->count,
+          pScales->count,
           count));
     }
   }
@@ -720,10 +720,10 @@ std::vector<glm::dmat4> getMeshGpuInstancingTransforms(
     return errorOut("No valid instance data");
   }
   instances.resize(static_cast<size_t>(count), glm::dmat4(1.0));
-  if (translations) {
+  if (pTranslations) {
     AccessorView<CesiumGltf::AccessorTypes::VEC3<float>> translationAccessor(
         model,
-        *translations);
+        *pTranslations);
     if (translationAccessor.status() == AccessorViewStatus::Valid) {
       for (unsigned i = 0; i < count; ++i) {
         auto transVec = toGlm<glm::dvec3>(translationAccessor[i]);
@@ -733,8 +733,8 @@ std::vector<glm::dmat4> getMeshGpuInstancingTransforms(
       return errorOut("invalid accessor for instance translations");
     }
   }
-  if (rotations) {
-    auto quatAccessorView = getQuaternionAccessorView(model, *rotations);
+  if (pRotations) {
+    auto quatAccessorView = getQuaternionAccessorView(model, *pRotations);
     std::visit(
         [&](auto&& arg) {
           for (unsigned i = 0; i < count; ++i) {
@@ -744,10 +744,10 @@ std::vector<glm::dmat4> getMeshGpuInstancingTransforms(
         },
         quatAccessorView);
   }
-  if (scales) {
+  if (pScales) {
     AccessorView<CesiumGltf::AccessorTypes::VEC3<float>> scaleAccessor(
         model,
-        *scales);
+        *pScales);
     if (scaleAccessor.status() == AccessorViewStatus::Valid) {
       for (unsigned i = 0; i < count; ++i) {
         auto scaleFactors = toGlm<glm::dvec3>(scaleAccessor[i]);

--- a/Cesium3DTilesContent/src/I3dmToGltfConverter.cpp
+++ b/Cesium3DTilesContent/src/I3dmToGltfConverter.cpp
@@ -734,7 +734,7 @@ std::vector<glm::dmat4> getMeshGpuInstancingTransforms(
     }
   }
   if (rotations) {
-    auto quatAccessorView = getQuaternionAccessorView(model, rotations);
+    auto quatAccessorView = getQuaternionAccessorView(model, *rotations);
     std::visit(
         [&](auto&& arg) {
           for (unsigned i = 0; i < count; ++i) {

--- a/CesiumGltf/include/CesiumGltf/AccessorUtility.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorUtility.h
@@ -82,15 +82,15 @@ getPositionAccessorView(const Model& model, const MeshPrimitive& primitive);
  * Visitor that retrieves the position from the given accessor type
  * as a `glm::dvec3`.
  *
- * There are technically no invalid position values, so `std::nullopt` is used to
- * denote an erroneous value.
+ * There are technically no invalid position values, so `std::nullopt` is used
+ * to denote an erroneous value.
  */
 struct PositionFromAccessor {
   /**
    * @brief Attempts to obtain a `glm::dvec3` at the given index from an
-   * accessor over a vec3. The values will be cast to `double` and, if applicable,
-   * normalized based on `std::numeric_limits<T>::max()`. If the index is invalid,
-   * `std::nullopt` is returned instead.
+   * accessor over a vec3. The values will be cast to `double` and, if
+   * applicable, normalized based on `std::numeric_limits<T>::max()`. If the
+   * index is invalid, `std::nullopt` is returned instead.
    */
   template <typename T>
   std::optional<glm::dvec3>
@@ -143,9 +143,9 @@ getNormalAccessorView(const Model& model, const MeshPrimitive& primitive);
 struct NormalFromAccessor {
   /**
    * @brief Attempts to obtain a `glm::dvec3` at the given index from an
-   * accessor over a vec3. The values will be cast to `double` and, if applicable,
-   * normalized based on `std::numeric_limits<T>::max()`. If the index is invalid,
-   * `std::nullopt` is returned instead.
+   * accessor over a vec3. The values will be cast to `double` and, if
+   * applicable, normalized based on `std::numeric_limits<T>::max()`. If the
+   * index is invalid, `std::nullopt` is returned instead.
    */
   template <typename T>
   std::optional<glm::dvec3>
@@ -465,11 +465,11 @@ TexCoordAccessorType getTexCoordAccessorView(
  * as a glm::dvec2. This should be initialized with the target index.
  *
  * There are technically no invalid UV values because of clamp / wrap
-* Visitor that retrieves the texture coordinates from the given accessor type
-* as a `glm::dvec2`. This should be initialized with the target index.
-*
-* There are technically no invalid UV values because of clamp / wrap
-* behavior, so `std::nullopt` is used to denote an erroneous value.
+ * Visitor that retrieves the texture coordinates from the given accessor type
+ * as a `glm::dvec2`. This should be initialized with the target index.
+ *
+ * There are technically no invalid UV values because of clamp / wrap
+ * behavior, so `std::nullopt` is used to denote an erroneous value.
  */
 struct TexCoordFromAccessor {
   /**
@@ -544,9 +544,9 @@ getQuaternionAccessorView(const Model& model, int32_t accessorIndex);
 struct QuaternionFromAccessor {
   /**
    * @brief Attempts to obtain a `glm::dquat` at the given index from an
-   * accessor over a vec4. The values will be cast to `double` and, if applicable,
-   * normalized based on `std::numeric_limits<T>::max()`. If the index is invalid,
-   * `std::nullopt` is returned instead.
+   * accessor over a vec4. The values will be cast to `double` and, if
+   * applicable, normalized based on `std::numeric_limits<T>::max()`. If the
+   * index is invalid, `std::nullopt` is returned instead.
    */
   template <typename T>
   std::optional<glm::dquat>

--- a/CesiumGltf/include/CesiumGltf/AccessorUtility.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorUtility.h
@@ -4,11 +4,26 @@
 #include <CesiumGltf/MeshPrimitive.h>
 
 #include <glm/common.hpp>
+#include <glm/ext/quaternion_double.hpp>
 
 #include <array>
+#include <type_traits>
 #include <variant>
 
 namespace CesiumGltf {
+
+namespace CesiumImpl {
+template <typename T> double denormalize(T value) {
+  if constexpr (std::is_floating_point_v<T>) {
+    return double(value);
+  } else if constexpr (std::is_signed_v<T>) {
+    return glm::max(double(value) / std::numeric_limits<T>::max(), -1.0);
+  } else {
+    return double(value) / std::numeric_limits<T>::max();
+  }
+}
+} // namespace CesiumImpl
+
 /**
  * @brief Visitor that retrieves the count of elements in the given accessor
  * type as an int64_t.
@@ -45,9 +60,15 @@ struct StatusFromAccessor {
 };
 
 /**
- * Type definition for position accessor.
+ * Type definition for all kinds of position (POSITION) accessors.
  */
-typedef AccessorView<AccessorTypes::VEC3<float>> PositionAccessorType;
+typedef std::variant<
+    AccessorView<AccessorTypes::VEC3<int8_t>>,
+    AccessorView<AccessorTypes::VEC3<uint8_t>>,
+    AccessorView<AccessorTypes::VEC3<int16_t>>,
+    AccessorView<AccessorTypes::VEC3<uint16_t>>,
+    AccessorView<AccessorTypes::VEC3<float>>>
+    PositionAccessorType;
 
 /**
  * Retrieves an accessor view for the position attribute from the given glTF
@@ -58,9 +79,51 @@ PositionAccessorType
 getPositionAccessorView(const Model& model, const MeshPrimitive& primitive);
 
 /**
- * Type definition for normal accessor.
+ * Visitor that retrieves the position from the given accessor type
+ * as a glm::dvec3.
+ *
+ * There are technically no invalid position values, so we use std::nullopt to
+ * denote an erroneous value.
  */
-typedef AccessorView<AccessorTypes::VEC3<float>> NormalAccessorType;
+struct PositionFromAccessor {
+  /**
+   * @brief Attempts to obtain a `glm::dvec3` at the given index from an
+   * accessor over a vec3. The values will be cast to `double` and normalized
+   * based on `std::numeric_limits<T>::max()`. If the index is invalid,
+   * `std::nullopt` is returned instead.
+   */
+  template <typename T>
+  std::optional<glm::dvec3>
+  operator()(const AccessorView<AccessorTypes::VEC3<T>>& value) {
+    if (index < 0 || index >= value.size()) {
+      return std::nullopt;
+    }
+
+    if (value.normalized()) {
+      return glm::dvec3(
+          CesiumImpl::denormalize(value[index].value[0]),
+          CesiumImpl::denormalize(value[index].value[1]),
+          CesiumImpl::denormalize(value[index].value[2]));
+    } else {
+      return glm::dvec3(
+          value[index].value[0],
+          value[index].value[1],
+          value[index].value[2]);
+    }
+  }
+
+  /** @brief The index of the position to obtain. */
+  int64_t index;
+};
+
+/**
+ * Type definition for all kinds of normal (NORMAL) accessors.
+ */
+typedef std::variant<
+    AccessorView<AccessorTypes::VEC3<int8_t>>,
+    AccessorView<AccessorTypes::VEC3<int16_t>>,
+    AccessorView<AccessorTypes::VEC3<float>>>
+    NormalAccessorType;
 
 /**
  * Retrieves an accessor view for the normal attribute from the given glTF
@@ -69,6 +132,44 @@ typedef AccessorView<AccessorTypes::VEC3<float>> NormalAccessorType;
  */
 NormalAccessorType
 getNormalAccessorView(const Model& model, const MeshPrimitive& primitive);
+
+/**
+ * Visitor that retrieves the normal from the given accessor type
+ * as a glm::dvec3.
+ *
+ * There are technically no invalid normal values, so we use std::nullopt to
+ * denote an erroneous value.
+ */
+struct NormalFromAccessor {
+  /**
+   * @brief Attempts to obtain a `glm::dvec3` at the given index from an
+   * accessor over a vec3. The values will be cast to `double` and normalized
+   * based on `std::numeric_limits<T>::max()`. If the index is invalid,
+   * `std::nullopt` is returned instead.
+   */
+  template <typename T>
+  std::optional<glm::dvec3>
+  operator()(const AccessorView<AccessorTypes::VEC3<T>>& value) {
+    if (index < 0 || index >= value.size()) {
+      return std::nullopt;
+    }
+
+    if (value.normalized()) {
+      return glm::dvec3(
+          CesiumImpl::denormalize(value[index].value[0]),
+          CesiumImpl::denormalize(value[index].value[1]),
+          CesiumImpl::denormalize(value[index].value[2]));
+    } else {
+      return glm::dvec3(
+          value[index].value[0],
+          value[index].value[1],
+          value[index].value[2]);
+    }
+  }
+
+  /** @brief The index of the normal to obtain. */
+  int64_t index;
+};
 
 /**
  * Type definition for all kinds of feature ID attribute accessors.
@@ -342,7 +443,9 @@ struct IndexFromAccessor {
  * Type definition for all kinds of texture coordinate (TEXCOORD_n) accessors.
  */
 typedef std::variant<
+    AccessorView<AccessorTypes::VEC2<int8_t>>,
     AccessorView<AccessorTypes::VEC2<uint8_t>>,
+    AccessorView<AccessorTypes::VEC2<int16_t>>,
     AccessorView<AccessorTypes::VEC2<uint16_t>>,
     AccessorView<AccessorTypes::VEC2<float>>>
     TexCoordAccessorType;
@@ -367,20 +470,6 @@ TexCoordAccessorType getTexCoordAccessorView(
 struct TexCoordFromAccessor {
   /**
    * @brief Attempts to obtain a `glm::dvec2` at the given index from an
-   * accessor over a vec2 of floats. If the index is invalid, `std::nullopt` is
-   * returned instead.
-   */
-  std::optional<glm::dvec2>
-  operator()(const AccessorView<AccessorTypes::VEC2<float>>& value) {
-    if (index < 0 || index >= value.size()) {
-      return std::nullopt;
-    }
-
-    return glm::dvec2(value[index].value[0], value[index].value[1]);
-  }
-
-  /**
-   * @brief Attempts to obtain a `glm::dvec2` at the given index from an
    * accessor over a vec2. The values will be cast to `double` and normalized
    * based on `std::numeric_limits<T>::max()`. If the index is invalid,
    * `std::nullopt` is returned instead.
@@ -392,14 +481,13 @@ struct TexCoordFromAccessor {
       return std::nullopt;
     }
 
-    double u = static_cast<double>(value[index].value[0]);
-    double v = static_cast<double>(value[index].value[1]);
-
-    // TODO: do normalization logic in accessor view?
-    u /= std::numeric_limits<T>::max();
-    v /= std::numeric_limits<T>::max();
-
-    return glm::dvec2(u, v);
+    if (value.normalized()) {
+      return glm::dvec2(
+          CesiumImpl::denormalize(value[index].value[0]),
+          CesiumImpl::denormalize(value[index].value[1]));
+    } else {
+      return glm::dvec2(value[index].value[0], value[index].value[1]);
+    }
   }
 
   /** @brief The index of texcoords to obtain. */
@@ -411,10 +499,10 @@ struct TexCoordFromAccessor {
  * ExtMeshGpuInstancing rotations and animation samplers.
  */
 typedef std::variant<
-    AccessorView<AccessorTypes::VEC4<uint8_t>>,
     AccessorView<AccessorTypes::VEC4<int8_t>>,
-    AccessorView<AccessorTypes::VEC4<uint16_t>>,
+    AccessorView<AccessorTypes::VEC4<uint8_t>>,
     AccessorView<AccessorTypes::VEC4<int16_t>>,
+    AccessorView<AccessorTypes::VEC4<uint16_t>>,
     AccessorView<AccessorTypes::VEC4<float>>>
     QuaternionAccessorType;
 
@@ -422,26 +510,65 @@ typedef std::variant<
  * @brief Obtains a \ref QuaternionAccessorType from the given \ref Accessor on
  * the given \ref Model.
  *
- * @param model The model containing the quaternion.
+ * @param model The model containing the quaternion accessor.
  * @param accessor An accessor from which the quaternion will be obtained.
- * @returns A quaternion from the data in `accessor`. If no quaternion could be
- * obtained, the default value for \ref QuaternionAccessorType will be returned
- * instead.
- */
-QuaternionAccessorType
-getQuaternionAccessorView(const Model& model, const Accessor* accessor);
-
-/**
- * @brief Obtains a \ref QuaternionAccessorType from the given \ref Accessor on
- * the given \ref Model.
- *
- * @param model The model containing the quaternion.
- * @param accessorIndex An index to the accessor from which the quaternion will
- * be obtained.
- * @returns A quaternion from the data in the accessor at `accessorIndex`. If no
+ * @returns A quaternion accessor view from the data in `accessor`. If no
  * quaternion could be obtained, the default value for \ref
  * QuaternionAccessorType will be returned instead.
  */
 QuaternionAccessorType
+getQuaternionAccessorView(const Model& model, const Accessor& accessor);
+
+/**
+ * @brief Obtains a \ref QuaternionAccessorType from the given accessor index on
+ * the given \ref Model.
+ *
+ * @param model The model containing the quaternion accessor.
+ * @param accessorIndex An index to the accessor from which the quaternion will
+ * be obtained.
+ * @returns A quaternion accessor view from the data in the accessor at
+ * `accessorIndex`. If no quaternion could be obtained, the default value for
+ * \ref QuaternionAccessorType will be returned instead.
+ */
+QuaternionAccessorType
 getQuaternionAccessorView(const Model& model, int32_t accessorIndex);
+
+/**
+ * Visitor that retrieves the quaternion from the given accessor type
+ * as a glm::dquat.
+ */
+struct QuaternionFromAccessor {
+  /**
+   * @brief Attempts to obtain a `glm::dquat` at the given index from an
+   * accessor over a vec4. The values will be cast to `double` and normalized
+   * based on `std::numeric_limits<T>::max()`. If the index is invalid,
+   * `std::nullopt` is returned instead.
+   */
+  template <typename T>
+  std::optional<glm::dquat>
+  operator()(const AccessorView<AccessorTypes::VEC4<T>>& value) {
+    if (index < 0 || index >= value.size()) {
+      return std::nullopt;
+    }
+
+    if (value.normalized()) {
+      // glm quat constructor is w,x,y,z
+      return glm::dquat(
+          CesiumImpl::denormalize(value[index].value[3]),
+          CesiumImpl::denormalize(value[index].value[0]),
+          CesiumImpl::denormalize(value[index].value[1]),
+          CesiumImpl::denormalize(value[index].value[2]));
+    } else {
+      // glm quat constructor is w,x,y,z
+      return glm::dquat(
+          value[index].value[3],
+          value[index].value[0],
+          value[index].value[1],
+          value[index].value[2]);
+    }
+  }
+
+  /** @brief The index of the quaternion to obtain. */
+  int64_t index;
+};
 } // namespace CesiumGltf

--- a/CesiumGltf/include/CesiumGltf/AccessorUtility.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorUtility.h
@@ -462,10 +462,6 @@ TexCoordAccessorType getTexCoordAccessorView(
 
 /**
  * Visitor that retrieves the texture coordinates from the given accessor type
- * as a glm::dvec2. This should be initialized with the target index.
- *
- * There are technically no invalid UV values because of clamp / wrap
- * Visitor that retrieves the texture coordinates from the given accessor type
  * as a `glm::dvec2`. This should be initialized with the target index.
  *
  * There are technically no invalid UV values because of clamp / wrap

--- a/CesiumGltf/include/CesiumGltf/AccessorUtility.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorUtility.h
@@ -80,16 +80,16 @@ getPositionAccessorView(const Model& model, const MeshPrimitive& primitive);
 
 /**
  * Visitor that retrieves the position from the given accessor type
- * as a glm::dvec3.
+ * as a `glm::dvec3`.
  *
- * There are technically no invalid position values, so we use std::nullopt to
+ * There are technically no invalid position values, so `std::nullopt` is used to
  * denote an erroneous value.
  */
 struct PositionFromAccessor {
   /**
    * @brief Attempts to obtain a `glm::dvec3` at the given index from an
-   * accessor over a vec3. The values will be cast to `double` and normalized
-   * based on `std::numeric_limits<T>::max()`. If the index is invalid,
+   * accessor over a vec3. The values will be cast to `double` and, if applicable,
+   * normalized based on `std::numeric_limits<T>::max()`. If the index is invalid,
    * `std::nullopt` is returned instead.
    */
   template <typename T>
@@ -135,16 +135,16 @@ getNormalAccessorView(const Model& model, const MeshPrimitive& primitive);
 
 /**
  * Visitor that retrieves the normal from the given accessor type
- * as a glm::dvec3.
+ * as a `glm::dvec3`.
  *
- * There are technically no invalid normal values, so we use std::nullopt to
+ * There are technically no invalid normal values, so `std::nullopt` is used to
  * denote an erroneous value.
  */
 struct NormalFromAccessor {
   /**
    * @brief Attempts to obtain a `glm::dvec3` at the given index from an
-   * accessor over a vec3. The values will be cast to `double` and normalized
-   * based on `std::numeric_limits<T>::max()`. If the index is invalid,
+   * accessor over a vec3. The values will be cast to `double` and, if applicable,
+   * normalized based on `std::numeric_limits<T>::max()`. If the index is invalid,
    * `std::nullopt` is returned instead.
    */
   template <typename T>
@@ -465,7 +465,11 @@ TexCoordAccessorType getTexCoordAccessorView(
  * as a glm::dvec2. This should be initialized with the target index.
  *
  * There are technically no invalid UV values because of clamp / wrap
- * behavior, so we use std::nullopt to denote an erroneous value.
+* Visitor that retrieves the texture coordinates from the given accessor type
+* as a `glm::dvec2`. This should be initialized with the target index.
+*
+* There are technically no invalid UV values because of clamp / wrap
+* behavior, so `std::nullopt` is used to denote an erroneous value.
  */
 struct TexCoordFromAccessor {
   /**
@@ -513,7 +517,7 @@ typedef std::variant<
  * @param model The model containing the quaternion accessor.
  * @param accessor An accessor from which the quaternion will be obtained.
  * @returns A quaternion accessor view from the data in `accessor`. If no
- * quaternion could be obtained, the default value for \ref
+ * such view could be obtained, the default value for \ref
  * QuaternionAccessorType will be returned instead.
  */
 QuaternionAccessorType
@@ -527,7 +531,7 @@ getQuaternionAccessorView(const Model& model, const Accessor& accessor);
  * @param accessorIndex An index to the accessor from which the quaternion will
  * be obtained.
  * @returns A quaternion accessor view from the data in the accessor at
- * `accessorIndex`. If no quaternion could be obtained, the default value for
+ * `accessorIndex`. If no such view could be obtained, the default value for
  * \ref QuaternionAccessorType will be returned instead.
  */
 QuaternionAccessorType
@@ -540,8 +544,8 @@ getQuaternionAccessorView(const Model& model, int32_t accessorIndex);
 struct QuaternionFromAccessor {
   /**
    * @brief Attempts to obtain a `glm::dquat` at the given index from an
-   * accessor over a vec4. The values will be cast to `double` and normalized
-   * based on `std::numeric_limits<T>::max()`. If the index is invalid,
+   * accessor over a vec4. The values will be cast to `double` and, if applicable,
+   * normalized based on `std::numeric_limits<T>::max()`. If the index is invalid,
    * `std::nullopt` is returned instead.
    */
   template <typename T>

--- a/CesiumGltf/include/CesiumGltf/AccessorView.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorView.h
@@ -90,6 +90,7 @@ private:
   int64_t _stride;
   int64_t _offset;
   int64_t _size;
+  bool _normalized;
   AccessorViewStatus _status;
 
 public:
@@ -109,7 +110,12 @@ public:
    */
   AccessorView(
       AccessorViewStatus status = AccessorViewStatus::InvalidAccessorIndex)
-      : _pData(nullptr), _stride(0), _offset(0), _size(0), _status(status) {}
+      : _pData(nullptr),
+        _stride(0),
+        _offset(0),
+        _size(0),
+        _normalized(false),
+        _status(status) {}
 
   /**
    * @brief Creates a new instance from low-level parameters.
@@ -121,16 +127,19 @@ public:
    * @param stride The stride, in bytes, between successive elements.
    * @param offset The offset from the start of the buffer to the first element.
    * @param size The total number of elements.
+   * @param normalized Whether the accessor values are normalized.
    */
   AccessorView(
       const std::byte* pData,
       int64_t stride,
       int64_t offset,
-      int64_t size)
+      int64_t size,
+      bool normalized)
       : _pData(pData),
         _stride(stride),
         _offset(offset),
         _size(size),
+        _normalized(normalized),
         _status(AccessorViewStatus::Valid) {}
 
   /**
@@ -223,6 +232,13 @@ public:
   int64_t offset() const noexcept { return this->_offset; }
 
   /**
+   * @brief Returns whether the accessor values are normalized.
+   *
+   * @returns Whether the accessor values are normalized.
+   */
+  bool normalized() const noexcept { return this->_normalized; }
+
+  /**
    * @brief Returns a pointer to the first byte of this accessor view's data.
    * The elements are stored contiguously, so the next one starts {@link stride} bytes later.
    *
@@ -288,6 +304,7 @@ private:
     this->_stride = accessorByteStride;
     this->_offset = accessor.byteOffset + pBufferView->byteOffset;
     this->_size = accessor.count;
+    this->_normalized = accessor.normalized;
     this->_status = AccessorViewStatus::Valid;
   }
 };

--- a/CesiumGltf/include/CesiumGltf/AccessorWriter.h
+++ b/CesiumGltf/include/CesiumGltf/AccessorWriter.h
@@ -26,9 +26,14 @@ public:
       : _accessor(accessorView) {}
 
   /** @copydoc AccessorView::AccessorView(const std::byte*, int64_t, int64_t,
-   * int64_t) */
-  AccessorWriter(std::byte* pData, int64_t stride, int64_t offset, int64_t size)
-      : _accessor(pData, stride, offset, size) {}
+   * int64_t, bool) */
+  AccessorWriter(
+      std::byte* pData,
+      int64_t stride,
+      int64_t offset,
+      int64_t size,
+      bool normalized)
+      : _accessor(pData, stride, offset, size, normalized) {}
 
   /** @copydoc AccessorView::AccessorView(const Model&,const Accessor&) */
   AccessorWriter(Model& model, const Accessor& accessor)
@@ -46,6 +51,9 @@ public:
 
   /** @copydoc AccessorView::size */
   int64_t size() const noexcept { return this->_accessor.size(); }
+
+  /** @copydoc AccessorView::normalized */
+  bool normalized() const noexcept { return this->_accessor->normalized(); }
 
   /**
    * @brief Gets the status of this accessor writer.

--- a/CesiumGltf/src/AccessorUtility.cpp
+++ b/CesiumGltf/src/AccessorUtility.cpp
@@ -19,12 +19,24 @@ getPositionAccessorView(const Model& model, const MeshPrimitive& primitive) {
 
   const Accessor* pAccessor =
       model.getSafe<Accessor>(&model.accessors, positionAttribute->second);
-  if (!pAccessor || pAccessor->type != Accessor::Type::VEC3 ||
-      pAccessor->componentType != Accessor::ComponentType::FLOAT) {
+  if (!pAccessor || pAccessor->type != Accessor::Type::VEC3) {
     return PositionAccessorType();
   }
 
-  return PositionAccessorType(model, *pAccessor);
+  switch (pAccessor->componentType) {
+  case Accessor::ComponentType::BYTE:
+    return AccessorView<AccessorTypes::VEC3<int8_t>>(model, *pAccessor);
+  case Accessor::ComponentType::UNSIGNED_BYTE:
+    return AccessorView<AccessorTypes::VEC3<uint8_t>>(model, *pAccessor);
+  case Accessor::ComponentType::SHORT:
+    return AccessorView<AccessorTypes::VEC3<int16_t>>(model, *pAccessor);
+  case Accessor::ComponentType::UNSIGNED_SHORT:
+    return AccessorView<AccessorTypes::VEC3<uint16_t>>(model, *pAccessor);
+  case Accessor::ComponentType::FLOAT:
+    return AccessorView<AccessorTypes::VEC3<float>>(model, *pAccessor);
+  default:
+    return PositionAccessorType();
+  }
 }
 
 NormalAccessorType
@@ -36,12 +48,30 @@ getNormalAccessorView(const Model& model, const MeshPrimitive& primitive) {
 
   const Accessor* pAccessor =
       model.getSafe<Accessor>(&model.accessors, normalAttribute->second);
-  if (!pAccessor || pAccessor->type != Accessor::Type::VEC3 ||
-      pAccessor->componentType != Accessor::ComponentType::FLOAT) {
+  if (!pAccessor || pAccessor->type != Accessor::Type::VEC3) {
     return NormalAccessorType();
   }
 
-  return NormalAccessorType(model, *pAccessor);
+  switch (pAccessor->componentType) {
+  case Accessor::ComponentType::BYTE:
+    if (pAccessor->normalized) {
+      return AccessorView<AccessorTypes::VEC3<int8_t>>(model, *pAccessor);
+    } else {
+      // Invalid accessor, BYTE must be normalized
+      return NormalAccessorType();
+    }
+  case Accessor::ComponentType::SHORT:
+    if (pAccessor->normalized) {
+      return AccessorView<AccessorTypes::VEC3<int16_t>>(model, *pAccessor);
+    } else {
+      // Invalid accessor, SHORT must be normalized
+      return NormalAccessorType();
+    }
+  case Accessor::ComponentType::FLOAT:
+    return AccessorView<AccessorTypes::VEC3<float>>(model, *pAccessor);
+  default:
+    return NormalAccessorType();
+  }
 }
 
 namespace {
@@ -161,18 +191,14 @@ TexCoordAccessorType getTexCoordAccessorView(
   }
 
   switch (pAccessor->componentType) {
+  case Accessor::ComponentType::BYTE:
+    return AccessorView<AccessorTypes::VEC2<int8_t>>(model, *pAccessor);
   case Accessor::ComponentType::UNSIGNED_BYTE:
-    if (pAccessor->normalized) {
-      // Unsigned byte texcoords must be normalized.
-      return AccessorView<AccessorTypes::VEC2<uint8_t>>(model, *pAccessor);
-    }
-    [[fallthrough]];
+    return AccessorView<AccessorTypes::VEC2<uint8_t>>(model, *pAccessor);
+  case Accessor::ComponentType::SHORT:
+    return AccessorView<AccessorTypes::VEC2<int16_t>>(model, *pAccessor);
   case Accessor::ComponentType::UNSIGNED_SHORT:
-    if (pAccessor->normalized) {
-      // Unsigned short texcoords must be normalized.
-      return AccessorView<AccessorTypes::VEC2<uint16_t>>(model, *pAccessor);
-    }
-    [[fallthrough]];
+    return AccessorView<AccessorTypes::VEC2<uint16_t>>(model, *pAccessor);
   case Accessor::ComponentType::FLOAT:
     return AccessorView<AccessorTypes::VEC2<float>>(model, *pAccessor);
   default:
@@ -181,25 +207,43 @@ TexCoordAccessorType getTexCoordAccessorView(
 }
 
 QuaternionAccessorType
-getQuaternionAccessorView(const Model& model, const Accessor* pAccessor) {
-  if (!pAccessor) {
+getQuaternionAccessorView(const Model& model, const Accessor& accessor) {
+  if (accessor.type != Accessor::Type::VEC4) {
     return QuaternionAccessorType();
   }
-  switch (pAccessor->componentType) {
+
+  switch (accessor.componentType) {
   case Accessor::ComponentType::BYTE:
-    return AccessorView<AccessorTypes::VEC4<int8_t>>(model, *pAccessor);
-    [[fallthrough]];
+    if (accessor.normalized) {
+      return AccessorView<AccessorTypes::VEC4<int8_t>>(model, accessor);
+    } else {
+      // Invalid accessor, BYTE must be normalized
+      return QuaternionAccessorType();
+    }
   case Accessor::ComponentType::UNSIGNED_BYTE:
-    return AccessorView<AccessorTypes::VEC4<uint8_t>>(model, *pAccessor);
-    [[fallthrough]];
+    if (accessor.normalized) {
+      return AccessorView<AccessorTypes::VEC4<uint8_t>>(model, accessor);
+    } else {
+      // Invalid accessor, UNSIGNED_BYTE must be normalized
+      return QuaternionAccessorType();
+    }
   case Accessor::ComponentType::SHORT:
-    return AccessorView<AccessorTypes::VEC4<int16_t>>(model, *pAccessor);
-    [[fallthrough]];
+    if (accessor.normalized) {
+      return AccessorView<AccessorTypes::VEC4<int16_t>>(model, accessor);
+    } else {
+      // Invalid accessor, SHORT must be normalized
+      return QuaternionAccessorType();
+    }
   case Accessor::ComponentType::UNSIGNED_SHORT:
-    return AccessorView<AccessorTypes::VEC4<uint16_t>>(model, *pAccessor);
-    [[fallthrough]];
+    if (accessor.normalized) {
+      return AccessorView<AccessorTypes::VEC4<uint16_t>>(model, accessor);
+    } else {
+      // Invalid accessor, UNSIGNED_SHORT must be normalized
+      return QuaternionAccessorType();
+    }
+
   case Accessor::ComponentType::FLOAT:
-    return AccessorView<AccessorTypes::VEC4<float>>(model, *pAccessor);
+    return AccessorView<AccessorTypes::VEC4<float>>(model, accessor);
   default:
     return QuaternionAccessorType();
   }
@@ -209,9 +253,9 @@ QuaternionAccessorType
 getQuaternionAccessorView(const Model& model, int32_t accessorIndex) {
   const Accessor* pAccessor =
       model.getSafe<Accessor>(&model.accessors, accessorIndex);
-  if (!pAccessor || pAccessor->type != Accessor::Type::VEC4) {
+  if (!pAccessor) {
     return QuaternionAccessorType();
   }
-  return getQuaternionAccessorView(model, pAccessor);
+  return getQuaternionAccessorView(model, *pAccessor);
 }
 } // namespace CesiumGltf

--- a/CesiumGltf/test/TestAccessorUtility.cpp
+++ b/CesiumGltf/test/TestAccessorUtility.cpp
@@ -10,9 +10,12 @@
 #include <CesiumGltf/Node.h>
 
 #include <doctest/doctest.h>
+#include <glm/ext/quaternion_double.hpp>
+#include <glm/ext/quaternion_float.hpp>
 #include <glm/ext/vector_float2.hpp>
 #include <glm/ext/vector_float3.hpp>
 #include <glm/ext/vector_uint2_sized.hpp>
+#include <glm/fwd.hpp>
 
 #include <cstdint>
 #include <cstring>
@@ -100,7 +103,7 @@ TEST_CASE("Test getPositionAccessorView") {
   }
 
   Mesh& mesh = model.meshes.emplace_back();
-  MeshPrimitive primitive = mesh.primitives.emplace_back();
+  MeshPrimitive& primitive = mesh.primitives.emplace_back();
   primitive.attributes.insert({"POSITION", 0});
 
   SUBCASE("Handles invalid accessor type") {
@@ -108,19 +111,23 @@ TEST_CASE("Test getPositionAccessorView") {
 
     PositionAccessorType positionAccessor =
         getPositionAccessorView(model, primitive);
-    REQUIRE(positionAccessor.status() != AccessorViewStatus::Valid);
-    REQUIRE(positionAccessor.size() == 0);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, positionAccessor) !=
+        AccessorViewStatus::Valid);
+    REQUIRE(std::visit(CountFromAccessor{}, positionAccessor) == 0);
 
     model.accessors[0].type = Accessor::Type::VEC3;
   }
 
   SUBCASE("Handles unsupported accessor component type") {
-    model.accessors[0].componentType = Accessor::ComponentType::BYTE;
+    model.accessors[0].componentType = Accessor::ComponentType::DOUBLE;
 
     PositionAccessorType positionAccessor =
         getPositionAccessorView(model, primitive);
-    REQUIRE(positionAccessor.status() != AccessorViewStatus::Valid);
-    REQUIRE(positionAccessor.size() == 0);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, positionAccessor) !=
+        AccessorViewStatus::Valid);
+    REQUIRE(std::visit(CountFromAccessor{}, positionAccessor) == 0);
 
     model.accessors[0].componentType = Accessor::ComponentType::FLOAT;
   }
@@ -128,8 +135,159 @@ TEST_CASE("Test getPositionAccessorView") {
   SUBCASE("Creates from valid accessor") {
     PositionAccessorType positionAccessor =
         getPositionAccessorView(model, primitive);
-    REQUIRE(positionAccessor.status() == AccessorViewStatus::Valid);
-    REQUIRE(static_cast<size_t>(positionAccessor.size()) == positions.size());
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, positionAccessor) ==
+        AccessorViewStatus::Valid);
+    REQUIRE(
+        static_cast<size_t>(
+            std::visit(CountFromAccessor{}, positionAccessor)) ==
+        positions.size());
+  }
+}
+
+TEST_CASE("Test PositionFromAccessor") {
+  Model model;
+  std::vector<glm::vec3> positions0{glm::vec3(0, 1, 2)};
+
+  // Float POSITION
+  {
+    Buffer& buffer = model.buffers.emplace_back();
+    buffer.cesium.data.resize(positions0.size() * sizeof(glm::vec3));
+    std::memcpy(
+        buffer.cesium.data.data(),
+        positions0.data(),
+        buffer.cesium.data.size());
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
+
+    BufferView& bufferView = model.bufferViews.emplace_back();
+    bufferView.buffer = 0;
+    bufferView.byteLength = buffer.byteLength;
+
+    Accessor& accessor = model.accessors.emplace_back();
+    accessor.bufferView = 0;
+    accessor.componentType = Accessor::ComponentType::FLOAT;
+    accessor.type = Accessor::Type::VEC3;
+    accessor.count = static_cast<int64_t>(positions0.size());
+
+    Mesh& mesh = model.meshes.emplace_back();
+    MeshPrimitive& primitive = mesh.primitives.emplace_back();
+    primitive.attributes.insert({"POSITION", 0});
+  }
+
+  std::vector<glm::u8vec3> positions1{glm::u8vec3(0, 127, 255)};
+
+  // Unsigned normalized POSITION
+  {
+    Buffer& buffer = model.buffers.emplace_back();
+    buffer.cesium.data.resize(positions1.size() * sizeof(glm::u8vec3));
+    std::memcpy(
+        buffer.cesium.data.data(),
+        positions1.data(),
+        buffer.cesium.data.size());
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
+
+    BufferView& bufferView = model.bufferViews.emplace_back();
+    bufferView.buffer = 1;
+    bufferView.byteLength = buffer.byteLength;
+
+    Accessor& accessor = model.accessors.emplace_back();
+    accessor.bufferView = 1;
+    accessor.componentType = Accessor::ComponentType::UNSIGNED_BYTE;
+    accessor.type = Accessor::Type::VEC3;
+    accessor.count = static_cast<int64_t>(positions1.size());
+    accessor.normalized = true;
+
+    Mesh& mesh = model.meshes.emplace_back();
+    MeshPrimitive& primitive = mesh.primitives.emplace_back();
+    primitive.attributes.insert({"POSITION", 1});
+  }
+
+  std::vector<glm::i8vec3> positions2{
+      glm::i8vec3(-128, 0, 127),
+      glm::i8vec3(-127, 0, 127),
+  };
+
+  // Signed normalized POSITION
+  {
+    Buffer& buffer = model.buffers.emplace_back();
+    buffer.cesium.data.resize(positions2.size() * sizeof(glm::i8vec3));
+    std::memcpy(
+        buffer.cesium.data.data(),
+        positions2.data(),
+        buffer.cesium.data.size());
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
+
+    BufferView& bufferView = model.bufferViews.emplace_back();
+    bufferView.buffer = 2;
+    bufferView.byteLength = buffer.byteLength;
+
+    Accessor& accessor = model.accessors.emplace_back();
+    accessor.bufferView = 2;
+    accessor.componentType = Accessor::ComponentType::BYTE;
+    accessor.type = Accessor::Type::VEC3;
+    accessor.count = static_cast<int64_t>(positions2.size());
+    accessor.normalized = true;
+
+    Mesh& mesh = model.meshes.emplace_back();
+    MeshPrimitive& primitive = mesh.primitives.emplace_back();
+    primitive.attributes.insert({"POSITION", 2});
+  }
+
+  SUBCASE("Handles invalid accessor") {
+    PositionAccessorType positionAccessor;
+    REQUIRE(!std::visit(PositionFromAccessor{0}, positionAccessor));
+  }
+
+  SUBCASE("Handles invalid index") {
+    PositionAccessorType positionAccessor =
+        getPositionAccessorView(model, model.meshes[0].primitives[0]);
+    REQUIRE(!std::visit(PositionFromAccessor{-1}, positionAccessor));
+    REQUIRE(!std::visit(PositionFromAccessor{10}, positionAccessor));
+  }
+
+  SUBCASE("Retrieves from valid accessor and index") {
+    PositionAccessorType positionAccessor =
+        getPositionAccessorView(model, model.meshes[0].primitives[0]);
+
+    for (size_t i = 0; i < positions0.size(); i++) {
+      auto maybePosition = std::visit(
+          PositionFromAccessor{static_cast<int64_t>(i)},
+          positionAccessor);
+      REQUIRE(maybePosition);
+      auto expected =
+          glm::dvec3(positions0[i][0], positions0[i][1], positions0[i][2]);
+      REQUIRE(*maybePosition == expected);
+    }
+  }
+
+  SUBCASE("Retrieves from valid unsigned normalized accessor and index") {
+    PositionAccessorType positionAccessor =
+        getPositionAccessorView(model, model.meshes[1].primitives[0]);
+    for (size_t i = 0; i < positions1.size(); i++) {
+      auto maybePosition = std::visit(
+          PositionFromAccessor{static_cast<int64_t>(i)},
+          positionAccessor);
+      REQUIRE(maybePosition);
+      auto expected =
+          glm::dvec3(positions1[i][0], positions1[i][1], positions1[i][2]);
+      expected /= 255.0;
+      REQUIRE(*maybePosition == expected);
+    }
+  }
+
+  SUBCASE("Retrieves from valid signed normalized accessor and index") {
+    PositionAccessorType positionAccessor =
+        getPositionAccessorView(model, model.meshes[2].primitives[0]);
+    for (size_t i = 0; i < positions2.size(); i++) {
+      auto maybePosition = std::visit(
+          PositionFromAccessor{static_cast<int64_t>(i)},
+          positionAccessor);
+      REQUIRE(maybePosition);
+      auto expected =
+          glm::dvec3(positions2[i][0], positions2[i][1], positions2[i][2]);
+      expected = glm::max(expected / 127.0, -1.0);
+      REQUIRE(*maybePosition == expected);
+    }
   }
 }
 
@@ -161,33 +319,156 @@ TEST_CASE("Test getNormalAccessorView") {
   }
 
   Mesh& mesh = model.meshes.emplace_back();
-  MeshPrimitive primitive = mesh.primitives.emplace_back();
+  MeshPrimitive& primitive = mesh.primitives.emplace_back();
   primitive.attributes.insert({"NORMAL", 0});
 
   SUBCASE("Handles invalid accessor type") {
     model.accessors[0].type = Accessor::Type::SCALAR;
 
     NormalAccessorType normalAccessor = getNormalAccessorView(model, primitive);
-    REQUIRE(normalAccessor.status() != AccessorViewStatus::Valid);
-    REQUIRE(normalAccessor.size() == 0);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, normalAccessor) !=
+        AccessorViewStatus::Valid);
+    REQUIRE(std::visit(CountFromAccessor{}, normalAccessor) == 0);
 
     model.accessors[0].type = Accessor::Type::VEC3;
   }
 
   SUBCASE("Handles unsupported accessor component type") {
+    model.accessors[0].componentType = Accessor::ComponentType::UNSIGNED_BYTE;
+
+    NormalAccessorType normalAccessor = getNormalAccessorView(model, primitive);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, normalAccessor) !=
+        AccessorViewStatus::Valid);
+    REQUIRE(std::visit(CountFromAccessor{}, normalAccessor) == 0);
+
+    model.accessors[0].componentType = Accessor::ComponentType::FLOAT;
+  }
+
+  SUBCASE("Handles invalid un-normalized normal") {
     model.accessors[0].componentType = Accessor::ComponentType::BYTE;
 
     NormalAccessorType normalAccessor = getNormalAccessorView(model, primitive);
-    REQUIRE(normalAccessor.status() != AccessorViewStatus::Valid);
-    REQUIRE(normalAccessor.size() == 0);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, normalAccessor) !=
+        AccessorViewStatus::Valid);
+    REQUIRE(std::visit(CountFromAccessor{}, normalAccessor) == 0);
 
     model.accessors[0].componentType = Accessor::ComponentType::FLOAT;
   }
 
   SUBCASE("Creates from valid accessor") {
     NormalAccessorType normalAccessor = getNormalAccessorView(model, primitive);
-    REQUIRE(normalAccessor.status() == AccessorViewStatus::Valid);
-    REQUIRE(static_cast<size_t>(normalAccessor.size()) == normals.size());
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, normalAccessor) ==
+        AccessorViewStatus::Valid);
+    REQUIRE(std::visit(CountFromAccessor{}, normalAccessor) == normals.size());
+  }
+}
+
+TEST_CASE("Test NormalFromAccessor") {
+  Model model;
+  std::vector<glm::vec3> normals0{
+      glm::vec3(0, 1, 0),
+      glm::vec3(-1, 0, 0),
+      glm::vec3(0, 0, 1)};
+
+  // Float NORMAL
+  {
+    Buffer& buffer = model.buffers.emplace_back();
+    buffer.cesium.data.resize(normals0.size() * sizeof(glm::vec3));
+    std::memcpy(
+        buffer.cesium.data.data(),
+        normals0.data(),
+        buffer.cesium.data.size());
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
+
+    BufferView& bufferView = model.bufferViews.emplace_back();
+    bufferView.buffer = 0;
+    bufferView.byteLength = buffer.byteLength;
+
+    Accessor& accessor = model.accessors.emplace_back();
+    accessor.bufferView = 0;
+    accessor.componentType = Accessor::ComponentType::FLOAT;
+    accessor.type = Accessor::Type::VEC3;
+    accessor.count = static_cast<int64_t>(normals0.size());
+
+    Mesh& mesh = model.meshes.emplace_back();
+    MeshPrimitive& primitive = mesh.primitives.emplace_back();
+    primitive.attributes.insert({"NORMAL", 0});
+  }
+
+  std::vector<glm::i8vec3> normals1{
+      glm::i8vec3(0, 127, 0),
+      glm::i8vec3(-128, 0, 0),
+      glm::i8vec3(0, 0, 127)};
+
+  // Signed normalized NORMAL
+  {
+    Buffer& buffer = model.buffers.emplace_back();
+    buffer.cesium.data.resize(normals1.size() * sizeof(glm::i8vec3));
+    std::memcpy(
+        buffer.cesium.data.data(),
+        normals1.data(),
+        buffer.cesium.data.size());
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
+
+    BufferView& bufferView = model.bufferViews.emplace_back();
+    bufferView.buffer = 1;
+    bufferView.byteLength = buffer.byteLength;
+
+    Accessor& accessor = model.accessors.emplace_back();
+    accessor.bufferView = 1;
+    accessor.componentType = Accessor::ComponentType::BYTE;
+    accessor.type = Accessor::Type::VEC3;
+    accessor.count = static_cast<int64_t>(normals1.size());
+    accessor.normalized = true;
+
+    Mesh& mesh = model.meshes.emplace_back();
+    MeshPrimitive& primitive = mesh.primitives.emplace_back();
+    primitive.attributes.insert({"NORMAL", 1});
+  }
+
+  SUBCASE("Handles invalid accessor") {
+    NormalAccessorType normalAccessor;
+    REQUIRE(!std::visit(NormalFromAccessor{0}, normalAccessor));
+  }
+
+  SUBCASE("Handles invalid index") {
+    NormalAccessorType normalAccessor =
+        getNormalAccessorView(model, model.meshes[0].primitives[0]);
+    REQUIRE(!std::visit(NormalFromAccessor{-1}, normalAccessor));
+    REQUIRE(!std::visit(NormalFromAccessor{10}, normalAccessor));
+  }
+
+  SUBCASE("Retrieves from valid accessor and index") {
+    NormalAccessorType normalAccessor =
+        getNormalAccessorView(model, model.meshes[0].primitives[0]);
+    for (size_t i = 0; i < normals0.size(); i++) {
+      auto maybeNormal = std::visit(
+          NormalFromAccessor{static_cast<int64_t>(i)},
+          normalAccessor);
+      REQUIRE(maybeNormal);
+      auto expected =
+          glm::dvec3(normals0[i][0], normals0[i][1], normals0[i][2]);
+      REQUIRE(*maybeNormal == expected);
+    }
+  }
+
+  SUBCASE("Retrieves from valid signed normalized accessor and index") {
+    NormalAccessorType normalAccessor =
+        getNormalAccessorView(model, model.meshes[1].primitives[0]);
+    for (size_t i = 0; i < normals1.size(); i++) {
+      auto maybeNormal = std::visit(
+          NormalFromAccessor{static_cast<int64_t>(i)},
+          normalAccessor);
+      REQUIRE(maybeNormal);
+      auto expected =
+          glm::dvec3(normals1[i][0], normals1[i][1], normals1[i][2]);
+      expected = glm::max(expected / 127.0, -1.0);
+      REQUIRE(*maybeNormal == expected);
+    }
   }
 }
 
@@ -241,7 +522,7 @@ TEST_CASE("Test getFeatureIdAccessorView") {
   }
 
   Mesh& mesh = model.meshes.emplace_back();
-  MeshPrimitive primitive = mesh.primitives.emplace_back();
+  MeshPrimitive& primitive = mesh.primitives.emplace_back();
 
   primitive.attributes.insert({"_FEATURE_ID_0", 0});
   primitive.attributes.insert({"_FEATURE_ID_1", 1});
@@ -454,7 +735,7 @@ TEST_CASE("Test getIndexAccessorView") {
   }
 
   Mesh& mesh = model.meshes.emplace_back();
-  MeshPrimitive primitive = mesh.primitives.emplace_back();
+  MeshPrimitive& primitive = mesh.primitives.emplace_back();
   primitive.indices = 0;
 
   SUBCASE("Handles invalid accessor type") {
@@ -901,14 +1182,14 @@ TEST_CASE("Test getTexCoordAccessorView") {
   }
 
   Mesh& mesh = model.meshes.emplace_back();
-  MeshPrimitive primitive = mesh.primitives.emplace_back();
+  MeshPrimitive& primitive = mesh.primitives.emplace_back();
 
   primitive.attributes.insert({"TEXCOORD_0", 0});
   primitive.attributes.insert({"TEXCOORD_1", 1});
 
   SUBCASE("Handles invalid texture coordinate set index") {
     TexCoordAccessorType texCoordAccessor =
-        getTexCoordAccessorView(model, primitive, 2);
+        getTexCoordAccessorView(model, primitive, 3);
     REQUIRE(
         std::visit(StatusFromAccessor{}, texCoordAccessor) !=
         AccessorViewStatus::Valid);
@@ -929,7 +1210,7 @@ TEST_CASE("Test getTexCoordAccessorView") {
   }
 
   SUBCASE("Handles unsupported accessor component type") {
-    model.accessors[0].componentType = Accessor::ComponentType::BYTE;
+    model.accessors[0].componentType = Accessor::ComponentType::DOUBLE;
 
     TexCoordAccessorType texCoordAccessor =
         getTexCoordAccessorView(model, primitive, 0);
@@ -939,19 +1220,6 @@ TEST_CASE("Test getTexCoordAccessorView") {
     REQUIRE(std::visit(CountFromAccessor{}, texCoordAccessor) == 0);
 
     model.accessors[0].componentType = Accessor::ComponentType::FLOAT;
-  }
-
-  SUBCASE("Handles invalid un-normalized texcoord") {
-    model.accessors[1].normalized = false;
-
-    TexCoordAccessorType texCoordAccessor =
-        getTexCoordAccessorView(model, primitive, 2);
-    REQUIRE(
-        std::visit(StatusFromAccessor{}, texCoordAccessor) !=
-        AccessorViewStatus::Valid);
-    REQUIRE(std::visit(CountFromAccessor{}, texCoordAccessor) == 0);
-
-    model.accessors[1].normalized = true;
   }
 
   SUBCASE("Creates from valid texture coordinate sets") {
@@ -1000,8 +1268,7 @@ TEST_CASE("Test TexCoordFromAccessor") {
     accessor.bufferView = 0;
     accessor.componentType = Accessor::ComponentType::FLOAT;
     accessor.type = Accessor::Type::VEC2;
-    accessor.count =
-        bufferView.byteLength / static_cast<int64_t>(sizeof(glm::vec2));
+    accessor.count = int64_t(texCoords0.size());
   }
 
   std::vector<glm::u8vec2> texCoords1{
@@ -1029,19 +1296,47 @@ TEST_CASE("Test TexCoordFromAccessor") {
     accessor.componentType = Accessor::ComponentType::UNSIGNED_BYTE;
     accessor.type = Accessor::Type::VEC2;
     accessor.normalized = true;
-    accessor.count =
-        bufferView.byteLength / static_cast<int64_t>(sizeof(glm::u8vec2));
+    accessor.count = int64_t(texCoords1.size());
+  }
+
+  std::vector<glm::i8vec2> texCoords2{
+      glm::i8vec2(0, 0),
+      glm::i8vec2(0, -128),
+      glm::i8vec2(-127, 127),
+      glm::i8vec2(127, 0)};
+
+  // Third TEXCOORD set
+  {
+    Buffer& buffer = model.buffers.emplace_back();
+    buffer.cesium.data.resize(texCoords2.size() * sizeof(glm::i8vec2));
+    std::memcpy(
+        buffer.cesium.data.data(),
+        texCoords2.data(),
+        buffer.cesium.data.size());
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
+
+    BufferView& bufferView = model.bufferViews.emplace_back();
+    bufferView.buffer = 2;
+    bufferView.byteLength = buffer.byteLength;
+
+    Accessor& accessor = model.accessors.emplace_back();
+    accessor.bufferView = 2;
+    accessor.componentType = Accessor::ComponentType::BYTE;
+    accessor.type = Accessor::Type::VEC2;
+    accessor.normalized = true;
+    accessor.count = int64_t(texCoords2.size());
   }
 
   Mesh& mesh = model.meshes.emplace_back();
-  MeshPrimitive primitive = mesh.primitives.emplace_back();
+  MeshPrimitive& primitive = mesh.primitives.emplace_back();
 
   primitive.attributes.insert({"TEXCOORD_0", 0});
   primitive.attributes.insert({"TEXCOORD_1", 1});
+  primitive.attributes.insert({"TEXCOORD_2", 2});
 
   SUBCASE("Handles invalid accessor") {
     TexCoordAccessorType texCoordAccessor =
-        getTexCoordAccessorView(model, primitive, 2);
+        getTexCoordAccessorView(model, primitive, 3);
     REQUIRE(!std::visit(TexCoordFromAccessor{0}, texCoordAccessor));
   }
 
@@ -1065,7 +1360,8 @@ TEST_CASE("Test TexCoordFromAccessor") {
       REQUIRE(*maybeTexCoord == expected);
     }
   }
-  SUBCASE("Retrieves from valid normalized accessor and index") {
+
+  SUBCASE("Retrieves from valid unsigned normalized accessor and index") {
     TexCoordAccessorType texCoordAccessor =
         getTexCoordAccessorView(model, primitive, 1);
     for (size_t i = 0; i < texCoords1.size(); i++) {
@@ -1074,9 +1370,273 @@ TEST_CASE("Test TexCoordFromAccessor") {
           texCoordAccessor);
       REQUIRE(maybeTexCoord);
       auto expected = glm::dvec2(texCoords1[i][0], texCoords1[i][1]);
-      expected /= 255;
+      expected /= 255.0;
 
       REQUIRE(*maybeTexCoord == expected);
+    }
+  }
+
+  SUBCASE("Retrieves from valid signed normalized accessor and index") {
+    TexCoordAccessorType texCoordAccessor =
+        getTexCoordAccessorView(model, primitive, 2);
+    for (size_t i = 0; i < texCoords2.size(); i++) {
+      auto maybeTexCoord = std::visit(
+          TexCoordFromAccessor{static_cast<int64_t>(i)},
+          texCoordAccessor);
+      REQUIRE(maybeTexCoord);
+      auto expected = glm::dvec2(texCoords2[i][0], texCoords2[i][1]);
+      expected = glm::max(expected / 127.0, -1.0);
+
+      REQUIRE(*maybeTexCoord == expected);
+    }
+  }
+}
+
+TEST_CASE("Test getQuaternionAccessorView") {
+  Model model;
+  std::vector<glm::quat> quaternions{
+      glm::quat(0, 1, 0, 0),
+      glm::quat(1, 0, 0, 0),
+      glm::quat(0, 0, 1, 1)};
+
+  {
+    Buffer& buffer = model.buffers.emplace_back();
+    buffer.cesium.data.resize(quaternions.size() * sizeof(glm::quat));
+    std::memcpy(
+        buffer.cesium.data.data(),
+        quaternions.data(),
+        buffer.cesium.data.size());
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
+
+    BufferView& bufferView = model.bufferViews.emplace_back();
+    bufferView.buffer = 0;
+    bufferView.byteLength = buffer.byteLength;
+
+    Accessor& accessor = model.accessors.emplace_back();
+    accessor.bufferView = 0;
+    accessor.componentType = Accessor::ComponentType::FLOAT;
+    accessor.type = Accessor::Type::VEC4;
+    accessor.count = static_cast<int64_t>(quaternions.size());
+  }
+
+  SUBCASE("Handles invalid accessor type") {
+    model.accessors[0].type = Accessor::Type::SCALAR;
+
+    QuaternionAccessorType quaternionAccessor =
+        getQuaternionAccessorView(model, model.accessors[0]);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, quaternionAccessor) !=
+        AccessorViewStatus::Valid);
+    REQUIRE(std::visit(CountFromAccessor{}, quaternionAccessor) == 0);
+
+    model.accessors[0].type = Accessor::Type::VEC4;
+  }
+
+  SUBCASE("Handles unsupported accessor component type") {
+    model.accessors[0].componentType = Accessor::ComponentType::DOUBLE;
+
+    QuaternionAccessorType quaternionAccessor =
+        getQuaternionAccessorView(model, model.accessors[0]);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, quaternionAccessor) !=
+        AccessorViewStatus::Valid);
+    REQUIRE(std::visit(CountFromAccessor{}, quaternionAccessor) == 0);
+
+    model.accessors[0].componentType = Accessor::ComponentType::FLOAT;
+  }
+
+  SUBCASE("Handles invalid un-normalized quaternion") {
+    model.accessors[0].componentType = Accessor::ComponentType::BYTE;
+
+    QuaternionAccessorType quaternionAccessor =
+        getQuaternionAccessorView(model, model.accessors[0]);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, quaternionAccessor) !=
+        AccessorViewStatus::Valid);
+    REQUIRE(std::visit(CountFromAccessor{}, quaternionAccessor) == 0);
+
+    model.accessors[0].componentType = Accessor::ComponentType::FLOAT;
+  }
+
+  SUBCASE("Creates from valid accessor") {
+    QuaternionAccessorType quaternionAccessor =
+        getQuaternionAccessorView(model, model.accessors[0]);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, quaternionAccessor) ==
+        AccessorViewStatus::Valid);
+    REQUIRE(
+        std::visit(CountFromAccessor{}, quaternionAccessor) ==
+        quaternions.size());
+  }
+
+  SUBCASE("Handles invalid accessor index") {
+    QuaternionAccessorType quaternionAccessor =
+        getQuaternionAccessorView(model, 1);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, quaternionAccessor) !=
+        AccessorViewStatus::Valid);
+    REQUIRE(std::visit(CountFromAccessor{}, quaternionAccessor) == 0);
+  }
+
+  SUBCASE("Creates from valid accessor index") {
+    QuaternionAccessorType quaternionAccessor =
+        getQuaternionAccessorView(model, 0);
+    REQUIRE(
+        std::visit(StatusFromAccessor{}, quaternionAccessor) ==
+        AccessorViewStatus::Valid);
+    REQUIRE(
+        std::visit(CountFromAccessor{}, quaternionAccessor) ==
+        quaternions.size());
+  }
+}
+
+TEST_CASE("Test PositionFromAccessor") {
+  Model model;
+  std::vector<glm::quat> quaternions0{
+      glm::quat(0, 1, 0, 0),
+      glm::quat(1, 0, 0, 0),
+      glm::quat(0, 0, 1, 1)};
+
+  // Float quaternions
+  {
+    Buffer& buffer = model.buffers.emplace_back();
+    buffer.cesium.data.resize(quaternions0.size() * sizeof(glm::quat));
+    std::memcpy(
+        buffer.cesium.data.data(),
+        quaternions0.data(),
+        buffer.cesium.data.size());
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
+
+    BufferView& bufferView = model.bufferViews.emplace_back();
+    bufferView.buffer = 0;
+    bufferView.byteLength = buffer.byteLength;
+
+    Accessor& accessor = model.accessors.emplace_back();
+    accessor.bufferView = 0;
+    accessor.componentType = Accessor::ComponentType::FLOAT;
+    accessor.type = Accessor::Type::VEC4;
+    accessor.count = static_cast<int64_t>(quaternions0.size());
+  }
+
+  std::vector<glm::u8vec4> quaternions1{glm::u8vec4(0, 127, 255, 255)};
+
+  // Unsigned normalized quaternions
+  {
+    Buffer& buffer = model.buffers.emplace_back();
+    buffer.cesium.data.resize(quaternions1.size() * sizeof(glm::u8vec4));
+    std::memcpy(
+        buffer.cesium.data.data(),
+        quaternions1.data(),
+        buffer.cesium.data.size());
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
+
+    BufferView& bufferView = model.bufferViews.emplace_back();
+    bufferView.buffer = 1;
+    bufferView.byteLength = buffer.byteLength;
+
+    Accessor& accessor = model.accessors.emplace_back();
+    accessor.bufferView = 1;
+    accessor.componentType = Accessor::ComponentType::UNSIGNED_BYTE;
+    accessor.type = Accessor::Type::VEC4;
+    accessor.count = static_cast<int64_t>(quaternions1.size());
+    accessor.normalized = true;
+  }
+
+  std::vector<glm::i8vec4> quaternions2{
+      glm::i8vec4(-128, 0, 127, -127),
+  };
+
+  // Signed normalized quaternions
+  {
+    Buffer& buffer = model.buffers.emplace_back();
+    buffer.cesium.data.resize(quaternions2.size() * sizeof(glm::i8vec4));
+    std::memcpy(
+        buffer.cesium.data.data(),
+        quaternions2.data(),
+        buffer.cesium.data.size());
+    buffer.byteLength = static_cast<int64_t>(buffer.cesium.data.size());
+
+    BufferView& bufferView = model.bufferViews.emplace_back();
+    bufferView.buffer = 2;
+    bufferView.byteLength = buffer.byteLength;
+
+    Accessor& accessor = model.accessors.emplace_back();
+    accessor.bufferView = 2;
+    accessor.componentType = Accessor::ComponentType::BYTE;
+    accessor.type = Accessor::Type::VEC4;
+    accessor.count = static_cast<int64_t>(quaternions2.size());
+    accessor.normalized = true;
+  }
+
+  SUBCASE("Handles invalid accessor") {
+    QuaternionAccessorType quaternionAccessor;
+    REQUIRE(!std::visit(QuaternionFromAccessor{0}, quaternionAccessor));
+  }
+
+  SUBCASE("Handles invalid index") {
+    QuaternionAccessorType quaternionAccessor =
+        getQuaternionAccessorView(model, model.accessors[0]);
+    REQUIRE(!std::visit(QuaternionFromAccessor{-1}, quaternionAccessor));
+    REQUIRE(!std::visit(QuaternionFromAccessor{10}, quaternionAccessor));
+  }
+
+  SUBCASE("Retrieves from valid accessor and index") {
+    QuaternionAccessorType quaternionAccessor =
+        getQuaternionAccessorView(model, model.accessors[0]);
+
+    for (size_t i = 0; i < quaternions0.size(); i++) {
+      auto maybeQuaternion = std::visit(
+          QuaternionFromAccessor{static_cast<int64_t>(i)},
+          quaternionAccessor);
+      REQUIRE(maybeQuaternion);
+      // glm quat constructor is w,x,y,z
+      auto expected = glm::dquat(
+          quaternions0[i][3],
+          quaternions0[i][0],
+          quaternions0[i][1],
+          quaternions0[i][2]);
+      REQUIRE(*maybeQuaternion == expected);
+    }
+  }
+
+  SUBCASE("Retrieves from valid unsigned normalized accessor and index") {
+    QuaternionAccessorType quaternionAccessor =
+        getQuaternionAccessorView(model, model.accessors[1]);
+    for (size_t i = 0; i < quaternions1.size(); i++) {
+      auto maybeQuaternion = std::visit(
+          QuaternionFromAccessor{static_cast<int64_t>(i)},
+          quaternionAccessor);
+      REQUIRE(maybeQuaternion);
+      // glm quat constructor is w,x,y,z
+      auto expected = glm::dquat(
+          quaternions1[i][3],
+          quaternions1[i][0],
+          quaternions1[i][1],
+          quaternions1[i][2]);
+      expected /= 255.0;
+      REQUIRE(*maybeQuaternion == expected);
+    }
+  }
+
+  SUBCASE("Retrieves from valid signed normalized accessor and index") {
+    QuaternionAccessorType positionAccessor =
+        getQuaternionAccessorView(model, model.accessors[2]);
+    for (size_t i = 0; i < quaternions2.size(); i++) {
+      auto maybeQuaternion = std::visit(
+          QuaternionFromAccessor{static_cast<int64_t>(i)},
+          positionAccessor);
+      REQUIRE(maybeQuaternion);
+      // glm quat constructor is w,x,y,z
+      auto expected = glm::dquat(
+          quaternions2[i][3],
+          quaternions2[i][0],
+          quaternions2[i][1],
+          quaternions2[i][2]);
+      expected.x = glm::max(expected.x / 127.0, -1.0);
+      expected.y = glm::max(expected.y / 127.0, -1.0);
+      expected.z = glm::max(expected.z / 127.0, -1.0);
+      expected.w = glm::max(expected.w / 127.0, -1.0);
+      REQUIRE(*maybeQuaternion == expected);
     }
   }
 }

--- a/CesiumGltf/test/TestAccessorUtility.cpp
+++ b/CesiumGltf/test/TestAccessorUtility.cpp
@@ -1490,7 +1490,7 @@ TEST_CASE("Test getQuaternionAccessorView") {
   }
 }
 
-TEST_CASE("Test PositionFromAccessor") {
+TEST_CASE("Test QuaternionFromAccessor") {
   Model model;
   std::vector<glm::quat> quaternions0{
       glm::quat(0, 1, 0, 0),


### PR DESCRIPTION
## Description

Updates `AccessorUtility` to support quantized positions, normals, and texcoords enabled by [KHR_mesh_quantization](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_mesh_quantization/README.md).

## Issue number or link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Author checklist

- [x] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [x] I have done a full self-review of my code.
- [x] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- [x] I have added or updated unit tests to ensure consistent code coverage as necessary.
- [x] I have updated the documentation as necessary.

## Reviewer checklist

Thank you for taking the time to review this PR. By approving a PR you are taking as much responsibility for these changes as the author.

As you review, please go through the checklist below:

- [x] Review and run all parts of the test plan on this branch and verify it matches expectations.
    - [ ] If the issue is a bug please make sure you can reproduce the bug in the main branch and then checkout this branch to make sure it actually solved the issue.
- [x] Review the code and make sure you do not have any remaining questions or concerns. You should understand the code change and the chosen approach. If you are not confident or have doubts about the code, please do not hesitate to ask questions.
    - [x] Code should follow the [C++ Style Guide](https://cesium.com/learn/cesium-native/ref-doc/style-guide.html)
- [x] Review the unit tests and make sure there are no missing tests or edge cases.
- [x] Review documentation changes and updates to `CHANGES.md` to make sure they accurately cover the work in this PR.
- [x] Verify that the [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) has been submitted, if needed.