### PR TITLE
Added support for reading arrays of arbitrary JSON values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v0.63.0 - 2026-08-03
+
+##### Additions :tada:
+
+- Added support for reading arrays of arbitrary JSON values in `CesiumJsonReader::ArrayJsonHandler`.
+
 ### v0.62.0 - 2026-07-01
 
 ##### Breaking Changes :mega:

--- a/CesiumJsonReader/include/CesiumJsonReader/ArrayJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/ArrayJsonHandler.h
@@ -160,7 +160,7 @@ public:
 
   ArrayJsonHandler() noexcept
       : JsonHandler(),
-        _objectHandler(std::make_unique<JsonObjectJsonHandler>()) {}
+        _objectHandler() {}
 
   /**
    * @brief Resets the parent and destination array of this \ref
@@ -171,7 +171,6 @@ public:
     JsonHandler::reset(pParent);
     this->_pArray = pArray;
     this->_arrayIsOpen = false;
-    this->_objectHandler = std::make_unique<JsonObjectJsonHandler>();
   }
 
   virtual IJsonHandler* readNull() override {
@@ -261,16 +260,16 @@ public:
 
     CESIUM_ASSERT(this->_pArray);
     CesiumUtility::JsonValue& o = this->_pArray->emplace_back();
-    this->_objectHandler->reset(this, &o);
-    return this->_objectHandler->readObjectStart();
+    this->_objectHandler.reset(this, &o);
+    return this->_objectHandler.readObjectStart();
   }
 
   virtual IJsonHandler* readObjectKey(const std::string_view& str) override {
-    return this->_objectHandler->readObjectKey(str);
+    return this->_objectHandler.readObjectKey(str);
   }
 
   virtual IJsonHandler* readObjectEnd() override {
-    return this->_objectHandler->readObjectEnd();
+    return this->_objectHandler.readObjectEnd();
   }
 
   virtual IJsonHandler* readArrayStart() override {
@@ -310,8 +309,7 @@ private:
 
   std::vector<CesiumUtility::JsonValue>* _pArray = nullptr;
   bool _arrayIsOpen = false;
-
-  std::unique_ptr<CesiumJsonReader::JsonObjectJsonHandler> _objectHandler;
+  CesiumJsonReader::JsonObjectJsonHandler _objectHandler;
 };
 
 /**

--- a/CesiumJsonReader/include/CesiumJsonReader/ArrayJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/ArrayJsonHandler.h
@@ -158,7 +158,9 @@ public:
   /** @brief The destination type. */
   using ValueType = std::vector<CesiumUtility::JsonValue>;
 
-  ArrayJsonHandler() noexcept : JsonHandler(), _objectHandler() {}
+  ArrayJsonHandler() noexcept
+      : JsonHandler(),
+        _objectHandler(std::make_unique<JsonObjectJsonHandler>()) {}
 
   /**
    * @brief Resets the parent and destination array of this \ref
@@ -169,7 +171,7 @@ public:
     JsonHandler::reset(pParent);
     this->_pArray = pArray;
     this->_arrayIsOpen = false;
-    this->_objectHandler.reset();
+    this->_objectHandler = std::make_unique<JsonObjectJsonHandler>();
   }
 
   virtual IJsonHandler* readNull() override {

--- a/CesiumJsonReader/include/CesiumJsonReader/ArrayJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/ArrayJsonHandler.h
@@ -274,12 +274,16 @@ public:
 
   virtual IJsonHandler* readArrayStart() override {
     if (this->_arrayIsOpen) {
-      return this->invalid("An array")->readArrayStart();
+      // An array inside an array
+      CESIUM_ASSERT(this->_pArray);
+      CesiumUtility::JsonValue& o = this->_pArray->emplace_back();
+      this->_objectHandler.reset(this, &o);
+      return this->_objectHandler.readArrayStart();
+    } else {
+      this->_arrayIsOpen = true;
+      this->_pArray->clear();
+      return this;
     }
-
-    this->_arrayIsOpen = true;
-    this->_pArray->clear();
-    return this;
   }
 
   virtual IJsonHandler* readArrayEnd() override { return this->parent(); }

--- a/CesiumJsonReader/include/CesiumJsonReader/ArrayJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/ArrayJsonHandler.h
@@ -158,9 +158,7 @@ public:
   /** @brief The destination type. */
   using ValueType = std::vector<CesiumUtility::JsonValue>;
 
