### PR TITLE
Fix WebP library dependencies for CesiumImage and CesiumGltfReader

### DIFF
--- a/CesiumGltfReader/CMakeLists.txt
+++ b/CesiumGltfReader/CMakeLists.txt
@@ -63,6 +63,4 @@ target_link_libraries(CesiumGltfReader
         meshoptimizer::meshoptimizer
         modp_b64::modp_b64
         spz::spz
-        WebP::webp
-        WebP::webpdecoder
 )

--- a/CesiumImage/CMakeLists.txt
+++ b/CesiumImage/CMakeLists.txt
@@ -51,6 +51,8 @@ target_link_libraries(CesiumImage
         CesiumUtility
     PRIVATE
         KTX::ktx
+        WebP::webp
+        WebP::webpdecoder
 )
 
 if(CESIUM_DISABLE_LIBJPEG_TURBO)


### PR DESCRIPTION
CesiumImage should depend directly on WebP, while CesiumGltfReader does not anymore. If not, programs that use CesiumImage directly, without CesiumGltfReader, won't link.