-  ArrayJsonHandler() noexcept
-      : JsonHandler(),
-        _objectHandler() {}
+  ArrayJsonHandler() noexcept : JsonHandler(), _objectHandler() {}
 
   /**
    * @brief Resets the parent and destination array of this \ref

--- a/CesiumJsonReader/include/CesiumJsonReader/ArrayJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/ArrayJsonHandler.h
@@ -3,9 +3,11 @@
 #include <CesiumJsonReader/DoubleJsonHandler.h>
 #include <CesiumJsonReader/IntegerJsonHandler.h>
 #include <CesiumJsonReader/JsonHandler.h>
+#include <CesiumJsonReader/JsonObjectJsonHandler.h>
 #include <CesiumJsonReader/Library.h>
 #include <CesiumJsonReader/StringJsonHandler.h>
 #include <CesiumUtility/Assert.h>
+#include <CesiumUtility/JsonValue.h>
 
 #include <functional>
 #include <memory>
@@ -145,6 +147,172 @@ private:
 };
 
 /**
+ * @brief Special case of \ref ArrayJsonHandler for handling arrays of arbitrary
+ * JSON values.
+ */
+template <>
+class CESIUMJSONREADER_API
+    ArrayJsonHandler<CesiumUtility::JsonValue, JsonObjectJsonHandler>
+    : public JsonHandler {
+public:
+  /** @brief The destination type. */
+  using ValueType = std::vector<CesiumUtility::JsonValue>;
+
+  ArrayJsonHandler() noexcept : JsonHandler(), _objectHandler() {}
+
+  /**
+   * @brief Resets the parent and destination array of this \ref
+   * ArrayJsonHandler.
+   */
+  void
+  reset(IJsonHandler* pParent, std::vector<CesiumUtility::JsonValue>* pArray) {
+    JsonHandler::reset(pParent);
+    this->_pArray = pArray;
+    this->_arrayIsOpen = false;
+    this->_objectHandler.reset();
+  }
+
+  virtual IJsonHandler* readNull() override {
+    if (!this->_arrayIsOpen) {
+      return this->invalid("A null")->readNull();
+    }
+
+    CESIUM_ASSERT(this->_pArray);
+    this->_pArray->emplace_back(nullptr);
+    return this;
+  }
+
+  virtual IJsonHandler* readBool(bool b) override {
+    if (!this->_arrayIsOpen) {
+      return this->invalid("A bool")->readBool(b);
+    }
+
+    CESIUM_ASSERT(this->_pArray);
+    this->_pArray->emplace_back(b);
+    return this;
+  }
+
+  virtual IJsonHandler* readInt32(int32_t i) override {
+    if (!this->_arrayIsOpen) {
+      return this->invalid("An integer")->readInt32(i);
+    }
+
+    CESIUM_ASSERT(this->_pArray);
+    this->_pArray->emplace_back(i);
+    return this;
+  }
+
+  virtual IJsonHandler* readUint32(uint32_t i) override {
+    if (!this->_arrayIsOpen) {
+      return this->invalid("An integer")->readUint32(i);
+    }
+
+    CESIUM_ASSERT(this->_pArray);
+    this->_pArray->emplace_back(i);
+    return this;
+  }
+
+  virtual IJsonHandler* readInt64(int64_t i) override {
+    if (!this->_arrayIsOpen) {
+      return this->invalid("An integer")->readInt64(i);
+    }
+
+    CESIUM_ASSERT(this->_pArray);
+    this->_pArray->emplace_back(i);
+    return this;
+  }
+
+  virtual IJsonHandler* readUint64(uint64_t i) override {
+    if (!this->_arrayIsOpen) {
+      return this->invalid("An integer")->readUint64(i);
+    }
+
+    CESIUM_ASSERT(this->_pArray);
+    this->_pArray->emplace_back(i);
+    return this;
+  }
+
+  virtual IJsonHandler* readDouble(double d) override {
+    if (!this->_arrayIsOpen) {
+      return this->invalid("A double (floating-point)")->readDouble(d);
+    }
+
+    CESIUM_ASSERT(this->_pArray);
+    this->_pArray->emplace_back(d);
+    return this;
+  }
+
+  virtual IJsonHandler* readString(const std::string_view& str) override {
+    if (!this->_arrayIsOpen) {
+      return this->invalid("A string")->readString(str);
+    }
+
+    CESIUM_ASSERT(this->_pArray);
+    this->_pArray->emplace_back(std::string(str));
+    return this;
+  }
+
+  virtual IJsonHandler* readObjectStart() override {
+    if (!this->_arrayIsOpen) {
+      return this->invalid("An object")->readObjectStart();
+    }
+
+    CESIUM_ASSERT(this->_pArray);
+    CesiumUtility::JsonValue& o = this->_pArray->emplace_back();
+    this->_objectHandler->reset(this, &o);
+    return this->_objectHandler->readObjectStart();
+  }
+
+  virtual IJsonHandler* readObjectKey(const std::string_view& str) override {
+    return this->_objectHandler->readObjectKey(str);
+  }
+
+  virtual IJsonHandler* readObjectEnd() override {
+    return this->_objectHandler->readObjectEnd();
+  }
+
+  virtual IJsonHandler* readArrayStart() override {
+    if (this->_arrayIsOpen) {
+      return this->invalid("An array")->readArrayStart();
+    }
+
+    this->_arrayIsOpen = true;
+    this->_pArray->clear();
+    return this;
+  }
+
+  virtual IJsonHandler* readArrayEnd() override { return this->parent(); }
+
+  virtual void reportWarning(
+      const std::string& warning,
+      std::vector<std::string>&& context =
+          std::vector<std::string>()) override {
+    context.push_back(
+        std::string("[") + std::to_string(this->_pArray->size()) + "]");
+    this->parent()->reportWarning(warning, std::move(context));
+  }
+
+private:
+  IJsonHandler* invalid(const std::string& type) {
+    if (this->_arrayIsOpen) {
+      this->reportWarning(
+          type + " value is not allowed in the JSON value array "
+                 "and has been replaced with a default value.");
+      this->_pArray->emplace_back();
+      return this->ignoreAndContinue();
+    } else {
+      this->reportWarning(type + " is not allowed and has been ignored.");
+      return this->ignoreAndReturnToParent();
+    }
+  }
+
+  std::vector<CesiumUtility::JsonValue>* _pArray = nullptr;
+  bool _arrayIsOpen = false;
+
+  std::unique_ptr<CesiumJsonReader::JsonObjectJsonHandler> _objectHandler;
+};
+
+/**
  * @brief Special case of \ref ArrayJsonHandler for handling arrays of double
  * values. This will read every scalar value as a double, regardless of whether
  * it's floating point or not. Attempting to read other values will cause a
@@ -219,7 +387,7 @@ public:
 
   virtual IJsonHandler* readDouble(double d) override {
     if (!this->_arrayIsOpen) {
-      return this->invalid("An integer")->readDouble(d);
+      return this->invalid("A double (floating-point)")->readDouble(d);
     }
 
     CESIUM_ASSERT(this->_pArray);

--- a/CesiumJsonReader/include/CesiumJsonReader/JsonObjectJsonHandler.h
+++ b/CesiumJsonReader/include/CesiumJsonReader/JsonObjectJsonHandler.h
@@ -56,7 +56,6 @@ private:
   IJsonHandler* doneElement();
 
   std::vector<CesiumUtility::JsonValue*> _stack;
-  std::string_view _currentKey;
 };
 
 } // namespace CesiumJsonReader

--- a/CesiumJsonReader/src/JsonObjectJsonHandler.cpp
+++ b/CesiumJsonReader/src/JsonObjectJsonHandler.cpp
@@ -103,7 +103,6 @@ JsonObjectJsonHandler::readObjectKey(const std::string_view& str) {
 
   auto it = pObject->emplace(str, CesiumUtility::JsonValue()).first;
   this->_stack.push_back(&it->second);
-  this->_currentKey = str;
   return this;
 }
 

--- a/CesiumJsonReader/test/TestArrayJsonHandler.cpp
+++ b/CesiumJsonReader/test/TestArrayJsonHandler.cpp
@@ -21,10 +21,9 @@ using namespace CesiumUtility;
 
 namespace {
 
-template <typename THandler>
-auto readArray(std::string_view json) {
+template <typename THandler> auto readArray(std::string_view json) {
   THandler handler;
-  auto bytes = std::span<const std::byte>(
+  std::span<const std::byte> bytes(
       reinterpret_cast<const std::byte*>(json.data()),
       json.size());
   return JsonReader::readJson(bytes, handler);
@@ -45,7 +44,7 @@ public:
 
   void reset(IJsonHandler* pParent, TestObject* pObject) {
     JsonHandler::reset(pParent);
-    _pObject = pObject;
+    this->_pObject = pObject;
   }
 
   IJsonHandler* readObjectKey(const std::string_view& str) override {
@@ -254,8 +253,7 @@ TEST_CASE("ArrayJsonHandler<std::string, StringJsonHandler>") {
   }
 
   SUBCASE("skips unexpected elements and can read later valid elements") {
-    auto result =
-        readArray<Handler>("[\"hello\", 42, true, null, \"world\"]");
+    auto result = readArray<Handler>("[\"hello\", 42, true, null, \"world\"]");
     REQUIRE(result.value.has_value());
     CHECK(result.warnings.size() == 3);
     REQUIRE(result.value->size() == 5);
@@ -283,6 +281,9 @@ TEST_CASE("ArrayJsonHandler<JsonValue, JsonObjectJsonHandler>") {
     CHECK((*result.value)[4].isDouble());
     CHECK((*result.value)[4].getDouble() == 2.5);
     CHECK((*result.value)[5].isObject());
+    const auto* pKey = (*result.value)[5].getValuePtrForKey("key");
+    REQUIRE(pKey != nullptr);
+    CHECK(pKey->getInt64() == 42);
   }
 
   SUBCASE("reads array of booleans") {
@@ -336,8 +337,7 @@ TEST_CASE("ArrayJsonHandler<JsonValue, JsonObjectJsonHandler>") {
     CHECK(pA->getInt64() == 1);
   }
 
-  SUBCASE("mixed types - booleans strings and numbers (original bug case)") {
-    // The original bug: keySet can be an array of strings, numbers, or booleans
+  SUBCASE("mixed types - booleans, strings, and numbers") {
     auto result = readArray<Handler>("[\"value1\", 42, true]");
     REQUIRE(result.value.has_value());
     CHECK(result.warnings.empty());
@@ -352,9 +352,8 @@ TEST_CASE("ArrayJsonHandler<T, THandler> (primary template, objects)") {
   using Handler = ArrayJsonHandler<TestObject, TestObjectJsonHandler>;
 
   SUBCASE("reads array of objects") {
-    auto result = readArray<Handler>(
-        "[{\"name\": \"foo\", \"value\": 1},"
-        " {\"name\": \"bar\", \"value\": 2}]");
+    auto result = readArray<Handler>("[{\"name\": \"foo\", \"value\": 1},"
+                                     " {\"name\": \"bar\", \"value\": 2}]");
     REQUIRE(result.value.has_value());
     CHECK(result.warnings.empty());
     REQUIRE(result.value->size() == 2);
@@ -382,9 +381,9 @@ TEST_CASE("ArrayJsonHandler<T, THandler> (primary template, objects)") {
   }
 
   SUBCASE("warns on string element and inserts default value") {
-    auto result = readArray<Handler>(
-        "[{\"name\": \"foo\", \"value\": 1}, \"bad\","
-        " {\"name\": \"bar\", \"value\": 2}]");
+    auto result =
+        readArray<Handler>("[{\"name\": \"foo\", \"value\": 1}, \"bad\","
+                           " {\"name\": \"bar\", \"value\": 2}]");
     REQUIRE(result.value.has_value());
     REQUIRE(result.warnings.size() == 1);
     CHECK(result.warnings[0].find("string") != std::string::npos);
@@ -398,9 +397,8 @@ TEST_CASE("ArrayJsonHandler<T, THandler> (primary template, objects)") {
   }
 
   SUBCASE("warns on integer element and inserts default value") {
-    auto result = readArray<Handler>(
-        "[{\"name\": \"foo\", \"value\": 1}, 42,"
-        " {\"name\": \"bar\", \"value\": 2}]");
+    auto result = readArray<Handler>("[{\"name\": \"foo\", \"value\": 1}, 42,"
+                                     " {\"name\": \"bar\", \"value\": 2}]");
     REQUIRE(result.value.has_value());
     REQUIRE(result.warnings.size() == 1);
     CHECK(result.warnings[0].find("integer") != std::string::npos);
@@ -411,9 +409,8 @@ TEST_CASE("ArrayJsonHandler<T, THandler> (primary template, objects)") {
   }
 
   SUBCASE("warns on bool element and inserts default value") {
-    auto result = readArray<Handler>(
-        "[{\"name\": \"foo\", \"value\": 1}, true,"
-        " {\"name\": \"bar\", \"value\": 2}]");
+    auto result = readArray<Handler>("[{\"name\": \"foo\", \"value\": 1}, true,"
+                                     " {\"name\": \"bar\", \"value\": 2}]");
     REQUIRE(result.value.has_value());
     REQUIRE(result.warnings.size() == 1);
     CHECK(result.warnings[0].find("boolean") != std::string::npos);
@@ -424,9 +421,8 @@ TEST_CASE("ArrayJsonHandler<T, THandler> (primary template, objects)") {
   }
 
   SUBCASE("warns on null element and inserts default value") {
-    auto result = readArray<Handler>(
-        "[{\"name\": \"foo\", \"value\": 1}, null,"
-        " {\"name\": \"bar\", \"value\": 2}]");
+    auto result = readArray<Handler>("[{\"name\": \"foo\", \"value\": 1}, null,"
+                                     " {\"name\": \"bar\", \"value\": 2}]");
     REQUIRE(result.value.has_value());
     REQUIRE(result.warnings.size() == 1);
     CHECK(result.warnings[0].find("null") != std::string::npos);
@@ -437,10 +433,9 @@ TEST_CASE("ArrayJsonHandler<T, THandler> (primary template, objects)") {
   }
 
   SUBCASE("skips unexpected elements and can read later valid elements") {
-    auto result = readArray<Handler>(
-        "[{\"name\": \"first\", \"value\": 1},"
-        " \"bad\", 42, true, null,"
-        " {\"name\": \"last\", \"value\": 5}]");
+    auto result = readArray<Handler>("[{\"name\": \"first\", \"value\": 1},"
+                                     " \"bad\", 42, true, null,"
+                                     " {\"name\": \"last\", \"value\": 5}]");
     REQUIRE(result.value.has_value());
     CHECK(result.warnings.size() == 4);
     REQUIRE(result.value->size() == 6);

--- a/CesiumJsonReader/test/TestArrayJsonHandler.cpp
+++ b/CesiumJsonReader/test/TestArrayJsonHandler.cpp
@@ -1,0 +1,452 @@
+#include <CesiumJsonReader/ArrayJsonHandler.h>
+#include <CesiumJsonReader/DoubleJsonHandler.h>
+#include <CesiumJsonReader/IntegerJsonHandler.h>
+#include <CesiumJsonReader/JsonObjectJsonHandler.h>
+#include <CesiumJsonReader/JsonReader.h>
+#include <CesiumJsonReader/ObjectJsonHandler.h>
+#include <CesiumJsonReader/StringJsonHandler.h>
+#include <CesiumUtility/JsonValue.h>
+
+#include <doctest/doctest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using namespace CesiumJsonReader;
+using namespace CesiumUtility;
+
+namespace {
+
+template <typename THandler>
+auto readArray(std::string_view json) {
+  THandler handler;
+  auto bytes = std::span<const std::byte>(
+      reinterpret_cast<const std::byte*>(json.data()),
+      json.size());
+  return JsonReader::readJson(bytes, handler);
+}
+
+// A simple struct and handler used to test the primary (non-specialized)
+// ArrayJsonHandler template, which is designed to read arrays of objects.
+struct TestObject {
+  std::string name;
+  int32_t value = 0;
+};
+
+class TestObjectJsonHandler : public ObjectJsonHandler {
+public:
+  using ValueType = TestObject;
+
+  TestObjectJsonHandler() noexcept = default;
+
+  void reset(IJsonHandler* pParent, TestObject* pObject) {
+    JsonHandler::reset(pParent);
+    _pObject = pObject;
+  }
+
+  IJsonHandler* readObjectKey(const std::string_view& str) override {
+    if (str == "name")
+      return this->property("name", _name, _pObject->name);
+    if (str == "value")
+      return this->property("value", _value, _pObject->value);
+    return this->ignoreAndContinue();
+  }
+
+private:
+  TestObject* _pObject = nullptr;
+  StringJsonHandler _name;
+  IntegerJsonHandler<int32_t> _value;
+};
+
+} // namespace
+
+TEST_CASE("ArrayJsonHandler<double, DoubleJsonHandler>") {
+  using Handler = ArrayJsonHandler<double, DoubleJsonHandler>;
+
+  SUBCASE("reads array of doubles") {
+    auto result = readArray<Handler>("[1.5, 2.0, -3.25]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.empty());
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0] == 1.5);
+    CHECK((*result.value)[1] == 2.0);
+    CHECK((*result.value)[2] == -3.25);
+  }
+
+  SUBCASE("reads integer values as doubles") {
+    auto result = readArray<Handler>("[1, 2, 3]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.empty());
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0] == 1.0);
+    CHECK((*result.value)[1] == 2.0);
+    CHECK((*result.value)[2] == 3.0);
+  }
+
+  SUBCASE("warns on string element and inserts default value") {
+    auto result = readArray<Handler>("[1.0, \"hello\", 3.0]");
+    REQUIRE(result.value.has_value());
+    REQUIRE(result.warnings.size() == 1);
+    CHECK(result.warnings[0].find("string") != std::string::npos);
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0] == 1.0);
+    CHECK((*result.value)[1] == 0.0); // default double
+    CHECK((*result.value)[2] == 3.0);
+  }
+
+  SUBCASE("warns on bool element and inserts default value") {
+    auto result = readArray<Handler>("[1.0, true, 3.0]");
+    REQUIRE(result.value.has_value());
+    REQUIRE(result.warnings.size() == 1);
+    CHECK(result.warnings[0].find("bool") != std::string::npos);
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0] == 1.0);
+    CHECK((*result.value)[1] == 0.0); // default double
+    CHECK((*result.value)[2] == 3.0);
+  }
+
+  SUBCASE("warns on null element and inserts default value") {
+    auto result = readArray<Handler>("[1.0, null, 3.0]");
+    REQUIRE(result.value.has_value());
+    REQUIRE(result.warnings.size() == 1);
+    CHECK(result.warnings[0].find("null") != std::string::npos);
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0] == 1.0);
+    CHECK((*result.value)[1] == 0.0); // default double
+    CHECK((*result.value)[2] == 3.0);
+  }
+
+  SUBCASE("warns on object element and inserts default value") {
+    auto result = readArray<Handler>("[1.0, {\"a\": 1}, 3.0]");
+    REQUIRE(result.value.has_value());
+    REQUIRE(result.warnings.size() == 1);
+    CHECK(result.warnings[0].find("object") != std::string::npos);
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0] == 1.0);
+    CHECK((*result.value)[1] == 0.0); // default double
+    CHECK((*result.value)[2] == 3.0);
+  }
+
+  SUBCASE("skips unexpected elements and can read later valid elements") {
+    auto result = readArray<Handler>("[1.0, \"bad\", true, null, 5.0]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.size() == 3);
+    REQUIRE(result.value->size() == 5);
+    CHECK((*result.value)[0] == 1.0);
+    CHECK((*result.value)[4] == 5.0);
+  }
+}
+
+TEST_CASE("ArrayJsonHandler<int32_t, IntegerJsonHandler<int32_t>>") {
+  using Handler = ArrayJsonHandler<int32_t, IntegerJsonHandler<int32_t>>;
+
+  SUBCASE("reads array of integers") {
+    auto result = readArray<Handler>("[1, 2, -3]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.empty());
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0] == 1);
+    CHECK((*result.value)[1] == 2);
+    CHECK((*result.value)[2] == -3);
+  }
+
+  SUBCASE("warns on string element and inserts default value") {
+    auto result = readArray<Handler>("[1, \"hello\", 3]");
+    REQUIRE(result.value.has_value());
+    REQUIRE(result.warnings.size() == 1);
+    CHECK(result.warnings[0].find("string") != std::string::npos);
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0] == 1);
+    CHECK((*result.value)[1] == 0); // default int
+    CHECK((*result.value)[2] == 3);
+  }
+
+  SUBCASE("warns on bool element and inserts default value") {
+    auto result = readArray<Handler>("[1, true, 3]");
+    REQUIRE(result.value.has_value());
+    REQUIRE(result.warnings.size() == 1);
+    CHECK(result.warnings[0].find("bool") != std::string::npos);
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0] == 1);
+    CHECK((*result.value)[1] == 0); // default int
+    CHECK((*result.value)[2] == 3);
+  }
+
+  SUBCASE("warns on double element and inserts default value") {
+    auto result = readArray<Handler>("[1, 2.5, 3]");
+    REQUIRE(result.value.has_value());
+    REQUIRE(result.warnings.size() == 1);
+    CHECK(result.warnings[0].find("double") != std::string::npos);
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0] == 1);
+    CHECK((*result.value)[1] == 0); // default int
+    CHECK((*result.value)[2] == 3);
+  }
+
+  SUBCASE("skips unexpected elements and can read later valid elements") {
+    auto result = readArray<Handler>("[1, \"bad\", true, 2.5, 5]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.size() == 3);
+    REQUIRE(result.value->size() == 5);
+    CHECK((*result.value)[0] == 1);
+    CHECK((*result.value)[4] == 5);
+  }
+}
+
+TEST_CASE("ArrayJsonHandler<std::string, StringJsonHandler>") {
+  using Handler = ArrayJsonHandler<std::string, StringJsonHandler>;
+
+  SUBCASE("reads array of strings") {
+    auto result = readArray<Handler>("[\"hello\", \"world\"]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.empty());
+    REQUIRE(result.value->size() == 2);
+    CHECK((*result.value)[0] == "hello");
+    CHECK((*result.value)[1] == "world");
+  }
+
+  SUBCASE("warns on integer element and inserts default value") {
+    auto result = readArray<Handler>("[\"hello\", 42, \"world\"]");
+    REQUIRE(result.value.has_value());
+    REQUIRE(result.warnings.size() == 1);
+    CHECK(result.warnings[0].find("integer") != std::string::npos);
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0] == "hello");
+    CHECK((*result.value)[1] == ""); // default string
+    CHECK((*result.value)[2] == "world");
+  }
+
+  SUBCASE("warns on bool element and inserts default value") {
+    auto result = readArray<Handler>("[\"hello\", true, \"world\"]");
+    REQUIRE(result.value.has_value());
+    REQUIRE(result.warnings.size() == 1);
+    CHECK(result.warnings[0].find("bool") != std::string::npos);
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0] == "hello");
+    CHECK((*result.value)[1] == ""); // default string
+    CHECK((*result.value)[2] == "world");
+  }
+
+  SUBCASE("warns on double element and inserts default value") {
+    auto result = readArray<Handler>("[\"hello\", 1.5, \"world\"]");
+    REQUIRE(result.value.has_value());
+    REQUIRE(result.warnings.size() == 1);
+    CHECK(result.warnings[0].find("double") != std::string::npos);
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0] == "hello");
+    CHECK((*result.value)[1] == ""); // default string
+    CHECK((*result.value)[2] == "world");
+  }
+
+  SUBCASE("warns on null element and inserts default value") {
+    auto result = readArray<Handler>("[\"hello\", null, \"world\"]");
+    REQUIRE(result.value.has_value());
+    REQUIRE(result.warnings.size() == 1);
+    CHECK(result.warnings[0].find("null") != std::string::npos);
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0] == "hello");
+    CHECK((*result.value)[1] == ""); // default string
+    CHECK((*result.value)[2] == "world");
+  }
+
+  SUBCASE("skips unexpected elements and can read later valid elements") {
+    auto result =
+        readArray<Handler>("[\"hello\", 42, true, null, \"world\"]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.size() == 3);
+    REQUIRE(result.value->size() == 5);
+    CHECK((*result.value)[0] == "hello");
+    CHECK((*result.value)[4] == "world");
+  }
+}
+
+TEST_CASE("ArrayJsonHandler<JsonValue, JsonObjectJsonHandler>") {
+  using Handler = ArrayJsonHandler<JsonValue, JsonObjectJsonHandler>;
+
+  SUBCASE("reads array of mixed JSON values") {
+    auto result =
+        readArray<Handler>("[1, \"hello\", true, null, 2.5, {\"key\": 42}]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.empty());
+    REQUIRE(result.value->size() == 6);
+    CHECK((*result.value)[0].isInt64());
+    CHECK((*result.value)[0].getInt64() == 1);
+    CHECK((*result.value)[1].isString());
+    CHECK((*result.value)[1].getString() == "hello");
+    CHECK((*result.value)[2].isBool());
+    CHECK((*result.value)[2].getBool() == true);
+    CHECK((*result.value)[3].isNull());
+    CHECK((*result.value)[4].isDouble());
+    CHECK((*result.value)[4].getDouble() == 2.5);
+    CHECK((*result.value)[5].isObject());
+  }
+
+  SUBCASE("reads array of booleans") {
+    auto result = readArray<Handler>("[true, false, true]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.empty());
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0].getBool() == true);
+    CHECK((*result.value)[1].getBool() == false);
+    CHECK((*result.value)[2].getBool() == true);
+  }
+
+  SUBCASE("reads array of strings") {
+    auto result = readArray<Handler>("[\"a\", \"b\", \"c\"]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.empty());
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0].getString() == "a");
+    CHECK((*result.value)[1].getString() == "b");
+    CHECK((*result.value)[2].getString() == "c");
+  }
+
+  SUBCASE("reads array of numbers") {
+    auto result = readArray<Handler>("[1, 2, 3]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.empty());
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0].getInt64() == 1);
+    CHECK((*result.value)[1].getInt64() == 2);
+    CHECK((*result.value)[2].getInt64() == 3);
+  }
+
+  SUBCASE("reads array of null values") {
+    auto result = readArray<Handler>("[null, null]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.empty());
+    REQUIRE(result.value->size() == 2);
+    CHECK((*result.value)[0].isNull());
+    CHECK((*result.value)[1].isNull());
+  }
+
+  SUBCASE("reads array of objects") {
+    auto result = readArray<Handler>("[{\"a\": 1}, {\"b\": \"two\"}]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.empty());
+    REQUIRE(result.value->size() == 2);
+    CHECK((*result.value)[0].isObject());
+    CHECK((*result.value)[1].isObject());
+    const auto* pA = (*result.value)[0].getValuePtrForKey("a");
+    REQUIRE(pA != nullptr);
+    CHECK(pA->getInt64() == 1);
+  }
+
+  SUBCASE("mixed types - booleans strings and numbers (original bug case)") {
+    // The original bug: keySet can be an array of strings, numbers, or booleans
+    auto result = readArray<Handler>("[\"value1\", 42, true]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.empty());
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0].getString() == "value1");
+    CHECK((*result.value)[1].getInt64() == 42);
+    CHECK((*result.value)[2].getBool() == true);
+  }
+}
+
+TEST_CASE("ArrayJsonHandler<T, THandler> (primary template, objects)") {
+  using Handler = ArrayJsonHandler<TestObject, TestObjectJsonHandler>;
+
+  SUBCASE("reads array of objects") {
+    auto result = readArray<Handler>(
+        "[{\"name\": \"foo\", \"value\": 1},"
+        " {\"name\": \"bar\", \"value\": 2}]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.empty());
+    REQUIRE(result.value->size() == 2);
+    CHECK((*result.value)[0].name == "foo");
+    CHECK((*result.value)[0].value == 1);
+    CHECK((*result.value)[1].name == "bar");
+    CHECK((*result.value)[1].value == 2);
+  }
+
+  SUBCASE("reads empty array") {
+    auto result = readArray<Handler>("[]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.empty());
+    CHECK(result.value->empty());
+  }
+
+  SUBCASE("unknown object keys are ignored without warnings") {
+    auto result = readArray<Handler>(
+        "[{\"name\": \"foo\", \"unknown\": 99, \"value\": 1}]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.empty());
+    REQUIRE(result.value->size() == 1);
+    CHECK((*result.value)[0].name == "foo");
+    CHECK((*result.value)[0].value == 1);
+  }
+
+  SUBCASE("warns on string element and inserts default value") {
+    auto result = readArray<Handler>(
+        "[{\"name\": \"foo\", \"value\": 1}, \"bad\","
+        " {\"name\": \"bar\", \"value\": 2}]");
+    REQUIRE(result.value.has_value());
+    REQUIRE(result.warnings.size() == 1);
+    CHECK(result.warnings[0].find("string") != std::string::npos);
+    CHECK(result.warnings[0].find("object array") != std::string::npos);
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0].name == "foo");
+    // default-constructed element inserted for the invalid "bad" element
+    CHECK((*result.value)[1].name == "");
+    CHECK((*result.value)[1].value == 0);
+    CHECK((*result.value)[2].name == "bar");
+  }
+
+  SUBCASE("warns on integer element and inserts default value") {
+    auto result = readArray<Handler>(
+        "[{\"name\": \"foo\", \"value\": 1}, 42,"
+        " {\"name\": \"bar\", \"value\": 2}]");
+    REQUIRE(result.value.has_value());
+    REQUIRE(result.warnings.size() == 1);
+    CHECK(result.warnings[0].find("integer") != std::string::npos);
+    CHECK(result.warnings[0].find("object array") != std::string::npos);
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0].name == "foo");
+    CHECK((*result.value)[2].name == "bar");
+  }
+
+  SUBCASE("warns on bool element and inserts default value") {
+    auto result = readArray<Handler>(
+        "[{\"name\": \"foo\", \"value\": 1}, true,"
+        " {\"name\": \"bar\", \"value\": 2}]");
+    REQUIRE(result.value.has_value());
+    REQUIRE(result.warnings.size() == 1);
+    CHECK(result.warnings[0].find("boolean") != std::string::npos);
+    CHECK(result.warnings[0].find("object array") != std::string::npos);
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0].name == "foo");
+    CHECK((*result.value)[2].name == "bar");
+  }
+
+  SUBCASE("warns on null element and inserts default value") {
+    auto result = readArray<Handler>(
+        "[{\"name\": \"foo\", \"value\": 1}, null,"
+        " {\"name\": \"bar\", \"value\": 2}]");
+    REQUIRE(result.value.has_value());
+    REQUIRE(result.warnings.size() == 1);
+    CHECK(result.warnings[0].find("null") != std::string::npos);
+    CHECK(result.warnings[0].find("object array") != std::string::npos);
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0].name == "foo");
+    CHECK((*result.value)[2].name == "bar");
+  }
+
+  SUBCASE("skips unexpected elements and can read later valid elements") {
+    auto result = readArray<Handler>(
+        "[{\"name\": \"first\", \"value\": 1},"
+        " \"bad\", 42, true, null,"
+        " {\"name\": \"last\", \"value\": 5}]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.size() == 4);
+    REQUIRE(result.value->size() == 6);
+    CHECK((*result.value)[0].name == "first");
+    CHECK((*result.value)[0].value == 1);
+    CHECK((*result.value)[5].name == "last");
+    CHECK((*result.value)[5].value == 5);
+  }
+}

--- a/CesiumJsonReader/test/TestArrayJsonHandler.cpp
+++ b/CesiumJsonReader/test/TestArrayJsonHandler.cpp
@@ -346,6 +346,20 @@ TEST_CASE("ArrayJsonHandler<JsonValue, JsonObjectJsonHandler>") {
     CHECK((*result.value)[1].getUint64() == 42);
     CHECK((*result.value)[2].getBool() == true);
   }
+
+  SUBCASE("reads array element that is itself an array") {
+    auto result = readArray<Handler>("[1, [2, 3], \"after\"]");
+    REQUIRE(result.value.has_value());
+    CHECK(result.warnings.empty());
+    REQUIRE(result.value->size() == 3);
+    CHECK((*result.value)[0].getUint64() == 1);
+    REQUIRE((*result.value)[1].isArray());
+    const auto& inner = (*result.value)[1].getArray();
+    REQUIRE(inner.size() == 2);
+    CHECK(inner[0].getUint64() == 2);
+    CHECK(inner[1].getUint64() == 3);
+    CHECK((*result.value)[2].getString() == "after");
+  }
 }
 
 TEST_CASE("ArrayJsonHandler<T, THandler> (primary template, objects)") {

--- a/CesiumJsonReader/test/TestArrayJsonHandler.cpp
+++ b/CesiumJsonReader/test/TestArrayJsonHandler.cpp
@@ -271,8 +271,8 @@ TEST_CASE("ArrayJsonHandler<JsonValue, JsonObjectJsonHandler>") {
     REQUIRE(result.value.has_value());
     CHECK(result.warnings.empty());
     REQUIRE(result.value->size() == 6);
-    CHECK((*result.value)[0].isInt64());
-    CHECK((*result.value)[0].getInt64() == 1);
+    CHECK((*result.value)[0].isUint64());
+    CHECK((*result.value)[0].getUint64() == 1);
     CHECK((*result.value)[1].isString());
     CHECK((*result.value)[1].getString() == "hello");
     CHECK((*result.value)[2].isBool());
@@ -283,7 +283,7 @@ TEST_CASE("ArrayJsonHandler<JsonValue, JsonObjectJsonHandler>") {
     CHECK((*result.value)[5].isObject());
     const auto* pKey = (*result.value)[5].getValuePtrForKey("key");
     REQUIRE(pKey != nullptr);
-    CHECK(pKey->getInt64() == 42);
+    CHECK(pKey->getUint64() == 42);
   }
 
   SUBCASE("reads array of booleans") {
@@ -311,9 +311,9 @@ TEST_CASE("ArrayJsonHandler<JsonValue, JsonObjectJsonHandler>") {
     REQUIRE(result.value.has_value());
     CHECK(result.warnings.empty());
     REQUIRE(result.value->size() == 3);
-    CHECK((*result.value)[0].getInt64() == 1);
-    CHECK((*result.value)[1].getInt64() == 2);
-    CHECK((*result.value)[2].getInt64() == 3);
+    CHECK((*result.value)[0].getUint64() == 1);
+    CHECK((*result.value)[1].getUint64() == 2);
+    CHECK((*result.value)[2].getUint64() == 3);
   }
 
   SUBCASE("reads array of null values") {
@@ -334,7 +334,7 @@ TEST_CASE("ArrayJsonHandler<JsonValue, JsonObjectJsonHandler>") {
     CHECK((*result.value)[1].isObject());
     const auto* pA = (*result.value)[0].getValuePtrForKey("a");
     REQUIRE(pA != nullptr);
-    CHECK(pA->getInt64() == 1);
+    CHECK(pA->getUint64() == 1);
   }
 
   SUBCASE("mixed types - booleans, strings, and numbers") {
@@ -343,7 +343,7 @@ TEST_CASE("ArrayJsonHandler<JsonValue, JsonObjectJsonHandler>") {
     CHECK(result.warnings.empty());
     REQUIRE(result.value->size() == 3);
     CHECK((*result.value)[0].getString() == "value1");
-    CHECK((*result.value)[1].getInt64() == 42);
+    CHECK((*result.value)[1].getUint64() == 42);
     CHECK((*result.value)[2].getBool() == true);
   }
 }

--- a/CesiumNativeTests/CMakeLists.txt
+++ b/CesiumNativeTests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(cesium_native_targets
     CesiumIonClient
     CesiumImage
     CesiumITwinClient
+    CesiumJsonReader
     CesiumVectorData
     CesiumVectorOverlays
     CesiumQuantizedMeshTerrain

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cesium/cesium-native",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cesium/cesium-native",
-      "version": "0.61.0",
+      "version": "0.62.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "clang-format": "^1.5.0",


### PR DESCRIPTION
## Description

I was getting some warnings when parsing [`keySet`](https://github.com/CesiumGS/3d-tiles/blob/ad47ad1f7e91b3d4deb9edfc42cb1293b5334306/extensions/3DTILES_content_conditional/schema/tileset.3DTILES_content_conditional.schema.json#L19-L26) in [`3DTILES_content_conditional`](https://github.com/CesiumGS/3d-tiles/pull/834):

```
[2026-07-07 14:41:18.714] [warning] CesiumNativeWriteTilesetError: errors A string value is not allowed in the object array and has been replaced with a default value.

  While parsing: .extensionsRequired.dimensions[1].keySet[0]
  From byte offset: 28192, A string value is not allowed in the object array and has been replaced with a default value.
  While parsing: .extensionsRequired.dimensions[2].keySet[0]
  From byte offset: 28285, A boolean value is not allowed in the object array and has been replaced with a default value.
  While parsing: .extensionsRequired.dimensions[3].keySet[0]
  From byte offset: 28354
```

`keySet` can be an array of strings, numbers, or boolean, so its generated type is

```c++
  CesiumJsonReader::ArrayJsonHandler<
      CesiumUtility::JsonValue,
      CesiumJsonReader::JsonObjectJsonHandler>
      _keySet;
```

This doesn't work with `ArrayJsonHandler` because it expects its elements to be objects (hence the warnings above). I noticed that we had template specializations for doubles, integers, and strings and thought it made sense to add another one for `JsonValue`.

## Issue number or link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Author checklist

- [x] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [x] I have done a full self-review of my code.
- [x] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- [ ] I have added or updated unit tests to ensure consistent code coverage as necessary.
- [x] I have updated the documentation as necessary.

We don't have any unit tests in `CesiumJsonReader` :/

## Remaining Tasks

<!-- Are there any remaining tasks to do or blocking questions to answer before we can merge this? -->

<!-- If so, please convert this to a draft PR and let us know how we can help. Otherwise, you may remove this section. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

<!-- Include links to any required data or screenshots. Mention any edge cases such as user error, invalid data, etc. -->

## Reviewer checklist

Thank you for taking the time to review this PR. By approving a PR you are taking as much responsibility for these changes as the author.

As you review, please go through the checklist below:

- [ ] Review and run all parts of the test plan on this branch and verify it matches expectations.
    - [ ] If the issue is a bug please make sure you can reproduce the bug in the main branch and then checkout this branch to make sure it actually solved the issue.
- [ ] Review the code and make sure you do not have any remaining questions or concerns. You should understand the code change and the chosen approach. If you are not confident or have doubts about the code, please do not hesitate to ask questions.
    - [ ] Code should follow the [C++ Style Guide](https://cesium.com/learn/cesium-native/ref-doc/style-guide.html)
- [ ] Review the unit tests and make sure there are no missing tests or edge cases.
- [ ] Review documentation changes and updates to `CHANGES.md` to make sure they accurately cover the work in this PR.
- [ ] Verify that the [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) has been submitted, if needed.